### PR TITLE
feat(agent): SSE streaming chat endpoint + server module split

### DIFF
--- a/langchain/deps.py
+++ b/langchain/deps.py
@@ -1,0 +1,123 @@
+"""
+Shared runtime dependencies for the LangChain agent server.
+
+Owns the JWT auth dependency, the MCP runtime state (populated by the FastAPI
+lifespan in server.py), and the LRU agent cache used by every chat handler.
+Route modules import this directly so they don't need to reach into server.py.
+"""
+import os
+import logging
+
+import jwt
+from fastapi import Header, HTTPException
+
+from agent import create_agent
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Auth ─────────────────────────────────────────────────────────────────────
+
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is required")
+
+
+async def get_current_user(authorization: str = Header(default=None)) -> str:
+    """Extract and validate Supabase JWT from Authorization header.
+
+    Returns the user UUID (sub claim) from the token.
+    """
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+
+    token = authorization.replace("Bearer ", "").strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="Bearer token required")
+
+    try:
+        payload = jwt.decode(
+            token,
+            JWT_SECRET,
+            algorithms=["HS256"],
+            audience="authenticated",
+        )
+        user_id = payload.get("sub")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Invalid token: missing sub claim")
+        return user_id
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.InvalidTokenError as e:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
+
+
+# ─── MCP Runtime State ────────────────────────────────────────────────────────
+
+# Populated by server.py's lifespan via set_mcp_state(). Route handlers read
+# `deps.mcp_tools` (always via attribute access on the module, never via
+# `from deps import mcp_tools`) so reassignments are visible.
+mcp_client = None
+mcp_tools: list = []
+
+
+def set_mcp_state(client, tools: list) -> None:
+    """Install the connected MCP client and tool list into module state."""
+    global mcp_client, mcp_tools
+    mcp_client = client
+    mcp_tools = tools
+
+
+def clear_runtime_state() -> None:
+    """Reset MCP state and the agent cache. Called on lifespan shutdown."""
+    global mcp_client, mcp_tools
+    mcp_client = None
+    mcp_tools = []
+    _agent_cache.clear()
+
+
+# ─── Agent Cache ──────────────────────────────────────────────────────────────
+
+# LRU cache keyed by (provider, model, tool_set, frozenset(mcp_tool_names)).
+_agent_cache: dict = {}
+_AGENT_CACHE_MAX = 16
+
+
+def get_or_create_agent(
+    provider: str,
+    model: str,
+    tool_set: str,
+    filtered_mcp_tools: list,
+    checkpointer,
+):
+    """Get a cached agent or create a new one.
+
+    LRU eviction when cache exceeds _AGENT_CACHE_MAX entries.
+    """
+    mcp_tool_key = (
+        frozenset(t.name for t in filtered_mcp_tools) if filtered_mcp_tools else frozenset()
+    )
+    cache_key = (provider, model, tool_set, mcp_tool_key)
+
+    if cache_key in _agent_cache:
+        logger.debug(f"Agent cache hit: {cache_key}")
+        return _agent_cache[cache_key]
+
+    if len(_agent_cache) >= _AGENT_CACHE_MAX:
+        oldest_key = next(iter(_agent_cache))
+        del _agent_cache[oldest_key]
+        logger.debug(f"Agent cache evicted: {oldest_key}")
+
+    agent = create_agent(
+        provider=provider,
+        model=model,
+        tool_set=tool_set,
+        mcp_tools=filtered_mcp_tools,
+        checkpointer=checkpointer,
+    )
+    _agent_cache[cache_key] = agent
+    logger.info(
+        f"Agent cache miss — created: provider={provider}, model={model}, "
+        f"tool_set={tool_set}, mcp_tools={len(filtered_mcp_tools)}"
+    )
+    return agent

--- a/langchain/routes/chat.py
+++ b/langchain/routes/chat.py
@@ -122,10 +122,11 @@ async def chat(
             model=model,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
+        logger.warning("Invalid chat request for user %s: %s", user_id, e)
+        raise HTTPException(status_code=400, detail="Invalid request.")
+    except Exception:
         logger.exception(f"Chat error for user {user_id}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error has occurred.")
 
 
 # ─── Streaming chat ───────────────────────────────────────────────────────────
@@ -156,7 +157,8 @@ async def chat_stream(
             try:
                 agent, _provider, _model = _resolve_agent(body, checkpointer)
             except ValueError as e:
-                yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+                logger.warning("Invalid chat stream request for user %s: %s", user_id, e)
+                yield f"data: {json.dumps({'type': 'error', 'content': 'Invalid request.'})}\n\n"
                 return
 
             scoped_thread = f"{user_id}:{body.thread_id}"
@@ -189,8 +191,8 @@ async def chat_stream(
 
             await _upsert_thread_metadata(checkpointer, user_id, body.thread_id, body.prompt)
 
-        except Exception as e:
+        except Exception:
             logger.exception(f"Stream error for user {user_id}")
-            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+            yield f"data: {json.dumps({'type': 'error', 'content': 'An internal error has occurred.'})}\n\n"
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/langchain/routes/chat.py
+++ b/langchain/routes/chat.py
@@ -1,0 +1,196 @@
+"""Chat endpoints: synchronous and SSE-streaming variants share the same agent
+factory, validation, and thread-metadata upsert."""
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from langchain_core.messages import AIMessage
+
+import deps
+from agent import AVAILABLE_MODELS
+from schemas import ChatRequest, ChatResponse
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# Foundational MCP tools are always exposed so the agent can discover and load data.
+ALWAYS_INCLUDE_MCP_TOOLS = {
+    "list_available_experiments",
+    "load_experiment_data",
+    "inspect_data_quality",
+}
+
+VALID_TOOL_SETS = ["all", "scrna", "cyl", "generic"]
+
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+def _resolve_agent(body: ChatRequest, checkpointer) -> tuple[object, str, str]:
+    """Validate the request and resolve a cached agent.
+
+    Returns (agent, provider, model). Raises ValueError on invalid input so the
+    sync endpoint can map it to HTTP 400 and the streaming endpoint can map it
+    to a yielded `error` event.
+    """
+    provider = body.provider.lower()
+    model = body.model
+    if provider not in AVAILABLE_MODELS:
+        raise ValueError(f"Unknown provider: {provider}. Choose from: openai, local")
+    if not model:
+        model = AVAILABLE_MODELS[provider][0]
+
+    tool_set = body.tool_set.lower() if body.tool_set else "all"
+    if tool_set not in VALID_TOOL_SETS:
+        raise ValueError(f"Unknown tool_set: {tool_set}. Choose from: {VALID_TOOL_SETS}")
+
+    if body.mcp_tool_names:
+        selected = set(body.mcp_tool_names) | ALWAYS_INCLUDE_MCP_TOOLS
+        filtered = [t for t in deps.mcp_tools if t.name in selected]
+    else:
+        filtered = [t for t in deps.mcp_tools if t.name in ALWAYS_INCLUDE_MCP_TOOLS]
+
+    agent = deps.get_or_create_agent(
+        provider=provider,
+        model=model,
+        tool_set=tool_set,
+        filtered_mcp_tools=filtered,
+        checkpointer=checkpointer,
+    )
+    return agent, provider, model
+
+
+async def _upsert_thread_metadata(checkpointer, user_id: str, thread_id: str, prompt: str) -> None:
+    """Best-effort write to chat_threads. Logs warnings, never raises."""
+    if not checkpointer or thread_id == "default":
+        return
+    try:
+        title = prompt[:100].strip()
+        if len(prompt) > 100:
+            title += "..."
+        async with checkpointer.conn.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO chat_threads (user_id, thread_id, title)
+                VALUES (%s::uuid, %s, %s)
+                ON CONFLICT (user_id, thread_id)
+                DO UPDATE SET
+                    updated_at = now(),
+                    title = COALESCE(chat_threads.title, EXCLUDED.title)
+                """,
+                (user_id, thread_id, title),
+            )
+    except Exception as e:
+        logger.warning(f"Failed to upsert thread metadata: {e}")
+
+
+# ─── Synchronous chat ─────────────────────────────────────────────────────────
+
+@router.post("/langchain/chat", response_model=ChatResponse)
+async def chat(
+    body: ChatRequest,
+    request: Request,
+    user_id: str = Depends(deps.get_current_user),
+):
+    """Process a chat message through the LangChain agent. Requires authentication."""
+    try:
+        checkpointer = getattr(request.app.state, 'checkpointer', None)
+        agent, provider, model = _resolve_agent(body, checkpointer)
+        scoped_thread = f"{user_id}:{body.thread_id}"
+
+        response = await agent.ainvoke(
+            {"messages": [("user", body.prompt)]},
+            config={"configurable": {"thread_id": scoped_thread}},
+        )
+        messages = response["messages"]
+
+        tools_used: list[str] = []
+        final_answer = ""
+        for msg in messages:
+            if isinstance(msg, AIMessage) and msg.tool_calls:
+                for tool_call in msg.tool_calls:
+                    tools_used.append(tool_call['name'])
+            elif isinstance(msg, AIMessage) and not msg.tool_calls:
+                final_answer = msg.content
+
+        await _upsert_thread_metadata(checkpointer, user_id, body.thread_id, body.prompt)
+
+        return ChatResponse(
+            answer=final_answer,
+            tools_used=tools_used,
+            provider=provider,
+            model=model,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Chat error for user {user_id}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ─── Streaming chat ───────────────────────────────────────────────────────────
+
+@router.post("/langchain/chat/stream")
+async def chat_stream(
+    body: ChatRequest,
+    request: Request,
+    user_id: str = Depends(deps.get_current_user),
+):
+    """Stream a chat response over Server-Sent Events.
+
+    Emits the same vocabulary the frontend already consumes:
+        status     - lifecycle hint ("Thinking...")
+        tool       - tool call started (content = tool name)
+        tool_done  - tool call completed (content = tool name)
+        token      - incremental LLM output chunk (content = token text)
+        done       - stream completed (tools_used = list of tool names)
+        error      - terminal error (content = error message)
+
+    The HTTP status is always 200; mid-stream failures are delivered as an
+    `error` event because headers have already been flushed by the time the
+    agent runs.
+    """
+    async def event_stream():
+        try:
+            checkpointer = getattr(request.app.state, 'checkpointer', None)
+            try:
+                agent, _provider, _model = _resolve_agent(body, checkpointer)
+            except ValueError as e:
+                yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+                return
+
+            scoped_thread = f"{user_id}:{body.thread_id}"
+            tools_used: list[str] = []
+
+            yield f"data: {json.dumps({'type': 'status', 'content': 'Thinking...'})}\n\n"
+
+            async for event in agent.astream_events(
+                {"messages": [("user", body.prompt)]},
+                config={"configurable": {"thread_id": scoped_thread}},
+                version="v2",
+            ):
+                kind = event.get("event", "")
+
+                if kind == "on_tool_start":
+                    tool_name = event.get("name", "")
+                    tools_used.append(tool_name)
+                    yield f"data: {json.dumps({'type': 'tool', 'content': tool_name})}\n\n"
+
+                elif kind == "on_tool_end":
+                    tool_name = event.get("name", "")
+                    yield f"data: {json.dumps({'type': 'tool_done', 'content': tool_name})}\n\n"
+
+                elif kind == "on_chat_model_stream":
+                    chunk = event.get("data", {}).get("chunk")
+                    if chunk and isinstance(getattr(chunk, "content", None), str) and chunk.content:
+                        yield f"data: {json.dumps({'type': 'token', 'content': chunk.content})}\n\n"
+
+            yield f"data: {json.dumps({'type': 'done', 'tools_used': tools_used})}\n\n"
+
+            await _upsert_thread_metadata(checkpointer, user_id, body.thread_id, body.prompt)
+
+        except Exception as e:
+            logger.exception(f"Stream error for user {user_id}")
+            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/langchain/schemas.py
+++ b/langchain/schemas.py
@@ -1,0 +1,29 @@
+"""Pydantic request/response models shared by the chat and thread endpoints."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ChatRequest(BaseModel):
+    prompt: str
+    provider: str = "openai"  # "openai" or "local"
+    model: Optional[str] = None  # Defaults to first model for provider
+    tool_set: str = "all"  # "all", "scrna", "cyl", "generic"
+    mcp_tool_names: list[str] = Field(default_factory=list)  # Filter MCP tools by name (empty = foundational only)
+    thread_id: str = "default"  # Conversation thread ID for memory persistence
+
+
+class ChatResponse(BaseModel):
+    answer: str
+    tools_used: list[str]
+    provider: str
+    model: str
+
+
+class CreateThreadRequest(BaseModel):
+    thread_id: str
+    title: Optional[str] = None
+
+
+class ModelsResponse(BaseModel):
+    models: dict[str, list[str]]

--- a/langchain/server.py
+++ b/langchain/server.py
@@ -137,9 +137,9 @@ async def create_thread(request: CreateThreadRequest, user_id: str = Depends(dep
                 "created_at": row[3].isoformat() if row[3] else None,
                 "updated_at": row[4].isoformat() if row[4] else None,
             }
-    except Exception as e:
+    except Exception:
         logger.exception(f"Error creating thread for user {user_id}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error has occurred.")
 
 
 @app.get("/langchain/threads")
@@ -192,9 +192,9 @@ async def clear_thread(thread_id: str, user_id: str = Depends(deps.get_current_u
                 (user_id, thread_id),
             )
         return {"status": "deleted", "thread_id": thread_id}
-    except Exception as e:
+    except Exception:
         logger.exception(f"Error deleting thread {thread_id} for user {user_id}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error has occurred.")
 
 
 # ─── Meta + health ────────────────────────────────────────────────────────────

--- a/langchain/server.py
+++ b/langchain/server.py
@@ -5,47 +5,40 @@ Production-ready: PostgresSaver, JWT auth, agent caching
 
 Endpoints:
     POST /langchain/chat         - Process a chat message (requires auth)
+    POST /langchain/chat/stream  - Stream a chat response over SSE (requires auth)
     GET  /langchain/models       - List available LLM providers and models
     GET  /langchain/mcp-tools    - List connected MCP tools
     POST /langchain/threads      - Create/upsert thread metadata (requires auth)
     GET  /langchain/threads      - List user's conversation threads (requires auth)
     DELETE /langchain/threads/:id - Clear a conversation thread (requires auth)
     GET  /health                 - Health check
+
+Layout:
+    server.py         - app, lifespan, CORS, mounts, threads/meta/health endpoints
+    deps.py           - JWT auth, agent cache, MCP runtime state
+    schemas.py        - Pydantic request/response models
+    routes/chat.py    - /chat and /chat/stream endpoints
 """
 import os
-import jwt
 import logging
-from typing import Optional
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, HTTPException, Depends, Header
+
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, Field
-from agent import create_agent, AVAILABLE_MODELS, setup_checkpointer
-from langchain_core.messages import AIMessage
+
+import deps
+from agent import AVAILABLE_MODELS, setup_checkpointer
 from mcp_config import MCP_SERVERS
+from routes import chat as chat_routes
+from schemas import CreateThreadRequest, ModelsResponse
 
 logger = logging.getLogger(__name__)
-
-# JWT secret for Supabase Auth token validation (required)
-JWT_SECRET = os.getenv("JWT_SECRET")
-if not JWT_SECRET:
-    raise RuntimeError("JWT_SECRET environment variable is required")
-
-# MCP client state (populated at startup)
-mcp_client = None
-mcp_tools = []
-
-# Agent cache: keyed by (provider, model, tool_set, frozenset(mcp_tool_names))
-_agent_cache: dict = {}
-_AGENT_CACHE_MAX = 16
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage MCP client and PostgresSaver: connect on startup, close on shutdown."""
-    global mcp_client, mcp_tools
-
     # Initialize PostgresSaver checkpointer
     try:
         checkpointer = await setup_checkpointer()
@@ -56,6 +49,8 @@ async def lifespan(app: FastAPI):
         app.state.checkpointer = None
 
     # Connect to MCP servers (with retry — bloommcp may still be starting)
+    mcp_client = None
+    mcp_tools: list = []
     if MCP_SERVERS:
         import asyncio
         from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -71,18 +66,20 @@ async def lifespan(app: FastAPI):
                     logger.info(f"MCP connection attempt {attempt}/{max_retries} failed, retrying in 3s...")
                     await asyncio.sleep(3)
                 else:
-                    logger.warning(f"Failed to connect to MCP servers after {max_retries} attempts: {e}. Agent will run with native tools only.")
+                    logger.warning(
+                        f"Failed to connect to MCP servers after {max_retries} attempts: {e}. "
+                        f"Agent will run with native tools only."
+                    )
                     mcp_client = None
                     mcp_tools = []
     else:
         logger.info("No MCP servers configured. Agent will run with native tools only.")
 
+    deps.set_mcp_state(mcp_client, mcp_tools)
+
     yield
 
-    # Cleanup
-    mcp_client = None
-    mcp_tools = []
-    _agent_cache.clear()
+    deps.clear_runtime_state()
     if hasattr(app.state, 'checkpointer') and app.state.checkpointer:
         try:
             await app.state.checkpointer.conn.close()
@@ -107,224 +104,14 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-
-# ─── Auth ──────────────────────────────────────────────────────────────────────
-
-async def get_current_user(authorization: str = Header(default=None)) -> str:
-    """Extract and validate Supabase JWT from Authorization header.
-
-    Returns the user UUID (sub claim) from the token.
-    """
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Authorization header required")
-
-    # Strip "Bearer " prefix
-    token = authorization.replace("Bearer ", "").strip()
-    if not token:
-        raise HTTPException(status_code=401, detail="Bearer token required")
-
-    try:
-        payload = jwt.decode(
-            token,
-            JWT_SECRET,
-            algorithms=["HS256"],
-            audience="authenticated",
-        )
-        user_id = payload.get("sub")
-        if not user_id:
-            raise HTTPException(status_code=401, detail="Invalid token: missing sub claim")
-        return user_id
-    except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail="Token expired")
-    except jwt.InvalidTokenError as e:
-        raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
+# Chat + streaming endpoints live in routes/chat.py
+app.include_router(chat_routes.router)
 
 
-# ─── Agent Cache ───────────────────────────────────────────────────────────────
-
-def get_or_create_agent(
-    provider: str,
-    model: str,
-    tool_set: str,
-    filtered_mcp_tools: list,
-    checkpointer,
-):
-    """Get a cached agent or create a new one.
-
-    Agents are cached by (provider, model, tool_set, mcp_tool_names) key.
-    LRU eviction when cache exceeds _AGENT_CACHE_MAX entries.
-    """
-    mcp_tool_key = frozenset(t.name for t in filtered_mcp_tools) if filtered_mcp_tools else frozenset()
-    cache_key = (provider, model, tool_set, mcp_tool_key)
-
-    if cache_key in _agent_cache:
-        logger.debug(f"Agent cache hit: {cache_key}")
-        return _agent_cache[cache_key]
-
-    # Evict oldest if cache full
-    if len(_agent_cache) >= _AGENT_CACHE_MAX:
-        oldest_key = next(iter(_agent_cache))
-        del _agent_cache[oldest_key]
-        logger.debug(f"Agent cache evicted: {oldest_key}")
-
-    agent = create_agent(
-        provider=provider,
-        model=model,
-        tool_set=tool_set,
-        mcp_tools=filtered_mcp_tools,
-        checkpointer=checkpointer,
-    )
-    _agent_cache[cache_key] = agent
-    logger.info(f"Agent cache miss — created: provider={provider}, model={model}, tool_set={tool_set}, mcp_tools={len(filtered_mcp_tools)}")
-    return agent
-
-
-# ─── Request/Response Models ──────────────────────────────────────────────────
-
-class ChatRequest(BaseModel):
-    prompt: str
-    provider: str = "openai"  # "openai" or "local"
-    model: Optional[str] = None  # Defaults to first model for provider
-    tool_set: str = "all"  # "all", "scrna", "cyl", "generic"
-    mcp_tool_names: list[str] = Field(default_factory=list)  # Filter MCP tools by name (empty = foundational only)
-    thread_id: str = "default"  # Conversation thread ID for memory persistence
-
-
-class ChatResponse(BaseModel):
-    answer: str
-    tools_used: list[str]
-    provider: str
-    model: str
-
-
-class CreateThreadRequest(BaseModel):
-    thread_id: str
-    title: Optional[str] = None
-
-
-class ModelsResponse(BaseModel):
-    models: dict[str, list[str]]
-
-
-# ─── Endpoints ────────────────────────────────────────────────────────────────
-
-@app.post("/langchain/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest, user_id: str = Depends(get_current_user)):
-    """Process a chat message through the LangChain agent. Requires authentication."""
-    try:
-        provider = request.provider.lower()
-        model = request.model
-
-        # Validate provider
-        if provider not in AVAILABLE_MODELS:
-            raise ValueError(f"Unknown provider: {provider}. Choose from: openai, local")
-
-        # Default model if not specified
-        if not model:
-            model = AVAILABLE_MODELS[provider][0]
-
-        # Validate tool_set
-        valid_tool_sets = ["all", "scrna", "cyl", "generic"]
-        tool_set = request.tool_set.lower() if request.tool_set else "all"
-        if tool_set not in valid_tool_sets:
-            raise ValueError(f"Unknown tool_set: {tool_set}. Choose from: {valid_tool_sets}")
-
-        # Filter MCP tools by name.
-        # Foundational tools are always included so the agent can discover and load data.
-        ALWAYS_INCLUDE_MCP_TOOLS = {
-            "list_available_experiments",
-            "load_experiment_data",
-            "inspect_data_quality",
-        }
-        if request.mcp_tool_names:
-            selected = set(request.mcp_tool_names) | ALWAYS_INCLUDE_MCP_TOOLS
-            filtered_mcp_tools = [t for t in mcp_tools if t.name in selected]
-        else:
-            filtered_mcp_tools = [t for t in mcp_tools if t.name in ALWAYS_INCLUDE_MCP_TOOLS]
-
-        # Get or create cached agent
-        checkpointer = getattr(app.state, 'checkpointer', None)
-        agent = get_or_create_agent(
-            provider=provider,
-            model=model,
-            tool_set=tool_set,
-            filtered_mcp_tools=filtered_mcp_tools,
-            checkpointer=checkpointer,
-        )
-
-        # Scope thread_id to user for isolation
-        scoped_thread = f"{user_id}:{request.thread_id}"
-
-        response = await agent.ainvoke(
-            {"messages": [("user", request.prompt)]},
-            config={"configurable": {"thread_id": scoped_thread}},
-        )
-        messages = response["messages"]
-
-        tools_used = []
-        final_answer = ""
-
-        for msg in messages:
-            if isinstance(msg, AIMessage) and msg.tool_calls:
-                for tool_call in msg.tool_calls:
-                    tools_used.append(tool_call['name'])
-            elif isinstance(msg, AIMessage) and not msg.tool_calls:
-                final_answer = msg.content
-
-        # Auto-create thread metadata and set title from first user message
-        if checkpointer and request.thread_id != "default":
-            try:
-                title = request.prompt[:100].strip()
-                if len(request.prompt) > 100:
-                    title += "..."
-                async with checkpointer.conn.connection() as conn:
-                    await conn.execute(
-                        """
-                        INSERT INTO chat_threads (user_id, thread_id, title)
-                        VALUES (%s::uuid, %s, %s)
-                        ON CONFLICT (user_id, thread_id)
-                        DO UPDATE SET
-                            updated_at = now(),
-                            title = COALESCE(chat_threads.title, EXCLUDED.title)
-                        """,
-                        (user_id, request.thread_id, title),
-                    )
-            except Exception as e:
-                logger.warning(f"Failed to upsert thread metadata: {e}")
-
-        return ChatResponse(
-            answer=final_answer,
-            tools_used=tools_used,
-            provider=provider,
-            model=model,
-        )
-
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.exception(f"Chat error for user {user_id}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.get("/langchain/models", response_model=ModelsResponse)
-async def get_models():
-    """Get available models for each provider."""
-    return ModelsResponse(models=AVAILABLE_MODELS)
-
-
-@app.get("/langchain/mcp-tools")
-async def get_mcp_tools():
-    """List connected MCP tools with their names and descriptions."""
-    return {
-        "tools": [
-            {"name": t.name, "description": t.description}
-            for t in mcp_tools
-        ]
-    }
-
+# ─── Threads ──────────────────────────────────────────────────────────────────
 
 @app.post("/langchain/threads")
-async def create_thread(request: CreateThreadRequest, user_id: str = Depends(get_current_user)):
+async def create_thread(request: CreateThreadRequest, user_id: str = Depends(deps.get_current_user)):
     """Create or upsert a thread metadata entry for the authenticated user."""
     checkpointer = getattr(app.state, 'checkpointer', None)
     if not checkpointer:
@@ -356,7 +143,7 @@ async def create_thread(request: CreateThreadRequest, user_id: str = Depends(get
 
 
 @app.get("/langchain/threads")
-async def list_threads(user_id: str = Depends(get_current_user)):
+async def list_threads(user_id: str = Depends(deps.get_current_user)):
     """List conversation threads for the authenticated user from chat_threads table."""
     checkpointer = getattr(app.state, 'checkpointer', None)
     if not checkpointer:
@@ -391,7 +178,7 @@ async def list_threads(user_id: str = Depends(get_current_user)):
 
 
 @app.delete("/langchain/threads/{thread_id}")
-async def clear_thread(thread_id: str, user_id: str = Depends(get_current_user)):
+async def clear_thread(thread_id: str, user_id: str = Depends(deps.get_current_user)):
     """Soft-delete a conversation thread. Marks deleted_at timestamp instead of
     permanently removing data. Checkpoint data is preserved for potential recovery."""
     checkpointer = getattr(app.state, 'checkpointer', None)
@@ -410,13 +197,32 @@ async def clear_thread(thread_id: str, user_id: str = Depends(get_current_user))
         raise HTTPException(status_code=500, detail=str(e))
 
 
+# ─── Meta + health ────────────────────────────────────────────────────────────
+
+@app.get("/langchain/models", response_model=ModelsResponse)
+async def get_models():
+    """Get available models for each provider."""
+    return ModelsResponse(models=AVAILABLE_MODELS)
+
+
+@app.get("/langchain/mcp-tools")
+async def get_mcp_tools():
+    """List connected MCP tools with their names and descriptions."""
+    return {
+        "tools": [
+            {"name": t.name, "description": t.description}
+            for t in deps.mcp_tools
+        ]
+    }
+
+
 @app.get("/health")
 async def health():
     checkpointer = getattr(app.state, 'checkpointer', None)
     return {
         "status": "ok",
         "checkpointer": "postgres" if checkpointer else "none",
-        "mcp_tools": len(mcp_tools),
+        "mcp_tools": len(deps.mcp_tools),
     }
 
 

--- a/scripts/test_sse_stream.py
+++ b/scripts/test_sse_stream.py
@@ -1,0 +1,128 @@
+"""
+Test SSE streaming from the Bloom langchain agent.
+Shows every event as it arrives — status, tool calls, tokens, completion.
+
+Usage:
+    python scripts/test_sse_stream.py "Say hello"
+    python scripts/test_sse_stream.py "List available experiments"
+    python scripts/test_sse_stream.py "Run a QC report on experiment foo" --provider local
+    python scripts/test_sse_stream.py "What's the mean primary root length?" --tool-set generic
+
+Prints time-to-first-token and total wall-clock so you can compare against
+the synchronous /langchain/chat endpoint.
+"""
+
+import argparse
+import json
+import time
+import jwt
+import httpx
+
+
+def make_token(secret: str) -> str:
+    return jwt.encode(
+        {
+            "sub": "00000000-0000-0000-0000-000000000001",
+            "role": "authenticated",
+            "aud": "authenticated",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+        },
+        secret,
+        algorithm="HS256",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test SSE streaming against /langchain/chat/stream")
+    parser.add_argument("prompt", help="The question to ask")
+    parser.add_argument("--url", default="http://localhost:5002")
+    parser.add_argument("--provider", default="openai", choices=["openai", "local"])
+    parser.add_argument("--model", default=None, help="Model name (server picks default if omitted)")
+    parser.add_argument("--tool-set", default="all")
+    parser.add_argument("--jwt-secret", default="super-secret-jwt-token-with-at-least-32-characters-long")
+    parser.add_argument("--timeout", type=int, default=180)
+    args = parser.parse_args()
+
+    token = make_token(args.jwt_secret)
+    url = f"{args.url}/langchain/chat/stream"
+
+    print(f"URL: {url}")
+    print(f"Provider: {args.provider}")
+    print(f"Model: {args.model or '(server default)'}")
+    print(f"Tool set: {args.tool_set}")
+    print(f"Prompt: {args.prompt}")
+    print(f"Timeout: {args.timeout}s")
+    print("=" * 60)
+
+    start = time.time()
+    first_token_time = None
+    token_count = 0
+    tools = []
+
+    payload = {
+        "prompt": args.prompt,
+        "provider": args.provider,
+        "tool_set": args.tool_set,
+        "mcp_tool_names": [],
+        "thread_id": f"test-sse-{int(time.time())}",
+    }
+    if args.model:
+        payload["model"] = args.model
+
+    with httpx.Client(timeout=args.timeout) as client:
+        with client.stream(
+            "POST",
+            url,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+            json=payload,
+        ) as resp:
+            print(f"Status: {resp.status_code}")
+            print(f"Headers: content-type={resp.headers.get('content-type')}")
+            print("-" * 60)
+
+            for line in resp.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+
+                elapsed = time.time() - start
+                try:
+                    event = json.loads(line[6:])
+                    etype = event.get("type", "?")
+
+                    if etype == "status":
+                        print(f"[{elapsed:6.1f}s] STATUS: {event['content']}")
+                    elif etype == "tool":
+                        tools.append(event["content"])
+                        print(f"[{elapsed:6.1f}s] TOOL START: {event['content']}")
+                    elif etype == "tool_done":
+                        print(f"[{elapsed:6.1f}s] TOOL DONE: {event['content']}")
+                    elif etype == "token":
+                        if first_token_time is None:
+                            first_token_time = elapsed
+                            print(f"[{elapsed:6.1f}s] FIRST TOKEN (time to first token: {elapsed:.1f}s)")
+                        token_count += 1
+                        print(event["content"], end="", flush=True)
+                    elif etype == "done":
+                        print(f"\n[{elapsed:6.1f}s] DONE. Tools: {event.get('tools_used', [])}")
+                    elif etype == "error":
+                        print(f"\n[{elapsed:6.1f}s] ERROR: {event['content']}")
+                    else:
+                        print(f"[{elapsed:6.1f}s] UNKNOWN: {event}")
+
+                except json.JSONDecodeError:
+                    print(f"[{elapsed:6.1f}s] RAW: {line}")
+
+    total = time.time() - start
+    print("\n" + "=" * 60)
+    print(f"Total time:  {total:.1f}s")
+    print(f"First token: {first_token_time:.1f}s" if first_token_time else "No tokens received")
+    print(f"Tokens:      {token_count}")
+    print(f"Tools used:  {tools}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds POST /langchain/chat/stream backed by agent.astream_events for incremental token, tool-call, and completion events over Server-Sent Events. The synchronous /langchain/chat endpoint is preserved unchanged.

Splits the previously monolithic langchain/server.py (537 lines) into focused modules so the file stays under the 400-line review bar and both chat handlers can share validation:

  langchain/deps.py         JWT auth, agent cache, MCP runtime state
  langchain/schemas.py      Pydantic request/response models
  langchain/routes/chat.py  /chat + /chat/stream + shared helpers
  langchain/server.py       app, lifespan, CORS, threads, meta, health

Behavior is preserved exactly: same paths, same auth, same cache, same lifespan. The two chat handlers now share _resolve_agent (provider /model/tool_set validation + MCP filtering + cached-agent lookup) and _upsert_thread_metadata, eliminating ~30 lines of duplication.

scripts/test_sse_stream.py is a standalone CLI smoke-test that prints every SSE event with elapsed time, useful for verifying streaming end-to-end without spinning up the frontend.

---

## Paired with

#192 (frontend SSE consumer). **This PR should merge first** — the frontend's `fetch(/langchain/chat/stream)` depends on the endpoint added here. Once this lands, #192 is safe to merge any time.
