### PR TITLE
fix(scripts): correct domain names + /data paths in generate-env-config.sh

### DIFF
--- a/scripts/generate-env-config.sh
+++ b/scripts/generate-env-config.sh
@@ -24,8 +24,6 @@ if [ "$ENV" = "prod" ]; then
   CADDY_HTTP_PORT=""
   # Data paths live on /data (40 TB) — root filesystem is only 98 GB.
   MINIO_DATA_PATH="/data/bloom/minio-data"
-  # Standard 443 = no port suffix in user-facing URLs.
-  URL_PORT_SUFFIX=""
   DEPLOY_PATH="/data/bloom/production"
 elif [ "$ENV" = "staging" ]; then
   # Staging uses `staging-` prefix on each subdomain so users and logs can
@@ -38,10 +36,20 @@ elif [ "$ENV" = "staging" ]; then
   CADDY_HTTPS_LISTEN_PORT="8443"
   CADDY_HTTP_PORT=""
   MINIO_DATA_PATH="/data/bloom/minio-staging"
-  # Non-standard HTTPS port must appear in all user-facing URLs so browsers
-  # and clients know where to connect.
-  URL_PORT_SUFFIX=":${CADDY_HTTPS_LISTEN_PORT}"
   DEPLOY_PATH="/data/bloom/staging"
+else
+  echo "Error: ENV must be 'prod' or 'staging' (got '$ENV')" >&2
+  echo "Usage: $0 [prod|staging]" >&2
+  exit 1
+fi
+
+# Standard HTTPS (443) = no port suffix in user-facing URLs.
+# Non-standard (e.g. 8443) must appear in URLs so clients know where to connect.
+# Computed once from the env-specific port so there's only one source of truth.
+if [ "$CADDY_HTTPS_LISTEN_PORT" = "443" ]; then
+  URL_PORT_SUFFIX=""
+else
+  URL_PORT_SUFFIX=":${CADDY_HTTPS_LISTEN_PORT}"
 fi
 
 SITE_URL="https://${DOMAIN_MAIN}${URL_PORT_SUFFIX}"

--- a/scripts/generate-env-config.sh
+++ b/scripts/generate-env-config.sh
@@ -13,26 +13,40 @@ ENV="${1:-prod}"
 PREFIX=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
 
 if [ "$ENV" = "prod" ]; then
-  DOMAIN_MAIN="bloom.salk.edu"
-  DOMAIN_STUDIO="studio.bloom.salk.edu"
-  DOMAIN_MINIO="minio.bloom.salk.edu"
+  # Production uses the server's hostname-matching domain (bloom-dev.salk.edu)
+  # since bloom-dev IS the production host. The parent domain already resolves
+  # in Salk DNS; Salk IT only needs to add the studio./minio. subdomains.
+  DOMAIN_MAIN="bloom-dev.salk.edu"
+  DOMAIN_STUDIO="studio.bloom-dev.salk.edu"
+  DOMAIN_MINIO="minio.bloom-dev.salk.edu"
   CADDY_HTTP_LISTEN_PORT="80"
   CADDY_HTTPS_LISTEN_PORT="443"
   CADDY_HTTP_PORT=""
-  MINIO_DATA_PATH="/data/bloom/minio"
-  SITE_URL="https://${DOMAIN_MAIN}"
-  DEPLOY_PATH="/opt/bloom/production"
+  # Data paths live on /data (40 TB) — root filesystem is only 98 GB.
+  MINIO_DATA_PATH="/data/bloom/minio-data"
+  # Standard 443 = no port suffix in user-facing URLs.
+  URL_PORT_SUFFIX=""
+  DEPLOY_PATH="/data/bloom/production"
 elif [ "$ENV" = "staging" ]; then
-  DOMAIN_MAIN="staging.bloom.salk.edu"
-  DOMAIN_STUDIO="staging-studio.bloom.salk.edu"
-  DOMAIN_MINIO="staging-minio.bloom.salk.edu"
+  # Staging uses `staging-` prefix on each subdomain so users and logs can
+  # tell environments apart at a glance. Non-standard ports so prod + staging
+  # can coexist on the same server.
+  DOMAIN_MAIN="staging-bloom-dev.salk.edu"
+  DOMAIN_STUDIO="staging-studio.bloom-dev.salk.edu"
+  DOMAIN_MINIO="staging-minio.bloom-dev.salk.edu"
   CADDY_HTTP_LISTEN_PORT="8080"
   CADDY_HTTPS_LISTEN_PORT="8443"
   CADDY_HTTP_PORT=""
   MINIO_DATA_PATH="/data/bloom/minio-staging"
-  SITE_URL="https://${DOMAIN_MAIN}"
-  DEPLOY_PATH="/opt/bloom/staging"
+  # Non-standard HTTPS port must appear in all user-facing URLs so browsers
+  # and clients know where to connect.
+  URL_PORT_SUFFIX=":${CADDY_HTTPS_LISTEN_PORT}"
+  DEPLOY_PATH="/data/bloom/staging"
 fi
+
+SITE_URL="https://${DOMAIN_MAIN}${URL_PORT_SUFFIX}"
+STUDIO_URL="https://${DOMAIN_STUDIO}${URL_PORT_SUFFIX}"
+MINIO_URL="https://${DOMAIN_MINIO}${URL_PORT_SUFFIX}"
 
 echo "=================================================="
 echo "Environment config for: $ENV"
@@ -79,12 +93,12 @@ echo "${PREFIX}_DASHBOARD_USERNAME                | admin"
 # Studio
 echo "${PREFIX}_STUDIO_DEFAULT_ORGANIZATION       | Bloom"
 echo "${PREFIX}_STUDIO_DEFAULT_PROJECT             | default"
-echo "${PREFIX}_STUDIO_SUPABASE_PUBLIC_URL         | https://${DOMAIN_STUDIO}"
+echo "${PREFIX}_STUDIO_SUPABASE_PUBLIC_URL         | $STUDIO_URL"
 
 # MinIO
 echo "${PREFIX}_MINIO_ROOT_USER                   | supabase"
 echo "${PREFIX}_MINIO_DATA_PATH                   | $MINIO_DATA_PATH"
-echo "${PREFIX}_MINIO_BROWSER_REDIRECT_URL         | https://${DOMAIN_MINIO}"
+echo "${PREFIX}_MINIO_BROWSER_REDIRECT_URL         | $MINIO_URL"
 
 # URLs
 echo "${PREFIX}_SITE_URL                          | $SITE_URL"


### PR DESCRIPTION
## What this PR does

Updates `scripts/generate-env-config.sh` to emit correct values for the Monday deploy:

- **Prod domains** → `bloom-dev.salk.edu`, `studio.bloom-dev.salk.edu`, `minio.bloom-dev.salk.edu` 
- **Staging domains** → `staging-` prefix on each (`staging-bloom-dev.salk.edu`, etc.)
- **Deploy paths** → `/data/bloom/production` and `/data/bloom/staging`
- **MinIO data paths** → `/data/bloom/minio-data` (prod) and `/data/bloom/minio-staging` (staging)
- **Port-aware URLs** → staging uses `:8443` in `SITE_URL`, `API_EXTERNAL_URL`, MinIO/Studio URLs since it runs on non-standard ports

## Why

The script was emitting old assumptions:
- `/opt/bloom/...` for deploy paths — but root fs is too tight; we use `/data/bloom/...`
- `https://<domain>` for staging URLs — but staging runs on port 8443, and clients need the port in the URL

## Verified

```
$ ./scripts/generate-env-config.sh prod | grep DOMAIN
PROD_DOMAIN_MAIN        | bloom-dev.salk.edu
PROD_DOMAIN_STUDIO      | studio.bloom-dev.salk.edu
PROD_DOMAIN_MINIO       | minio.bloom-dev.salk.edu

$ ./scripts/generate-env-config.sh staging | grep -E "DOMAIN|SITE_URL"
STAGING_DOMAIN_MAIN     | staging-bloom-dev.salk.edu
STAGING_DOMAIN_STUDIO   | staging-studio.bloom-dev.salk.edu
STAGING_DOMAIN_MINIO    | staging-minio.bloom-dev.salk.edu
STAGING_SITE_URL        | https://staging-bloom-dev.salk.edu:8443
```

## Ports (no conflicts)

| Host port | Prod | Staging |
|---|---|---|
| Caddy HTTP | 80 | 8080 |
| Caddy HTTPS | 443 | 8443 |
| Postgres (via PR #146) | 127.0.0.1:5432 | 127.0.0.1:5433 |

Both stacks coexist on the same server via separate compose project names (`bloom_v2_prod` vs `bloom_v2_staging`).

## Impact on existing secrets

The existing `PROD_*` and `STAGING_*` secrets in GitHub Settings were configured on 2026-04-08 with the OLD domain values. Those need to be updated to match this script's new output before the first deploy.

Related: #135 (Phase 1 secrets, Phase 3 domains).