### PR TITLE
feat(agent): top-level router with freeform fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ docker-compose.prod copy.yml
 DOCUMENTATION.md
 TROUBLESHOOTING.md
 prompts/
+# Re-include the langchain agent's prompt module (the gitignore rule above
+# catches Claude-Code planning folders named `prompts/`; this re-includes
+# the production code path the agent uses for graph-node prompts).
+!langchain/prompts/
+!langchain/prompts/**
 .claude/settings.local.json
 .claude/draft-pr/
 langchain/ANALYSIS_OUTPUT/

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -18,6 +18,7 @@ from rich.traceback import install
 from db_url import compose_postgres_url
 from graph.context_loader import make_context_loader_node
 from graph.freeform import build_freeform_subgraph
+from graph.router import make_top_router_node
 from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
 
@@ -389,10 +390,28 @@ def create_agent(
     # graph shape works for any tool subset selection.
     context_loader = make_context_loader_node(tool_set=tool_set)
 
+    # Top-level router: classifies every request into one of four buckets
+    # and writes state["route"]. Until Tier 2 subgraphs land, every route
+    # value dispatches to the existing freeform leaf — wiring only, no
+    # behaviour change for end users. The router uses the same LLM as the
+    # leaf (single-provider strategy per master Decision 4).
+    top_router = make_top_router_node(llm)
+
     builder = StateGraph(AgentState)
     builder.add_node("context_loader", context_loader)
+    builder.add_node("top_router", top_router)
     builder.add_node("freeform", freeform)
     builder.add_edge(START, "context_loader")
-    builder.add_edge("context_loader", "freeform")
+    builder.add_edge("context_loader", "top_router")
+    builder.add_conditional_edges(
+        "top_router",
+        lambda state: state["route"],
+        {
+            "phenotyping": "freeform",
+            "scrna": "freeform",
+            "analysis": "freeform",
+            "freeform": "freeform",
+        },
+    )
     builder.add_edge("freeform", END)
     return builder.compile(checkpointer=checkpointer)

--- a/langchain/graph/router.py
+++ b/langchain/graph/router.py
@@ -1,0 +1,98 @@
+"""Top-level router node — LLM-driven request classifier.
+
+Calls the LLM with structured-output coercion to one of four bucket values
+and writes `state["route"]`. Never wedges the request: any classification
+error (LLM exception, parse failure, missing user message) degrades to the
+`freeform` fallback so subsequent edges can still dispatch the request.
+
+The router uses the same provider/model as the leaf (single-provider
+strategy per the master proposal's Decision 4). The closure pattern lets
+`create_agent` build the node once with its already-configured LLM, then
+hand the resulting node to the StateGraph.
+"""
+import logging
+from typing import Literal
+
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, Field
+
+from prompts.router import ROUTER_FEW_SHOTS, TOP_ROUTER_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+# The classification target. Pydantic model rather than bare Literal so
+# `with_structured_output` accepts it across all backends and the LLM gets
+# field-level metadata (description) to anchor on.
+class TopRouteDecision(BaseModel):
+    """LLM-emitted top-level route classification."""
+
+    route: Literal["phenotyping", "scrna", "analysis", "freeform"] = Field(
+        description=(
+            "phenotyping = cylinder/turface scans + plant traits; "
+            "scrna = single-cell RNA-seq; "
+            "analysis = run a numerical analysis (QC, stats, PCA, viz); "
+            "freeform = anything ambiguous or multi-domain."
+        )
+    )
+
+
+FALLBACK_ROUTE: Literal["freeform"] = "freeform"
+
+
+def _build_classifier_messages(user_text: str) -> list[dict]:
+    """Compose the system prompt + few-shot examples + the new user request."""
+    messages: list[dict] = [{"role": "system", "content": TOP_ROUTER_PROMPT}]
+    for example_user, example_route in ROUTER_FEW_SHOTS:
+        messages.append({"role": "user", "content": example_user})
+        messages.append({"role": "assistant", "content": example_route})
+    messages.append({"role": "user", "content": user_text})
+    return messages
+
+
+def _latest_user_text(messages: list) -> str | None:
+    """Return the content of the most recent HumanMessage, or None."""
+    for msg in reversed(messages):
+        if isinstance(msg, HumanMessage):
+            content = msg.content
+            return content if isinstance(content, str) else str(content)
+    return None
+
+
+def make_top_router_node(llm):
+    """Build the top_router node bound to a specific LLM instance.
+
+    Closure over `llm` so the node signature stays `(state) -> dict` and
+    the parent graph wires it without threading config.
+    """
+    classifier = llm.with_structured_output(TopRouteDecision)
+
+    async def top_router_node(state) -> dict:
+        user_text = _latest_user_text(state.get("messages", []) or [])
+        if user_text is None:
+            logger.warning("top_router: no HumanMessage in state, falling back to %s", FALLBACK_ROUTE)
+            return {"route": FALLBACK_ROUTE}
+
+        try:
+            messages = _build_classifier_messages(user_text)
+            decision = await classifier.ainvoke(messages)
+        except Exception as exc:
+            logger.warning(
+                "top_router: classifier raised %s, falling back to %s",
+                type(exc).__name__,
+                FALLBACK_ROUTE,
+            )
+            return {"route": FALLBACK_ROUTE}
+
+        route = getattr(decision, "route", None)
+        if route not in ("phenotyping", "scrna", "analysis", "freeform"):
+            logger.warning(
+                "top_router: classifier returned unknown route %r, falling back to %s",
+                route,
+                FALLBACK_ROUTE,
+            )
+            return {"route": FALLBACK_ROUTE}
+
+        return {"route": route}
+
+    return top_router_node

--- a/langchain/prompts/__init__.py
+++ b/langchain/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt strings for graph nodes — each module exports a single PROMPT constant."""

--- a/langchain/prompts/router.py
+++ b/langchain/prompts/router.py
@@ -1,0 +1,47 @@
+"""Top-level router prompt.
+
+Classifies an incoming user request into one of four buckets so the
+hierarchical routing topology can dispatch to the appropriate subgraph.
+The classifier is intentionally narrow — when uncertain, choose `freeform`
+so the request still gets answered (just without leaf specialization).
+"""
+
+TOP_ROUTER_PROMPT = """You are a request classifier for a plant phenotyping platform.
+Classify the user's most recent request into exactly one of four buckets.
+Choose `freeform` whenever the request is ambiguous, multi-domain, or doesn't
+fit the other three.
+
+Buckets:
+
+- **phenotyping** — Cylinder/turface scan data, plant traits, root measurements,
+  experiment metadata. Examples: "show me waves for alfalfa", "list cylinder
+  scans from May", "what plants do we have for species X".
+
+- **scrna** — Single-cell RNA-seq data, gene expression, UMAP clusters,
+  cell-type annotations. Examples: "what's the expression of AT1G01010?",
+  "show the UMAP for dataset GSE123", "which clusters are pericycle".
+
+- **analysis** — Any request to RUN a numerical analysis on phenotyping data:
+  QC, outlier detection, descriptive stats, ANOVA, heritability, PCA,
+  clustering, visualization, cross-experiment correlation. Examples: "run a
+  QC report on alfalfa", "do a PCA on the wave 2 traits", "make a heatmap
+  of trait correlations", "find outliers in the foo dataset".
+
+- **freeform** — Anything else: explanations, multi-domain queries, agent
+  meta-questions, ambiguous prompts. Examples: "what can you do?",
+  "explain heritability to me", "compare cylinder vs turface platforms".
+
+Respond with the single chosen bucket value."""
+
+
+# Few-shot examples reinforce the bucket boundaries. Order matters: examples
+# are listed in order of frequency in expected production traffic so the most
+# common patterns dominate the router's prior.
+ROUTER_FEW_SHOTS = [
+    ("List the experiments available for cylinder phenotyping.", "phenotyping"),
+    ("Run a QC report on cylinder_alfalfa_gwas_wave2.csv.", "analysis"),
+    ("What's the expression of AT1G01010 in the dataset?", "scrna"),
+    ("Detect outliers in the wave 2 traits using isolation forest.", "analysis"),
+    ("How does the cylinder platform differ from turface?", "freeform"),
+    ("What plants from species Solanum lycopersicum do we have?", "phenotyping"),
+]

--- a/tests/integration/test_top_router.py
+++ b/tests/integration/test_top_router.py
@@ -1,0 +1,175 @@
+"""top_router_node — LLM-driven request classifier with freeform fallback.
+
+These tests exercise the router node directly with a mocked LLM (no live
+network, no compose stack). They verify the contract:
+
+  - Success: LLM returns a valid Literal value → state["route"] = that value.
+  - LLM exception → fallback to "freeform" + log a warning.
+  - LLM returns an out-of-enum value → fallback to "freeform".
+  - Structured-output parse failure → fallback to "freeform".
+
+Per the "Freeform fallback at every router level" master decision, a
+classification error MUST never wedge the request — it always degrades to
+the freeform leaf so the agent keeps responding.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+_TMP = tempfile.mkdtemp(prefix="top_router_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from langchain_core.messages import HumanMessage  # noqa: E402
+
+from graph.router import (  # noqa: E402
+    FALLBACK_ROUTE,
+    TopRouteDecision,
+    make_top_router_node,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Pin async tests to asyncio only — trio isn't a project dependency."""
+    return "asyncio"
+
+
+def _mock_llm_returning(value):
+    """Build a mock chat model where with_structured_output returns a chain
+    whose ainvoke yields the given value."""
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(return_value=value)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+def _mock_llm_raising(exc: Exception):
+    """Build a mock chat model whose structured-output ainvoke raises exc."""
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(side_effect=exc)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+# ─── Success path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_success_phenotyping():
+    decision = TopRouteDecision(route="phenotyping")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="list cylinder plants from wave 2")]})
+
+    assert result == {"route": "phenotyping"}
+
+
+@pytest.mark.anyio
+async def test_router_success_analysis():
+    decision = TopRouteDecision(route="analysis")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="run a QC report on alfalfa")]})
+
+    assert result == {"route": "analysis"}
+
+
+@pytest.mark.anyio
+async def test_router_uses_most_recent_user_message():
+    """Router should classify based on the latest HumanMessage, not the first."""
+    decision = TopRouteDecision(route="scrna")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    state = {
+        "messages": [
+            HumanMessage(content="something earlier and unrelated"),
+            HumanMessage(content="show me the UMAP for dataset X"),
+        ]
+    }
+    result = await node(state)
+
+    assert result == {"route": "scrna"}
+
+
+# ─── Fallback paths — every error degrades to freeform ───────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_llm_exception():
+    """Network failure or LLM crash should not wedge the request."""
+    llm = _mock_llm_raising(RuntimeError("vLLM unreachable"))
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="anything")]})
+
+    assert result == {"route": FALLBACK_ROUTE}
+    assert FALLBACK_ROUTE == "freeform"
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_parse_error():
+    """If the LLM's structured output can't be parsed (validation error
+    from the wrapping layer), fall back to freeform."""
+    from pydantic import ValidationError as _VE
+    # Construct a real pydantic ValidationError by intentionally validating
+    # an out-of-enum value, so the exception path matches what production
+    # would see when with_structured_output retries fail.
+    try:
+        TopRouteDecision(route="not_a_real_route")
+    except _VE as exc:
+        validation_error = exc
+
+    llm = _mock_llm_raising(validation_error)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="ambiguous prompt")]})
+
+    assert result == {"route": FALLBACK_ROUTE}
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_when_no_user_message():
+    """Defensive: state with no HumanMessage shouldn't crash; route to freeform."""
+    llm = _mock_llm_returning(TopRouteDecision(route="phenotyping"))
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": []})
+
+    # Empty input should not even reach the LLM; freeform fallback.
+    assert result == {"route": FALLBACK_ROUTE}
+
+
+# ─── Determinism ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_node_signature_returns_only_route_field():
+    """The router updates only state['route'], nothing else."""
+    decision = TopRouteDecision(route="freeform")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="hi")]})
+
+    assert set(result.keys()) == {"route"}


### PR DESCRIPTION
## Summary

Adds the deterministic-shape LLM classifier that sits between `context_loader` and the leaf, writing `state['route']` for use by subsequent tiers. Wiring only — every classification currently dispatches to the existing `freeform` leaf, so behaviour is byte-for-byte unchanged for end users until subgraphs replace each destination.

## What's in this PR

**New** `langchain/graph/router.py` — `make_top_router_node(llm)`

**Three-way fallback to `freeform`:**
1. LLM exception (network/vLLM down)
2. Out-of-enum response (validation failure)
3. Missing `HumanMessage` in state

Every fallback logs a structured warning so routing failures are observable. `"Freeform fallback at every router level"` (master Decision) is now an enforced guarantee, not hope.

**New** `langchain/prompts/router.py` — `TOP_ROUTER_PROMPT` + 6 few-shot examples covering each bucket. Few-shots are in expected-frequency order so the most common patterns dominate the router's prior.

**Modified** `langchain/agent.py::create_agent` — wires `context_loader → top_router → freeform` with a conditional edge that maps every route value.

## File-change footprint

- `langchain/prompts/__init__.py` — NEW (package marker)
- `langchain/prompts/router.py` — NEW
- `langchain/graph/router.py` — NEW
- `langchain/agent.py` — MODIFIED
- `tests/integration/test_top_router.py` — NEW
- `.gitignore` — MODIFIED (re-include `langchain/prompts/`; the existing `prompts/` rule was for Claude-Code planning folders)


## Stacking notes

PR base is `feat/agent-context-loader` (PR #200). Logical dependencies:
- **PR #196** — StateGraph foundation (parent graph to attach router to)
- **PR #195** — system-message merge fix (router emits a system prompt; needs to merge with leaf's system prompt at LLM-call time)
- **PR #200** — context-loader (graph wires `context_loader → top_router`)

When all three merge to staging, this PR's base should be retargeted to `staging` for a clean diff.