### PR TITLE
feat: improve LangChain agent — local Qwen only, auto-detect, summarization

### DIFF
--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -221,12 +221,44 @@ def make_pre_model_hook(provider: str = "openai", llm=None):
 #################################################### LLM Setup ####################################################
 
 
-AVAILABLE_MODELS = {
-    "local": ["Qwen/Qwen3.5-9B"],
-}
-
 # Local LLM configuration (OpenAI-compatible endpoint, e.g., vLLM)
 LOCAL_LLM_URL = os.getenv("LOCAL_LLM_URL")
+LOCAL_LLM_MODEL = os.getenv("LOCAL_LLM_MODEL")
+
+
+def _detect_vllm_model() -> str:
+    """Auto-detect model name from vLLM /v1/models endpoint."""
+    if LOCAL_LLM_MODEL:
+        return LOCAL_LLM_MODEL
+    if not LOCAL_LLM_URL:
+        raise RuntimeError("LOCAL_LLM_URL environment variable is required")
+    try:
+        import httpx
+        response = httpx.get(f"{LOCAL_LLM_URL}/models", timeout=5)
+        response.raise_for_status()
+        models = response.json().get("data", [])
+        if models:
+            model_name = models[0].get("id", "")
+            logger.info(f"Auto-detected vLLM model: {model_name}")
+            return model_name
+    except Exception as e:
+        logger.warning(f"Failed to auto-detect vLLM model: {e}")
+    raise RuntimeError("Could not detect model. Set LOCAL_LLM_MODEL env var.")
+
+
+_cached_model = None
+
+def get_local_model() -> str:
+    """Get local model name — from env, auto-detect, or cache."""
+    global _cached_model
+    if _cached_model:
+        return _cached_model
+    _cached_model = _detect_vllm_model()
+    return _cached_model
+
+AVAILABLE_MODELS = {
+    "local": [LOCAL_LLM_MODEL or "auto-detect"],
+}
 
 
 def get_llm(
@@ -245,7 +277,7 @@ def get_llm(
         LLM instance configured for the specified provider
     """
     if not model:
-        model = AVAILABLE_MODELS.get(provider, ["gpt-4o-mini"])[0]
+        model = get_local_model()
 
     if provider == "local":
         if not LOCAL_LLM_URL:

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -222,7 +222,6 @@ def make_pre_model_hook(provider: str = "openai", llm=None):
 
 
 AVAILABLE_MODELS = {
-    "openai": ["gpt-4o"],
     "local": ["Qwen/Qwen3.5-9B"],
 }
 

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -258,7 +258,7 @@ def get_local_model() -> str:
     return _cached_model
 
 AVAILABLE_MODELS = {
-    "local": [LOCAL_LLM_MODEL or "auto-detect"],
+    "local": [get_local_model()],
 }
 
 

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -253,8 +253,9 @@ def get_llm(
         return ChatOpenAI(
             model=model,
             base_url=LOCAL_LLM_URL,
-            api_key="not-needed",  # vLLM doesn't require a real key
+            api_key="not-needed",
             temperature=0.0,
+            request_timeout=30,
         )
 
     else:  # Default to OpenAI

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -18,6 +18,7 @@ from rich.traceback import install
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
 
 install()
+logger = logging.getLogger(__name__)
 
 logging.basicConfig(
     level=logging.DEBUG,

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -287,7 +287,8 @@ def get_llm(
             base_url=LOCAL_LLM_URL,
             api_key="not-needed",
             temperature=0.0,
-            request_timeout=30,
+            request_timeout=300,
+            max_retries=1,
         )
 
     else:  # Default to OpenAI

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -112,7 +112,7 @@ CONVERSATION:
 
 SUMMARY:"""
 
-# used fro summarizations when the LLM call fails
+# used for summarization when the LLM call fails
 def _extract_summary(messages: list) -> str:
     """Fallback: extract key items from messages without an LLM call."""
     key_items = []

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -8,14 +8,13 @@ from typing import Optional, Literal
 from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import trim_messages
+from langchain_core.messages import trim_messages, SystemMessage, AIMessage, HumanMessage
 from psycopg_pool import AsyncConnectionPool
 
 import logging
 from rich.logging import RichHandler
 from rich.traceback import install
-from tools import all_tools, generic_tools, scrna_tools, cyl_tools
-from config import FRONTEND_URL
+from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
 
 install()
 
@@ -79,27 +78,152 @@ async def setup_checkpointer() -> AsyncPostgresSaver:
     return checkpointer
 
 
-def trim_conversation(state):
-    """Pre-model hook: trim messages to fit within model context limits.
+#################################################### Context Management ####################################################
 
-    Uses llm_input_messages so the full history remains in the checkpointer
-    but only recent messages are sent to the LLM. Keeps last ~8000 tokens
+
+def _count_tokens(messages) -> int:
+    """Approximate token count (~4 chars per token)."""
+    return sum(len(str(m.content)) for m in messages) // 4
+
+
+def _has_context_call(messages) -> bool:
+    """Check if get_agent_context was already called in the conversation."""
+    for msg in messages:
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            for tc in msg.tool_calls:
+                if tc.get("name") == "get_agent_context":
+                    return True
+    return False
+
+
+SUMMARIZATION_PROMPT = """Summarize the following conversation between a user and an AI assistant on a plant biology platform.
+
+RULES:
+- Preserve ALL gene IDs (e.g., AT1G01010), dataset IDs, species names, and numeric results
+- Preserve key findings (GO terms, interaction partners, expression values, trait measurements)
+- Preserve user decisions and preferences
+- Keep it concise — aim for 200-400 words
+- Use bullet points grouped by topic
+
+CONVERSATION:
+{conversation}
+
+SUMMARY:"""
+
+# used fro summarizations when the LLM call fails
+def _extract_summary(messages: list) -> str:
+    """Fallback: extract key items from messages without an LLM call."""
+    key_items = []
+    for msg in messages:
+        content = str(msg.content)
+        if isinstance(msg, HumanMessage):
+            key_items.append(f"User asked: {content[:200]}")
+        elif isinstance(msg, AIMessage):
+            if msg.tool_calls:
+                for tc in msg.tool_calls:
+                    key_items.append(f"Called {tc.get('name', 'tool')}({str(tc.get('args', ''))[:100]})")
+            elif content:
+                key_items.append(f"Assistant: {content[:200]}")
+    return "Conversation summary:\n" + "\n".join(f"- {item}" for item in key_items)
+
+
+async def _llm_summarize(messages: list, llm) -> str:
+    """Summarize messages using the active LLM. Falls back to extraction on failure."""
+    logger = logging.getLogger(__name__)
+    try:
+        # Build conversation text from messages
+        lines = []
+        for msg in messages:
+            content = str(msg.content)[:500]
+            if isinstance(msg, HumanMessage):
+                lines.append(f"User: {content}")
+            elif isinstance(msg, AIMessage):
+                if msg.tool_calls:
+                    for tc in msg.tool_calls:
+                        lines.append(f"Assistant [tool call]: {tc.get('name', 'tool')}({str(tc.get('args', ''))[:200]})")
+                if content:
+                    lines.append(f"Assistant: {content}")
+
+        conversation_text = "\n".join(lines)
+        prompt = SUMMARIZATION_PROMPT.format(conversation=conversation_text)
+
+        response = await llm.ainvoke(prompt)
+        summary = response.content.strip()
+        logger.info(f"LLM summarization complete ({len(summary)} chars)")
+        return f"Conversation summary:\n{summary}"
+    except Exception as e:
+        logger.warning(f"LLM summarization failed ({e}), falling back to extraction")
+        return _extract_summary(messages)
+
+
+# Token thresholds by provider
+TOKEN_THRESHOLDS = {
+    "local": {"summarize_at": 6000, "keep_recent": 4000},
+    "openai": {"summarize_at": 100000, "keep_recent": 50000},
+}
+
+
+def make_pre_model_hook(provider: str = "openai", llm=None):
+    """Create a pre-model hook with LLM summarization and context injection.
+
+    Returns an async function that:
+    1. Checks if get_agent_context was called; if not, injects a reminder
+    2. When messages exceed the token threshold, uses the LLM to summarize old messages
+    3. Returns trimmed messages for the LLM
     """
-    messages = state["messages"]
-    trimmed = trim_messages(
-        messages,
-        strategy="last",
-        max_tokens=8000,
-        token_counter=lambda msgs: sum(len(str(m.content)) for m in msgs),  # char-based approx: ~4 chars per token
-        include_system=True,
-        allow_partial=False,
-        start_on="human",
-    )
-    return {"llm_input_messages": trimmed}
+    # uses openai 100K threshold as default if not set
+    thresholds = TOKEN_THRESHOLDS.get(provider, TOKEN_THRESHOLDS["openai"])
+
+    async def pre_model_hook(state):
+        messages = state["messages"]
+        # Safety net: remind to call get_agent_context on first turn
+        if len(messages) <= 2 and not _has_context_call(messages):
+                reminder = SystemMessage(
+                    content="Remember: call get_agent_context to learn about available data sources before answering."
+                )
+                messages = [messages[0], reminder] + messages[1:] if messages else [reminder]
+        total_tokens = _count_tokens(messages)
+        if total_tokens > thresholds["summarize_at"]:
+            # Find the split point: keep the last N tokens of messages
+            keep_tokens = thresholds["keep_recent"]
+            recent = []
+            running = 0
+            for msg in reversed(messages):
+                msg_tokens = len(str(msg.content)) // 4
+                if running + msg_tokens > keep_tokens:
+                    break
+                recent.insert(0, msg)
+                running += msg_tokens
+            # Summarize the old messages using LLM (with extraction fallback)
+            old_messages = messages[:len(messages) - len(recent)]
+            if old_messages:
+                if llm:
+                    summary_text = await _llm_summarize(old_messages, llm)
+                else:
+                    summary_text = _extract_summary(old_messages)
+                summary_msg = SystemMessage(content=summary_text)
+                messages = [summary_msg] + recent
+        else:
+            # Simple trim as fallback
+            messages = trim_messages(
+                messages,
+                strategy="last",
+                max_tokens=thresholds["summarize_at"],
+                token_counter=lambda msgs: sum(len(str(m.content)) for m in msgs) // 4,
+                include_system=True,
+                allow_partial=False,
+                start_on="human",
+            )
+        return {"llm_input_messages": messages}
+    return pre_model_hook
+
+
+#################################################### LLM Setup ####################################################
+
 
 AVAILABLE_MODELS = {
     "openai": ["gpt-4o"],
-    "local": ["Qwen/Qwen3-8B"],
+    "local": ["Qwen/Qwen3.5-9B"],
 }
 
 # Local LLM configuration (OpenAI-compatible endpoint, e.g., vLLM)
@@ -145,71 +269,20 @@ def get_llm(
         )
 
 
-# System prompts for different tool configurations
-# Note: {frontend_url} will be replaced at runtime with the actual URL
-# Tool usage instructions are NOT repeated here — the LLM reads each tool's docstring automatically.
-# The prompt only provides context the LLM can't infer from tool descriptions alone.
+#################################################### Agent Creation ####################################################
 
-SYSTEM_PROMPT_SCRNA = """You are a helpful assistant for the Bloom plant phenotyping platform.
-You have READ-ONLY access (GET requests only). You cannot create, update, or delete data.
 
-## Database Tables
-- scrna_datasets: id, name, species_id, strain, assembly, annotation
-- scrna_cells: id, dataset_id, cell_number, barcode, x, y, cluster_id, replicate
-- scrna_genes: id, dataset_id, gene_number, gene_name
-- scrna_counts: cell_id, gene_id, count
-- scrna_de: id, dataset_id, file_path, cluster_id
-
-## UI Links — Include in Responses
-- Expression Explorer: [{frontend_url}/app/expression/{{species_id}}/{{dataset_id}}]({frontend_url}/app/expression/{{species_id}}/{{dataset_id}})
-"""
-
-SYSTEM_PROMPT_CYL = """You are a helpful assistant for the Bloom plant phenotyping platform.
-You have READ-ONLY access (GET requests only). You cannot create, update, or delete data.
-
-## Database Tables
-- cyl_experiments: id, name, scientist_id, species_id, created_at
-- cyl_waves: id, experiment_id, name, planting_date
-- cyl_plants: id, experiment_id, wave_id, qr_code, accession_id
-- cyl_scans: id, plant_id, date_scanned, scanner_id
-- cyl_images: id, scan_id, path, angle
-- cyl_scan_traits: id, scan_id, trait_name, value
-- cyl_scanners: id, name, location
-
-## UI Links — Include in Responses
-- Greenhouse: [{frontend_url}/app/greenhouse]({frontend_url}/app/greenhouse)
-- Phenotypes: [{frontend_url}/app/phenotypes]({frontend_url}/app/phenotypes)
-- Plant Viewer: {frontend_url}/app/greenhouse/{{experiment_id}}/plant/{{plant_id}}
-"""
-
-SYSTEM_PROMPT_FULL = """You are a helpful assistant for the Bloom plant phenotyping platform.
-You have READ-ONLY access (GET requests only). You cannot create, update, or delete data.
-
-## Two Data Sources — Use the Right Tools
-
-### 1. Database tables → use specialized tools (scrna_*, cyl_*, list_species) or query_database
-Tables: scrna_datasets, scrna_cells, scrna_genes, scrna_counts, scrna_de,
-species, accessions, cyl_experiments, cyl_waves, cyl_plants, cyl_scans,
-cyl_images, cyl_scan_traits, cyl_scanners
-
-### 2. CSV experiment files → use MCP tools (list_available_experiments, load_experiment_data, etc.)
-Files like cylinder_alfalfa_gwas_wave2, turface_rice_treatment_exp1 are CSV files
-on the filesystem — NOT database tables. Never use query_database for these.
-
-## UI Links — Include in Responses
-- Expression Explorer: {frontend_url}/app/expression/{{species_id}}/{{dataset_id}}
-- Greenhouse: [{frontend_url}/app/greenhouse]({frontend_url}/app/greenhouse)
-- Phenotypes: [{frontend_url}/app/phenotypes]({frontend_url}/app/phenotypes)
-- Plant Viewer: {frontend_url}/app/greenhouse/{{experiment_id}}/plant/{{plant_id}}
-"""
+SYSTEM_PROMPT = """You are a helpful assistant for the Bloom plant phenotyping platform.
+You have READ-ONLY access. You cannot create, update, or delete data.
+Call get_agent_context at the start of a conversation to learn about available data sources and schema."""
 
 
 def create_agent(
     provider: str = "openai",
     model: Optional[str] = None,
-    tool_set: str = "all",  # "all", "scrna", "cyl", "generic"
-    mcp_tools: list = None,  # Tools from MCP servers (bloommcp, external)
-    checkpointer=None,  # PostgresSaver instance (from server lifespan)
+    tool_set: str = "all",
+    mcp_tools: list = None,
+    checkpointer=None,
 ):
     """
     Create the LangChain agent with specified LLM provider and tool set.
@@ -218,7 +291,7 @@ def create_agent(
         provider: "openai" or "local"
         model: Model name
         tool_set: Which tools to include:
-            - "all": All tools (generic + scrna + cyl)
+            - "all": All tools (context + generic + scrna + cyl)
             - "scrna": Only scRNA-seq tools
             - "cyl": Only cylinder phenotyping tools
             - "generic": Only generic database tools
@@ -227,31 +300,24 @@ def create_agent(
     """
     llm = get_llm(provider=provider, model=model)
 
-    # Select tools and prompt based on tool_set
+    # Select tools based on tool_set (context_tools always included)
     if tool_set == "scrna":
-        tools = generic_tools + scrna_tools
-        system_prompt = SYSTEM_PROMPT_SCRNA
+        tools = context_tools + generic_tools + scrna_tools
     elif tool_set == "cyl":
-        tools = generic_tools + cyl_tools
-        system_prompt = SYSTEM_PROMPT_CYL
+        tools = context_tools + generic_tools + cyl_tools
     elif tool_set == "generic":
-        tools = generic_tools
-        system_prompt = SYSTEM_PROMPT_FULL
+        tools = context_tools + generic_tools
     else:  # "all"
-        tools = all_tools
-        system_prompt = SYSTEM_PROMPT_FULL
+        tools = context_tools + all_tools
 
     # Append MCP tools if provided
     if mcp_tools:
         tools = tools + mcp_tools
 
-    # Format prompt with frontend URL for clickable links
-    system_prompt = system_prompt.format(frontend_url=FRONTEND_URL)
-
     return create_react_agent(
         model=llm,
         tools=tools,
-        prompt=system_prompt,
+        prompt=SYSTEM_PROMPT,
         checkpointer=checkpointer,
-        pre_model_hook=trim_conversation,
+        pre_model_hook=make_pre_model_hook(provider, llm=llm),
     )

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -5,6 +5,7 @@ Supports multiple LLM providers: OpenAI, Local (vLLM)
 import os
 from typing import Optional, Literal
 
+import httpx
 from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langchain_openai import ChatOpenAI
@@ -233,7 +234,6 @@ def _detect_vllm_model() -> str:
     if not LOCAL_LLM_URL:
         raise RuntimeError("LOCAL_LLM_URL environment variable is required")
     try:
-        import httpx
         response = httpx.get(f"{LOCAL_LLM_URL}/models", timeout=5)
         response.raise_for_status()
         models = response.json().get("data", [])

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -117,13 +117,13 @@ def _extract_summary(messages: list) -> str:
     for msg in messages:
         content = str(msg.content)
         if isinstance(msg, HumanMessage):
-            key_items.append(f"User asked: {content[:200]}")
+            key_items.append(f"User asked: {content[:500]}")
         elif isinstance(msg, AIMessage):
             if msg.tool_calls:
                 for tc in msg.tool_calls:
                     key_items.append(f"Called {tc.get('name', 'tool')}({str(tc.get('args', ''))[:100]})")
             elif content:
-                key_items.append(f"Assistant: {content[:200]}")
+                key_items.append(f"Assistant: {content[:500]}")
     return "Conversation summary:\n" + "\n".join(f"- {item}" for item in key_items)
 
 

--- a/langchain/tools/__init__.py
+++ b/langchain/tools/__init__.py
@@ -50,6 +50,12 @@ from .cyl_tools import (
     get_plant_scan_history_tool,
 )
 
+from .context_tools import (
+    context_tools,
+    get_agent_context,
+    list_available_tools,
+)
+
 # Combined tool lists for convenience
 all_tools = generic_tools + scrna_tools + cyl_tools
 
@@ -90,6 +96,10 @@ __all__ = [
     "list_scanners_tool",
     "list_phenotypers_tool",
     "get_plant_scan_history_tool",
+    # Context tools
+    "context_tools",
+    "get_agent_context",
+    "list_available_tools",
     # Utilities
     "REST_URL",
     "get_headers",

--- a/langchain/tools/context_tools.py
+++ b/langchain/tools/context_tools.py
@@ -1,0 +1,155 @@
+"""
+Context tools for the LangChain agent.
+
+Provides on-demand schema, rules, and tool discovery so the system prompt
+stays minimal and tokens are only spent when needed.
+"""
+from langchain_core.tools import tool
+
+
+# ==================== Context Payloads ====================
+
+CONTEXT_SCRNA = """## scRNA-seq Data (Supabase/PostgREST)
+
+### Tables
+- scrna_datasets: id, name, species_id, strain, assembly, annotation
+- scrna_cells: id, dataset_id, cell_number, barcode, x, y, cluster_id, replicate
+- scrna_genes: id, dataset_id, gene_number, gene_name
+- scrna_counts: cell_id, gene_id, count
+- scrna_de: id, dataset_id, file_path, cluster_id
+
+### Tools
+- get_all_datasets_tool: List all scRNA datasets
+- get_dataset_by_id_tool: Get dataset details
+- search_datasets_by_species_tool: Find datasets by species
+- get_clusters_by_dataset_tool: Get clusters and cell counts
+- get_genes_by_dataset_tool: List genes in a dataset
+- search_gene_tool: Search genes by name
+- get_differential_expression_files_tool: Get DE result files
+- get_top_de_genes_tool: Top differentially expressed genes per cluster
+- get_cells_by_cluster_tool: Cells with coordinates per cluster
+- get_gene_counts_tool: Expression counts per cell
+- get_gene_expression_by_cluster_tool: Expression summary per cluster
+
+### UI Links
+- Expression Explorer: {frontend_url}/app/expression/{{species_id}}/{{dataset_id}}
+"""
+
+CONTEXT_CYL = """## Cylinder Phenotyping Data (Supabase/PostgREST)
+
+### Tables
+- cyl_experiments: id, name, scientist_id, species_id, created_at
+- cyl_waves: id, experiment_id, name, planting_date
+- cyl_plants: id, experiment_id, wave_id, qr_code, accession_id
+- cyl_scans: id, plant_id, date_scanned, scanner_id
+- cyl_images: id, scan_id, path, angle
+- cyl_scan_traits: id, scan_id, trait_name, value
+- cyl_scanners: id, name, location
+
+### Tools
+- list_experiments_tool: List phenotyping experiments
+- get_experiment_by_id_tool: Get experiment details
+- list_waves_by_experiment_tool: Planting waves per experiment
+- list_plants_tool: Plants with accessions
+- get_plant_by_qr_tool: Look up plant by QR code
+- list_scans_tool / get_scan_tool: Plant scan data
+- get_scan_traits_tool: Measured traits for a scan
+- get_plant_scan_history_tool: Full scan history for a plant
+- get_plant_growth_timeline_tool: Chronological growth data
+- get_trait_growth_stats_tool: Growth statistics for a trait
+- compare_waves_trait_tool: Compare trait across waves
+- get_experiment_trait_stats_tool: Experiment-wide trait statistics
+
+### UI Links
+- Greenhouse: {frontend_url}/app/greenhouse
+- Phenotypes: {frontend_url}/app/phenotypes
+- Plant Viewer: {frontend_url}/app/greenhouse/{{experiment_id}}/plant/{{plant_id}}
+"""
+
+CONTEXT_GENERIC = """## Generic Database Tools (Supabase/PostgREST)
+
+### Tools
+- query_database: Query any table with REST filters (NOT SQL)
+- count_rows: Count rows in a table
+- get_table_columns: Inspect table schema
+- list_tables: List available tables
+- list_species_tool: List all species
+
+### Query Syntax (PostgREST filters, NOT SQL)
+- Equality: {{'column': 'eq.value'}}
+- Search: {{'name': 'ilike.*pattern*'}}
+- Greater than: {{'id': 'gt.5'}}
+- In list: {{'id': 'in.(1,2,3)'}}
+- Nested joins: 'id,name,species(common_name)'
+"""
+
+CONTEXT_MCP = """## CSV Experiment Files (MCP Tools)
+
+Files like cylinder_alfalfa_gwas_wave2, turface_rice_treatment_exp1 are CSV files
+on the filesystem — NOT database tables. Never use query_database for these.
+
+### Tools
+- list_available_experiments: List CSV experiment files
+- load_experiment_data: Load a CSV experiment file
+- inspect_data_quality: Check data quality of an experiment
+"""
+
+# Map tool_set → relevant context sections
+CONTEXT_MAP = {
+    "scrna": [CONTEXT_SCRNA, CONTEXT_GENERIC],
+    "cyl": [CONTEXT_CYL, CONTEXT_GENERIC],
+    "generic": [CONTEXT_GENERIC],
+    "all": [CONTEXT_SCRNA, CONTEXT_CYL, CONTEXT_GENERIC, CONTEXT_MCP],
+}
+
+
+# ==================== Tools ====================
+
+
+@tool
+def get_agent_context(tool_set: str = "all") -> str:
+    """Get schema, rules, and available tools for the current data context.
+
+    Call this at the start of a conversation to learn what data sources,
+    tables, and tools are available. You only need to call this once.
+
+    Args:
+        tool_set: The active tool set — "scrna", "cyl", "generic", or "all"
+
+    Returns:
+        Schema details, available tools, and UI links for the active tool set.
+    """
+    from config import FRONTEND_URL
+
+    sections = CONTEXT_MAP.get(tool_set, CONTEXT_MAP["all"])
+    context = "\n".join(sections)
+    context = context.format(frontend_url=FRONTEND_URL)
+
+    return (
+        "# Agent Context\n\n"
+        "You have READ-ONLY access. You cannot create, update, or delete data.\n\n"
+        f"Active tool set: **{tool_set}**\n\n"
+        f"{context}"
+    )
+
+
+@tool
+def list_available_tools() -> list[dict]:
+    """List all tools currently available to you with short descriptions.
+
+    Call this when you're unsure which tool to use for a task.
+
+    Returns:
+        List of tool names and descriptions.
+    """
+    from tools import all_tools
+
+    return [
+        {"name": t.name, "description": t.description.split("\n")[0].strip()}
+        for t in all_tools
+    ]
+
+
+# ==================== Tool List ====================
+
+context_tools = [get_agent_context, list_available_tools]

--- a/langchain/tools/scrna_tools.py
+++ b/langchain/tools/scrna_tools.py
@@ -83,14 +83,19 @@ def get_clusters_by_dataset_tool(dataset_id: int) -> list:
         headers=get_headers(),
         params={
             "dataset_id": f"eq.{dataset_id}",
-            "select": "cluster_id,cell_count:count()",
+            "select": "cluster_id"
         }
     )
     if response.status_code != 200:
         raise Exception(f"Failed to fetch clusters: {response.text}")
 
-    rows = response.json()
-    return sorted(rows, key=lambda r: r.get("cluster_id", ""))
+    cells = response.json()
+    cluster_counts = {}
+    for cell in cells:
+        cid = cell.get("cluster_id", "unknown")
+        cluster_counts[cid] = cluster_counts.get(cid, 0) + 1
+
+    return [{"cluster_id": k, "cell_count": v} for k, v in sorted(cluster_counts.items())]
 
 
 @tool

--- a/supabase/migrations/20260414001000_soft_delete_ownership.sql
+++ b/supabase/migrations/20260414001000_soft_delete_ownership.sql
@@ -58,9 +58,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Restrict soft_delete to bloom_admin only
-REVOKE EXECUTE ON FUNCTION soft_delete(TEXT, BIGINT) FROM public;
-GRANT EXECUTE ON FUNCTION soft_delete(TEXT, BIGINT) TO bloom_admin;
+-- Note: REVOKE/GRANT for soft_delete is in migration 002 (after bloom_admin role is created)
 
 -- -------------------
 -- 4. Auto-set created_by on insert via trigger

--- a/supabase/migrations/20260414002000_security_groups.sql
+++ b/supabase/migrations/20260414002000_security_groups.sql
@@ -66,7 +66,6 @@ ALTER TABLE cyl_experiments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cyl_scans ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cyl_plants ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cyl_waves ENABLE ROW LEVEL SECURITY;
-ALTER TABLE proteins ENABLE ROW LEVEL SECURITY;
 ALTER TABLE gene_candidates ENABLE ROW LEVEL SECURITY;
 ALTER TABLE people ENABLE ROW LEVEL SECURITY;
 ALTER TABLE chat_threads ENABLE ROW LEVEL SECURITY;
@@ -82,7 +81,7 @@ ALTER TABLE chat_threads ENABLE ROW LEVEL SECURITY;
 -- 5. RLS Policies — bloom_user
 -- ===========================
 
--- Tables like scrna_cells, cyl_scans, proteins use USING (true) — this means
+-- Tables like scrna_cells, cyl_scans, people use USING (true) — this means
 -- "allow all rows" but ONLY for the role named in the policy (bloom_user here).
 -- With RLS enabled, a role with no policy gets zero rows even if they have a GRANT.
 -- These are shared scientific datasets where every authenticated user sees all rows.
@@ -97,7 +96,6 @@ CREATE POLICY user_read_cyl_experiments ON cyl_experiments FOR SELECT TO bloom_u
 CREATE POLICY user_read_cyl_scans ON cyl_scans FOR SELECT TO bloom_user USING (true);
 CREATE POLICY user_read_cyl_plants ON cyl_plants FOR SELECT TO bloom_user USING (true);
 CREATE POLICY user_read_cyl_waves ON cyl_waves FOR SELECT TO bloom_user USING (true);
-CREATE POLICY user_read_proteins ON proteins FOR SELECT TO bloom_user USING (true);
 CREATE POLICY user_read_gene_candidates ON gene_candidates FOR SELECT TO bloom_user USING (deleted_at IS NULL);
 CREATE POLICY user_read_people ON people FOR SELECT TO bloom_user USING (true);
 CREATE POLICY user_read_chat_threads ON chat_threads FOR SELECT TO bloom_user USING (deleted_at IS NULL);
@@ -126,7 +124,6 @@ CREATE POLICY admin_all_cyl_experiments ON cyl_experiments FOR ALL TO bloom_admi
 CREATE POLICY admin_all_cyl_scans ON cyl_scans FOR ALL TO bloom_admin USING (true) WITH CHECK (true);
 CREATE POLICY admin_all_cyl_plants ON cyl_plants FOR ALL TO bloom_admin USING (true) WITH CHECK (true);
 CREATE POLICY admin_all_cyl_waves ON cyl_waves FOR ALL TO bloom_admin USING (true) WITH CHECK (true);
-CREATE POLICY admin_all_proteins ON proteins FOR ALL TO bloom_admin USING (true) WITH CHECK (true);
 CREATE POLICY admin_all_gene_candidates ON gene_candidates FOR ALL TO bloom_admin USING (true) WITH CHECK (true);
 CREATE POLICY admin_all_people ON people FOR ALL TO bloom_admin USING (true) WITH CHECK (true);
 CREATE POLICY admin_all_chat_threads ON chat_threads FOR ALL TO bloom_admin USING (true) WITH CHECK (true);
@@ -144,7 +141,6 @@ CREATE POLICY agent_read_cyl_experiments ON cyl_experiments FOR SELECT TO bloom_
 CREATE POLICY agent_read_cyl_scans ON cyl_scans FOR SELECT TO bloom_agent USING (true);
 CREATE POLICY agent_read_cyl_plants ON cyl_plants FOR SELECT TO bloom_agent USING (true);
 CREATE POLICY agent_read_cyl_waves ON cyl_waves FOR SELECT TO bloom_agent USING (true);
-CREATE POLICY agent_read_proteins ON proteins FOR SELECT TO bloom_agent USING (true);
 CREATE POLICY agent_read_gene_candidates ON gene_candidates FOR SELECT TO bloom_agent USING (deleted_at IS NULL);
 CREATE POLICY agent_read_people ON people FOR SELECT TO bloom_agent USING (true);
 CREATE POLICY agent_read_chat_threads ON chat_threads FOR SELECT TO bloom_agent USING (deleted_at IS NULL);

--- a/supabase/migrations/20260414002000_security_groups.sql
+++ b/supabase/migrations/20260414002000_security_groups.sql
@@ -33,6 +33,10 @@ GRANT bloom_user TO authenticator;
 GRANT bloom_admin TO authenticator;
 GRANT bloom_agent TO authenticator;
 
+-- Restrict soft_delete (from migration 001) to bloom_admin only
+REVOKE EXECUTE ON FUNCTION soft_delete(TEXT, BIGINT) FROM public;
+GRANT EXECUTE ON FUNCTION soft_delete(TEXT, BIGINT) TO bloom_admin;
+
 -- ===========================
 -- 2. Schema + Table Permissions
 -- ===========================

--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -475,7 +475,7 @@ export default function MCPChat() {
               LLM Provider
             </div>
             <div style={{ display: "flex", gap: 6, marginBottom: 12 }}>
-              {(["local", "openai"] as Provider[]).map((p) => (
+              {(Object.keys(AVAILABLE_MODELS) as Provider[]).map((p) => (
                 <button
                   key={p}
                   onClick={() => handleProviderChange(p)}

--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState, useCallback } from "react";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 
 type Message = { from: "user" | "bot"; text: string };
-type Provider = "openai" | "local";
+type Provider = "local";
 type ToolSet = "all" | "scrna" | "cyl" | "generic" | "";
 
 interface MCPTool {
@@ -34,12 +34,10 @@ const TOOL_SET_OPTIONS: { value: ToolSet; label: string; description: string }[]
 ];
 
 const AVAILABLE_MODELS: Record<Provider, string[]> = {
-  openai: ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"],
   local: ["Qwen/Qwen3-8B"],
 };
 
 const PROVIDER_LABELS: Record<Provider, string> = {
-  openai: "OpenAI",
   local: "Local LLM",
 };
 
@@ -514,20 +512,6 @@ export default function MCPChat() {
               ))}
             </select>
 
-            {settings.provider === "openai" && (
-              <div
-                style={{
-                  marginTop: 10,
-                  padding: 10,
-                  background: "#eff6ff",
-                  borderRadius: 8,
-                  fontSize: 11,
-                  color: "#1d4ed8",
-                }}
-              >
-                OpenAI API key is configured on the server.
-              </div>
-            )}
 
             {settings.provider === "local" && (
               <div

--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -158,7 +158,7 @@ export default function MCPChat() {
   const [AVAILABLE_MODELS, setAvailableModels] = useState<Record<string, string[]>>(AVAILABLE_MODELS_DEFAULT);
 
   useEffect(() => {
-    fetch("/api/langchain/models")
+    fetch(`${API_BASE_URL}/langchain/models`)
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();

--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -33,9 +33,20 @@ const TOOL_SET_OPTIONS: { value: ToolSet; label: string; description: string }[]
   { value: "generic", label: "Generic", description: "Basic database queries only" },
 ];
 
-const AVAILABLE_MODELS: Record<Provider, string[]> = {
-  local: ["Qwen/Qwen3-8B"],
+// Default models — overwritten by /langchain/models API on load
+let AVAILABLE_MODELS: Record<string, string[]> = {
+  local: ["loading..."],
 };
+
+// Fetch models from backend on module load
+if (typeof window !== "undefined") {
+  fetch("/api/langchain/models")
+    .then((r) => r.json())
+    .then((data) => {
+      if (data.models) AVAILABLE_MODELS = data.models;
+    })
+    .catch(() => {});
+}
 
 const PROVIDER_LABELS: Record<Provider, string> = {
   local: "Local LLM",

--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -33,20 +33,9 @@ const TOOL_SET_OPTIONS: { value: ToolSet; label: string; description: string }[]
   { value: "generic", label: "Generic", description: "Basic database queries only" },
 ];
 
-// Default models — overwritten by /langchain/models API on load
-let AVAILABLE_MODELS: Record<string, string[]> = {
-  local: ["loading..."],
+const AVAILABLE_MODELS_DEFAULT: Record<string, string[]> = {
+  local: [],
 };
-
-// Fetch models from backend on module load
-if (typeof window !== "undefined") {
-  fetch("/api/langchain/models")
-    .then((r) => r.json())
-    .then((data) => {
-      if (data.models) AVAILABLE_MODELS = data.models;
-    })
-    .catch(() => {});
-}
 
 const PROVIDER_LABELS: Record<Provider, string> = {
   local: "Local LLM",
@@ -164,6 +153,21 @@ export default function MCPChat() {
 
   // MCP Tools collapsible
   const [mcpToolsCollapsed, setMcpToolsCollapsed] = useState(true);
+
+  // Available models — fetched from backend
+  const [AVAILABLE_MODELS, setAvailableModels] = useState<Record<string, string[]>>(AVAILABLE_MODELS_DEFAULT);
+
+  useEffect(() => {
+    fetch("/api/langchain/models")
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data) => {
+        if (data.models) setAvailableModels(data.models);
+      })
+      .catch(() => {});
+  }, []);
 
   // LLM Settings
   const [settings, setSettings] = useState<LLMSettings>(() => ({


### PR DESCRIPTION
## Summary
- Replace 4 static system prompts with on-demand `get_agent_context` tool (saves tokens)
- Add conversation summarization using the local LLM, if the summarization call fails fallback to extracting the last 10 messages with 500-char excerpts
- Make local Qwen the default LLM, keep OpenAI as optional secondary for future use
- Auto-detect model from vLLM `/v1/models` endpoint (falls back to `LOCAL_LLM_MODEL` env var)
- Add 300s request timeout with max_retries=1 for local vLLM
- Frontend fetches model list from `/langchain/models` API using React state + useEffect
- Fix cluster counting in scrna_tools (broken PostgREST count → Python aggregation)

Closes #100
Refs #99, #101, #102

## Commits
- `f101dc6` feat: refactor agent context management and add LLM-based summarization
- `9491057` feat: remove OpenAI provider, local Qwen only
- `5423053` feat: add 30s request timeout to local LLM calls
- `38bbef2` feat: auto-detect local model from vLLM /v1/models endpoint
- `cf43ee0` feat: frontend fetches model list from /langchain/models API
- `1b7f155` fix: fix cluster counting query
- `16ed827` fix: use AVAILABLE_MODELS keys for provider buttons
- `dd9fd01` fix: move model-list fetch into React state + useEffect
- `ce20fe1` fix: bump timeout to 300s, add max_retries=1
- `47d6a1c` fix: define logger at module level
- `cae26e8` fix: resolve real model name instead of placeholder

## Test plan
- [x] Agent works with local Qwen model
- [x] Auto-detects model from vLLM on startup
- [x] Conversation summarization triggers on long chats
- [x] Frontend shows models fetched from API
- [x] Request timeout set to 300s for local vLLM