### PR TITLE
Fix/(agent) : reconcile saved model

### DIFF
--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -94,7 +94,7 @@ function saveThreadId(id: string) {
 function loadSettings(): LLMSettings {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) return { provider: "local", model: "Qwen/Qwen3-8B", toolSet: "generic", mcpToolNames: [] };
+    if (!raw) return { provider: "local", model: "Qwen/Qwen3.5-9B", toolSet: "generic", mcpToolNames: [] };
     const parsed = JSON.parse(raw);
     if (!parsed.toolSet) parsed.toolSet = "generic";
     if (!parsed.mcpToolNames) parsed.mcpToolNames = [];
@@ -102,7 +102,7 @@ function loadSettings(): LLMSettings {
     if (parsed.provider === "claude") parsed.provider = "local";
     return parsed;
   } catch {
-    return { provider: "local", model: "Qwen/Qwen3-8B", toolSet: "generic", mcpToolNames: [] };
+    return { provider: "local", model: "Qwen/Qwen3.5-9B", toolSet: "generic", mcpToolNames: [] };
   }
 }
 
@@ -166,7 +166,19 @@ export default function MCPChat() {
         return r.json();
       })
       .then((data) => {
-        if (data.models) setAvailableModels(data.models);
+        if (!data.models) return;
+        setAvailableModels(data.models);
+        // Reconcile saved model against what the backend is actually serving.
+        // If the saved model isn't in the available list, swap to the first one
+        // and persist. Prevents 404s from a stale localStorage entry pointing at
+        // a model that's been replaced or renamed server-side.
+        setSettings((prev) => {
+          const valid = data.models[prev.provider] || [];
+          if (valid.length === 0 || valid.includes(prev.model)) return prev;
+          const fixed = { ...prev, model: valid[0] };
+          saveSettings(fixed);
+          return fixed;
+        });
       })
       .catch(() => {});
   }, []);
@@ -174,7 +186,7 @@ export default function MCPChat() {
   // LLM Settings
   const [settings, setSettings] = useState<LLMSettings>(() => ({
     provider: "local",
-    model: "Qwen/Qwen3-8B",
+    model: "Qwen/Qwen3.5-9B",
     toolSet: "generic",
     mcpToolNames: [],
   }));


### PR DESCRIPTION
## Summary

The chat client was preconfigured with Qwen/Qwen3-8B, our vLLM now serves `Qwen/Qwen3.5-9B`.
The frontend stores the user's selected model in browser localStorage under mcp_llm_settings, this caused stale `localStorage.mcp_llm_settings.model` causing 404 on every chat request.

### Fixes:

- Update three hard-coded defaults to `Qwen/Qwen3.5-9B`.
- Added reconciliation logic inside the existing useEffect that fetches /langchain/models. After the backend's list of available models comes back, we check whether the user's currently-saved model is actually in that list for their selected provider. If it isn't, we swap to the first valid model and persist the corrected setting to localStorage. Existing users with stale browser state get auto-corrected on their next page load.