### PR TITLE
fix(deploy): storage check + run supabase CLI inside db-prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -360,13 +360,7 @@ jobs:
           PENDING=$(ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             set -euo pipefail
             cd ${{ secrets.PROD_DEPLOY_PATH }}
-            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.prod | cut -d= -f2-)
-            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
-            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.prod | cut -d= -f2-)
-            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.prod | cut -d= -f2-)
-            supabase migration list --debug \
-              --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" \
-              2>/dev/null \
+            bash scripts/deploy_run_supabase.sh prod 'migration list --debug' 2>/dev/null \
               | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END { if (NR < 3) { print \"unknown\"; exit 2 } print c+0 }'
           ") || PENDING="unknown"
           case "$PENDING" in ''|*[!0-9]*) PENDING="unknown" ;; esac
@@ -405,15 +399,7 @@ jobs:
               echo \"::error::Supabase CLI version mismatch on server: expected $EXPECTED_CLI_VERSION, got \$ACTUAL_CLI_VERSION\"
               exit 1
             fi
-            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.prod | cut -d= -f2-)
-            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
-            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.prod | cut -d= -f2-)
-            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.prod | cut -d= -f2-)
-            : \"\${PG_USER:?POSTGRES_USER missing from .env.prod}\"
-            : \"\${PG_PASSWORD:?POSTGRES_PASSWORD missing from .env.prod}\"
-            : \"\${PG_DB:?POSTGRES_DB missing from .env.prod}\"
-            : \"\${PG_HOST_PORT:?POSTGRES_HOST_PORT missing from .env.prod}\"
-            supabase db push --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" --debug --yes
+            bash scripts/deploy_run_supabase.sh prod 'db push --debug --yes'
           " || {
             echo '::error title=Migration failed (production)::See the Migration summary at top of run and the Show-migration-status step for applied vs pending state.'
             exit 1
@@ -427,12 +413,7 @@ jobs:
           echo "::add-mask::${{ secrets.PROD_POSTGRES_PASSWORD }}"
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             cd ${{ secrets.PROD_DEPLOY_PATH }}
-            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.prod | cut -d= -f2-)
-            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
-            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.prod | cut -d= -f2-)
-            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.prod | cut -d= -f2-)
-            : \"\${PG_HOST_PORT:?POSTGRES_HOST_PORT missing from .env.prod}\"
-            supabase migration list --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" --debug
+            bash scripts/deploy_run_supabase.sh prod 'migration list --debug'
           " || echo '::warning::Could not fetch migration status'
 
       # Layer C: migration state as a fenced code block in the run summary.
@@ -448,12 +429,7 @@ jobs:
             echo '```'
             ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
               cd ${{ secrets.PROD_DEPLOY_PATH }}
-              PG_USER=\$(grep -E '^POSTGRES_USER=' .env.prod | cut -d= -f2-)
-              PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
-              PG_DB=\$(grep -E '^POSTGRES_DB=' .env.prod | cut -d= -f2-)
-              PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.prod | cut -d= -f2-)
-              : \"\${PG_HOST_PORT:?POSTGRES_HOST_PORT missing from .env.prod}\"
-              supabase migration list --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" --debug
+              bash scripts/deploy_run_supabase.sh prod 'migration list --debug'
             " 2>/dev/null || echo '(migration state fetch failed)'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
@@ -785,13 +761,7 @@ jobs:
           PENDING=$(ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             set -euo pipefail
             cd ${{ secrets.STAGING_DEPLOY_PATH }}
-            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.staging | cut -d= -f2-)
-            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
-            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.staging | cut -d= -f2-)
-            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.staging | cut -d= -f2-)
-            supabase migration list --debug \
-              --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" \
-              2>/dev/null \
+            bash scripts/deploy_run_supabase.sh staging 'migration list --debug' 2>/dev/null \
               | awk -F'|' 'NR>2 && \$1 ~ /[0-9]{14}/ && \$2 !~ /[0-9]/ {c++} END { if (NR < 3) { print \"unknown\"; exit 2 } print c+0 }'
           ") || PENDING="unknown"
           case "$PENDING" in ''|*[!0-9]*) PENDING="unknown" ;; esac
@@ -824,15 +794,7 @@ jobs:
               echo \"::error::Supabase CLI version mismatch on server: expected $EXPECTED_CLI_VERSION, got \$ACTUAL_CLI_VERSION\"
               exit 1
             fi
-            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.staging | cut -d= -f2-)
-            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
-            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.staging | cut -d= -f2-)
-            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.staging | cut -d= -f2-)
-            : \"\${PG_USER:?POSTGRES_USER missing from .env.staging}\"
-            : \"\${PG_PASSWORD:?POSTGRES_PASSWORD missing from .env.staging}\"
-            : \"\${PG_DB:?POSTGRES_DB missing from .env.staging}\"
-            : \"\${PG_HOST_PORT:?POSTGRES_HOST_PORT missing from .env.staging}\"
-            supabase db push --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" --debug --yes
+            bash scripts/deploy_run_supabase.sh staging 'db push --debug --yes'
           " || {
             echo '::error title=Migration failed (staging)::See the Migration summary at top of run and the Show-migration-status step for applied vs pending state.'
             exit 1
@@ -844,12 +806,7 @@ jobs:
           echo "::add-mask::${{ secrets.STAGING_POSTGRES_PASSWORD }}"
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             cd ${{ secrets.STAGING_DEPLOY_PATH }}
-            PG_USER=\$(grep -E '^POSTGRES_USER=' .env.staging | cut -d= -f2-)
-            PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
-            PG_DB=\$(grep -E '^POSTGRES_DB=' .env.staging | cut -d= -f2-)
-            PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.staging | cut -d= -f2-)
-            : \"\${PG_HOST_PORT:?POSTGRES_HOST_PORT missing from .env.staging}\"
-            supabase migration list --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" --debug
+            bash scripts/deploy_run_supabase.sh staging 'migration list --debug'
           " || echo '::warning::Could not fetch migration status'
 
       - name: Migration summary (staging)
@@ -862,12 +819,7 @@ jobs:
             echo '```'
             ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
               cd ${{ secrets.STAGING_DEPLOY_PATH }}
-              PG_USER=\$(grep -E '^POSTGRES_USER=' .env.staging | cut -d= -f2-)
-              PG_PASSWORD=\$(grep -E '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
-              PG_DB=\$(grep -E '^POSTGRES_DB=' .env.staging | cut -d= -f2-)
-              PG_HOST_PORT=\$(grep -E '^POSTGRES_HOST_PORT=' .env.staging | cut -d= -f2-)
-              : \"\${PG_HOST_PORT:?POSTGRES_HOST_PORT missing from .env.staging}\"
-              supabase migration list --db-url \"postgresql://\${PG_USER}:\${PG_PASSWORD}@127.0.0.1:\${PG_HOST_PORT}/\${PG_DB}?sslmode=disable\" --debug
+              bash scripts/deploy_run_supabase.sh staging 'migration list --debug'
             " 2>/dev/null || echo '(migration state fetch failed)'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -330,8 +330,10 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             cd ${{ secrets.PROD_DEPLOY_PATH }}
+            PG_PASSWORD=\$(grep '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
             for i in \$(seq 1 60); do
-              if docker compose -f docker-compose.prod.yml --env-file .env.prod exec -T db-prod \
+              if docker compose -f docker-compose.prod.yml --env-file .env.prod exec -T \
+                   -e PGPASSWORD=\"\$PG_PASSWORD\" db-prod \
                    psql -U supabase_admin -d postgres -tAc \
                    \"SELECT 1 FROM information_schema.tables WHERE table_schema='storage' AND table_name='buckets'\" 2>/dev/null \
                    | grep -q '^1\$'; then
@@ -758,8 +760,10 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             cd ${{ secrets.STAGING_DEPLOY_PATH }}
+            PG_PASSWORD=\$(grep '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
             for i in \$(seq 1 60); do
-              if docker compose -p bloom_v2_staging -f docker-compose.prod.yml --env-file .env.staging exec -T db-prod \
+              if docker compose -p bloom_v2_staging -f docker-compose.prod.yml --env-file .env.staging exec -T \
+                   -e PGPASSWORD=\"\$PG_PASSWORD\" db-prod \
                    psql -U supabase_admin -d postgres -tAc \
                    \"SELECT 1 FROM information_schema.tables WHERE table_schema='storage' AND table_name='buckets'\" 2>/dev/null \
                    | grep -q '^1\$'; then

--- a/scripts/deploy_run_supabase.sh
+++ b/scripts/deploy_run_supabase.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Run a supabase CLI command inside the db-prod container.
+#
+# Why this exists: on the Salk deploy server, the host's supabase CLI (Go pgx
+# driver) cannot reach Postgres on 127.0.0.1 — Go's net.Dial times out where
+# Python and libpq connect fine on the same address. The root cause hasn't
+# been pinned down (likely a kernel/network-namespace interaction), but the
+# workaround is reliable: run the CLI inside the db-prod container, where
+# localhost:5432 reaches the Postgres process directly without the docker-proxy
+# hop the host must go through.
+#
+# This script copies the CLI binary + the supabase/ project directory into
+# the running db-prod container, runs the requested supabase subcommand, and
+# cleans up the temp files afterwards.
+#
+# Usage:
+#   scripts/deploy_run_supabase.sh <env> <supabase-subcommand-with-flags>
+# Examples:
+#   scripts/deploy_run_supabase.sh staging "migration list --debug"
+#   scripts/deploy_run_supabase.sh prod    "db push --debug --yes"
+#
+# Must be run from the deploy directory (where docker-compose.prod.yml and
+# .env.{prod,staging} live), with `supabase` CLI on PATH.
+#
+# Cleanup is guaranteed via `trap EXIT` — even if the supabase command fails,
+# the temp files in /tmp/sb and /tmp/proj inside the container are removed.
+# =============================================================================
+set -euo pipefail
+
+ENV="${1:?missing environment arg (staging|prod)}"
+shift
+SUBCMD="$*"
+: "${SUBCMD:?missing supabase subcommand}"
+
+case "$ENV" in
+  prod)
+    PROJECT="bloom_v2_prod"
+    ENV_FILE=".env.prod"
+    ;;
+  staging)
+    PROJECT="bloom_v2_staging"
+    ENV_FILE=".env.staging"
+    ;;
+  *)
+    echo "::error::Unknown environment: $ENV (expected 'prod' or 'staging')" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "::error::env file not found: $ENV_FILE (run from deploy dir)" >&2
+  exit 2
+fi
+
+PG_USER=$(grep -E '^POSTGRES_USER=' "$ENV_FILE" | cut -d= -f2-)
+PG_PASSWORD=$(grep -E '^POSTGRES_PASSWORD=' "$ENV_FILE" | cut -d= -f2-)
+PG_DB=$(grep -E '^POSTGRES_DB=' "$ENV_FILE" | cut -d= -f2-)
+: "${PG_USER:?POSTGRES_USER missing from $ENV_FILE}"
+: "${PG_PASSWORD:?POSTGRES_PASSWORD missing from $ENV_FILE}"
+: "${PG_DB:?POSTGRES_DB missing from $ENV_FILE}"
+
+CONTAINER="${PROJECT}-db-prod-1"
+COMPOSE="docker compose -p ${PROJECT} -f docker-compose.prod.yml --env-file ${ENV_FILE}"
+
+command -v supabase >/dev/null || {
+  echo "::error::supabase CLI not found on host PATH" >&2
+  exit 1
+}
+
+# Always cleanup, even if setup fails partway. Cleanup is idempotent
+# (rm -rf + 2>/dev/null), so registering the trap before the setup commands
+# is safe — and necessary, otherwise a failure between line 1 of setup and
+# the trap registration would orphan files in the container.
+cleanup() {
+  $COMPOSE exec -T db-prod rm -rf /tmp/sb /tmp/proj 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Copy CLI binary + project files into db-prod.
+# Stderr from docker cp is preserved so real errors aren't hidden; stdout
+# (the "Successfully copied ..." progress lines) is suppressed so the
+# Migration summary code block in the run summary panel stays clean.
+#
+# rm -rf /tmp/proj before the second cp: docker cp into an existing directory
+# MERGES contents rather than replacing them. Without the rm, stale migration
+# files from a prior run (where cleanup was swallowed by `|| true`) would mix
+# with the current commit's migrations — could re-apply migrations that were
+# deleted or modified upstream.
+docker cp "$(which supabase)" "${CONTAINER}:/tmp/sb" >/dev/null
+$COMPOSE exec -T db-prod rm -rf /tmp/proj >/dev/null
+$COMPOSE exec -T db-prod mkdir -p /tmp/proj >/dev/null
+docker cp ./supabase "${CONTAINER}:/tmp/proj/" >/dev/null
+
+# Run the supabase subcommand inside the container.
+# - DO_NOT_TRACK=1 disables PostHog telemetry (Salk's network may block it).
+# - PGPASSWORD is the standard libpq/pgx env var for the connection password.
+#   Using it + a passwordless --db-url keeps the password out of the supabase
+#   process's argv (otherwise visible via /proc/<pid>/cmdline to anyone with
+#   `docker exec` rights inside the container).
+# - --db-url uses localhost (intra-container loopback to local Postgres).
+$COMPOSE exec -T \
+  -e DO_NOT_TRACK=1 \
+  -e PGPASSWORD="$PG_PASSWORD" \
+  db-prod \
+  bash -c "cd /tmp/proj && /tmp/sb $SUBCMD --db-url \"postgresql://${PG_USER}@localhost:5432/${PG_DB}?sslmode=disable\""


### PR DESCRIPTION
## Summary

Two related deploy issues discovered during PR #182's first staging deploy attempt.

## What's in this PR

### 1. Storage schema check failed because of a missing password

The 'Wait for storage schema' step ran psql inside db-prod but didn't pass the database password. psql hit a password prompt, the prompt went to /dev/null, and the polling loop never saw a successful query — it timed out at 120s on every deploy.

The same step in pr-checks.yml was correct (passes \`-e PGPASSWORD\`). The bug only existed in deploy.yml, so CI never executed the broken version.

Fix: read POSTGRES_PASSWORD from the deployed env file and pass via \`-e PGPASSWORD\` to docker exec.

### 2. Migration steps couldn't reach Postgres from the host

On the Salk deploy server, the supabase CLI on the host can't reach the database — Go's network library times out where Python and other tools connect fine on the same address. Root cause unclear (something about the kernel or network namespace), but the workaround is reliable: run the CLI inside the db-prod container, where local connections work.

Fix: introduced \`scripts/deploy_run_supabase.sh\` that copies the CLI binary and migration files into db-prod, runs the requested supabase command, and cleans up afterwards. All four migration-related steps (Check / Apply / Show-on-failure / Summary) in both prod and staging stanzas now route through this helper.

## Manual verification (already done)

## What this PR does NOT change

- The smoke test (already correct from PR #182)
- Any application code (no Next.js, langchain, or bloommcp changes)
- The compose file
- Database schema (migrations were applied manually before the PR; deploy will see them as already-applied)

## Test plan

- [ ] CI passes
- [ ] After merge, staging deploy:
  - [ ] Storage schema check passes (PGPASSWORD fix)
  - [ ] Migration check returns 0 pending (already applied manually)
  - [ ] Migration apply step skipped (nothing to apply)
  - [ ] Deploy completes end-to-end
- [ ] Future PRs that add migrations will be applied automatically by the helper, no host-CLI timeout

## Out-of-scope follow-ups

- Mask PG_PASSWORD inside the helper (defense in depth)
- Pin supabase CLI binary path / verify checksum
- Add prod \`-p bloom_v2_prod\` to storage-wait step (asymmetric with staging)
- Default the \`--debug\` flag inside the helper
- Add bats/pytest test for the helper script
- Add shellcheck job in CI
- Reconsider sidecar-container approach vs running CLI inside db-prod
- Root-cause the Go pgx timeout so the helper can eventually go away