### PR TITLE
feat(expression): cluster detail panel + hint pill [3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ scripts/compute_de_genes.py
 scripts/compute_de_local.py
 scripts/compute_de.py
 scripts/generate_KEYS
+scripts/dev/
 *.bak
 
 prompts/.claude/

--- a/web/components/expression-cluster-detail-panel.tsx
+++ b/web/components/expression-cluster-detail-panel.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  fetchClusterStats,
+  fetchDeFilePath,
+  type ClusterStatsRow,
+} from "@/components/expression-lib/cluster-markers";
+
+export interface ExpressionClusterDetailPanelProps {
+  datasetId: number;
+  clusterId: string;
+  clusterName: string | null;
+  clusterColor: string | null;
+}
+
+/**
+ * Right-hand drawer describing the currently soloed cluster.
+ * Mounted by the cockpit only when exactly one cluster is visible so the
+ * UMAP canvas keeps its full width when nothing is soloed.
+ */
+export function ExpressionClusterDetailPanel({
+  datasetId,
+  clusterId,
+  clusterName,
+  clusterColor,
+}: ExpressionClusterDetailPanelProps) {
+  const [stats, setStats] = useState<ClusterStatsRow | null>(null);
+  const [deFilePath, setDeFilePath] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([
+      fetchClusterStats(datasetId, clusterId),
+      fetchDeFilePath(datasetId, clusterId),
+    ]).then(([s, fp]) => {
+      if (cancelled) return;
+      setStats(s);
+      setDeFilePath(fp);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, clusterId]);
+
+  const name = clusterName ?? clusterId;
+  const markers = stats?.markers ?? null;
+  const pctHuman =
+    stats?.pct != null ? (stats.pct * 100).toFixed(1) : "—";
+  const cellsHuman =
+    stats?.cell_count != null
+      ? new Intl.NumberFormat("en-US").format(stats.cell_count)
+      : "—";
+
+  return (
+    <aside className="w-80 shrink-0 border-l border-stone-200 bg-white overflow-y-auto">
+      <div className="p-5 border-b border-stone-200">
+        <div className="flex items-center gap-2 mb-3">
+          <span
+            aria-hidden
+            className="inline-block h-2.5 w-2.5 rounded-full"
+            style={{ background: clusterColor ?? "#65a30d" }}
+          />
+          <span className="text-xs uppercase tracking-widest text-stone-500">
+            Cluster
+          </span>
+        </div>
+        <h2
+          className="text-2xl font-serif italic text-stone-900 truncate"
+          title={name}
+        >
+          {name}
+        </h2>
+        <div className="mt-1 text-sm text-stone-500">
+          cluster_id {clusterId} · {cellsHuman} cells
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 border-b border-stone-200">
+        <StatTile label="% of dataset" value={`${pctHuman}%`} suffix={false} />
+        <StatTile
+          label="DE genes Q<.01"
+          value={markers ? String(markers.n_significant) : "—"}
+          borderLeft
+        />
+      </div>
+
+      <div className="p-5 border-b border-stone-200">
+        <div className="flex items-baseline gap-2 mb-3">
+          <span className="text-xs uppercase tracking-widest text-stone-500">
+            Top markers
+          </span>
+          <span className="text-[10px] text-stone-400">(scrna_de)</span>
+        </div>
+
+        {loading ? (
+          <div className="text-xs italic text-stone-400">Loading…</div>
+        ) : !markers || markers.top.length === 0 ? (
+          <div className="text-xs italic text-stone-400">
+            No markers yet — waiting on DE ingest.
+          </div>
+        ) : (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-widest text-stone-500">
+                <th className="text-left font-normal pb-2">Gene</th>
+                <th className="text-right font-normal pb-2">Log₂FC</th>
+                <th className="text-right font-normal pb-2">Q</th>
+                <th className="text-right font-normal pb-2">Pct.1</th>
+              </tr>
+            </thead>
+            <tbody>
+              {markers.top.map((m) => (
+                <tr
+                  key={m.gene}
+                  className="border-b border-dashed border-stone-200/70 last:border-0"
+                >
+                  <td className="py-2 font-mono text-stone-800">{m.gene}</td>
+                  <td className="py-2 text-right tabular-nums text-lime-700 font-semibold">
+                    {m.log2fc.toFixed(2)}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-stone-500">
+                    {m.q.toExponential(0)}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-stone-600">
+                    {m.pct_1.toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="p-5 flex gap-4 text-xs">
+        <button
+          type="button"
+          className="text-lime-700 hover:underline"
+          onClick={() => {
+            /* Rename — placeholder, follow-up PR wires the real modal */
+          }}
+        >
+          Rename
+        </button>
+        <span className="text-stone-300">·</span>
+        {deFilePath ? (
+          <a
+            href={deFilePath}
+            target="_blank"
+            rel="noopener"
+            className="text-lime-700 hover:underline"
+          >
+            Export CSV
+          </a>
+        ) : (
+          <span className="text-stone-400 cursor-not-allowed" title="No DE CSV yet">
+            Export CSV
+          </span>
+        )}
+        <span className="text-stone-300">·</span>
+        <button
+          type="button"
+          className="text-lime-700 hover:underline"
+          onClick={() => {
+            /* Run DE vs. all — placeholder */
+          }}
+        >
+          Run DE vs. all
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  borderLeft = false,
+  suffix = true,
+}: {
+  label: string;
+  value: string;
+  borderLeft?: boolean;
+  suffix?: boolean;
+}) {
+  const percentMatch = suffix ? value.match(/^(.*?)(%)$/) : null;
+  const head = percentMatch ? percentMatch[1] : value;
+  const tail = percentMatch ? percentMatch[2] : null;
+  return (
+    <div
+      className={[
+        "p-5",
+        borderLeft ? "border-l border-stone-200" : "",
+      ].join(" ")}
+    >
+      <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-2">
+        {label}
+      </div>
+      <div className="text-2xl font-semibold text-stone-900 tabular-nums">
+        {head}
+        {tail ? (
+          <span className="ml-0.5 text-sm text-stone-500 font-normal">
+            {tail}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default ExpressionClusterDetailPanel;

--- a/web/components/expression-lib/cluster-markers.ts
+++ b/web/components/expression-lib/cluster-markers.ts
@@ -1,0 +1,99 @@
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+
+/**
+ * Shape of the `markers` JSON column on `public.scrna_cluster_stats`.
+ * Written by the ingest pipeline; consumed read-only by the cluster
+ * detail panel.
+ */
+export type ClusterMarker = {
+  gene: string;
+  log2fc: number;
+  q: number;
+  pct_1: number;
+  pct_2: number;
+};
+
+export type ClusterMarkers = {
+  top: ClusterMarker[];
+  n_significant: number;
+};
+
+export type ClusterStatsRow = {
+  dataset_id: number;
+  cluster_id: string;
+  cell_count: number;
+  pct: number;
+  markers: ClusterMarkers | null;
+};
+
+/**
+ * Defensive parse — returns null for anything that doesn't match the
+ * documented shape. Lets the panel render its empty state instead of
+ * crashing on a half-populated or legacy row.
+ */
+export function parseMarkers(raw: unknown): ClusterMarkers | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const top = obj.top;
+  if (!Array.isArray(top)) return null;
+  const parsedTop: ClusterMarker[] = [];
+  for (const m of top) {
+    if (!m || typeof m !== "object") continue;
+    const r = m as Record<string, unknown>;
+    if (typeof r.gene !== "string") continue;
+    parsedTop.push({
+      gene: r.gene,
+      log2fc: typeof r.log2fc === "number" ? r.log2fc : 0,
+      q: typeof r.q === "number" ? r.q : 1,
+      pct_1: typeof r.pct_1 === "number" ? r.pct_1 : 0,
+      pct_2: typeof r.pct_2 === "number" ? r.pct_2 : 0,
+    });
+  }
+  const n_significant =
+    typeof obj.n_significant === "number" ? obj.n_significant : 0;
+  return { top: parsedTop, n_significant };
+}
+
+/**
+ * Fetch the stats row for one cluster.
+ * Returns null when the row is missing.
+ */
+export async function fetchClusterStats(
+  datasetId: number,
+  clusterId: string,
+): Promise<ClusterStatsRow | null> {
+  const supabase = createClientSupabaseClient();
+  const { data, error } = await supabase
+    .from("scrna_cluster_stats")
+    .select("dataset_id, cluster_id, cell_count, pct, markers")
+    .eq("dataset_id", datasetId)
+    .eq("cluster_id", clusterId)
+    .maybeSingle();
+  if (error) throw new Error(`fetchClusterStats failed: ${error.message}`);
+  if (!data) return null;
+  return {
+    dataset_id: data.dataset_id,
+    cluster_id: data.cluster_id,
+    cell_count: data.cell_count,
+    pct: data.pct,
+    markers: parseMarkers(data.markers),
+  };
+}
+
+/**
+ * Fetch whether this cluster has a DE CSV file to export.
+ * Returns null when no scrna_de row exists for this (dataset, cluster).
+ */
+export async function fetchDeFilePath(
+  datasetId: number,
+  clusterId: string,
+): Promise<string | null> {
+  const supabase = createClientSupabaseClient();
+  const { data } = await supabase
+    .from("scrna_de")
+    .select("file_path")
+    .eq("dataset_id", datasetId)
+    .eq("cluster_id", clusterId)
+    .maybeSingle();
+  return data?.file_path ?? null;
+}

--- a/web/components/expression-view.tsx
+++ b/web/components/expression-view.tsx
@@ -8,6 +8,7 @@ import { ExpressionUmap } from "@/components/expression-umap";
 import { ExpressionGeneSearch } from "@/components/expression-gene-search";
 import { ExpressionColorbar } from "@/components/expression-colorbar";
 import { ExpressionClusterSidebar } from "@/components/expression-cluster-sidebar";
+import { ExpressionClusterDetailPanel } from "@/components/expression-cluster-detail-panel";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 import type { Database } from "@/lib/database.types";
 
@@ -166,6 +167,21 @@ export function ExpressionView({ datasetId }: ExpressionViewProps) {
               disabled={!meta}
             />
           </Box>
+          {(() => {
+            const clusters = meta?.clusters ?? [];
+            if (clusters.length === 0) return null;
+            const soloCount = clusters.length - hidden.size;
+            if (soloCount === 1) return null;
+            return (
+              <span
+                className="ml-auto inline-flex items-center gap-2 rounded-full border border-lime-200 bg-lime-50/70 px-3 py-1 text-xs text-lime-800"
+                role="status"
+              >
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-lime-500 shadow-[0_0_4px_rgba(132,204,22,0.8)]" />
+                Click a cluster for details
+              </span>
+            );
+          })()}
         </Box>
 
         {/* canvas */}
@@ -178,18 +194,35 @@ export function ExpressionView({ datasetId }: ExpressionViewProps) {
         />
       </Box>
 
-      {/* colorbar: only when a gene is selected */}
-      <Box sx={{ width: 120, display: "flex", justifyContent: "flex-start", pt: 6 }}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 2 }}>
         {geneName && exprRange && (
-          <ExpressionColorbar
-            geneName={geneName}
-            dataMin={exprRange.min}
-            dataMax={exprRange.max}
-            range={exprRange}
-            onRangeChange={setExprRange}
-            unitsLabel={unitsLabel}
-          />
+          <Box sx={{ width: 120 }}>
+            <ExpressionColorbar
+              geneName={geneName}
+              dataMin={exprRange.min}
+              dataMax={exprRange.max}
+              range={exprRange}
+              onRangeChange={setExprRange}
+              unitsLabel={unitsLabel}
+            />
+          </Box>
         )}
+        {(() => {
+          const clusters = meta?.clusters ?? [];
+          if (clusters.length === 0) return null;
+          const soloCount = clusters.length - hidden.size;
+          if (soloCount !== 1) return null;
+          const soloCluster = clusters.find((c) => !hidden.has(c.ordinal));
+          if (!soloCluster) return null;
+          return (
+            <ExpressionClusterDetailPanel
+              datasetId={datasetId}
+              clusterId={soloCluster.cluster_id}
+              clusterName={soloCluster.name}
+              clusterColor={soloCluster.color}
+            />
+          );
+        })()}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
Adds a right-side detail panel to the expression cockpit. When you solo a single cluster (click its row in the sidebar), the panel mounts and shows that cluster's name, share of the dataset, top marker genes, and a few action links. With nothing selected, the rail stays empty and the UMAP uses the full width - a small "Click a cluster for details" hint shows up in the toolbar instead.

## Files changed
- `web/components/expression-lib/cluster-markers.ts` (new) — `ClusterMarkers` type, `parseMarkers()` defensive guard, `fetchClusterStats()`, `fetchDeFilePath()`
- `web/components/expression-cluster-detail-panel.tsx` (new) — the rail component + `<StatTile>` helper
- `web/components/expression-view.tsx` — mount panel when `soloCount === 1`; render hint pill in toolbar otherwise

Data source
Reads from the existing scrna_cluster_stats.markers jsonb column. Expected shape:
{ top: [{ gene, log2fc, q, pct_1, pct_2 }], n_significant }
If the column is null or missing fields, the panel shows "No markers yet - waiting on DE ingest"


