### PR TITLE
fix(deploy): #146 follow-ups — idempotency test + gate db push when no pending

### DIFF
--- a/.claude/commands/ci-debug.md
+++ b/.claude/commands/ci-debug.md
@@ -214,7 +214,7 @@ docker build --target builder -f web/Dockerfile.bloom-web.prod .
 docker exec db-dev pg_isready -U supabase_admin -h localhost
 
 # Apply migrations
-make apply-migrations-local
+make migrate-local
 
 # Check migration status
 docker exec db-dev psql -U supabase_admin -d postgres -c "SELECT * FROM _migrations ORDER BY applied_at;"
@@ -298,7 +298,7 @@ When CI fails:
 - [ ] Can you reproduce locally?
 - [ ] Are all Docker services healthy? (`docker compose ps`)
 - [ ] Is the database ready? (`docker exec db-dev pg_isready`)
-- [ ] Are migrations applied? (`make apply-migrations-local`)
+- [ ] Are migrations applied? (`make migrate-local`)
 - [ ] Are environment variables set?
 - [ ] Did a dependency update introduce a CVE? (`npm audit` / `uv export | uvx pip-audit`)
 - [ ] Is the Docker build cache stale? (`docker compose build --no-cache`)

--- a/.claude/commands/database-migration.md
+++ b/.claude/commands/database-migration.md
@@ -16,7 +16,7 @@ Guide for creating and managing database migrations in Bloom. The project uses s
 make new-migration name=add_experiment_status
 
 # Apply pending migrations to local dev database
-make apply-migrations-local
+make migrate-local
 
 # Generate TypeScript types from database schema
 make gen-types
@@ -86,7 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_experiments_created_by ON public.experiments(crea
 make dev-up
 
 # Apply the migration
-make apply-migrations-local
+make migrate-local
 ```
 
 ### 4. Generate Types
@@ -158,7 +158,7 @@ CREATE POLICY "Service role full access" ON public.my_table
 # Stop dev stack, remove volumes, restart, reapply migrations
 docker compose -f docker-compose.dev.yml down -v
 make dev-up
-make apply-migrations-local
+make migrate-local
 
 # Optionally reload test data
 make load-test-data
@@ -180,7 +180,7 @@ PGPASSWORD=postgres psql -h localhost -p 5432 -U supabase_admin -d postgres \
     -c "DELETE FROM _migrations WHERE name = '<filename>.sql';"
 
 # Re-apply
-make apply-migrations-local
+make migrate-local
 ```
 
 ### Foreign key constraint errors

--- a/.claude/commands/docs-review.md
+++ b/.claude/commands/docs-review.md
@@ -235,7 +235,7 @@ ls -lh supabase/migrations/
   - [ ] Policy configuration (public vs private)
 - [ ] **Supabase configuration documented**
   - [ ] Self-hosted setup
-  - [ ] Migration workflow (`make apply-migrations-local`)
+  - [ ] Migration workflow (`make migrate-local`)
   - [ ] RLS policy guidelines
   - [ ] Studio UI access
   - [ ] Subpath deployment configuration
@@ -679,7 +679,7 @@ cp .env.dev.example .env.dev
 make dev-up
 
 # 5. Initialize database
-make apply-migrations-local
+make migrate-local
 
 # 6. Load test data
 cd web && npm run init-env
@@ -752,7 +752,7 @@ docker compose -f docker-compose.dev.yml logs -f web
 - [ ] Set up domain DNS records
 - [ ] Configure Supabase production instance
 - [ ] Initialize MinIO buckets and policies
-- [ ] Run database migrations: `make apply-migrations-local`
+- [ ] Run database migrations: `make migrate-local`
 - [ ] Test all endpoints with production URLs
 - [ ] Set up backup strategy (PostgreSQL, MinIO)
 - [ ] Configure monitoring and alerting
@@ -894,7 +894,7 @@ docker compose ps
 \```bash
 
 # Run Supabase migrations
-make apply-migrations-local
+make migrate-local
 
 # Load test data (optional)
 cd web && npm run init-env
@@ -962,7 +962,7 @@ docker compose -f docker-compose.dev.yml logs -f web
 **Database:**
 
 - Edit schemas in `supabase/migrations/`
-- Apply migrations: `make apply-migrations-local`
+- Apply migrations: `make migrate-local`
 - Create new migration: `supabase migration new <name>`
 
 ### Stopping Services
@@ -990,7 +990,7 @@ docker volume rm bloom_db-data
 
 # Restart and re-initialize
 make dev-up
-make apply-migrations-local
+make migrate-local
 cd web && npm run init-env
 \```
 

--- a/.claude/commands/pr-description.md
+++ b/.claude/commands/pr-description.md
@@ -72,7 +72,7 @@ If the PR modifies `web/`:
 
 If the PR includes migrations in `supabase/migrations/`:
 
-- [ ] Migration tested locally: `make apply-migrations-local`
+- [ ] Migration tested locally: `make migrate-local`
 - [ ] RLS policies added for new tables
 - [ ] TypeScript types regenerated: `make gen-types`
 - [ ] Rollback SQL documented (if destructive)

--- a/.claude/commands/validate-env.md
+++ b/.claude/commands/validate-env.md
@@ -52,7 +52,7 @@ Key services: `bloom-web`, `langchain-agent`, `bloommcp`, `db-dev`, `supabase-mi
 
 ```bash
 docker exec db-dev pg_isready -U supabase_admin -h localhost
-make apply-migrations-local
+make migrate-local
 make gen-types
 ```
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -307,30 +307,40 @@ jobs:
 
       # Gate: only invoke `supabase db push` when pending > 0. Parses
       # `supabase migration list` output — rows with a LOCAL timestamp but
-      # no REMOTE timestamp are pending migrations. Fail-open: an empty /
-      # unparseable result defaults to 1 so the push still runs.
+      # no REMOTE timestamp are pending migrations. `--debug` is required to
+      # dodge supabase/cli#4839 (TLS handshake against non-TLS Postgres).
+      # Fail-open: any SSH/CLI error, empty stdout, or header-only output
+      # produces `pending=unknown`, which the Apply step's `!= '0'` check
+      # treats as "run the push" — never silently skip on ambiguous signal.
       - name: Check for pending migrations (production)
         id: check_migrations_prod
         run: |
           echo "::add-mask::${{ secrets.PROD_POSTGRES_PASSWORD }}"
           PENDING=$(ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
-            set -eu
+            set -euo pipefail
             cd ${{ secrets.PROD_DEPLOY_PATH }}
             PG_USER=\$(grep -E '^POSTGRES_USER=' .env.prod | cut -d= -f2-)
             PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
             PG_DB=\$(grep -E '^POSTGRES_DB=' .env.prod | cut -d= -f2-)
             PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.prod | cut -d= -f2-)
-            supabase migration list \
+            supabase migration list --debug \
               --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" \
               2>/dev/null \
-              | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END {print c+0}'
-          ")
-          echo "Pending migrations: ${PENDING:-unknown}"
-          echo "pending=${PENDING:-1}" >> "$GITHUB_OUTPUT"
-          if [ "${PENDING:-1}" -eq 0 ]; then
-            echo "::notice title=Migrations::No pending migrations — skipping db push"
+              | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END { if (NR < 3) { print \"unknown\"; exit 2 } print c+0 }'
+          ") || PENDING="unknown"
+          case "$PENDING" in ''|*[!0-9]*) PENDING="unknown" ;; esac
+          if [ "$PENDING" = "unknown" ]; then
+            echo "pending=unknown" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Migrations::Could not determine pending migration count — forcing db push (fail-open)"
+            echo "⚠️ Migration gate (prod): unable to parse \`supabase migration list\` output — forcing \`db push\` (fail-open)." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$PENDING" -eq 0 ]; then
+            echo "pending=0" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Migrations::No pending migrations — skipping db push"
+            echo "ℹ️ Migration gate (prod): 0 pending — \`supabase db push\` skipped." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "::notice title=Migrations::${PENDING:-1} pending migration(s) — running db push"
+            echo "pending=$PENDING" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Migrations::$PENDING pending migration(s) — running db push"
+            echo "✅ Migration gate (prod): $PENDING pending — running \`supabase db push\`." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # Apply migrations via Supabase CLI (installed on the Salk server per #135).
@@ -707,28 +717,37 @@ jobs:
             exit 1
           "
 
+      # See the production gate (above) for the full rationale — staging
+      # uses the identical pattern so the two envs can't silently diverge.
       - name: Check for pending migrations (staging)
         id: check_migrations_staging
         run: |
           echo "::add-mask::${{ secrets.STAGING_POSTGRES_PASSWORD }}"
           PENDING=$(ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
-            set -eu
+            set -euo pipefail
             cd ${{ secrets.STAGING_DEPLOY_PATH }}
             PG_USER=\$(grep -E '^POSTGRES_USER=' .env.staging | cut -d= -f2-)
             PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
             PG_DB=\$(grep -E '^POSTGRES_DB=' .env.staging | cut -d= -f2-)
             PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.staging | cut -d= -f2-)
-            supabase migration list \
+            supabase migration list --debug \
               --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" \
               2>/dev/null \
-              | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END {print c+0}'
-          ")
-          echo "Pending migrations: ${PENDING:-unknown}"
-          echo "pending=${PENDING:-1}" >> "$GITHUB_OUTPUT"
-          if [ "${PENDING:-1}" -eq 0 ]; then
-            echo "::notice title=Migrations::No pending migrations — skipping db push"
+              | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END { if (NR < 3) { print \"unknown\"; exit 2 } print c+0 }'
+          ") || PENDING="unknown"
+          case "$PENDING" in ''|*[!0-9]*) PENDING="unknown" ;; esac
+          if [ "$PENDING" = "unknown" ]; then
+            echo "pending=unknown" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Migrations::Could not determine pending migration count — forcing db push (fail-open)"
+            echo "⚠️ Migration gate (staging): unable to parse \`supabase migration list\` output — forcing \`db push\` (fail-open)." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$PENDING" -eq 0 ]; then
+            echo "pending=0" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Migrations::No pending migrations — skipping db push"
+            echo "ℹ️ Migration gate (staging): 0 pending — \`supabase db push\` skipped." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "::notice title=Migrations::${PENDING:-1} pending migration(s) — running db push"
+            echo "pending=$PENDING" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Migrations::$PENDING pending migration(s) — running db push"
+            echo "✅ Migration gate (staging): $PENDING pending — running \`supabase db push\`." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Apply database migrations (staging)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -305,6 +305,34 @@ jobs:
             exit 1
           "
 
+      # Gate: only invoke `supabase db push` when pending > 0. Parses
+      # `supabase migration list` output — rows with a LOCAL timestamp but
+      # no REMOTE timestamp are pending migrations. Fail-open: an empty /
+      # unparseable result defaults to 1 so the push still runs.
+      - name: Check for pending migrations (production)
+        id: check_migrations_prod
+        run: |
+          echo "::add-mask::${{ secrets.PROD_POSTGRES_PASSWORD }}"
+          PENDING=$(ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
+            set -eu
+            cd ${{ secrets.PROD_DEPLOY_PATH }}
+            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.prod | cut -d= -f2-)
+            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
+            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.prod | cut -d= -f2-)
+            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.prod | cut -d= -f2-)
+            supabase migration list \
+              --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" \
+              2>/dev/null \
+              | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END {print c+0}'
+          ")
+          echo "Pending migrations: ${PENDING:-unknown}"
+          echo "pending=${PENDING:-1}" >> "$GITHUB_OUTPUT"
+          if [ "${PENDING:-1}" -eq 0 ]; then
+            echo "::notice title=Migrations::No pending migrations — skipping db push"
+          else
+            echo "::notice title=Migrations::${PENDING:-1} pending migration(s) — running db push"
+          fi
+
       # Apply migrations via Supabase CLI (installed on the Salk server per #135).
       # Extract only Postgres connection vars — avoids leaking JWT_SECRET / keys
       # into the subprocess environment. The `: "${VAR:?msg}"` guards fail the
@@ -312,6 +340,7 @@ jobs:
       # rather than letting `supabase db push` fail later with a cryptic URL
       # parse / auth error.
       - name: Apply database migrations (production)
+        if: steps.check_migrations_prod.outputs.pending != '0'
         env:
           EXPECTED_CLI_VERSION: ${{ env.SUPABASE_VERSION }}
         run: |
@@ -678,7 +707,32 @@ jobs:
             exit 1
           "
 
+      - name: Check for pending migrations (staging)
+        id: check_migrations_staging
+        run: |
+          echo "::add-mask::${{ secrets.STAGING_POSTGRES_PASSWORD }}"
+          PENDING=$(ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
+            set -eu
+            cd ${{ secrets.STAGING_DEPLOY_PATH }}
+            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.staging | cut -d= -f2-)
+            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
+            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.staging | cut -d= -f2-)
+            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.staging | cut -d= -f2-)
+            supabase migration list \
+              --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" \
+              2>/dev/null \
+              | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END {print c+0}'
+          ")
+          echo "Pending migrations: ${PENDING:-unknown}"
+          echo "pending=${PENDING:-1}" >> "$GITHUB_OUTPUT"
+          if [ "${PENDING:-1}" -eq 0 ]; then
+            echo "::notice title=Migrations::No pending migrations — skipping db push"
+          else
+            echo "::notice title=Migrations::${PENDING:-1} pending migration(s) — running db push"
+          fi
+
       - name: Apply database migrations (staging)
+        if: steps.check_migrations_staging.outputs.pending != '0'
         env:
           EXPECTED_CLI_VERSION: ${{ env.SUPABASE_VERSION }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@echo "  make reset-storage    - Reset dev DB and storage (destructive)"
 	@echo "  make drop-tables      - Drop all tables in public schema"
 	@echo "  make new-migration name=xxx - Create a new migration file"
-	@echo "  make apply-migrations-local - Apply database migrations locally"
+	@echo "  make migrate-local    - Apply migrations to local dev DB via Supabase CLI"
 	@echo "  make load-test-data   - Load CSV test data into dev database"
 	@echo "  make upload-images    - Upload test images to MinIO storage"
 	@echo "  make create-bucket    - Create a new S3 bucket (BUCKET=name [PUBLIC=true])"
@@ -193,38 +193,24 @@ new-migration:
 	echo "" >> $$filename; \
 	echo "Created: $$filename"
 
-## Apply database migrations locally (only unapplied ones)
-.PHONY: apply-migrations-local
-apply-migrations-local:
-	@echo "Applying database migrations to local development database..."
+## Apply migrations to local dev DB via Supabase CLI.
+## Tracking lives in `supabase_migrations.schema_migrations` (CLI-managed) —
+## the old `public._migrations` table used by the removed apply-migrations-local
+## rule is no longer read or written.
+.PHONY: migrate-local
+migrate-local:
+	@command -v supabase >/dev/null 2>&1 || ( \
+		echo "Error: supabase CLI not found on PATH."; \
+		echo "Install: brew install supabase/tap/supabase"; \
+		exit 1; \
+	)
 	@if ! docker ps | grep -q db-dev; then \
 		echo "Error: Development database not running. Start with 'make dev-up' first."; \
 		exit 1; \
 	fi
-	@echo "Creating migrations tracking table if not exists..."
-	@PGPASSWORD=$${POSTGRES_PASSWORD:-postgres} psql -h localhost -p 5432 -U supabase_admin -d postgres -c \
-		"CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY, applied_at TIMESTAMP DEFAULT NOW());" > /dev/null 2>&1
-	@echo "Checking for unapplied migrations..."
-	@applied=0; \
-	for file in $$(ls -1 supabase/migrations/*.sql 2>/dev/null | sort); do \
-		if [ -f "$$file" ]; then \
-			filename=$$(basename "$$file"); \
-			is_applied=$$(PGPASSWORD=$${POSTGRES_PASSWORD:-postgres} psql -h localhost -p 5432 -U supabase_admin -d postgres -tAc \
-				"SELECT 1 FROM _migrations WHERE name = '$$filename';" 2>/dev/null); \
-			if [ -z "$$is_applied" ]; then \
-				echo "Applying: $$filename"; \
-				PGPASSWORD=$${POSTGRES_PASSWORD:-postgres} psql -h localhost -p 5432 -U supabase_admin -d postgres -f "$$file" 2>&1 | grep -v "already exists" | grep -v "does not exist, skipping" || true; \
-				PGPASSWORD=$${POSTGRES_PASSWORD:-postgres} psql -h localhost -p 5432 -U supabase_admin -d postgres -c \
-					"INSERT INTO _migrations (name) VALUES ('$$filename');" > /dev/null 2>&1; \
-				applied=$$((applied + 1)); \
-			fi \
-		fi \
-	done; \
-	if [ $$applied -eq 0 ]; then \
-		echo "No new migrations to apply."; \
-	else \
-		echo "Applied $$applied migration(s) successfully."; \
-	fi
+	@supabase db push \
+		--db-url "postgresql://supabase_admin:$${POSTGRES_PASSWORD:-postgres}@127.0.0.1:5432/postgres?sslmode=disable" \
+		--yes
 
 # Preflight helper: fail fast with an actionable message if `uv` is not on PATH.
 # Used as a prerequisite by every target that invokes `uv run ...` below so the

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -128,3 +128,12 @@ def pg_conn():
         yield conn
     finally:
         conn.close()
+
+
+@pytest.fixture
+def supabase_db_url():
+    """Postgres connection URL formatted for `supabase db push --db-url`."""
+    return (
+        f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:"
+        f"{POSTGRES_HOST_PORT}/{POSTGRES_DB}?sslmode=disable"
+    )

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -8,7 +8,11 @@ on POSTGRES_HOST_PORT.
 """
 
 import glob
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).parent.parent.parent
@@ -110,3 +114,39 @@ def test_migration_timestamps_are_unique(pg_conn):
             f"Duplicate timestamps in tracking table: {duplicates}. "
             f"Two migration files share a 14-digit prefix — rename one."
         )
+
+
+def test_db_push_is_idempotent(pg_conn, supabase_db_url):
+    """
+    `supabase db push` must be a no-op when every local migration is already
+    recorded in the remote tracking table. If idempotency breaks, every deploy
+    re-applies all migrations — the destructive ones (DROP TABLE, DROP COLUMN)
+    would silently wipe real data on the second run.
+    """
+    if not shutil.which("supabase"):
+        pytest.skip("supabase CLI not on PATH")
+
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM supabase_migrations.schema_migrations")
+        before = cur.fetchone()[0]
+
+    result = subprocess.run(
+        ["supabase", "db", "push", "--db-url", supabase_db_url, "--yes"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"`supabase db push` returned {result.returncode} on second run "
+        f"(expected no-op). stderr tail: {result.stderr[-500:]}"
+    )
+
+    pg_conn.rollback()
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM supabase_migrations.schema_migrations")
+        after = cur.fetchone()[0]
+
+    assert after == before, (
+        f"tracking table changed (before={before}, after={after}) when no "
+        f"migrations were pending — idempotency invariant broken"
+    )

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -8,11 +8,22 @@ on POSTGRES_HOST_PORT.
 """
 
 import glob
+import re
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+
+
+def _scrub_db_url(text: str) -> str:
+    """Redact embedded password from any `postgresql://user:pass@host/...` URL
+    before the string is included in an assertion message that may surface in
+    CI logs. `supabase db push --debug` can echo connection diagnostics to
+    stderr; we don't want to trust third-party CLIs to keep secrets out of
+    their debug output across version bumps.
+    """
+    return re.sub(r"(postgresql://[^:/@]+:)[^@\s]+(@)", r"\1***\2", text)
 
 
 REPO_ROOT = Path(__file__).parent.parent.parent
@@ -137,13 +148,20 @@ def test_db_push_is_idempotent(pg_conn, supabase_db_url):
         ["supabase", "db", "push", "--db-url", supabase_db_url, "--debug", "--yes"],
         capture_output=True,
         text=True,
-        timeout=300,
+        timeout=60,
     )
     assert result.returncode == 0, (
         f"`supabase db push` returned {result.returncode} on second run "
-        f"(expected no-op). stderr tail: {result.stderr[-500:]}"
+        f"(expected no-op). "
+        f"stdout tail: {_scrub_db_url(result.stdout[-500:])} "
+        f"stderr tail: {_scrub_db_url(result.stderr[-500:])}"
     )
 
+    # psycopg3 connections default to autocommit=False, so the `before`
+    # SELECT above opened a transaction and pinned an MVCC snapshot.
+    # End that transaction so the `after` SELECT reads a fresh snapshot
+    # that can observe any writes the out-of-process `supabase db push`
+    # may have committed concurrently.
     pg_conn.rollback()
     with pg_conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM supabase_migrations.schema_migrations")

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -130,8 +130,11 @@ def test_db_push_is_idempotent(pg_conn, supabase_db_url):
         cur.execute("SELECT count(*) FROM supabase_migrations.schema_migrations")
         before = cur.fetchone()[0]
 
+    # `--debug` works around supabase/cli#4839 — without it the CLI tries a
+    # TLS handshake against a non-TLS Postgres and fails. The deploy
+    # workflow passes --debug for the same reason.
     result = subprocess.run(
-        ["supabase", "db", "push", "--db-url", supabase_db_url, "--yes"],
+        ["supabase", "db", "push", "--db-url", supabase_db_url, "--debug", "--yes"],
         capture_output=True,
         text=True,
         timeout=300,


### PR DESCRIPTION
## Summary

Three follow-up improvements to #146's migration runner:

1. **Idempotency test** — locks in the invariant that `supabase db push` is a no-op when every local migration is already applied. If a future CLI version breaks this, CI fails instead of production silently re-running destructive migrations.
2. **Gate on pending count** — `supabase db push` only runs when `supabase migration list` reports pending migrations. Saves ~10–30s per no-op deploy and reduces reliance on the idempotency guarantee.
3. **`make migrate-local`** — replaces the old `make apply-migrations-local` (psql loop tracking in `public._migrations`) with a CLI wrapper tracking in `supabase_migrations.schema_migrations` — same as the deploy pipeline.

## Test plan
- [ ] CI `compose-health-check` passes including the new `test_db_push_is_idempotent`
- [ ] `make migrate-local` against dev stack runs `supabase db push` cleanly
- [ ] Gate fail-open path: if the SSH/CLI returns empty output, `pending` defaults to 1 → push still runs

## Notes
- Keeps SSH pattern from #146; becomes `localhost → localhost` once #144 (self-hosted runner) lands. A cleanup PR can strip SSH across all deploy.yml steps then.
- Based on current `main` (post-#146 squash merge). 3 commits, ~118 lines added.