### PR TITLE
fix: remove analytics container from dev and prod

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -115,9 +115,6 @@ services:
       timeout: 10s
       interval: 5s
       retries: 3
-    depends_on:
-      analytics:
-        condition: service_healthy
     environment:
       STUDIO_PG_META_URL: http://meta:8080
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -146,8 +143,6 @@ services:
     volumes:
       - ./volumes/api/kong.yml:/home/kong/temp.yml:ro,z
     depends_on:
-      analytics:
-        condition: service_healthy
     environment:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
@@ -182,8 +177,6 @@ services:
     depends_on:
       db-dev:
         condition: service_healthy
-      analytics:
-        condition: service_healthy
     environment:
       GOTRUE_API_HOST: 0.0.0.0
       GOTRUE_API_PORT: 9999
@@ -214,8 +207,6 @@ services:
     depends_on:
       db-dev:
         condition: service_healthy
-      analytics:
-        condition: service_healthy
     environment:
       PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
       PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS}
@@ -237,8 +228,6 @@ services:
     restart: unless-stopped
     depends_on:
       db-dev:
-        condition: service_healthy
-      analytics:
         condition: service_healthy
     healthcheck:
       test:
@@ -384,8 +373,6 @@ services:
     depends_on:
       db-dev:
         condition: service_healthy
-      analytics:
-        condition: service_healthy
     environment:
       PG_META_PORT: 8080
       PG_META_DB_HOST: ${POSTGRES_HOST}
@@ -394,43 +381,8 @@ services:
       PG_META_DB_USER: supabase_admin
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
 
-  analytics:
-    container_name: supabase-analytics-dev
-    image: supabase/logflare:1.14.2
-    restart: unless-stopped
-    networks:
-      - supanet
-    ports:
-      - 4000:4000
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "http://localhost:4000/health"
-        ]
-      timeout: 5s
-      interval: 5s
-      retries: 10
-    depends_on:
-      db-dev:
-        condition: service_healthy
-    environment:
-      LOGFLARE_NODE_HOST: 127.0.0.1
-      DB_USERNAME: supabase_admin
-      DB_DATABASE: _supabase
-      DB_HOSTNAME: ${POSTGRES_HOST}
-      DB_PORT: ${POSTGRES_PORT}
-      DB_PASSWORD: ${POSTGRES_PASSWORD}
-      DB_SCHEMA: _analytics
-      LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
-      LOGFLARE_PRIVATE_ACCESS_TOKEN: ${LOGFLARE_PRIVATE_ACCESS_TOKEN}
-      LOGFLARE_SINGLE_TENANT: true
-      LOGFLARE_SUPABASE_MODE: true
-      LOGFLARE_MIN_CLUSTER_SIZE: 1
-      POSTGRES_BACKEND_URL: postgresql://supabase_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/_supabase
-      POSTGRES_BACKEND_SCHEMA: _analytics
-      LOGFLARE_FEATURE_FLAG_OVERRIDE: multibackend=true
+  # NOTE: analytics (Logflare) removed — makes unauthorized outbound
+  # connections to DataDog. See: https://github.com/supabase/cli/issues/3254
 
   db-dev:
     container_name: db-dev
@@ -438,7 +390,6 @@ services:
     restart: unless-stopped 
     volumes:
       - ./volumes/db/_supabase.sh:/docker-entrypoint-initdb.d/96-_supabase.sh:Z
-      - ./volumes/db/_analytics.sh:/docker-entrypoint-initdb.d/97-_analytics.sh:Z
       - ./volumes/db/data:/var/lib/postgresql/data:Z
       - ./volumes/db/realtime.sql:/docker-entrypoint-initdb.d/migrations/99-realtime.sql:Z
       - ./volumes/db/webhooks.sql:/docker-entrypoint-initdb.d/init-scripts/98-webhooks.sql:Z
@@ -524,8 +475,6 @@ services:
       retries: 5
     depends_on:
       db-dev:
-        condition: service_healthy
-      analytics:
         condition: service_healthy
     environment:
       PORT: 4000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,9 +6,9 @@
 #   RAM:     16 GB
 #   Disk:    100 GB SSD
 #
-# Services: ~17 containers (nginx, bloom-web, langchain-agent, bloommcp,
+# Services: ~15 containers (nginx, bloom-web, langchain-agent, bloommcp,
 #   kong, auth, rest, realtime, minio, minio-init, storage, imgproxy,
-#   meta, analytics, db-prod, supavisor, studio)
+#   meta, db-prod, supavisor, studio)
 #
 # Host-exposed ports:
 #   80/443  - nginx (public HTTP/HTTPS)
@@ -462,8 +462,6 @@ services:
     depends_on:
       db-prod:
         condition: service_healthy
-      analytics:
-        condition: service_healthy
     environment:
       PG_META_PORT: 8080
       PG_META_DB_HOST: ${POSTGRES_HOST}
@@ -472,44 +470,9 @@ services:
       PG_META_DB_USER: supabase_admin
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
   
-  analytics:
-    container_name: supabase-analytics-prod
-    image: supabase/logflare:1.14.2
-    restart: unless-stopped
-    networks:
-      - supanet
-    expose:
-      - "4000"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "http://localhost:4000/health"
-        ]
-      timeout: 5s
-      interval: 5s
-      retries: 10
-    depends_on:
-      db-prod:
-        condition: service_healthy
-    environment:
-      LOGFLARE_NODE_HOST: 127.0.0.1
-      DB_USERNAME: supabase_admin
-      DB_DATABASE: _supabase
-      DB_HOSTNAME: ${POSTGRES_HOST}
-      DB_PORT: ${POSTGRES_PORT}
-      DB_PASSWORD: ${POSTGRES_PASSWORD}
-      DB_SCHEMA: _analytics
-      LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
-      LOGFLARE_PRIVATE_ACCESS_TOKEN: ${LOGFLARE_PRIVATE_ACCESS_TOKEN}
-      LOGFLARE_SINGLE_TENANT: true
-      LOGFLARE_SUPABASE_MODE: true
-      LOGFLARE_MIN_CLUSTER_SIZE: 1
-      POSTGRES_BACKEND_URL: postgresql://supabase_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/_supabase
-      POSTGRES_BACKEND_SCHEMA: _analytics
-      LOGFLARE_FEATURE_FLAG_OVERRIDE: multibackend=true
-  
+  # NOTE: analytics (Logflare) removed — makes unauthorized outbound
+  # connections to DataDog. See: https://github.com/supabase/cli/issues/3254
+
 volumes:
   db-config:
 

--- a/scripts/init-db-roles.sh
+++ b/scripts/init-db-roles.sh
@@ -35,8 +35,7 @@ $PSQL -c "ALTER USER pgbouncer WITH PASSWORD '$PGPASSWORD';" 2>/dev/null || true
 $PSQL -c "ALTER USER postgres WITH PASSWORD '$PGPASSWORD';" 2>/dev/null || true
 
 echo ""
-echo "=== Creating _supabase database ==="
-$PSQL -c "CREATE DATABASE _supabase;" 2>/dev/null || echo "  _supabase already exists"
+echo "=== Skipping _supabase database (analytics removed) ==="
 
 echo ""
 echo "=== Done. Restart services: ==="

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -80,8 +80,6 @@ if [[ "$TRIAL" == true ]]; then
   SUPAVISOR_ENC_KEY="$(gen_hex 32)"
   SECRET_KEY_BASE="$(gen_hex 64)"
   DB_ENC_KEY="trial-dbenc-$(gen_alnum 32)"
-  LOGFLARE_PUBLIC_TOKEN="trial-logflare-pub-$(gen_alnum 16)"
-  LOGFLARE_PRIVATE_TOKEN="trial-logflare-priv-$(gen_alnum 16)"
 else
   info "Generating cryptographically secure credentials"
   JWT_SECRET="$(gen_secret 48)"
@@ -93,8 +91,6 @@ else
   SUPAVISOR_ENC_KEY="$(gen_hex 32)"
   SECRET_KEY_BASE="$(gen_hex 64)"
   DB_ENC_KEY="$(gen_secret 32)"
-  LOGFLARE_PUBLIC_TOKEN="$(gen_alnum 24)"
-  LOGFLARE_PRIVATE_TOKEN="$(gen_alnum 24)"
 fi
 
 # --- Set env-specific values ---
@@ -211,9 +207,6 @@ BLOOMMCP_API_KEY=${BLOOMMCP_API_KEY}
 # OPENAI_API_KEY is only used by Supabase Studio's optional AI assistant
 
 # --- Logflare/Analytics ---
-LOGFLARE_PUBLIC_ACCESS_TOKEN=${LOGFLARE_PUBLIC_TOKEN}
-LOGFLARE_PRIVATE_ACCESS_TOKEN=${LOGFLARE_PRIVATE_TOKEN}
-
 # --- Supabase Services ---
 ADDITIONAL_REDIRECT_URLS=
 DISABLE_SIGNUP=false

--- a/scripts/verify-stack.sh
+++ b/scripts/verify-stack.sh
@@ -46,7 +46,6 @@ EXPECTED_SERVICES=(
   "studio"
   "supabase-imgproxy-prod"
   "supabase-meta-prod"
-  "supabase-analytics-prod"
 )
 
 # Get running containers


### PR DESCRIPTION
## Summary
Remove the analytics container from dev and prod stacks.
Known Supabase issue: https://github.com/supabase/cli/issues/3254

## Commits to Review
- `8430e30` fix: remove analytics container from dev and prod

## Files Changed
- `docker-compose.prod.yml` — removed analytics service, removed meta dependency on analytics
- `docker-compose.dev.yml` — removed analytics service, removed all 7 analytics dependencies, removed _analytics.sh volume mount
- `scripts/verify-stack.sh` — removed analytics from expected containers list
- `scripts/setup-env.sh` — removed LOGFLARE token generation
- `scripts/init-db-roles.sh` — removed _supabase database creation

## Impact
- Studio log viewer will not work (acceptable — not used)
- No impact on Bloom frontend, API, auth, database, or any core services
- Eliminates outbound traffic to DataDog

## Local Tests
- [-] Run `make prod-up` — verify all services start without analytics
- [-] Run `make dev-up` — verify all services start without analytics
- [-] Verify no outbound connections: `sudo ss -tnp | grep -v "127.0.0\|172.18"`
- [-] Run `./scripts/verify-stack.sh`

Closes #50