### PR TITLE
feat(bloommcp): versioned, append-only phenotyping storage layer

### DIFF
--- a/bloommcp/server.py
+++ b/bloommcp/server.py
@@ -27,6 +27,7 @@ from tools import (
     outlier_tools,
     viz_tools,
     correlation_tools,
+    storage_tools,
 )
 
 # --- Authentication ---
@@ -62,6 +63,7 @@ clustering_tools.register(mcp)
 outlier_tools.register(mcp)
 viz_tools.register(mcp)
 correlation_tools.register(mcp)
+storage_tools.register(mcp)
 
 # --- Health Endpoint ---
 # GET for Docker healthchecks. Bypasses MCP's SSE/JSON-RPC

--- a/bloommcp/source/experiment_utils.py
+++ b/bloommcp/source/experiment_utils.py
@@ -166,39 +166,97 @@ def _find_column(columns, patterns: list[str]) -> Optional[str]:
     return None
 
 
+def _resolve_versioned_cleaned(
+    o_dir: Path,
+    stem: str,
+    version: str,
+) -> tuple[Optional[Path], Optional[str], Optional[str]]:
+    """Resolve a versioned cleaned CSV via the QC manifest.
+
+    Returns (path, source_label, error). On success, error is None and path
+    points at an existing _cleaned.csv. On miss with version="latest", returns
+    (None, None, None) so the caller falls back. On explicit version="v<N>"
+    miss, returns (None, None, error_string).
+    """
+    from storage import AnalysisDir, ManifestSchemaError
+
+    analysis_dir = AnalysisDir(o_dir, f"{stem}.csv", "qc")
+    try:
+        entry = analysis_dir.get_version(version)
+    except ManifestSchemaError as e:
+        return None, None, f"manifest schema error for '{stem}': {e}"
+
+    if entry is None:
+        if version == "latest":
+            return None, None, None
+        return None, None, (
+            f"Version {version!r} not found for experiment '{stem}'. "
+            f"Use list_existing_analyses to see available versions."
+        )
+
+    rel = (entry.get("outputs") or {}).get("_cleaned.csv")
+    if not rel:
+        if version == "latest":
+            return None, None, None
+        return None, None, (
+            f"Version {entry['id']} has no cleaned CSV output."
+        )
+
+    path = analysis_dir.path / rel
+    if not path.exists():
+        return None, None, (
+            f"Manifest references {rel} for version {entry['id']} but the file is missing."
+        )
+    return path, f"{entry['id']}_cleaned", None
+
+
 def load_experiment_data(
     filename: str,
     traits_dir: Optional[Path] = None,
     output_dir: Optional[Path] = None,
     require_clean: bool = False,
+    version: str = "latest",
 ) -> tuple:
     """Load experiment CSV with auto-detected columns.
 
-    Checks for cleaned CSV first, falls back to raw.
+    Resolution order for version="latest" (the default):
+      1. Versioned manifest entry (qc_<stem>/manifest.json -> latest -> _cleaned.csv)
+      2. Legacy un-versioned cleaned CSV (qc_<stem>/<stem>_cleaned.csv) — preserves
+         pre-migration behaviour; replaced by v0_legacy after the Phase B migration runs
+      3. Raw CSV from BLOOM_TRAITS_DIR
 
     Args:
         filename: CSV filename (e.g., "alfalfa_gwas_wave2.csv")
         traits_dir: Override for BLOOM_TRAITS_DIR
         output_dir: Override for BLOOM_OUTPUT_DIR
         require_clean: If True, fail when no cleaned CSV exists (for UMAP)
+        version: "latest" (default), "raw", or an explicit "v<N>"
 
     Returns:
         (df, trait_cols, column_config, source_label)
-        column_config is the dict from detect_columns()
+        source_label is one of "raw", "legacy_cleaned", or "v<N>_cleaned".
         On error: (None, None, None, error_string)
     """
     t_dir = traits_dir or TRAITS_DIR
     o_dir = output_dir or OUTPUT_DIR
     stem = Path(filename).stem
 
-    # 1. Check for cleaned CSV from previous QC run
-    cleaned_path = o_dir / f"qc_{stem}" / f"{stem}_cleaned.csv"
-    if cleaned_path.exists():
-        df = pd.read_csv(cleaned_path)
-        config = detect_columns(df)
-        return df, config["trait_cols"], config, f"cleaned ({cleaned_path.name})"
+    if version != "raw":
+        cleaned_path, source_label, error = _resolve_versioned_cleaned(o_dir, stem, version)
+        if error:
+            return None, None, None, error
+        if cleaned_path is not None:
+            df = pd.read_csv(cleaned_path)
+            config = detect_columns(df)
+            return df, config["trait_cols"], config, source_label
 
-    # 2. Hard-fail if clean required (e.g., UMAP)
+        if version == "latest":
+            legacy_path = o_dir / f"qc_{stem}" / f"{stem}_cleaned.csv"
+            if legacy_path.exists():
+                df = pd.read_csv(legacy_path)
+                config = detect_columns(df)
+                return df, config["trait_cols"], config, "legacy_cleaned"
+
     if require_clean:
         return None, None, None, (
             f"No cleaned dataset found for '{filename}'. "
@@ -206,14 +264,12 @@ def load_experiment_data(
             "Run clean_experiment_data first."
         )
 
-    # 3. Fallback to raw CSV
     raw_path = t_dir / filename
     if raw_path.exists():
         df = pd.read_csv(raw_path)
         config = detect_columns(df)
-        return df, config["trait_cols"], config, "raw (run clean_experiment_data for better results)"
+        return df, config["trait_cols"], config, "raw"
 
-    # 4. Not found
     available = [f.name for f in t_dir.glob("*.csv")] if t_dir.exists() else []
     avail_str = ", ".join(available) if available else "none"
     return None, None, None, f"File '{filename}' not found in {t_dir}. Available: {avail_str}"

--- a/bloommcp/source/experiment_utils.py
+++ b/bloommcp/source/experiment_utils.py
@@ -194,20 +194,20 @@ def _resolve_versioned_cleaned(
             f"Use list_existing_analyses to see available versions."
         )
 
-    rel = (entry.get("outputs") or {}).get("_cleaned.csv")
+    rel = entry.outputs.get("_cleaned.csv")
     if not rel:
         if version == "latest":
             return None, None, None
         return None, None, (
-            f"Version {entry['id']} has no cleaned CSV output."
+            f"Version {entry.id} has no cleaned CSV output."
         )
 
     path = analysis_dir.path / rel
     if not path.exists():
         return None, None, (
-            f"Manifest references {rel} for version {entry['id']} but the file is missing."
+            f"Manifest references {rel} for version {entry.id} but the file is missing."
         )
-    return path, f"{entry['id']}_cleaned", None
+    return path, f"{entry.id}_cleaned", None
 
 
 def load_experiment_data(

--- a/bloommcp/storage/__init__.py
+++ b/bloommcp/storage/__init__.py
@@ -8,12 +8,24 @@ from .manifest import (
     validate_schema,
     write_manifest_atomic,
 )
+from .schema import (
+    CURRENT_SCHEMA_VERSION,
+    CodeVersions,
+    ExperimentBlock,
+    Manifest,
+    VersionEntry,
+)
 from .versioning import next_version_id, slugify, version_dir_name
 
 __all__ = [
     "AnalysisDir",
+    "CURRENT_SCHEMA_VERSION",
+    "CodeVersions",
+    "ExperimentBlock",
     "KNOWN_SCHEMA_VERSION",
+    "Manifest",
     "ManifestSchemaError",
+    "VersionEntry",
     "get_code_versions",
     "next_version_id",
     "read_manifest",

--- a/bloommcp/storage/__init__.py
+++ b/bloommcp/storage/__init__.py
@@ -1,0 +1,24 @@
+"""Versioned, append-only storage layer for phenotyping analysis artifacts."""
+from .analysis_dir import AnalysisDir
+from .code_versions import get_code_versions
+from .manifest import (
+    KNOWN_SCHEMA_VERSION,
+    ManifestSchemaError,
+    read_manifest,
+    validate_schema,
+    write_manifest_atomic,
+)
+from .versioning import next_version_id, slugify, version_dir_name
+
+__all__ = [
+    "AnalysisDir",
+    "KNOWN_SCHEMA_VERSION",
+    "ManifestSchemaError",
+    "get_code_versions",
+    "next_version_id",
+    "read_manifest",
+    "slugify",
+    "validate_schema",
+    "version_dir_name",
+    "write_manifest_atomic",
+]

--- a/bloommcp/storage/analysis_dir.py
+++ b/bloommcp/storage/analysis_dir.py
@@ -1,0 +1,61 @@
+"""Per-experiment, per-tool-class directory abstraction (read-only in Phase A)."""
+import hashlib
+from pathlib import Path
+
+from .manifest import read_manifest
+
+_HASH_CHUNK_BYTES = 1024 * 1024
+
+
+class AnalysisDir:
+    """Wraps <output_root>/<tool_class>_<stem>/ and its manifest."""
+
+    def __init__(
+        self,
+        output_root: Path,
+        experiment_filename: str,
+        tool_class: str,
+    ) -> None:
+        self.output_root = Path(output_root)
+        self.experiment_filename = experiment_filename
+        self.tool_class = tool_class
+        self.stem = Path(experiment_filename).stem
+        self.path = self.output_root / f"{tool_class}_{self.stem}"
+        self._cached_input_sha256: str | None = None
+
+    def read_manifest(self) -> dict | None:
+        if not self.path.exists():
+            return None
+        return read_manifest(self.path)
+
+    def list_versions(self) -> list[dict]:
+        """All version entries sorted by created_at; empty list if no manifest."""
+        manifest = self.read_manifest()
+        if not manifest:
+            return []
+        versions = list(manifest.get("versions", []))
+        return sorted(versions, key=lambda v: v.get("created_at", ""))
+
+    def get_version(self, version_id: str) -> dict | None:
+        """Resolve a version by id, or "latest" via the manifest's latest pointer."""
+        manifest = self.read_manifest()
+        if not manifest:
+            return None
+        target_id = manifest.get("latest") if version_id == "latest" else version_id
+        if not target_id:
+            return None
+        for entry in manifest.get("versions", []):
+            if entry.get("id") == target_id:
+                return entry
+        return None
+
+    def input_sha256(self, source_csv: Path) -> str:
+        """Stream-hash the source CSV; cached on the instance after first call."""
+        if self._cached_input_sha256 is not None:
+            return self._cached_input_sha256
+        h = hashlib.sha256()
+        with open(source_csv, "rb") as f:
+            for chunk in iter(lambda: f.read(_HASH_CHUNK_BYTES), b""):
+                h.update(chunk)
+        self._cached_input_sha256 = h.hexdigest()
+        return self._cached_input_sha256

--- a/bloommcp/storage/analysis_dir.py
+++ b/bloommcp/storage/analysis_dir.py
@@ -1,4 +1,4 @@
-"""Per-experiment, per-tool-class directory abstraction (read-only in Phase A)."""
+"""Per-experiment, per-tool-class directory abstraction."""
 import hashlib
 from pathlib import Path
 from typing import Optional

--- a/bloommcp/storage/analysis_dir.py
+++ b/bloommcp/storage/analysis_dir.py
@@ -1,8 +1,10 @@
 """Per-experiment, per-tool-class directory abstraction (read-only in Phase A)."""
 import hashlib
 from pathlib import Path
+from typing import Optional
 
 from .manifest import read_manifest
+from .schema import Manifest, VersionEntry
 
 _HASH_CHUNK_BYTES = 1024 * 1024
 
@@ -21,31 +23,30 @@ class AnalysisDir:
         self.tool_class = tool_class
         self.stem = Path(experiment_filename).stem
         self.path = self.output_root / f"{tool_class}_{self.stem}"
-        self._cached_input_sha256: str | None = None
+        self._cached_input_sha256: Optional[str] = None
 
-    def read_manifest(self) -> dict | None:
+    def read_manifest(self) -> Optional[Manifest]:
         if not self.path.exists():
             return None
         return read_manifest(self.path)
 
-    def list_versions(self) -> list[dict]:
+    def list_versions(self) -> list[VersionEntry]:
         """All version entries sorted by created_at; empty list if no manifest."""
         manifest = self.read_manifest()
-        if not manifest:
+        if manifest is None:
             return []
-        versions = list(manifest.get("versions", []))
-        return sorted(versions, key=lambda v: v.get("created_at", ""))
+        return sorted(manifest.versions, key=lambda v: v.created_at)
 
-    def get_version(self, version_id: str) -> dict | None:
+    def get_version(self, version_id: str) -> Optional[VersionEntry]:
         """Resolve a version by id, or "latest" via the manifest's latest pointer."""
         manifest = self.read_manifest()
-        if not manifest:
+        if manifest is None:
             return None
-        target_id = manifest.get("latest") if version_id == "latest" else version_id
+        target_id = manifest.latest if version_id == "latest" else version_id
         if not target_id:
             return None
-        for entry in manifest.get("versions", []):
-            if entry.get("id") == target_id:
+        for entry in manifest.versions:
+            if entry.id == target_id:
                 return entry
         return None
 

--- a/bloommcp/storage/code_versions.py
+++ b/bloommcp/storage/code_versions.py
@@ -1,0 +1,17 @@
+"""Read installed package versions for manifest provenance."""
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _version_or_unknown(package_name: str) -> str:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def get_code_versions() -> dict[str, str]:
+    """Return installed versions of packages whose provenance is captured per run."""
+    return {
+        "bloommcp": _version_or_unknown("bloommcp"),
+        "sleap_roots_analyze": _version_or_unknown("sleap-roots-analyze"),
+    }

--- a/bloommcp/storage/code_versions.py
+++ b/bloommcp/storage/code_versions.py
@@ -1,6 +1,8 @@
 """Read installed package versions for manifest provenance."""
 from importlib.metadata import PackageNotFoundError, version
 
+from .schema import CodeVersions
+
 
 def _version_or_unknown(package_name: str) -> str:
     try:
@@ -9,9 +11,9 @@ def _version_or_unknown(package_name: str) -> str:
         return "unknown"
 
 
-def get_code_versions() -> dict[str, str]:
+def get_code_versions() -> CodeVersions:
     """Return installed versions of packages whose provenance is captured per run."""
-    return {
-        "bloommcp": _version_or_unknown("bloommcp"),
-        "sleap_roots_analyze": _version_or_unknown("sleap-roots-analyze"),
-    }
+    return CodeVersions(
+        bloommcp=_version_or_unknown("bloommcp"),
+        sleap_roots_analyze=_version_or_unknown("sleap-roots-analyze"),
+    )

--- a/bloommcp/storage/manifest.py
+++ b/bloommcp/storage/manifest.py
@@ -3,8 +3,11 @@ import json
 import os
 import uuid
 from pathlib import Path
+from typing import Optional
 
-KNOWN_SCHEMA_VERSION = 1
+from .schema import CURRENT_SCHEMA_VERSION, Manifest
+
+KNOWN_SCHEMA_VERSION = CURRENT_SCHEMA_VERSION
 
 
 class ManifestSchemaError(Exception):
@@ -12,7 +15,12 @@ class ManifestSchemaError(Exception):
 
 
 def validate_schema(manifest: dict) -> None:
-    """Refuse manifests whose schema version is newer than KNOWN_SCHEMA_VERSION."""
+    """Refuse manifests whose schema version is newer than KNOWN_SCHEMA_VERSION.
+
+    Runs *before* Pydantic parsing so a forward-incompatible manifest produces
+    a clear "schema too new" error rather than a confusing "extra field" error
+    from strict Pydantic validation.
+    """
     schema_version = manifest.get("manifest_schema_version")
     if schema_version is None:
         raise ManifestSchemaError(
@@ -25,25 +33,26 @@ def validate_schema(manifest: dict) -> None:
         )
 
 
-def read_manifest(experiment_dir: Path) -> dict | None:
-    """Return the parsed manifest, or None if absent."""
+def read_manifest(experiment_dir: Path) -> Optional[Manifest]:
+    """Return the parsed and validated manifest, or None if absent."""
     manifest_path = experiment_dir / "manifest.json"
     if not manifest_path.exists():
         return None
     with manifest_path.open("r", encoding="utf-8") as f:
-        manifest = json.load(f)
-    validate_schema(manifest)
-    return manifest
+        raw = json.load(f)
+    validate_schema(raw)
+    return Manifest.model_validate(raw)
 
 
-def write_manifest_atomic(experiment_dir: Path, manifest: dict) -> None:
+def write_manifest_atomic(experiment_dir: Path, manifest: Manifest) -> None:
     """Write manifest.json atomically: write to a unique tmp file, fsync, then rename."""
-    validate_schema(manifest)
+    payload = manifest.model_dump(mode="json")
+    validate_schema(payload)
     experiment_dir.mkdir(parents=True, exist_ok=True)
     target = experiment_dir / "manifest.json"
     tmp = experiment_dir / f"manifest.json.tmp.{uuid.uuid4().hex}"
     with tmp.open("w", encoding="utf-8") as f:
-        json.dump(manifest, f, indent=2, sort_keys=True)
+        json.dump(payload, f, indent=2, sort_keys=True)
         f.flush()
         os.fsync(f.fileno())
     os.rename(tmp, target)

--- a/bloommcp/storage/manifest.py
+++ b/bloommcp/storage/manifest.py
@@ -1,0 +1,49 @@
+"""Atomic JSON manifest read/write with rename-and-swap for safe concurrent access."""
+import json
+import os
+import uuid
+from pathlib import Path
+
+KNOWN_SCHEMA_VERSION = 1
+
+
+class ManifestSchemaError(Exception):
+    """Raised when a manifest's schema version is newer than this code understands."""
+
+
+def validate_schema(manifest: dict) -> None:
+    """Refuse manifests whose schema version is newer than KNOWN_SCHEMA_VERSION."""
+    schema_version = manifest.get("manifest_schema_version")
+    if schema_version is None:
+        raise ManifestSchemaError(
+            "manifest.json is missing the 'manifest_schema_version' field"
+        )
+    if not isinstance(schema_version, int) or schema_version > KNOWN_SCHEMA_VERSION:
+        raise ManifestSchemaError(
+            f"manifest_schema_version {schema_version!r} is newer than supported "
+            f"(this code understands up to {KNOWN_SCHEMA_VERSION})"
+        )
+
+
+def read_manifest(experiment_dir: Path) -> dict | None:
+    """Return the parsed manifest, or None if absent."""
+    manifest_path = experiment_dir / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    with manifest_path.open("r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    validate_schema(manifest)
+    return manifest
+
+
+def write_manifest_atomic(experiment_dir: Path, manifest: dict) -> None:
+    """Write manifest.json atomically: write to a unique tmp file, fsync, then rename."""
+    validate_schema(manifest)
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    target = experiment_dir / "manifest.json"
+    tmp = experiment_dir / f"manifest.json.tmp.{uuid.uuid4().hex}"
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
+    os.rename(tmp, target)

--- a/bloommcp/storage/schema.py
+++ b/bloommcp/storage/schema.py
@@ -1,0 +1,61 @@
+"""Pydantic schema for manifest.json (manifest_schema_version: 1).
+
+Each per-experiment, per-tool-class directory (e.g. BLOOM_OUTPUT_DIR/qc_<stem>/)
+contains exactly one manifest.json that catalogs every prior analysis run on
+that experiment. The models below are the canonical shape of that file at
+schema version 1; any future change to the shape MUST bump the version
+constant in manifest.py and add a migration path.
+
+Models are strict by default (extra fields rejected) so writer bugs that emit
+unexpected keys surface as ValidationError at commit time rather than silently
+corrupting the on-disk catalog.
+"""
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CURRENT_SCHEMA_VERSION = 1
+
+
+class _StrictModel(BaseModel):
+    """Common base: forbid unknown fields so writer bugs raise loudly."""
+    model_config = ConfigDict(extra="forbid")
+
+
+class CodeVersions(_StrictModel):
+    """Installed package versions captured at write time for provenance."""
+    bloommcp: str
+    sleap_roots_analyze: str
+
+
+class ExperimentBlock(_StrictModel):
+    """Identifies the experiment whose analyses this manifest catalogs."""
+    filename: str
+    source_path: str
+    input_sha256: str
+
+
+class VersionEntry(_StrictModel):
+    """One analysis run recorded in the manifest's versions list.
+
+    `id` is "v<N>" for normal runs, or "v0_legacy" for the synthesised entry
+    written by the on-startup migration. `outputs` maps a stable short name
+    (e.g. "_cleaned.csv") to its path relative to the experiment-class
+    directory.
+    """
+    id: str
+    created_at: str
+    tool: str
+    params: dict
+    based_on_version: str
+    code_versions: CodeVersions
+    outputs: dict[str, str]
+    user_label: Optional[str] = None
+
+
+class Manifest(_StrictModel):
+    """Top-level manifest.json schema."""
+    manifest_schema_version: int = Field(default=CURRENT_SCHEMA_VERSION)
+    experiment: ExperimentBlock
+    versions: list[VersionEntry] = Field(default_factory=list)
+    latest: Optional[str] = None

--- a/bloommcp/storage/versioning.py
+++ b/bloommcp/storage/versioning.py
@@ -1,4 +1,4 @@
-"""Version-label allocation and on-disk directory-name construction."""
+"""Functions enabling correct Version-label allocation and on-disk directory-name construction."""
 import re
 from datetime import date
 from typing import Optional

--- a/bloommcp/storage/versioning.py
+++ b/bloommcp/storage/versioning.py
@@ -1,6 +1,9 @@
 """Version-label allocation and on-disk directory-name construction."""
 import re
 from datetime import date
+from typing import Optional
+
+from .schema import Manifest
 
 _SLUG_PATTERN = re.compile(r"[^a-z0-9_]+")
 _MAX_SLUG_LEN = 32
@@ -14,13 +17,13 @@ def slugify(label: str) -> str:
     return s[:_MAX_SLUG_LEN]
 
 
-def next_version_id(manifest: dict | None) -> str:
+def next_version_id(manifest: Optional[Manifest]) -> str:
     """Return the next v<N> id, never reusing N even after deletion."""
-    if not manifest or not manifest.get("versions"):
+    if manifest is None or not manifest.versions:
         return "v1"
     max_n = 0
-    for entry in manifest["versions"]:
-        vid = entry.get("id", "")
+    for entry in manifest.versions:
+        vid = entry.id
         if not vid.startswith("v"):
             continue
         head = vid[1:].split("_", 1)[0]
@@ -33,8 +36,8 @@ def next_version_id(manifest: dict | None) -> str:
 
 def version_dir_name(
     version_id: str,
-    user_label: str | None = None,
-    today: date | None = None,
+    user_label: Optional[str] = None,
+    today: Optional[date] = None,
 ) -> str:
     """Build v<N>_<YYYY-MM-DD>[_<slug>]."""
     d = (today or date.today()).isoformat()

--- a/bloommcp/storage/versioning.py
+++ b/bloommcp/storage/versioning.py
@@ -1,0 +1,46 @@
+"""Version-label allocation and on-disk directory-name construction."""
+import re
+from datetime import date
+
+_SLUG_PATTERN = re.compile(r"[^a-z0-9_]+")
+_MAX_SLUG_LEN = 32
+
+
+def slugify(label: str) -> str:
+    """Lowercase, alphanumerics + underscore only, max 32 chars, stripped of edge underscores."""
+    s = label.strip().lower().replace("-", "_").replace(" ", "_")
+    s = _SLUG_PATTERN.sub("", s)
+    s = s.strip("_")
+    return s[:_MAX_SLUG_LEN]
+
+
+def next_version_id(manifest: dict | None) -> str:
+    """Return the next v<N> id, never reusing N even after deletion."""
+    if not manifest or not manifest.get("versions"):
+        return "v1"
+    max_n = 0
+    for entry in manifest["versions"]:
+        vid = entry.get("id", "")
+        if not vid.startswith("v"):
+            continue
+        head = vid[1:].split("_", 1)[0]
+        if head.isdigit():
+            n = int(head)
+            if n > max_n:
+                max_n = n
+    return f"v{max_n + 1}"
+
+
+def version_dir_name(
+    version_id: str,
+    user_label: str | None = None,
+    today: date | None = None,
+) -> str:
+    """Build v<N>_<YYYY-MM-DD>[_<slug>]."""
+    d = (today or date.today()).isoformat()
+    base = f"{version_id}_{d}"
+    if user_label:
+        slug = slugify(user_label)
+        if slug:
+            return f"{base}_{slug}"
+    return base

--- a/bloommcp/tools/storage_tools.py
+++ b/bloommcp/tools/storage_tools.py
@@ -1,0 +1,69 @@
+"""MCP tool: list every prior analysis on file for an experiment."""
+import json
+
+import source.experiment_utils as _eu
+from storage import AnalysisDir, ManifestSchemaError
+
+TOOL_CLASSES = (
+    "qc",
+    "stats",
+    "dimred",
+    "clustering",
+    "outlier",
+    "viz",
+    "correlation",
+)
+
+
+def list_existing_analyses(experiment_filename: str) -> str:
+    """List every prior analysis recorded on disk for this experiment.
+
+    Walks each tool-class directory (qc_*, stats_*, dimred_*, clustering_*,
+    outlier_*, viz_*, correlation_*) under BLOOM_OUTPUT_DIR and aggregates
+    every version recorded in each manifest. Use this at the start of any
+    analysis session to see what's already been done and avoid redundant
+    computation.
+
+    Args:
+        experiment_filename: CSV filename, e.g. "alfalfa_gwas_wave2.csv"
+    """
+    raw_path = _eu.TRAITS_DIR / experiment_filename
+    if not raw_path.exists():
+        available = ", ".join(e["filename"] for e in _eu.list_experiments()) or "none"
+        return json.dumps(
+            {
+                "error": f"Experiment '{experiment_filename}' not found in {_eu.TRAITS_DIR}",
+                "available_experiments": available,
+            },
+            indent=2,
+        )
+
+    by_tool_class: dict[str, list[dict]] = {}
+    errors: list[str] = []
+
+    for tool_class in TOOL_CLASSES:
+        analysis_dir = AnalysisDir(_eu.OUTPUT_DIR, experiment_filename, tool_class)
+        try:
+            versions = analysis_dir.list_versions()
+        except ManifestSchemaError as e:
+            errors.append(f"{tool_class}: {e}")
+            continue
+        if versions:
+            by_tool_class[tool_class] = versions
+
+    response = {
+        "experiment_filename": experiment_filename,
+        "analyses": by_tool_class,
+    }
+    if not by_tool_class:
+        response["message"] = (
+            f"No prior analyses found for '{experiment_filename}'."
+        )
+    if errors:
+        response["errors"] = errors
+    return json.dumps(response, indent=2, default=str)
+
+
+def register(mcp):
+    """Register storage introspection tools with the MCP server."""
+    mcp.tool()(list_existing_analyses)

--- a/bloommcp/tools/storage_tools.py
+++ b/bloommcp/tools/storage_tools.py
@@ -49,9 +49,9 @@ def list_existing_analyses(experiment_filename: str) -> str:
             errors.append(f"{tool_class}: {e}")
             continue
         if versions:
-            by_tool_class[tool_class] = versions
+            by_tool_class[tool_class] = [v.model_dump(mode="json") for v in versions]
 
-    response = {
+    response: dict = {
         "experiment_filename": experiment_filename,
         "analyses": by_tool_class,
     }
@@ -61,7 +61,7 @@ def list_existing_analyses(experiment_filename: str) -> str:
         )
     if errors:
         response["errors"] = errors
-    return json.dumps(response, indent=2, default=str)
+    return json.dumps(response, indent=2)
 
 
 def register(mcp):

--- a/langchain/routes/chat.py
+++ b/langchain/routes/chat.py
@@ -20,6 +20,7 @@ ALWAYS_INCLUDE_MCP_TOOLS = {
     "list_available_experiments",
     "load_experiment_data",
     "inspect_data_quality",
+    "list_existing_analyses",
 }
 
 VALID_TOOL_SETS = ["all", "scrna", "cyl", "generic"]

--- a/tests/integration/test_versioned_storage_phase_a.py
+++ b/tests/integration/test_versioned_storage_phase_a.py
@@ -1,4 +1,4 @@
-"""Phase A storage layer: read-side, manifest, version resolution, introspection.
+"""storage layer: read-side, manifest, version resolution, introspection.
 
 These tests are filesystem-only — they do NOT require the compose stack. They
 run against the storage modules directly, using tmp_path for isolation.

--- a/tests/integration/test_versioned_storage_phase_a.py
+++ b/tests/integration/test_versioned_storage_phase_a.py
@@ -32,9 +32,15 @@ os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP_BASE)
 os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP_BASE)
 os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
 
+from pydantic import ValidationError  # noqa: E402
+
 from storage import (  # noqa: E402
     AnalysisDir,
+    CodeVersions,
+    ExperimentBlock,
+    Manifest,
     ManifestSchemaError,
+    VersionEntry,
     next_version_id,
     read_manifest,
     slugify,
@@ -42,6 +48,49 @@ from storage import (  # noqa: E402
     version_dir_name,
     write_manifest_atomic,
 )
+
+
+def _make_version_entry(
+    *,
+    id: str = "v1",
+    created_at: str = "2026-04-20T00:00:00Z",
+    tool: str = "clean_experiment_data",
+    params: dict | None = None,
+    based_on_version: str = "raw",
+    code_versions: CodeVersions | None = None,
+    outputs: dict[str, str] | None = None,
+    user_label: str | None = None,
+) -> VersionEntry:
+    return VersionEntry(
+        id=id,
+        created_at=created_at,
+        tool=tool,
+        params=params or {},
+        based_on_version=based_on_version,
+        code_versions=code_versions
+        or CodeVersions(bloommcp="0.1.0", sleap_roots_analyze="unknown"),
+        outputs=outputs or {},
+        user_label=user_label,
+    )
+
+
+def _make_manifest(
+    *,
+    filename: str = "foo.csv",
+    versions: list[VersionEntry] | None = None,
+    latest: str | None = None,
+    input_sha256: str = "abc",
+) -> Manifest:
+    versions = versions or []
+    return Manifest(
+        experiment=ExperimentBlock(
+            filename=filename,
+            source_path=f".../{filename}",
+            input_sha256=input_sha256,
+        ),
+        versions=versions,
+        latest=latest if latest is not None else (versions[-1].id if versions else None),
+    )
 
 
 # ─── Manifest schema enforcement ───────────────────────────────────────────────
@@ -71,53 +120,64 @@ def test_read_manifest_rejects_unknown_future_version(tmp_path):
 # ─── Atomic writes ─────────────────────────────────────────────────────────────
 
 def test_write_manifest_atomic_round_trips(tmp_path):
-    manifest = {
-        "manifest_schema_version": 1,
-        "experiment": {"filename": "foo.csv", "source_path": "...", "input_sha256": "abc"},
-        "versions": [
-            {
-                "id": "v1",
-                "created_at": "2026-04-20T14:23:11Z",
-                "tool": "clean_experiment_data",
-                "params": {"contamination": 0.05},
-                "based_on_version": "raw",
-                "code_versions": {"bloommcp": "0.1.0", "sleap_roots_analyze": "unknown"},
-                "outputs": {"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
-                "user_label": None,
-            }
-        ],
-        "latest": "v1",
-    }
+    entry = _make_version_entry(
+        id="v1",
+        created_at="2026-04-20T14:23:11Z",
+        tool="clean_experiment_data",
+        params={"contamination": 0.05},
+        outputs={"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
+    )
+    manifest = _make_manifest(versions=[entry], latest="v1")
     write_manifest_atomic(tmp_path, manifest)
     assert (tmp_path / "manifest.json").exists()
-    assert read_manifest(tmp_path) == manifest
+    round_tripped = read_manifest(tmp_path)
+    assert round_tripped == manifest
 
 
 def test_write_manifest_atomic_leaves_no_tmp_files(tmp_path):
-    write_manifest_atomic(tmp_path, {"manifest_schema_version": 1, "versions": []})
+    write_manifest_atomic(tmp_path, _make_manifest())
     leftover_tmps = list(tmp_path.glob("manifest.json.tmp.*"))
     assert leftover_tmps == []
+
+
+def test_manifest_rejects_extra_fields():
+    """Strict mode catches writer bugs that emit unexpected keys."""
+    with pytest.raises(ValidationError):
+        Manifest.model_validate({
+            "manifest_schema_version": 1,
+            "experiment": {"filename": "x.csv", "source_path": "...", "input_sha256": ""},
+            "versions": [],
+            "latest": None,
+            "this_field_should_not_exist": True,
+        })
 
 
 # ─── Versioning ────────────────────────────────────────────────────────────────
 
 def test_next_version_id_starts_at_v1():
     assert next_version_id(None) == "v1"
-    assert next_version_id({"versions": []}) == "v1"
+    assert next_version_id(_make_manifest(versions=[])) == "v1"
 
 
 def test_next_version_id_skips_deleted_ids():
-    manifest = {
-        "versions": [
-            {"id": "v1"},
-            {"id": "v3"},
+    manifest = _make_manifest(
+        versions=[
+            _make_version_entry(id="v1"),
+            _make_version_entry(id="v3"),
         ],
-    }
+        latest="v3",
+    )
     assert next_version_id(manifest) == "v4"
 
 
 def test_next_version_id_handles_legacy_suffix():
-    manifest = {"versions": [{"id": "v0_legacy"}, {"id": "v2"}]}
+    manifest = _make_manifest(
+        versions=[
+            _make_version_entry(id="v0_legacy"),
+            _make_version_entry(id="v2"),
+        ],
+        latest="v2",
+    )
     assert next_version_id(manifest) == "v3"
 
 
@@ -136,7 +196,7 @@ def test_version_dir_name_with_and_without_label():
 
 # ─── AnalysisDir ───────────────────────────────────────────────────────────────
 
-def _seed_qc_dir(output_root: Path, stem: str, manifest: dict) -> Path:
+def _seed_qc_dir(output_root: Path, stem: str, manifest: Manifest) -> Path:
     qc_dir = output_root / f"qc_{stem}"
     qc_dir.mkdir(parents=True)
     write_manifest_atomic(qc_dir, manifest)
@@ -152,36 +212,32 @@ def test_analysis_dir_no_manifest(tmp_path):
 
 
 def test_analysis_dir_resolves_latest_pointer(tmp_path):
-    manifest = {
-        "manifest_schema_version": 1,
-        "experiment": {"filename": "foo.csv", "source_path": "...", "input_sha256": ""},
-        "versions": [
-            {"id": "v1", "created_at": "2026-04-20T00:00:00Z"},
-            {"id": "v2", "created_at": "2026-04-25T00:00:00Z"},
+    manifest = _make_manifest(
+        versions=[
+            _make_version_entry(id="v1", created_at="2026-04-20T00:00:00Z"),
+            _make_version_entry(id="v2", created_at="2026-04-25T00:00:00Z"),
         ],
-        "latest": "v2",
-    }
+        latest="v2",
+    )
     _seed_qc_dir(tmp_path, "foo", manifest)
     ad = AnalysisDir(tmp_path, "foo.csv", "qc")
 
-    assert ad.get_version("latest")["id"] == "v2"
-    assert ad.get_version("v1")["id"] == "v1"
+    assert ad.get_version("latest").id == "v2"
+    assert ad.get_version("v1").id == "v1"
     assert ad.get_version("v99") is None
 
 
 def test_analysis_dir_list_versions_sorted_by_created_at(tmp_path):
-    manifest = {
-        "manifest_schema_version": 1,
-        "experiment": {"filename": "foo.csv", "source_path": "...", "input_sha256": ""},
-        "versions": [
-            {"id": "v2", "created_at": "2026-04-25T00:00:00Z"},
-            {"id": "v1", "created_at": "2026-04-20T00:00:00Z"},
+    manifest = _make_manifest(
+        versions=[
+            _make_version_entry(id="v2", created_at="2026-04-25T00:00:00Z"),
+            _make_version_entry(id="v1", created_at="2026-04-20T00:00:00Z"),
         ],
-        "latest": "v2",
-    }
+        latest="v2",
+    )
     _seed_qc_dir(tmp_path, "foo", manifest)
     ad = AnalysisDir(tmp_path, "foo.csv", "qc")
-    ids = [v["id"] for v in ad.list_versions()]
+    ids = [v.id for v in ad.list_versions()]
     assert ids == ["v1", "v2"]
 
 
@@ -244,23 +300,15 @@ def test_load_experiment_data_raw_skips_cached_cleaned(tmp_path):
     _write_csv(version_subdir / "_cleaned.csv", "trait_a,trait_b\n9.9,9.9\n")
     write_manifest_atomic(
         qc_dir,
-        {
-            "manifest_schema_version": 1,
-            "experiment": {"filename": "bar.csv", "source_path": "...", "input_sha256": ""},
-            "versions": [
-                {
-                    "id": "v1",
-                    "created_at": "2026-04-20T00:00:00Z",
-                    "tool": "clean_experiment_data",
-                    "params": {},
-                    "based_on_version": "raw",
-                    "code_versions": {"bloommcp": "0.1.0", "sleap_roots_analyze": "unknown"},
-                    "outputs": {"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
-                    "user_label": None,
-                }
+        _make_manifest(
+            filename="bar.csv",
+            versions=[
+                _make_version_entry(
+                    outputs={"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
+                ),
             ],
-            "latest": "v1",
-        },
+            latest="v1",
+        ),
     )
 
     df_raw, _, _, source_raw = load_experiment_data(
@@ -323,23 +371,16 @@ def test_list_existing_analyses_reports_qc_versions(tmp_path, monkeypatch):
     output_dir = tmp_path / "output"
     _write_csv(traits_dir / "bar.csv", "trait_a\n1.0\n")
 
-    qc_manifest = {
-        "manifest_schema_version": 1,
-        "experiment": {"filename": "bar.csv", "source_path": "...", "input_sha256": "abc"},
-        "versions": [
-            {
-                "id": "v1",
-                "created_at": "2026-04-20T00:00:00Z",
-                "tool": "clean_experiment_data",
-                "params": {"contamination": 0.05},
-                "based_on_version": "raw",
-                "code_versions": {"bloommcp": "0.1.0", "sleap_roots_analyze": "unknown"},
-                "outputs": {"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
-                "user_label": None,
-            }
+    qc_manifest = _make_manifest(
+        filename="bar.csv",
+        versions=[
+            _make_version_entry(
+                params={"contamination": 0.05},
+                outputs={"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
+            ),
         ],
-        "latest": "v1",
-    }
+        latest="v1",
+    )
     _seed_qc_dir(output_dir, "bar", qc_manifest)
 
     import source.experiment_utils as eu

--- a/tests/integration/test_versioned_storage_phase_a.py
+++ b/tests/integration/test_versioned_storage_phase_a.py
@@ -1,0 +1,375 @@
+"""Phase A storage layer: read-side, manifest, version resolution, introspection.
+
+These tests are filesystem-only — they do NOT require the compose stack. They
+run against the storage modules directly, using tmp_path for isolation.
+
+Pandas-dependent tests (the load_experiment_data integration assertions) are
+skipped when pandas isn't installed in the test runner's environment.
+"""
+import json
+import os
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+# Make bloommcp's flat-package layout importable. bloommcp ships with its
+# packages (`source`, `tools`, `storage`) directly under bloommcp/ rather
+# than nested under a top-level `bloommcp` namespace, so tests must add
+# that directory to sys.path before importing.
+_BLOOMMCP_DIR = Path(__file__).resolve().parents[2] / "bloommcp"
+if str(_BLOOMMCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_BLOOMMCP_DIR))
+
+# experiment_utils._validate_dirs() runs at import time and requires these
+# four env vars to point at extant directories. If the local env doesn't
+# have them, fall back to a tmp dir so the import doesn't crash collection.
+_TMP_BASE = tempfile.mkdtemp(prefix="bloommcp_phase_a_default_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP_BASE)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP_BASE)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP_BASE)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+
+from storage import (  # noqa: E402
+    AnalysisDir,
+    ManifestSchemaError,
+    next_version_id,
+    read_manifest,
+    slugify,
+    validate_schema,
+    version_dir_name,
+    write_manifest_atomic,
+)
+
+
+# ─── Manifest schema enforcement ───────────────────────────────────────────────
+
+def test_validate_schema_rejects_unknown_future_version():
+    with pytest.raises(ManifestSchemaError):
+        validate_schema({"manifest_schema_version": 99, "versions": []})
+
+
+def test_validate_schema_rejects_missing_field():
+    with pytest.raises(ManifestSchemaError):
+        validate_schema({"versions": []})
+
+
+def test_read_manifest_returns_none_when_absent(tmp_path):
+    assert read_manifest(tmp_path) is None
+
+
+def test_read_manifest_rejects_unknown_future_version(tmp_path):
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({"manifest_schema_version": 99, "versions": []})
+    )
+    with pytest.raises(ManifestSchemaError):
+        read_manifest(tmp_path)
+
+
+# ─── Atomic writes ─────────────────────────────────────────────────────────────
+
+def test_write_manifest_atomic_round_trips(tmp_path):
+    manifest = {
+        "manifest_schema_version": 1,
+        "experiment": {"filename": "foo.csv", "source_path": "...", "input_sha256": "abc"},
+        "versions": [
+            {
+                "id": "v1",
+                "created_at": "2026-04-20T14:23:11Z",
+                "tool": "clean_experiment_data",
+                "params": {"contamination": 0.05},
+                "based_on_version": "raw",
+                "code_versions": {"bloommcp": "0.1.0", "sleap_roots_analyze": "unknown"},
+                "outputs": {"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
+                "user_label": None,
+            }
+        ],
+        "latest": "v1",
+    }
+    write_manifest_atomic(tmp_path, manifest)
+    assert (tmp_path / "manifest.json").exists()
+    assert read_manifest(tmp_path) == manifest
+
+
+def test_write_manifest_atomic_leaves_no_tmp_files(tmp_path):
+    write_manifest_atomic(tmp_path, {"manifest_schema_version": 1, "versions": []})
+    leftover_tmps = list(tmp_path.glob("manifest.json.tmp.*"))
+    assert leftover_tmps == []
+
+
+# ─── Versioning ────────────────────────────────────────────────────────────────
+
+def test_next_version_id_starts_at_v1():
+    assert next_version_id(None) == "v1"
+    assert next_version_id({"versions": []}) == "v1"
+
+
+def test_next_version_id_skips_deleted_ids():
+    manifest = {
+        "versions": [
+            {"id": "v1"},
+            {"id": "v3"},
+        ],
+    }
+    assert next_version_id(manifest) == "v4"
+
+
+def test_next_version_id_handles_legacy_suffix():
+    manifest = {"versions": [{"id": "v0_legacy"}, {"id": "v2"}]}
+    assert next_version_id(manifest) == "v3"
+
+
+def test_slugify_normalises_user_labels():
+    assert slugify("Iso Method") == "iso_method"
+    assert slugify("contamination=0.05") == "contamination005"
+    assert slugify("--bad chars--") == "bad_chars"
+    assert slugify("a" * 50) == "a" * 32
+
+
+def test_version_dir_name_with_and_without_label():
+    d = date(2026, 4, 20)
+    assert version_dir_name("v1", None, today=d) == "v1_2026-04-20"
+    assert version_dir_name("v2", "iso_method", today=d) == "v2_2026-04-20_iso_method"
+
+
+# ─── AnalysisDir ───────────────────────────────────────────────────────────────
+
+def _seed_qc_dir(output_root: Path, stem: str, manifest: dict) -> Path:
+    qc_dir = output_root / f"qc_{stem}"
+    qc_dir.mkdir(parents=True)
+    write_manifest_atomic(qc_dir, manifest)
+    return qc_dir
+
+
+def test_analysis_dir_no_manifest(tmp_path):
+    ad = AnalysisDir(tmp_path, "foo.csv", "qc")
+    assert ad.read_manifest() is None
+    assert ad.list_versions() == []
+    assert ad.get_version("latest") is None
+    assert ad.get_version("v1") is None
+
+
+def test_analysis_dir_resolves_latest_pointer(tmp_path):
+    manifest = {
+        "manifest_schema_version": 1,
+        "experiment": {"filename": "foo.csv", "source_path": "...", "input_sha256": ""},
+        "versions": [
+            {"id": "v1", "created_at": "2026-04-20T00:00:00Z"},
+            {"id": "v2", "created_at": "2026-04-25T00:00:00Z"},
+        ],
+        "latest": "v2",
+    }
+    _seed_qc_dir(tmp_path, "foo", manifest)
+    ad = AnalysisDir(tmp_path, "foo.csv", "qc")
+
+    assert ad.get_version("latest")["id"] == "v2"
+    assert ad.get_version("v1")["id"] == "v1"
+    assert ad.get_version("v99") is None
+
+
+def test_analysis_dir_list_versions_sorted_by_created_at(tmp_path):
+    manifest = {
+        "manifest_schema_version": 1,
+        "experiment": {"filename": "foo.csv", "source_path": "...", "input_sha256": ""},
+        "versions": [
+            {"id": "v2", "created_at": "2026-04-25T00:00:00Z"},
+            {"id": "v1", "created_at": "2026-04-20T00:00:00Z"},
+        ],
+        "latest": "v2",
+    }
+    _seed_qc_dir(tmp_path, "foo", manifest)
+    ad = AnalysisDir(tmp_path, "foo.csv", "qc")
+    ids = [v["id"] for v in ad.list_versions()]
+    assert ids == ["v1", "v2"]
+
+
+def test_analysis_dir_input_sha256_caches_after_first_call(tmp_path):
+    csv_path = tmp_path / "foo.csv"
+    csv_path.write_bytes(b"col_a,col_b\n1,2\n3,4\n")
+    ad = AnalysisDir(tmp_path, "foo.csv", "qc")
+
+    first = ad.input_sha256(csv_path)
+    csv_path.write_bytes(b"DIFFERENT CONTENT")
+    second = ad.input_sha256(csv_path)
+
+    assert first == second  # second call returns cached value, not re-hashed
+
+
+# ─── Version-aware loader ──────────────────────────────────────────────────────
+
+def _import_loader():
+    """Importing experiment_utils triggers env-var validation; defer to test time
+    so the test file's import phase stays fast and deterministic."""
+    from source.experiment_utils import load_experiment_data
+    return load_experiment_data
+
+
+def _write_csv(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_load_experiment_data_falls_back_to_raw_when_no_manifest(tmp_path):
+    pytest.importorskip("pandas")
+    load_experiment_data = _import_loader()
+
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    _write_csv(traits_dir / "bar.csv", "trait_a,trait_b\n1.0,2.0\n3.0,4.0\n")
+
+    df, trait_cols, _config, source = load_experiment_data(
+        "bar.csv",
+        traits_dir=traits_dir,
+        output_dir=output_dir,
+        version="latest",
+    )
+
+    assert df is not None
+    assert source == "raw"
+    assert "trait_a" in trait_cols
+
+
+def test_load_experiment_data_raw_skips_cached_cleaned(tmp_path):
+    pytest.importorskip("pandas")
+    load_experiment_data = _import_loader()
+
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    _write_csv(traits_dir / "bar.csv", "trait_a,trait_b\n1.0,2.0\n")
+
+    qc_dir = output_dir / "qc_bar"
+    version_subdir = qc_dir / "v1_2026-04-20"
+    _write_csv(version_subdir / "_cleaned.csv", "trait_a,trait_b\n9.9,9.9\n")
+    write_manifest_atomic(
+        qc_dir,
+        {
+            "manifest_schema_version": 1,
+            "experiment": {"filename": "bar.csv", "source_path": "...", "input_sha256": ""},
+            "versions": [
+                {
+                    "id": "v1",
+                    "created_at": "2026-04-20T00:00:00Z",
+                    "tool": "clean_experiment_data",
+                    "params": {},
+                    "based_on_version": "raw",
+                    "code_versions": {"bloommcp": "0.1.0", "sleap_roots_analyze": "unknown"},
+                    "outputs": {"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
+                    "user_label": None,
+                }
+            ],
+            "latest": "v1",
+        },
+    )
+
+    df_raw, _, _, source_raw = load_experiment_data(
+        "bar.csv", traits_dir=traits_dir, output_dir=output_dir, version="raw"
+    )
+    df_latest, _, _, source_latest = load_experiment_data(
+        "bar.csv", traits_dir=traits_dir, output_dir=output_dir, version="latest"
+    )
+
+    assert source_raw == "raw"
+    assert df_raw["trait_a"].iloc[0] == 1.0
+    assert source_latest == "v1_cleaned"
+    assert df_latest["trait_a"].iloc[0] == 9.9
+
+
+def test_load_experiment_data_explicit_missing_version_errors(tmp_path):
+    pytest.importorskip("pandas")
+    load_experiment_data = _import_loader()
+
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    _write_csv(traits_dir / "bar.csv", "trait_a\n1.0\n")
+
+    df, trait_cols, _config, source = load_experiment_data(
+        "bar.csv",
+        traits_dir=traits_dir,
+        output_dir=output_dir,
+        version="v99",
+    )
+
+    assert df is None and trait_cols is None
+    assert "v99" in source
+
+
+# ─── list_existing_analyses introspection tool ─────────────────────────────────
+
+def test_list_existing_analyses_empty_when_no_dirs(tmp_path, monkeypatch):
+    pytest.importorskip("pandas")
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    _write_csv(traits_dir / "bar.csv", "trait_a\n1.0\n")
+    output_dir.mkdir()
+
+    # Storage tool reads OUTPUT_DIR / TRAITS_DIR from experiment_utils module-globals
+    import source.experiment_utils as eu
+    monkeypatch.setattr(eu, "OUTPUT_DIR", output_dir)
+    monkeypatch.setattr(eu, "TRAITS_DIR", traits_dir)
+
+    from tools.storage_tools import list_existing_analyses
+    payload = json.loads(list_existing_analyses("bar.csv"))
+
+    assert payload["experiment_filename"] == "bar.csv"
+    assert payload["analyses"] == {}
+    assert "No prior analyses" in payload["message"]
+
+
+def test_list_existing_analyses_reports_qc_versions(tmp_path, monkeypatch):
+    pytest.importorskip("pandas")
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    _write_csv(traits_dir / "bar.csv", "trait_a\n1.0\n")
+
+    qc_manifest = {
+        "manifest_schema_version": 1,
+        "experiment": {"filename": "bar.csv", "source_path": "...", "input_sha256": "abc"},
+        "versions": [
+            {
+                "id": "v1",
+                "created_at": "2026-04-20T00:00:00Z",
+                "tool": "clean_experiment_data",
+                "params": {"contamination": 0.05},
+                "based_on_version": "raw",
+                "code_versions": {"bloommcp": "0.1.0", "sleap_roots_analyze": "unknown"},
+                "outputs": {"_cleaned.csv": "v1_2026-04-20/_cleaned.csv"},
+                "user_label": None,
+            }
+        ],
+        "latest": "v1",
+    }
+    _seed_qc_dir(output_dir, "bar", qc_manifest)
+
+    import source.experiment_utils as eu
+    monkeypatch.setattr(eu, "OUTPUT_DIR", output_dir)
+    monkeypatch.setattr(eu, "TRAITS_DIR", traits_dir)
+
+    from tools.storage_tools import list_existing_analyses
+    payload = json.loads(list_existing_analyses("bar.csv"))
+
+    assert "qc" in payload["analyses"]
+    qc_versions = payload["analyses"]["qc"]
+    assert len(qc_versions) == 1
+    assert qc_versions[0]["id"] == "v1"
+    assert qc_versions[0]["tool"] == "clean_experiment_data"
+    assert qc_versions[0]["code_versions"]["bloommcp"] == "0.1.0"
+
+
+def test_list_existing_analyses_unknown_experiment_returns_error(tmp_path, monkeypatch):
+    pytest.importorskip("pandas")
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    traits_dir.mkdir()
+    output_dir.mkdir()
+
+    import source.experiment_utils as eu
+    monkeypatch.setattr(eu, "OUTPUT_DIR", output_dir)
+    monkeypatch.setattr(eu, "TRAITS_DIR", traits_dir)
+
+    from tools.storage_tools import list_existing_analyses
+    payload = json.loads(list_existing_analyses("missing.csv"))
+
+    assert "error" in payload
+    assert "missing.csv" in payload["error"]


### PR DESCRIPTION
## Summary

Adds a versioned, append-only storage layer to bloommcp so phenotyping
analyses no longer silently overwrite each other, and gives the agent
an introspection tool to discover what's already been computed for an
experiment. Read-side only — the write-side refactor of QC + outlier
tools and the on-startup migration of legacy un-versioned dirs land in
a follow-up PR.

## What's in this PR

**New package `bloommcp/storage/`** (5 modules)

- `schema.py` — Pydantic models (`Manifest`, `VersionEntry`,
  `ExperimentBlock`, `CodeVersions`) in strict mode (`extra="forbid"`)
  so writer bugs raise at construction time, not silently on disk
- `manifest.py` — atomic rename-and-swap I/O + a version-gate that
  refuses future-format manifests
- `versioning.py` — monotonic `next_version_id()` (never reuses N even
  after deletion) + slugified user labels
- `analysis_dir.py` — per-experiment, per-tool-class navigation
- `code_versions.py` — installed `bloommcp` + `sleap-roots-analyze`
  versions for provenance, falls back to `"unknown"`

**New MCP tool**

- `list_existing_analyses(experiment_filename)` walks every tool-class
  directory under `BLOOM_OUTPUT_DIR` and returns a structured listing
  of all prior runs grouped by tool class. Registered as a foundational
  tool in `langchain/routes/chat.py::ALWAYS_INCLUDE_MCP_TOOLS` so every
  agent leaf gets it without per-leaf opt-in.

**Modified loader**

- `experiment_utils.load_experiment_data()` gains
  `version="latest"|"raw"|"v<N>"`. Resolution order:
  versioned manifest → legacy un-versioned `_cleaned.csv` → raw.
  Same 4-tuple return shape so all 30+ existing callers keep working.
  `source_label` is now machine-readable: `"raw"` / `"legacy_cleaned"`
  / `"v<N>_cleaned"`.

## Commits

Two commits, each independently reviewable:

1. **`feat(bloommcp): versioned, append-only phenotyping storage layer`** —
   storage package, version-aware loader, introspection tool. Plain
   dict-based manifests.
2. **`refactor(bloommcp/storage): formalize manifest schema with Pydantic models`** —
   adds `schema.py`, threads typed models through the storage layer
   and consumers. Pure type/validation refactor, no behavior change on
   disk.