### PR TITLE
feat(agent): deterministic context-loader node before any LLM call

### DIFF
--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -16,6 +16,7 @@ import logging
 from rich.logging import RichHandler
 from rich.traceback import install
 from db_url import compose_postgres_url
+from graph.context_loader import make_context_loader_node
 from graph.freeform import build_freeform_subgraph
 from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
@@ -82,16 +83,6 @@ async def setup_checkpointer() -> AsyncPostgresSaver:
 def _count_tokens(messages) -> int:
     """Approximate token count (~4 chars per token)."""
     return sum(len(str(m.content)) for m in messages) // 4
-
-
-def _has_context_call(messages) -> bool:
-    """Check if get_agent_context was already called in the conversation."""
-    for msg in messages:
-        if isinstance(msg, AIMessage) and msg.tool_calls:
-            for tc in msg.tool_calls:
-                if tc.get("name") == "get_agent_context":
-                    return True
-    return False
 
 
 SUMMARIZATION_PROMPT = """Summarize the following conversation between a user and an AI assistant on a plant biology platform.
@@ -174,12 +165,10 @@ def make_pre_model_hook(provider: str = "openai", llm=None):
 
     async def pre_model_hook(state):
         messages = state["messages"]
-        # Safety net: remind to call get_agent_context on first turn
-        if len(messages) <= 2 and not _has_context_call(messages):
-                reminder = SystemMessage(
-                    content="Remember: call get_agent_context to learn about available data sources before answering."
-                )
-                messages = [messages[0], reminder] + messages[1:] if messages else [reminder]
+        # Reminder injection removed — `graph.context_loader.context_loader_node`
+        # injects the agent context deterministically as a SystemMessage at the
+        # start of every graph invocation, so the LLM no longer needs a hint to
+        # remember to call get_agent_context.
         total_tokens = _count_tokens(messages)
         if total_tokens > thresholds["summarize_at"]:
             # Find the split point: keep the last N tokens of messages
@@ -392,8 +381,18 @@ def create_agent(
         checkpointer=None,
     )
 
+    # Deterministic context-loader runs before the ReAct loop on every
+    # invocation. Replaces the prior reminder-injection branch in
+    # make_pre_model_hook — the LLM no longer needs to be told to call
+    # get_agent_context because the context is already in state.messages
+    # by the time freeform runs. Closure over tool_set so the same parent
+    # graph shape works for any tool subset selection.
+    context_loader = make_context_loader_node(tool_set=tool_set)
+
     builder = StateGraph(AgentState)
+    builder.add_node("context_loader", context_loader)
     builder.add_node("freeform", freeform)
-    builder.add_edge(START, "freeform")
+    builder.add_edge(START, "context_loader")
+    builder.add_edge("context_loader", "freeform")
     builder.add_edge("freeform", END)
     return builder.compile(checkpointer=checkpointer)

--- a/langchain/graph/context_loader.py
+++ b/langchain/graph/context_loader.py
@@ -1,0 +1,44 @@
+"""Deterministic context-loader node.
+
+Runs at the start of every graph invocation, before any LLM call. Calls the
+existing `get_agent_context` tool deterministically and injects the result as a
+`SystemMessage` into state via the `add_messages` reducer.
+
+Replaces the pre-model-hook reminder hack (a string instruction telling the
+LLM to *"remember"* to call `get_agent_context`) with a graph-level guarantee:
+every leaf subgraph in the routed architecture inherits this property without
+re-implementing it.
+
+Idempotency is enforced by tagging the injected SystemMessage with
+`CONTEXT_MARKER`. On follow-up turns within the same thread, the node detects
+the prior tagged message in state and returns `{}` — no duplicate injection.
+"""
+from typing import Optional
+
+from langchain_core.messages import SystemMessage
+
+from tools.context_tools import get_agent_context
+
+# Marker substring distinguishing context-loader output from other SystemMessages
+# (e.g. conversation summaries written by the pre-model hook).
+CONTEXT_MARKER = "<!-- agent-context -->"
+
+
+def make_context_loader_node(tool_set: str = "all"):
+    """Build a context_loader node bound to a specific tool_set.
+
+    The closure pattern keeps the node signature `(state) -> dict` while
+    letting the parent graph build different agents for different tool_set
+    selections without changing how the graph wires together.
+    """
+
+    def context_loader_node(state) -> dict:
+        for msg in state.get("messages", []) or []:
+            if isinstance(msg, SystemMessage) and CONTEXT_MARKER in str(msg.content):
+                return {}
+
+        context_text = get_agent_context.invoke({"tool_set": tool_set})
+        marked_content = f"{CONTEXT_MARKER}\n{context_text}"
+        return {"messages": [SystemMessage(content=marked_content)]}
+
+    return context_loader_node

--- a/tests/integration/test_context_loader.py
+++ b/tests/integration/test_context_loader.py
@@ -1,0 +1,112 @@
+"""context_loader_node — deterministic agent-context injection before any LLM call.
+
+These tests exercise the context-loader node directly (no LLM, no compose stack).
+They verify the contract:
+  - First call on a fresh state injects a marked SystemMessage.
+  - Subsequent calls within the same thread are no-ops (idempotent).
+  - The closure honours the bound tool_set.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+# Some langchain modules read env vars at import time; provide safe defaults.
+_TMP = tempfile.mkdtemp(prefix="context_loader_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from langchain_core.messages import HumanMessage, SystemMessage  # noqa: E402
+
+from graph.context_loader import (  # noqa: E402
+    CONTEXT_MARKER,
+    make_context_loader_node,
+)
+
+
+def test_context_loader_injects_system_message_on_fresh_state():
+    node = make_context_loader_node(tool_set="all")
+    state = {"messages": [HumanMessage(content="hi")]}
+
+    result = node(state)
+
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert isinstance(msg, SystemMessage)
+    assert CONTEXT_MARKER in msg.content
+    # The actual context content from get_agent_context is a non-empty string
+    assert len(msg.content) > len(CONTEXT_MARKER) + 10
+
+
+def test_context_loader_is_idempotent_on_second_call():
+    """If a marked SystemMessage already exists in state, return {} (no-op)."""
+    node = make_context_loader_node(tool_set="all")
+    state_after_first = {
+        "messages": [
+            HumanMessage(content="hi"),
+            SystemMessage(content=f"{CONTEXT_MARKER}\nsome cached context"),
+        ]
+    }
+    result = node(state_after_first)
+
+    # No new messages appended — node detected prior context-flagged message
+    assert result == {}
+
+
+def test_context_loader_appends_when_only_unmarked_system_message_exists():
+    """A SystemMessage WITHOUT the marker (e.g. summary) doesn't count as
+    prior context — node still injects."""
+    node = make_context_loader_node(tool_set="all")
+    state = {
+        "messages": [
+            SystemMessage(content="Conversation summary so far: ..."),
+            HumanMessage(content="follow-up"),
+        ]
+    }
+    result = node(state)
+
+    assert "messages" in result
+    assert isinstance(result["messages"][0], SystemMessage)
+    assert CONTEXT_MARKER in result["messages"][0].content
+
+
+def test_context_loader_respects_bound_tool_set():
+    """Different tool_set bindings produce different context content."""
+    all_node = make_context_loader_node(tool_set="all")
+    scrna_node = make_context_loader_node(tool_set="scrna")
+
+    state = {"messages": [HumanMessage(content="hi")]}
+    all_result = all_node(state)
+    scrna_result = scrna_node(state)
+
+    all_content = all_result["messages"][0].content
+    scrna_content = scrna_result["messages"][0].content
+
+    # Tool sets differ — content must differ. Both contain the marker.
+    assert CONTEXT_MARKER in all_content
+    assert CONTEXT_MARKER in scrna_content
+    assert all_content != scrna_content
+
+
+def test_context_loader_handles_empty_state():
+    """No messages in state: still inject the marker SystemMessage."""
+    node = make_context_loader_node(tool_set="all")
+    result = node({"messages": []})
+
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    assert CONTEXT_MARKER in result["messages"][0].content


### PR DESCRIPTION
## Summary

Replaces the pre-model-hook with a graph-level guarantee.A `context_loader_node` runs at the START of every invocation, calls `get_agent_context` for the bound tool_set, and injects the result as a `SystemMessage` into state via the `add_messages` reducer. The LLM sees the context already in `state.messages` by the time the freeform subgraph runs — no compliance hope.

## Why

Two problems with the pre-modal hook:

1. **The LLM may not comply.** *"call X"* is a hope, not a guarantee. Some prompts cause the LLM to skip the call and answer with stale assumptions.
2. Once this architecture expands and the top router and specialised subgraphs land, every leaf would need its own copy of the reminder logic, and every leaf's first-turn behaviour would depend on the LLM's compliance.

**Modified `langchain/agent.py`**

- Imported `make_context_loader_node`
- `create_agent`'s parent `StateGraph` now wires `START → context_loader → freeform → END`
- `context_loader` bound to the request's `tool_set` so scRNA / cyl / generic / all selections each get the right context block
- `pre_model_hook`'s reminder-injection branch removed (~5 lines). Hook keeps its summarisation and message-trimming responsibilities — only the reminder hack goes.
- `_has_context_call()` helper deleted (only caller was the reminder branch)

**Tests** — `tests/integration/test_context_loader.py`, 5 cases:

- First call on fresh state injects a marker-tagged SystemMessage
- Second call within the same thread is a no-op (idempotent)
- Unmarked SystemMessages (e.g. summaries) don't trigger the idempotency path — node still injects
- Different `tool_set` bindings produce different context content
- Empty state still gets context injected

## Stacking notes

This PR is logically downstream of TWO open PRs:

1. **PR #196** (`feat/agent-stategraph-foundation`) — provides the parent `StateGraph` to wire `context_loader` into. **This PR's base is set to `feat/agent-stategraph-foundation`** rather than `staging` for that reason.
2. **PR #195** (`fix/agent-system-message-merge-v2`, the merge fix) — without it, the additional `SystemMessage` injected by `context_loader` plus the `prompt=` passed to `create_react_agent` would violate vLLM's *"single system message at index 0"* rule on Qwen.

When both upstream PRs merge to `staging`, this PR's base should be retargeted to `staging` and the diff will read clean.

## File-change footprint

3 files: 1 new (context_loader), 1 modified (agent.py — net -1 line after deleting helper), 1 new test. **172 insertions / 17 deletions.**