### PR TITLE
ci: enforce staging-first merges to main

### DIFF
--- a/.github/workflows/enforce-staging-first.yml
+++ b/.github/workflows/enforce-staging-first.yml
@@ -1,0 +1,27 @@
+name: Enforce staging-first merge
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-source:
+    name: Enforce staging-first merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject if source is not staging or a revert branch
+        run: |
+          src="${{ github.head_ref }}"
+          if [ "$src" = "staging" ]; then
+            echo "source=$src — allowed"
+            exit 0
+          fi
+          if [[ "$src" == revert-* ]]; then
+            echo "source=$src — allowed (revert PR from GitHub UI)"
+            exit 0
+          fi
+          echo "::error::PRs to main must come from 'staging' (got: '$src'). Reverts from the GitHub UI (revert-*) are also allowed."
+          exit 1


### PR DESCRIPTION
## Summary

Adds a `.github/workflows/enforce-staging-first.yml` that rejects PRs targeting `main` unless the source branch is `staging` or a `revert-*` branch (GitHub's default naming for one-click UI reverts).

Makes `main` write-only through the staging promotion path: feature work lands on `staging`, `staging` gets promoted to `main`, emergency reverts via the UI remain possible.

## Base branch note

This PR itself goes to `main` (one-time setup). After it merges, add `Enforce staging-first merge` to main's required status checks and the restriction activates.

## Known exclusion

Dependabot / security PRs typically target `main` directly and would be blocked by this check. Tracked as a follow-up issue.

## Follow-up issue draft: ci: enforce-staging-first blocks Dependabot / security PRs — add bypass

The `Enforce staging-first merge` workflow (added in this PR) blocks any PR to `main` whose source branch isn't `staging` or `revert-*`. That's intentional for human PRs, but accidentally blocks two automated flows:

- **Dependabot PRs** — branches like `dependabot/npm_and_yarn/next-16.2.1`
- **GitHub automated security fix PRs** — branches like `github-security-advisory/...`

Both typically land on `main` without first going through `staging`.

### Acceptance

- Dependabot PRs pass `Enforce staging-first merge`
- Human PRs from arbitrary branches still blocked