### PR TITLE
feat(bloommcp): versioned writes for QC + outlier tools

### DIFF
--- a/bloommcp/server.py
+++ b/bloommcp/server.py
@@ -13,12 +13,15 @@ Tool modules (39 tools total):
   - correlation_tools: 8 tools  (cross-experiment correlations, power analysis)
 """
 import hmac
+import logging
 import os
 
 from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
+from source.experiment_utils import OUTPUT_DIR
+from storage import migrate_legacy_dirs
 from tools import (
     qc_tools,
     stats_tools,
@@ -29,6 +32,18 @@ from tools import (
     correlation_tools,
     storage_tools,
 )
+
+logger = logging.getLogger(__name__)
+
+# One-time migration: convert any pre-existing un-versioned analysis dirs into
+# v0_legacy form so list_existing_analyses can enumerate them and downstream
+# loaders can resolve them through the manifest.
+try:
+    _migrated = migrate_legacy_dirs(OUTPUT_DIR)
+    if _migrated:
+        logger.info("Migrated %d legacy analysis dirs to versioned format", _migrated)
+except Exception as exc:  # noqa: BLE001 - migration must never crash startup
+    logger.warning("Migration helper raised on startup, continuing: %s", exc)
 
 # --- Authentication ---
 

--- a/bloommcp/storage/__init__.py
+++ b/bloommcp/storage/__init__.py
@@ -8,6 +8,7 @@ from .manifest import (
     validate_schema,
     write_manifest_atomic,
 )
+from .migration import migrate_legacy_dirs
 from .schema import (
     CURRENT_SCHEMA_VERSION,
     CodeVersions,
@@ -16,9 +17,11 @@ from .schema import (
     VersionEntry,
 )
 from .versioning import next_version_id, slugify, version_dir_name
+from .writer import AnalysisWriter
 
 __all__ = [
     "AnalysisDir",
+    "AnalysisWriter",
     "CURRENT_SCHEMA_VERSION",
     "CodeVersions",
     "ExperimentBlock",
@@ -27,6 +30,7 @@ __all__ = [
     "ManifestSchemaError",
     "VersionEntry",
     "get_code_versions",
+    "migrate_legacy_dirs",
     "next_version_id",
     "read_manifest",
     "slugify",

--- a/bloommcp/storage/analysis_dir.py
+++ b/bloommcp/storage/analysis_dir.py
@@ -1,7 +1,8 @@
 """Per-experiment, per-tool-class directory abstraction."""
 import hashlib
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from .manifest import read_manifest
 from .schema import Manifest, VersionEntry
@@ -60,3 +61,18 @@ class AnalysisDir:
                 h.update(chunk)
         self._cached_input_sha256 = h.hexdigest()
         return self._cached_input_sha256
+
+    @contextmanager
+    def with_snapshot(self) -> Iterator[Optional[Manifest]]:
+        """Pin the manifest at entry; sibling commits during the context don't change the view.
+
+        Used by parallel-recipe orchestrators so all fan-out branches resolve
+        the same source version even if a sibling commits a new version
+        mid-recipe. Yields the live Manifest at entry (or None if no manifest
+        exists yet); the yielded value is the caller's local snapshot.
+        """
+        snapshot = self.read_manifest()
+        try:
+            yield snapshot
+        finally:
+            pass  # snapshot is a local Pydantic instance — nothing to release

--- a/bloommcp/storage/migration.py
+++ b/bloommcp/storage/migration.py
@@ -1,0 +1,151 @@
+"""One-time migration: convert pre-existing un-versioned tool-class directories to v0_legacy."""
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .manifest import write_manifest_atomic
+from .schema import (
+    CodeVersions,
+    ExperimentBlock,
+    Manifest,
+    VersionEntry,
+)
+
+logger = logging.getLogger(__name__)
+
+CANONICAL_TOOL_CLASSES = ("qc", "stats", "dimred", "clustering", "outlier", "viz", "correlation")
+LEGACY_PREFIX_ALIASES = {
+    "outliers": "outlier",  # plural → singular
+    "pca": "dimred",        # PCA was its own dir before dimred became the umbrella
+}
+MIGRATED_MARKER = ".migrated"
+
+
+def migrate_legacy_dirs(output_root: Path) -> int:
+    """Walk output_root and convert un-versioned tool-class directories into v<N>_legacy form.
+
+    Idempotent: dirs containing .migrated or manifest.json are skipped. If a
+    single directory fails to migrate, the helper logs and continues with the
+    rest — bloommcp startup never crashes on migration error.
+
+    Returns the count of directories successfully migrated this call.
+    """
+    output_root = Path(output_root)
+    if not output_root.exists():
+        return 0
+
+    migrated = 0
+    for child in sorted(output_root.iterdir()):
+        if not child.is_dir():
+            continue
+        if not _looks_like_tool_class_dir(child.name):
+            continue
+        if (child / "manifest.json").exists() or (child / MIGRATED_MARKER).exists():
+            continue
+
+        try:
+            target = _resolve_canonical_dir(output_root, child)
+            _migrate_one(child, target)
+            migrated += 1
+        except Exception as exc:
+            logger.warning("Could not migrate %s: %s", child, exc)
+            continue
+
+    if migrated:
+        logger.info("Migrated %d legacy analysis dirs to versioned format", migrated)
+    return migrated
+
+
+def _looks_like_tool_class_dir(name: str) -> bool:
+    """True if `name` starts with a canonical or legacy tool-class prefix + underscore."""
+    for prefix in CANONICAL_TOOL_CLASSES:
+        if name.startswith(f"{prefix}_"):
+            return True
+    for legacy in LEGACY_PREFIX_ALIASES:
+        if name.startswith(f"{legacy}_"):
+            return True
+    return False
+
+
+def _resolve_canonical_dir(output_root: Path, legacy_dir: Path) -> Path:
+    """Return the canonical-named directory for this legacy dir.
+
+    For aliased prefixes (outliers → outlier, pca → dimred), this rewrites the
+    name so all per-experiment data lives under the canonical TOOL_CLASSES
+    naming. For already-canonical names, returns the directory unchanged.
+    """
+    name = legacy_dir.name
+    for legacy_prefix, canonical_prefix in LEGACY_PREFIX_ALIASES.items():
+        if name.startswith(f"{legacy_prefix}_"):
+            stem = name[len(legacy_prefix) + 1:]
+            return output_root / f"{canonical_prefix}_{stem}"
+    return legacy_dir
+
+
+def _migrate_one(legacy_dir: Path, target_dir: Path) -> None:
+    """Move loose files from `legacy_dir` into `target_dir/v0_legacy/` and synthesize a manifest.
+
+    If legacy_dir != target_dir (alias rename), the legacy dir is removed after
+    its contents are relocated.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    v0 = target_dir / "v0_legacy"
+    v0.mkdir(exist_ok=False)
+
+    moved_outputs: dict[str, str] = {}
+    for entry in sorted(legacy_dir.iterdir()):
+        if entry.name == MIGRATED_MARKER or entry.name == "manifest.json":
+            continue
+        if entry.is_dir() and entry.name.startswith("v"):
+            # Probably a partially-versioned dir; skip to be safe
+            continue
+        dest = v0 / entry.name
+        shutil.move(str(entry), str(dest))
+        moved_outputs[entry.name] = f"v0_legacy/{entry.name}"
+
+    if not moved_outputs:
+        # Nothing to migrate — clean up and bail
+        v0.rmdir()
+        return
+
+    experiment_filename = _stem_to_experiment_filename(target_dir)
+    manifest = Manifest(
+        experiment=ExperimentBlock(
+            filename=experiment_filename,
+            source_path="",
+            input_sha256="",
+        ),
+        versions=[
+            VersionEntry(
+                id="v0_legacy",
+                created_at=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+                tool="unknown",
+                params={},
+                based_on_version="raw",
+                code_versions=CodeVersions(bloommcp="unknown", sleap_roots_analyze="unknown"),
+                outputs=moved_outputs,
+                user_label=None,
+            )
+        ],
+        latest="v0_legacy",
+    )
+    write_manifest_atomic(target_dir, manifest)
+    (target_dir / MIGRATED_MARKER).touch()
+
+    if legacy_dir != target_dir:
+        # Alias rename: drop the now-empty plural-named legacy dir
+        try:
+            legacy_dir.rmdir()
+        except OSError:
+            # Non-empty (shouldn't happen given we moved everything) — leave alone
+            pass
+
+
+def _stem_to_experiment_filename(target_dir: Path) -> str:
+    """Reverse `<tool_class>_<stem>` → `<stem>.csv` for the manifest's experiment block."""
+    name = target_dir.name
+    for prefix in CANONICAL_TOOL_CLASSES:
+        if name.startswith(f"{prefix}_"):
+            return f"{name[len(prefix) + 1:]}.csv"
+    return f"{name}.csv"

--- a/bloommcp/storage/writer.py
+++ b/bloommcp/storage/writer.py
@@ -1,0 +1,132 @@
+"""AnalysisWriter — atomic, versioned writes to a per-experiment, per-tool-class directory."""
+import fcntl
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Optional
+
+from .analysis_dir import AnalysisDir
+from .code_versions import get_code_versions
+from .manifest import write_manifest_atomic
+from .schema import (
+    CodeVersions,
+    ExperimentBlock,
+    Manifest,
+    VersionEntry,
+)
+from .versioning import next_version_id, version_dir_name
+
+
+class AnalysisWriter:
+    """Owns the write side of one tool's run on one experiment.
+
+    Lifecycle: construct → create_version() → tool writes outputs into the
+    returned directory → commit({...}) appends the manifest entry atomically.
+    Each instance commits exactly once.
+
+    Concurrency: create_version() acquires an fcntl.flock on the experiment
+    directory and holds it until commit() completes, serializing concurrent
+    writers (in-process threads or cross-process). On POSIX only — bloommcp
+    runs on Linux containers, dev on macOS, both POSIX.
+    """
+
+    def __init__(
+        self,
+        output_root: Path,
+        experiment_filename: str,
+        tool_class: str,
+        source_csv: Optional[Path] = None,
+    ) -> None:
+        self.analysis_dir = AnalysisDir(output_root, experiment_filename, tool_class)
+        self.source_csv = source_csv
+        self._pending_version_id: Optional[str] = None
+        self._pending_version_dir: Optional[Path] = None
+        self._pending_tool_name: Optional[str] = None
+        self._pending_params: Optional[dict] = None
+        self._pending_user_label: Optional[str] = None
+        self._lock_handle: Optional[IO] = None
+
+    def _acquire_lock(self) -> None:
+        self.analysis_dir.path.mkdir(parents=True, exist_ok=True)
+        lock_path = self.analysis_dir.path / ".write_lock"
+        self._lock_handle = open(lock_path, "w")
+        fcntl.flock(self._lock_handle, fcntl.LOCK_EX)
+
+    def _release_lock(self) -> None:
+        if self._lock_handle is not None:
+            try:
+                fcntl.flock(self._lock_handle, fcntl.LOCK_UN)
+            finally:
+                self._lock_handle.close()
+                self._lock_handle = None
+
+    def create_version(
+        self,
+        tool_name: str,
+        params: dict,
+        user_label: Optional[str] = None,
+    ) -> Path:
+        """Allocate the next v<N>, create the directory, return the path."""
+        self._acquire_lock()
+        try:
+            manifest = self.analysis_dir.read_manifest()
+            version_id = next_version_id(manifest)
+            dir_name = version_dir_name(version_id, user_label)
+            version_dir = self.analysis_dir.path / dir_name
+            version_dir.mkdir(parents=True, exist_ok=False)
+        except Exception:
+            self._release_lock()
+            raise
+
+        self._pending_version_id = version_id
+        self._pending_version_dir = version_dir
+        self._pending_tool_name = tool_name
+        self._pending_params = dict(params)  # defensive copy
+        self._pending_user_label = user_label
+        return version_dir
+
+    def commit(self, outputs: dict[str, str]) -> VersionEntry:
+        """Append the manifest entry atomically. outputs maps short name → relative path."""
+        if self._pending_version_id is None:
+            raise RuntimeError("commit() called before create_version()")
+
+        sha = ""
+        if self.source_csv is not None and self.source_csv.exists():
+            sha = self.analysis_dir.input_sha256(self.source_csv)
+
+        entry = VersionEntry(
+            id=self._pending_version_id,
+            created_at=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            tool=self._pending_tool_name,
+            params=self._pending_params,
+            based_on_version="raw",
+            code_versions=get_code_versions(),
+            outputs=dict(outputs),
+            user_label=self._pending_user_label,
+        )
+
+        existing = self.analysis_dir.read_manifest()
+        if existing is None:
+            manifest = Manifest(
+                experiment=ExperimentBlock(
+                    filename=self.analysis_dir.experiment_filename,
+                    source_path=str(self.source_csv) if self.source_csv else "",
+                    input_sha256=sha,
+                ),
+                versions=[entry],
+                latest=entry.id,
+            )
+        else:
+            existing.versions.append(entry)
+            existing.latest = entry.id
+            if not existing.experiment.input_sha256 and sha:
+                existing.experiment.input_sha256 = sha
+            manifest = existing
+
+        try:
+            write_manifest_atomic(self.analysis_dir.path, manifest)
+        finally:
+            # Reset pending state so a fresh create_version + commit pair can reuse the writer
+            self._pending_version_id = None
+            self._pending_version_dir = None
+            self._release_lock()
+        return entry

--- a/bloommcp/tools/outlier_tools.py
+++ b/bloommcp/tools/outlier_tools.py
@@ -2,7 +2,9 @@
 MCP Tool Wrappers for SLEAP Outlier Detection.
 
 Wraps functions from source/outlier_detection.py. Uses source/experiment_utils.py for
-dynamic experiment discovery and column auto-detection.
+dynamic experiment discovery and column auto-detection. All write sites use the
+versioned storage layer: each detection call lands in a new outlier_<stem>/v<N>_*/
+directory and appends a manifest entry.
 """
 
 import json
@@ -17,7 +19,19 @@ from source.outlier_detection import (
     combine_outlier_methods,
     remove_outliers_from_data,
 )
-from source.experiment_utils import load_experiment_data as _load_data, OUTPUT_DIR
+from source.experiment_utils import load_experiment_data as _load_data, OUTPUT_DIR, TRAITS_DIR
+from storage import AnalysisDir, AnalysisWriter
+
+
+def _writer_for(filename: str) -> AnalysisWriter:
+    """Build an AnalysisWriter targeting the canonical outlier_<stem> directory."""
+    source = TRAITS_DIR / filename
+    return AnalysisWriter(
+        OUTPUT_DIR,
+        filename,
+        "outlier",
+        source_csv=source if source.exists() else None,
+    )
 
 
 # ============================================================================
@@ -27,6 +41,7 @@ from source.experiment_utils import load_experiment_data as _load_data, OUTPUT_D
 def detect_outliers_mahalanobis(
     filename: str,
     chi2_percentile: float = 97.5,
+    user_label: str | None = None,
 ) -> str:
     """Detect outliers using Mahalanobis distance in PCA space.
 
@@ -37,6 +52,7 @@ def detect_outliers_mahalanobis(
     Args:
         filename: CSV filename from list_available_experiments
         chi2_percentile: Chi-squared percentile for threshold (default 97.5 = top 2.5%)
+        user_label: Optional sluggified label tagged onto the version directory
     """
     df, trait_cols, config, source = _load_data(filename)
     if df is None:
@@ -56,8 +72,26 @@ def detect_outliers_mahalanobis(
     n_outliers = result["n_outliers"]
     pct = n_outliers / n_samples * 100 if n_samples > 0 else 0
 
+    writer = _writer_for(filename)
+    version_dir = writer.create_version(
+        tool_name="detect_outliers_mahalanobis",
+        params={"chi2_percentile": chi2_percentile},
+        user_label=user_label,
+    )
+    summary = {
+        "method": "Mahalanobis",
+        "n_outliers": n_outliers,
+        "n_samples": n_samples,
+        "outlier_indices": result["outlier_indices"],
+        "chi2_percentile": chi2_percentile,
+    }
+    (version_dir / "mahalanobis_outliers.json").write_text(json.dumps(summary, indent=2))
+    entry = writer.commit({
+        "mahalanobis_outliers.json": f"{version_dir.name}/mahalanobis_outliers.json",
+    })
+
     lines = [
-        f"Mahalanobis Outlier Detection: {stem} (source: {source})",
+        f"Mahalanobis Outlier Detection: {stem} (source: {source}, version: {entry.id})",
         f"  {n_samples} samples, {len(trait_cols)} traits",
         f"  PCA components: {result['n_components']} (variance: {result['cumulative_variance_explained'] * 100:.1f}%)",
         f"  Threshold: chi2 at {chi2_percentile}th percentile = {result['threshold_value']:.2f}",
@@ -83,16 +117,7 @@ def detect_outliers_mahalanobis(
         for idx, dist in outlier_dists[:5]:
             lines.append(f"    Sample {idx}: distance = {dist:.2f}")
 
-    out_dir = OUTPUT_DIR / f"outliers_{stem}"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    summary = {
-        "method": "Mahalanobis",
-        "n_outliers": n_outliers,
-        "n_samples": n_samples,
-        "outlier_indices": result["outlier_indices"],
-        "chi2_percentile": chi2_percentile,
-    }
-    (out_dir / "mahalanobis_outliers.json").write_text(json.dumps(summary, indent=2))
+    lines.append(f"\n  Saved: {version_dir}/mahalanobis_outliers.json")
 
     return "\n".join(lines)
 
@@ -104,6 +129,7 @@ def detect_outliers_mahalanobis(
 def detect_outliers_isolation_forest(
     filename: str,
     contamination: float = 0.1,
+    user_label: str | None = None,
 ) -> str:
     """Detect outliers using Isolation Forest.
 
@@ -114,6 +140,7 @@ def detect_outliers_isolation_forest(
     Args:
         filename: CSV filename from list_available_experiments
         contamination: Expected proportion of outliers (default 0.1 = 10%)
+        user_label: Optional sluggified label tagged onto the version directory
     """
     df, trait_cols, config, source = _load_data(filename)
     if df is None:
@@ -136,8 +163,26 @@ def detect_outliers_isolation_forest(
     n_outliers = result["n_outliers"]
     pct = n_outliers / n_samples * 100 if n_samples > 0 else 0
 
+    writer = _writer_for(filename)
+    version_dir = writer.create_version(
+        tool_name="detect_outliers_isolation_forest",
+        params={"contamination": contamination},
+        user_label=user_label,
+    )
+    summary = {
+        "method": "IsolationForest",
+        "n_outliers": n_outliers,
+        "n_samples": n_samples,
+        "outlier_indices": result["outlier_indices"],
+        "contamination": contamination,
+    }
+    (version_dir / "isolation_forest_outliers.json").write_text(json.dumps(summary, indent=2))
+    entry = writer.commit({
+        "isolation_forest_outliers.json": f"{version_dir.name}/isolation_forest_outliers.json",
+    })
+
     lines = [
-        f"Isolation Forest Outlier Detection: {stem} (source: {source})",
+        f"Isolation Forest Outlier Detection: {stem} (source: {source}, version: {entry.id})",
         f"  {n_samples} samples, {len(trait_cols)} traits",
         f"  Contamination: {contamination} ({contamination * 100:.0f}% expected)",
         f"  Outliers found: {n_outliers} ({pct:.1f}%)",
@@ -153,16 +198,7 @@ def detect_outliers_isolation_forest(
         for idx, score in outlier_scores[:5]:
             lines.append(f"    Sample {idx}: anomaly score = {score:.4f}")
 
-    out_dir = OUTPUT_DIR / f"outliers_{stem}"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    summary = {
-        "method": "IsolationForest",
-        "n_outliers": n_outliers,
-        "n_samples": n_samples,
-        "outlier_indices": result["outlier_indices"],
-        "contamination": contamination,
-    }
-    (out_dir / "isolation_forest_outliers.json").write_text(json.dumps(summary, indent=2))
+    lines.append(f"\n  Saved: {version_dir}/isolation_forest_outliers.json")
 
     return "\n".join(lines)
 
@@ -174,6 +210,7 @@ def detect_outliers_isolation_forest(
 def detect_outliers_pca(
     filename: str,
     outlier_threshold: float = 2.5,
+    user_label: str | None = None,
 ) -> str:
     """Detect outliers using PCA reconstruction error.
 
@@ -184,6 +221,7 @@ def detect_outliers_pca(
     Args:
         filename: CSV filename from list_available_experiments
         outlier_threshold: Std deviations above mean error for outlier cutoff (default 2.5)
+        user_label: Optional sluggified label tagged onto the version directory
     """
     df, trait_cols, config, source = _load_data(filename)
     if df is None:
@@ -203,8 +241,26 @@ def detect_outliers_pca(
     n_outliers = result["n_outliers"]
     pct = n_outliers / n_samples * 100 if n_samples > 0 else 0
 
+    writer = _writer_for(filename)
+    version_dir = writer.create_version(
+        tool_name="detect_outliers_pca",
+        params={"outlier_threshold": outlier_threshold},
+        user_label=user_label,
+    )
+    summary = {
+        "method": "PCA",
+        "n_outliers": n_outliers,
+        "n_samples": n_samples,
+        "outlier_indices": result["outlier_indices"],
+        "outlier_threshold": outlier_threshold,
+    }
+    (version_dir / "pca_outliers.json").write_text(json.dumps(summary, indent=2))
+    entry = writer.commit({
+        "pca_outliers.json": f"{version_dir.name}/pca_outliers.json",
+    })
+
     lines = [
-        f"PCA Reconstruction Outlier Detection: {stem} (source: {source})",
+        f"PCA Reconstruction Outlier Detection: {stem} (source: {source}, version: {entry.id})",
         f"  {n_samples} samples, {len(trait_cols)} traits",
         f"  PCA components: {result['n_components']} (variance: {result['total_variance_explained'] * 100:.1f}%)",
         f"  Threshold: mean + {outlier_threshold} * std = {result['threshold_value']:.2f}",
@@ -221,16 +277,7 @@ def detect_outliers_pca(
         for idx, err in outlier_errs[:5]:
             lines.append(f"    Sample {idx}: error = {err:.4f}")
 
-    out_dir = OUTPUT_DIR / f"outliers_{stem}"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    summary = {
-        "method": "PCA",
-        "n_outliers": n_outliers,
-        "n_samples": n_samples,
-        "outlier_indices": result["outlier_indices"],
-        "outlier_threshold": outlier_threshold,
-    }
-    (out_dir / "pca_outliers.json").write_text(json.dumps(summary, indent=2))
+    lines.append(f"\n  Saved: {version_dir}/pca_outliers.json")
 
     return "\n".join(lines)
 
@@ -242,6 +289,7 @@ def detect_outliers_pca(
 def run_consensus_outlier_detection(
     filename: str,
     consensus_threshold: float = 0.5,
+    user_label: str | None = None,
 ) -> str:
     """Run all 3 outlier detection methods and report consensus results.
 
@@ -252,6 +300,7 @@ def run_consensus_outlier_detection(
     Args:
         filename: CSV filename from list_available_experiments
         consensus_threshold: Fraction of methods that must agree (default 0.5 = 2 of 3)
+        user_label: Optional sluggified label tagged onto the version directory
     """
     df, trait_cols, config, source = _load_data(filename)
     if df is None:
@@ -276,19 +325,37 @@ def run_consensus_outlier_detection(
     n_consensus = combined["n_consensus_outliers"]
     methods_used = combined["agreement_summary"]["methods_compared"]
 
-    lines = [
-        f"Consensus Outlier Detection: {stem} (source: {source})",
-        f"  Methods used: {', '.join(methods_used)} ({len(methods_used)} total)",
-        f"  Consensus rule: >= {consensus_threshold * 100:.0f}% agreement",
-        "",
-        "  Per-method results:",
-    ]
-
     method_counts = {
         "mahalanobis": mahal.get("n_outliers", 0) if "error" not in mahal else "failed",
         "isolation_forest": iso.get("n_outliers", 0) if "error" not in iso else "failed",
         "pca": pca_res.get("n_outliers", 0) if "error" not in pca_res else "failed",
     }
+
+    writer = _writer_for(filename)
+    version_dir = writer.create_version(
+        tool_name="run_consensus_outlier_detection",
+        params={"consensus_threshold": consensus_threshold},
+        user_label=user_label,
+    )
+    summary = {
+        "method": "Consensus",
+        "n_consensus_outliers": n_consensus,
+        "consensus_outliers": combined["consensus_outliers"],
+        "consensus_threshold": consensus_threshold,
+        "method_counts": {k: v for k, v in method_counts.items() if v != "failed"},
+    }
+    (version_dir / "consensus_outliers.json").write_text(json.dumps(summary, indent=2))
+    entry = writer.commit({
+        "consensus_outliers.json": f"{version_dir.name}/consensus_outliers.json",
+    })
+
+    lines = [
+        f"Consensus Outlier Detection: {stem} (source: {source}, version: {entry.id})",
+        f"  Methods used: {', '.join(methods_used)} ({len(methods_used)} total)",
+        f"  Consensus rule: >= {consensus_threshold * 100:.0f}% agreement",
+        "",
+        "  Per-method results:",
+    ]
 
     for method, count in method_counts.items():
         lines.append(f"    {method}: {count} outliers")
@@ -309,16 +376,7 @@ def run_consensus_outlier_detection(
         if n_consensus > 20:
             lines.append(f"    ... ({n_consensus - 20} more)")
 
-    out_dir = OUTPUT_DIR / f"outliers_{stem}"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    summary = {
-        "method": "Consensus",
-        "n_consensus_outliers": n_consensus,
-        "consensus_outliers": combined["consensus_outliers"],
-        "consensus_threshold": consensus_threshold,
-        "method_counts": {k: v for k, v in method_counts.items() if v != "failed"},
-    }
-    (out_dir / "consensus_outliers.json").write_text(json.dumps(summary, indent=2))
+    lines.append(f"\n  Saved: {version_dir}/consensus_outliers.json")
 
     return "\n".join(lines)
 
@@ -327,18 +385,64 @@ def run_consensus_outlier_detection(
 # Tool 5: Remove Detected Outliers
 # ============================================================================
 
+_METHOD_TOOL_NAMES = {
+    "consensus": "run_consensus_outlier_detection",
+    "mahalanobis": "detect_outliers_mahalanobis",
+    "isolation_forest": "detect_outliers_isolation_forest",
+    "pca": "detect_outliers_pca",
+}
+
+_METHOD_OUTPUT_FILES = {
+    "consensus": "consensus_outliers.json",
+    "mahalanobis": "mahalanobis_outliers.json",
+    "isolation_forest": "isolation_forest_outliers.json",
+    "pca": "pca_outliers.json",
+}
+
+
+def _find_latest_method_version(filename: str, method: str):
+    """Walk the outlier manifest for the latest entry produced by the named method.
+
+    Returns (version_entry, version_dir_path) or (None, None) if no run found.
+    """
+    analysis_dir = AnalysisDir(OUTPUT_DIR, filename, "outlier")
+    manifest = analysis_dir.read_manifest()
+    if manifest is None:
+        return None, None
+
+    target_tool = _METHOD_TOOL_NAMES[method]
+    expected_output = _METHOD_OUTPUT_FILES[method]
+    matching = [v for v in manifest.versions if v.tool == target_tool]
+    if not matching:
+        return None, None
+
+    matching.sort(key=lambda v: v.created_at, reverse=True)
+    for entry in matching:
+        rel = entry.outputs.get(expected_output)
+        if not rel:
+            continue
+        full = analysis_dir.path / rel
+        if full.exists():
+            return entry, full
+    return None, None
+
+
 def remove_detected_outliers(
     filename: str,
     method: str = "consensus",
+    user_label: str | None = None,
 ) -> str:
     """Remove outliers detected by a previous detection run and save cleaned CSV.
 
-    Reads outlier indices from a saved JSON result file and removes those
-    samples from the dataset. Saves cleaned CSV to BLOOM_OUTPUT_DIR.
+    Walks the outlier_<stem>/manifest.json for the latest run of the chosen
+    method, reads its outlier indices, removes those samples from the dataset,
+    and writes the cleaned CSV + flagged outlier rows into a new versioned
+    directory. Re-running creates a new v<N>_*/.
 
     Args:
         filename: CSV filename from list_available_experiments
         method: Which detection result to use (consensus, mahalanobis, isolation_forest, pca)
+        user_label: Optional sluggified label tagged onto the version directory
     """
     df, trait_cols, config, source = _load_data(filename)
     if df is None:
@@ -346,20 +450,11 @@ def remove_detected_outliers(
 
     stem = Path(filename).stem
 
-    method_files = {
-        "consensus": "consensus_outliers.json",
-        "mahalanobis": "mahalanobis_outliers.json",
-        "isolation_forest": "isolation_forest_outliers.json",
-        "pca": "pca_outliers.json",
-    }
+    if method not in _METHOD_OUTPUT_FILES:
+        return f"Unknown method '{method}'. Choose from: {', '.join(_METHOD_OUTPUT_FILES.keys())}"
 
-    if method not in method_files:
-        return f"Unknown method '{method}'. Choose from: {', '.join(method_files.keys())}"
-
-    out_dir = OUTPUT_DIR / f"outliers_{stem}"
-    json_path = out_dir / method_files[method]
-
-    if not json_path.exists():
+    src_entry, json_path = _find_latest_method_version(filename, method)
+    if json_path is None:
         return (
             f"No saved {method} results found for '{stem}'. "
             f"Run the detection tool first (e.g., run_consensus_outlier_detection)."
@@ -376,20 +471,28 @@ def remove_detected_outliers(
         df, outlier_indices, keep_metadata=True, return_outliers=True,
     )
 
-    cleaned_dir = OUTPUT_DIR / f"outliers_{stem}"
-    cleaned_dir.mkdir(parents=True, exist_ok=True)
-    cleaned_path = cleaned_dir / f"{stem}_outliers_removed.csv"
+    writer = _writer_for(filename)
+    version_dir = writer.create_version(
+        tool_name="remove_detected_outliers",
+        params={"method": method, "source_version": src_entry.id},
+        user_label=user_label,
+    )
+    cleaned_path = version_dir / f"{stem}_outliers_removed.csv"
     cleaned_df.to_csv(cleaned_path, index=False)
-
-    outlier_path = cleaned_dir / f"{stem}_outlier_samples.csv"
+    outlier_path = version_dir / f"{stem}_outlier_samples.csv"
     outlier_df.to_csv(outlier_path, index=False)
+
+    entry = writer.commit({
+        f"{stem}_outliers_removed.csv": f"{version_dir.name}/{stem}_outliers_removed.csv",
+        f"{stem}_outlier_samples.csv": f"{version_dir.name}/{stem}_outlier_samples.csv",
+    })
 
     n_original = len(df)
     n_removed = len(outlier_df)
     n_remaining = len(cleaned_df)
 
     lines = [
-        f"Outlier Removal: {stem} (method: {method})",
+        f"Outlier Removal: {stem} (method: {method}, version: {entry.id}, source: {src_entry.id})",
         f"  Original samples: {n_original}",
         f"  Outliers removed: {n_removed}",
         f"  Remaining samples: {n_remaining}",

--- a/bloommcp/tools/qc_tools.py
+++ b/bloommcp/tools/qc_tools.py
@@ -265,6 +265,7 @@ def clean_experiment_data(
     max_nans_per_trait: float = 0.3,
     max_nans_per_sample: float = 0.2,
     min_samples_per_trait: int = 10,
+    user_label: str | None = None,
 ) -> str:
     """Apply data cleanup filters to a SLEAP experiment and save cleaned CSV.
 
@@ -274,7 +275,9 @@ def clean_experiment_data(
     3. Remove samples with too many NaN values
     4. Remove traits with insufficient valid samples
 
-    Saves the cleaned CSV and a JSON log to the output directory.
+    Saves the cleaned CSV and a JSON log into a versioned subdirectory of
+    BLOOM_OUTPUT_DIR/qc_<stem>/. Re-running creates a new v<N>_*/ rather
+    than overwriting the prior result.
 
     Args:
         filename: CSV filename from list_available_experiments
@@ -282,6 +285,7 @@ def clean_experiment_data(
         max_nans_per_trait: Max fraction of NaN per trait before removal (0-1, default 0.3)
         max_nans_per_sample: Max fraction of NaN per sample before removal (0-1, default 0.2)
         min_samples_per_trait: Min valid samples per trait (default 10)
+        user_label: Optional sluggified label tagged onto the version directory
     """
     df, trait_cols, config, source = _load_data(filename)
     if df is None:
@@ -291,7 +295,6 @@ def clean_experiment_data(
     original_samples = len(df)
     original_traits = len(trait_cols)
 
-    # Apply cleanup filters
     df_clean, cleanup_log = cleanup.apply_data_cleanup_filters(
         df, trait_cols,
         max_zeros_per_trait=max_zeros_per_trait,
@@ -300,25 +303,42 @@ def clean_experiment_data(
         min_samples_per_trait=min_samples_per_trait,
     )
 
-    # Save cleaned data and log
     from source.data_utils import convert_to_json_serializable
+    from storage import AnalysisWriter
 
-    qc_dir = OUTPUT_DIR / f"qc_{stem}"
-    qc_dir.mkdir(parents=True, exist_ok=True)
+    writer = AnalysisWriter(
+        OUTPUT_DIR,
+        filename,
+        "qc",
+        source_csv=TRAITS_DIR / filename if (TRAITS_DIR / filename).exists() else None,
+    )
+    version_dir = writer.create_version(
+        tool_name="clean_experiment_data",
+        params={
+            "max_zeros_per_trait": max_zeros_per_trait,
+            "max_nans_per_trait": max_nans_per_trait,
+            "max_nans_per_sample": max_nans_per_sample,
+            "min_samples_per_trait": min_samples_per_trait,
+        },
+        user_label=user_label,
+    )
 
-    cleaned_csv_path = qc_dir / f"{stem}_cleaned.csv"
+    cleaned_csv_path = version_dir / "_cleaned.csv"
     df_clean.to_csv(cleaned_csv_path, index=False)
-
-    log_path = qc_dir / "cleanup_log.json"
+    log_path = version_dir / "cleanup_log.json"
     with open(log_path, "w") as f:
         json.dump(convert_to_json_serializable(cleanup_log), f, indent=2)
 
-    # Format results
+    entry = writer.commit({
+        "_cleaned.csv": f"{version_dir.name}/_cleaned.csv",
+        "cleanup_log.json": f"{version_dir.name}/cleanup_log.json",
+    })
+
     final_samples = cleanup_log["final_samples"]
     final_traits = cleanup_log["final_traits"]
 
     lines = [
-        f"Data Cleanup Results: {filename}",
+        f"Data Cleanup Results: {filename} (version: {entry.id})",
         f"  Samples: {original_samples} -> {final_samples} "
         f"({final_samples / original_samples * 100:.1f}% retained)",
         f"  Traits: {original_traits} -> {final_traits} "
@@ -344,7 +364,7 @@ def clean_experiment_data(
         if len(removed_traits) > 15:
             lines.append(f"  ... and {len(removed_traits) - 15} more")
 
-    lines.append(f"\nOutput files:")
+    lines.append(f"\nVersion: {entry.id}")
     lines.append(f"  Cleaned CSV: {cleaned_csv_path}")
     lines.append(f"  Cleanup log: {log_path}")
 

--- a/tests/integration/test_versioned_storage_phase_b.py
+++ b/tests/integration/test_versioned_storage_phase_b.py
@@ -1,0 +1,369 @@
+"""storage layer write-side: AnalysisWriter, migration, with_snapshot.
+
+These tests are filesystem-only — they do NOT require the compose stack. They
+run against the storage modules directly, using tmp_path for isolation.
+
+Pandas-dependent tests (the qc/outlier tool integration assertions) are skipped
+when pandas isn't installed in the test runner's environment.
+"""
+import json
+import os
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+_BLOOMMCP_DIR = Path(__file__).resolve().parents[2] / "bloommcp"
+if str(_BLOOMMCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_BLOOMMCP_DIR))
+
+_TMP_BASE = tempfile.mkdtemp(prefix="bloommcp_phase_b_default_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP_BASE)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP_BASE)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP_BASE)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+
+from storage import (  # noqa: E402
+    AnalysisDir,
+    AnalysisWriter,
+    Manifest,
+    migrate_legacy_dirs,
+    read_manifest,
+)
+
+
+# ─── AnalysisWriter — single-version creation and commit ───────────────────────
+
+
+def test_writer_first_version_creates_v1_dir_and_manifest(tmp_path):
+    csv = tmp_path / "foo.csv"
+    csv.write_bytes(b"col_a,col_b\n1,2\n")
+    writer = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+
+    version_dir = writer.create_version(
+        tool_name="clean_experiment_data",
+        params={"contamination": 0.05},
+    )
+    assert version_dir.exists()
+    assert version_dir.parent == tmp_path / "qc_foo"
+    assert version_dir.name.startswith("v1_")
+
+    (version_dir / "_cleaned.csv").write_text("col_a,col_b\n1,2\n")
+    entry = writer.commit({"_cleaned.csv": f"{version_dir.name}/_cleaned.csv"})
+
+    assert entry.id == "v1"
+    assert entry.tool == "clean_experiment_data"
+    assert entry.params == {"contamination": 0.05}
+    assert entry.outputs == {"_cleaned.csv": f"{version_dir.name}/_cleaned.csv"}
+    assert entry.based_on_version == "raw"
+
+    manifest = read_manifest(tmp_path / "qc_foo")
+    assert manifest is not None
+    assert manifest.latest == "v1"
+    assert len(manifest.versions) == 1
+    assert manifest.experiment.input_sha256  # non-empty
+
+
+def test_writer_second_version_creates_v2_and_preserves_v1(tmp_path):
+    csv = tmp_path / "foo.csv"
+    csv.write_bytes(b"col_a\n1\n")
+
+    w1 = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+    v1 = w1.create_version("clean_experiment_data", {})
+    (v1 / "_cleaned.csv").write_text("col_a\n1\n")
+    w1.commit({"_cleaned.csv": f"{v1.name}/_cleaned.csv"})
+
+    w2 = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+    v2 = w2.create_version("clean_experiment_data", {"max_nans": 0.1})
+    assert v2.name.startswith("v2_")
+    (v2 / "_cleaned.csv").write_text("col_a\n1\n")
+    entry = w2.commit({"_cleaned.csv": f"{v2.name}/_cleaned.csv"})
+
+    assert v1.exists()  # untouched
+    assert v2.exists()
+    manifest = read_manifest(tmp_path / "qc_foo")
+    assert [v.id for v in manifest.versions] == ["v1", "v2"]
+    assert manifest.latest == "v2"
+    assert entry.id == "v2"
+
+
+def test_writer_user_label_appears_in_dir_name_and_entry(tmp_path):
+    csv = tmp_path / "foo.csv"
+    csv.write_bytes(b"col_a\n1\n")
+
+    writer = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+    version_dir = writer.create_version(
+        tool_name="clean_experiment_data",
+        params={},
+        user_label="Iso Method",
+    )
+    assert "iso_method" in version_dir.name
+
+
+def test_writer_captures_code_versions_in_manifest(tmp_path):
+    csv = tmp_path / "foo.csv"
+    csv.write_bytes(b"col_a\n1\n")
+
+    writer = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+    v1 = writer.create_version("clean_experiment_data", {})
+    (v1 / "_cleaned.csv").write_text("col_a\n1\n")
+    entry = writer.commit({"_cleaned.csv": f"{v1.name}/_cleaned.csv"})
+
+    assert entry.code_versions.bloommcp  # one of "<ver>" or "unknown"
+    assert entry.code_versions.sleap_roots_analyze
+
+
+# ─── Concurrent writers ────────────────────────────────────────────────────────
+
+
+def test_concurrent_writers_get_distinct_version_ids(tmp_path):
+    """Three threads each create_version + commit; the manifest sequences them
+    monotonically without corruption."""
+    csv = tmp_path / "foo.csv"
+    csv.write_bytes(b"col_a\n1\n")
+
+    results: list = []
+    errors: list = []
+    barrier = threading.Barrier(3)
+
+    def worker():
+        try:
+            barrier.wait()
+            w = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+            v = w.create_version("clean_experiment_data", {})
+            (v / "_cleaned.csv").write_text("col_a\n1\n")
+            entry = w.commit({"_cleaned.csv": f"{v.name}/_cleaned.csv"})
+            results.append(entry.id)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert sorted(results) == ["v1", "v2", "v3"]
+    manifest = read_manifest(tmp_path / "qc_foo")
+    assert sorted(v.id for v in manifest.versions) == ["v1", "v2", "v3"]
+
+
+# ─── with_snapshot — pinned reads inside a recipe ──────────────────────────────
+
+
+def test_with_snapshot_pins_manifest_against_concurrent_commit(tmp_path):
+    csv = tmp_path / "foo.csv"
+    csv.write_bytes(b"col_a\n1\n")
+
+    seed = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+    v1 = seed.create_version("clean_experiment_data", {})
+    (v1 / "_cleaned.csv").write_text("col_a\n1\n")
+    seed.commit({"_cleaned.csv": f"{v1.name}/_cleaned.csv"})
+
+    ad = AnalysisDir(tmp_path, "foo.csv", "qc")
+    with ad.with_snapshot() as snapshot:
+        # Sibling commit happens mid-recipe
+        sibling = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+        v2 = sibling.create_version("clean_experiment_data", {"second": True})
+        (v2 / "_cleaned.csv").write_text("col_a\n1\n")
+        sibling.commit({"_cleaned.csv": f"{v2.name}/_cleaned.csv"})
+
+        # Inside the snapshot we still see only v1
+        assert snapshot.latest == "v1"
+        assert [v.id for v in snapshot.versions] == ["v1"]
+
+    # After the context exits, AnalysisDir reflects live state
+    assert ad.read_manifest().latest == "v2"
+
+
+# ─── migrate_legacy_dirs — un-versioned → v0_legacy ───────────────────────────
+
+
+def test_migration_creates_v0_legacy_from_loose_files(tmp_path):
+    qc_dir = tmp_path / "qc_foo"
+    qc_dir.mkdir()
+    (qc_dir / "foo_cleaned.csv").write_text("col_a\n1\n")
+    (qc_dir / "cleanup_log.json").write_text('{"step": "cleaned"}')
+
+    migrated = migrate_legacy_dirs(tmp_path)
+
+    assert migrated == 1
+    legacy = qc_dir / "v0_legacy"
+    assert legacy.exists()
+    assert (legacy / "foo_cleaned.csv").exists()
+    assert (legacy / "cleanup_log.json").exists()
+    assert (qc_dir / ".migrated").exists()
+
+    manifest = read_manifest(qc_dir)
+    assert manifest is not None
+    assert len(manifest.versions) == 1
+    entry = manifest.versions[0]
+    assert entry.id == "v0_legacy"
+    assert entry.tool == "unknown"
+    assert entry.code_versions.bloommcp == "unknown"
+    assert "foo_cleaned.csv" in entry.outputs
+    assert manifest.latest == "v0_legacy"
+
+
+def test_migration_is_idempotent(tmp_path):
+    qc_dir = tmp_path / "qc_foo"
+    qc_dir.mkdir()
+    (qc_dir / "foo_cleaned.csv").write_text("col_a\n1\n")
+
+    first = migrate_legacy_dirs(tmp_path)
+    second = migrate_legacy_dirs(tmp_path)
+
+    assert first == 1
+    assert second == 0
+    legacy = qc_dir / "v0_legacy"
+    assert (legacy / "foo_cleaned.csv").exists()
+
+
+def test_migration_renames_outliers_plural_to_outlier_singular(tmp_path):
+    """Existing outliers_<stem>/ (plural) directories migrate to
+    outlier_<stem>/v0_legacy/ (singular) to match TOOL_CLASSES naming."""
+    legacy = tmp_path / "outliers_foo"
+    legacy.mkdir()
+    (legacy / "mahalanobis_outliers.json").write_text("{}")
+
+    migrated = migrate_legacy_dirs(tmp_path)
+    assert migrated == 1
+
+    assert not legacy.exists()  # plural dir is gone
+    new = tmp_path / "outlier_foo"
+    assert new.exists()
+    assert (new / "v0_legacy" / "mahalanobis_outliers.json").exists()
+    assert read_manifest(new).latest == "v0_legacy"
+
+
+def test_migration_skips_already_versioned_dirs(tmp_path):
+    """A directory that already has a manifest.json should not be touched."""
+    qc_dir = tmp_path / "qc_foo"
+    v1 = qc_dir / "v1_2026-04-20"
+    v1.mkdir(parents=True)
+    (v1 / "_cleaned.csv").write_text("col_a\n1\n")
+    # Pre-write a valid manifest so migration sees it
+    csv = tmp_path / "foo.csv"
+    csv.write_bytes(b"col_a\n1\n")
+    seed = AnalysisWriter(tmp_path, "foo.csv", "qc", source_csv=csv)
+    # Use the same v1_dir for the actual commit so paths match
+    actual_v1 = seed.create_version("clean_experiment_data", {})
+    (actual_v1 / "_cleaned.csv").write_text("col_a\n1\n")
+    seed.commit({"_cleaned.csv": f"{actual_v1.name}/_cleaned.csv"})
+
+    migrated = migrate_legacy_dirs(tmp_path)
+    # qc_foo already has a manifest — skipped
+    assert migrated == 0
+
+
+def test_migration_continues_on_per_dir_error(tmp_path, monkeypatch):
+    """If migrating one dir fails, others still get migrated."""
+    good = tmp_path / "qc_good"
+    good.mkdir()
+    (good / "good_cleaned.csv").write_text("col_a\n1\n")
+
+    bad = tmp_path / "qc_bad"
+    bad.mkdir()
+    (bad / "bad_cleaned.csv").write_text("col_a\n1\n")
+
+    # Force the migration helper to raise on qc_bad
+    import storage.migration as mig
+    real_fn = mig._migrate_one
+    call_count = {"n": 0}
+
+    def fake_migrate(dir_path: Path, *args, **kwargs):
+        call_count["n"] += 1
+        if dir_path.name == "qc_bad":
+            raise OSError("simulated permission error")
+        return real_fn(dir_path, *args, **kwargs)
+
+    monkeypatch.setattr(mig, "_migrate_one", fake_migrate)
+
+    migrated = migrate_legacy_dirs(tmp_path)
+    assert migrated == 1  # good migrated, bad failed
+    assert (good / "v0_legacy" / "good_cleaned.csv").exists()
+    assert (bad / "bad_cleaned.csv").exists()  # untouched, still loose
+    assert not (bad / ".migrated").exists()
+
+
+# ─── Integration: refactored qc_tools.clean_experiment_data ────────────────────
+
+
+def test_clean_experiment_data_writes_versioned(tmp_path, monkeypatch):
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    traits_dir.mkdir()
+    output_dir.mkdir()
+
+    # Make a small experiment file
+    df = pd.DataFrame(
+        {
+            "scan_id": [f"S{i}" for i in range(20)],
+            "genotype": ["A"] * 10 + ["B"] * 10,
+            "trait_a": list(range(20)),
+            "trait_b": [float(i) for i in range(20)],
+        }
+    )
+    df.to_csv(traits_dir / "bar.csv", index=False)
+
+    import source.experiment_utils as eu
+    monkeypatch.setattr(eu, "TRAITS_DIR", traits_dir)
+    monkeypatch.setattr(eu, "OUTPUT_DIR", output_dir)
+
+    import tools.qc_tools as qc
+    monkeypatch.setattr(qc, "OUTPUT_DIR", output_dir)
+
+    result = qc.clean_experiment_data("bar.csv")
+    assert "v1" in result or "version" in result.lower()
+
+    qc_dir = output_dir / "qc_bar"
+    manifest = read_manifest(qc_dir)
+    assert manifest is not None
+    assert len(manifest.versions) == 1
+    assert manifest.versions[0].tool == "clean_experiment_data"
+
+
+def test_detect_outliers_pca_writes_versioned(tmp_path, monkeypatch):
+    pytest.importorskip("pandas")
+    pytest.importorskip("sklearn")
+    import pandas as pd
+    import numpy as np
+
+    traits_dir = tmp_path / "traits"
+    output_dir = tmp_path / "output"
+    traits_dir.mkdir()
+    output_dir.mkdir()
+
+    rng = np.random.default_rng(42)
+    df = pd.DataFrame(
+        {
+            "scan_id": [f"S{i}" for i in range(50)],
+            "genotype": ["A"] * 25 + ["B"] * 25,
+            "trait_a": rng.normal(size=50),
+            "trait_b": rng.normal(size=50),
+            "trait_c": rng.normal(size=50),
+        }
+    )
+    df.to_csv(traits_dir / "bar.csv", index=False)
+
+    import source.experiment_utils as eu
+    monkeypatch.setattr(eu, "TRAITS_DIR", traits_dir)
+    monkeypatch.setattr(eu, "OUTPUT_DIR", output_dir)
+
+    import tools.outlier_tools as ot
+    monkeypatch.setattr(ot, "OUTPUT_DIR", output_dir)
+
+    ot.detect_outliers_pca("bar.csv")
+
+    outlier_dir = output_dir / "outlier_bar"
+    assert outlier_dir.exists()
+    manifest = read_manifest(outlier_dir)
+    assert manifest is not None
+    assert len(manifest.versions) == 1
+    assert manifest.versions[0].tool == "detect_outliers_pca"


### PR DESCRIPTION
## Summary

Builds on PR #198 (versioned phenotyping storage layer, read-side) to make every QC and outlier write append-only and version-stamped. Re-running a tool no longer silently overwrites prior results — each run lands in a new `v<N>_<date>[_<label>]/` subdirectory and its manifest entry captures tool name, parameters, code versions, input file SHA-256, and resolved output paths.

This PR is **stacked on `feat/bloommcp-versioned-storage-phase-a` (PR #198)**. Reviewing or merging requires PR #198 to land first; otherwise this PR's diff against `staging` will be confusing because it relies on the storage layer added there.

## What's in this PR

**New `bloommcp/storage/writer.py`** — `AnalysisWriter`

Concurrent writers serialized by `fcntl.flock` on the experiment directory held from `create_version()` through `commit()`. Three threads calling `clean_experiment_data` simultaneously now produce v1/v2/v3 deterministically with no manifest corruption.

**New `bloommcp/storage/migration.py`** — `migrate_legacy_dirs(output_root)`

Scans for tool-class directories containing loose files but no `manifest.json`, moves them into `v0_legacy/`, and synthesises a manifest entry with `tool="unknown"`. Idempotent (drops a `.migrated` marker). 
Per-directory failures don't abort the rest. Also collapses two legacy alias prefixes to canonical names — `outliers_<stem>/` → `outlier_<stem>/` and `pca_<stem>/` → `dimred_<stem>/` — so on-disk layout matches the `TOOL_CLASSES` naming `list_existing_analyses` already walks.

**New `with_snapshot()` on `AnalysisDir`**

Pins the manifest at entry; sibling commits during the context don't change what callers see. Foundation for the parallel-recipe `Send`-based fan-out (separate proposal).

**Refactored 6 tools to use `AnalysisWriter`**

| Module | Tool | Outputs |
|---|---|---|
| `qc_tools` | `clean_experiment_data` | `_cleaned.csv` + `cleanup_log.json` → `qc_<stem>/v<N>_*/` |
| `outlier_tools` | `detect_outliers_mahalanobis` | `mahalanobis_outliers.json` → `outlier_<stem>/v<N>_*/` |
| `outlier_tools` | `detect_outliers_isolation_forest` | `isolation_forest_outliers.json` → `outlier_<stem>/v<N>_*/` |
| `outlier_tools` | `detect_outliers_pca` | `pca_outliers.json` → `outlier_<stem>/v<N>_*/` |
| `outlier_tools` | `run_consensus_outlier_detection` | `consensus_outliers.json` → `outlier_<stem>/v<N>_*/` |
| `outlier_tools` | `remove_detected_outliers` | cleaned + outlier-samples CSVs → `outlier_<stem>/v<N>_*/` |

`remove_detected_outliers` now walks the manifest for the latest run of the chosen method instead of reading a fixed path. Each function gains an optional `user_label: str | None = None` kwarg.

**Wired migration at startup** — `bloommcp/server.py` calls `migrate_legacy_dirs(OUTPUT_DIR)` once at module load. First deployment after merge auto-converts existing `qc_<stem>/<stem>_cleaned.csv` and `outliers_<stem>/*.json` into `v0_legacy/` form with no manual step.

## Tests

35 passing across both phases (22 Phase A + 13 Phase B). New Phase B tests:

- Writer atomic create + commit, monotonic v1/v2 sequencing
- `user_label` propagation into directory name + manifest entry
- `code_versions` capture at write time
- Three-thread concurrent allocation with `fcntl.flock` serialization
- `with_snapshot` pinning against sibling commit
- Migration creates `v0_legacy` from loose files
- Migration is idempotent
- Plural `outliers_<stem>` → singular `outlier_<stem>` rename on migration
- Migration skips already-versioned directories
- Migration continues on per-dir failure
- Integration: `clean_experiment_data` writes through refactored path
- Integration: `detect_outliers_pca` writes through refactored path

