### PR TITLE
fix(1): build shared packages in Docker before Next.js build

### DIFF
--- a/web/Dockerfile.bloom-web.prod
+++ b/web/Dockerfile.bloom-web.prod
@@ -30,6 +30,10 @@ RUN npm install
 COPY web ./web
 COPY packages ./packages
 
+# Build shared packages (dist/ is gitignored, must build here)
+RUN cd /app/packages/bloom-js && npx tsc -p tsconfig.json
+RUN cd /app/packages/bloom-fs && npx tsc -p tsconfig.json
+
 # Build the Next.js app
 WORKDIR /app/web
 RUN npm run build


### PR DESCRIPTION
Adds bloom-js and bloom-fs TypeScript compilation steps before Next.js build in the production Dockerfile.

## Commit to review
- adc68ef fix(1): build shared packages in Docker before Next.js build

Closes #59