### PR TITLE
fix(db): grant supabase storage api with the users specific access to bloom_user/admin/agent to access S3 items

### DIFF
--- a/supabase/migrations/20260428130000_storage_grants_for_bloom_roles.sql
+++ b/supabase/migrations/20260428130000_storage_grants_for_bloom_roles.sql
@@ -1,0 +1,22 @@
+-- Grant storage schema access to bloom_user, bloom_admin, bloom_agent.
+-- Without this, storage-api SET ROLE-ing into these roles cannot read
+-- storage.objects, which blocks all signed URL generation.
+
+BEGIN;
+
+GRANT USAGE ON SCHEMA storage TO bloom_user, bloom_admin, bloom_agent;
+
+-- bloom_user: read + write objects, read buckets
+GRANT SELECT, INSERT, UPDATE ON storage.objects TO bloom_user;
+GRANT SELECT ON storage.buckets TO bloom_user;
+
+-- bloom_admin: full CRUD
+GRANT ALL ON storage.objects, storage.buckets TO bloom_admin;
+
+-- bloom_agent: read-only
+GRANT SELECT ON storage.objects, storage.buckets TO bloom_agent;
+
+-- Sequences (for any auto-incrementing IDs)
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA storage TO bloom_user, bloom_admin;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Add a migration that grants `bloom_user`, `bloom_admin`, and `bloom_agent`
the schema-level permissions they need on the `storage` schema. Without
this, `storage-api` cannot read `storage.objects` after `SET ROLE`-ing into
one of these roles, which blocks signed URL generation for every image and
file in the app.

## What this fixes

When `storage-api` services a signed-URL request for an authenticated user,
it `SET ROLE`s into `bloom_user` (or whichever bloom role the JWT maps to)
and queries `storage.objects`. Migration `002_security_groups` granted these
roles access to the `public` schema but never touched the `storage` schema,
so every `select`/`insert` on `storage.objects` from these roles failed
with `permission denied`. Result on staging: every image returned 404 even
though the underlying MinIO objects existed.

## Grants applied

- `USAGE` on schema `storage` — all three roles
- `bloom_user`: `SELECT, INSERT, UPDATE` on `storage.objects`, `SELECT` on `storage.buckets`
- `bloom_admin`: `ALL` on both tables
- `bloom_agent`: `SELECT` on both tables (read-only)
- `USAGE, SELECT` on all sequences in `storage` for `bloom_user` and `bloom_admin`

No `DELETE` for `bloom_user` — matches the public-schema policy of "users
soft-delete via `deleted_at`, only admins hard-delete."
