### PR TITLE
fix: upgrade nginx 1.28.0 to 1.28.3 (security patches)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
   # Nginx 
   # -------------------
   nginx:
-    image: nginx:1.28.0-alpine
+    image: nginx:1.28.3-alpine
     container_name: bloom-nginx
     restart: unless-stopped
     logging:


### PR DESCRIPTION
## Summary
Upgrade nginx from 1.28.0-alpine to 1.28.3-alpine in prod to patch known CVEs.
Staging compose will be updated in PR #49.

## Commits to Review
- a0aadf0 fix: upgrade nginx 1.28.0 to 1.28.3 (security patches)

## Files Changed
- docker-compose.prod.yml — one line change

Closes #52