### PR TITLE
feat(agent): analysis subgraph with sub-router + analysis_freeform fallback (Tier 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ docker-compose.prod copy.yml
 DOCUMENTATION.md
 TROUBLESHOOTING.md
 prompts/
+# Re-include the langchain agent's prompt module (the gitignore rule above
+# catches Claude-Code planning folders named `prompts/`; this re-includes
+# the production code path the agent uses for graph-node prompts).
+!langchain/prompts/
+!langchain/prompts/**
 .claude/settings.local.json
 .claude/draft-pr/
 langchain/ANALYSIS_OUTPUT/

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -16,6 +16,7 @@ import logging
 from rich.logging import RichHandler
 from rich.traceback import install
 from db_url import compose_postgres_url
+from graph.context_loader import make_context_loader_node
 from graph.freeform import build_freeform_subgraph
 from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
@@ -82,16 +83,6 @@ async def setup_checkpointer() -> AsyncPostgresSaver:
 def _count_tokens(messages) -> int:
     """Approximate token count (~4 chars per token)."""
     return sum(len(str(m.content)) for m in messages) // 4
-
-
-def _has_context_call(messages) -> bool:
-    """Check if get_agent_context was already called in the conversation."""
-    for msg in messages:
-        if isinstance(msg, AIMessage) and msg.tool_calls:
-            for tc in msg.tool_calls:
-                if tc.get("name") == "get_agent_context":
-                    return True
-    return False
 
 
 SUMMARIZATION_PROMPT = """Summarize the following conversation between a user and an AI assistant on a plant biology platform.
@@ -174,12 +165,10 @@ def make_pre_model_hook(provider: str = "openai", llm=None):
 
     async def pre_model_hook(state):
         messages = state["messages"]
-        # Safety net: remind to call get_agent_context on first turn
-        if len(messages) <= 2 and not _has_context_call(messages):
-                reminder = SystemMessage(
-                    content="Remember: call get_agent_context to learn about available data sources before answering."
-                )
-                messages = [messages[0], reminder] + messages[1:] if messages else [reminder]
+        # Reminder injection removed — `graph.context_loader.context_loader_node`
+        # injects the agent context deterministically as a SystemMessage at the
+        # start of every graph invocation, so the LLM no longer needs a hint to
+        # remember to call get_agent_context.
         total_tokens = _count_tokens(messages)
         if total_tokens > thresholds["summarize_at"]:
             # Find the split point: keep the last N tokens of messages
@@ -363,8 +352,18 @@ def create_agent(
         checkpointer=None,
     )
 
+    # Deterministic context-loader runs before the ReAct loop on every
+    # invocation. Replaces the prior reminder-injection branch in
+    # make_pre_model_hook — the LLM no longer needs to be told to call
+    # get_agent_context because the context is already in state.messages
+    # by the time freeform runs. Closure over tool_set so the same parent
+    # graph shape works for any tool subset selection.
+    context_loader = make_context_loader_node(tool_set=tool_set)
+
     builder = StateGraph(AgentState)
+    builder.add_node("context_loader", context_loader)
     builder.add_node("freeform", freeform)
-    builder.add_edge(START, "freeform")
+    builder.add_edge(START, "context_loader")
+    builder.add_edge("context_loader", "freeform")
     builder.add_edge("freeform", END)
     return builder.compile(checkpointer=checkpointer)

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -18,6 +18,7 @@ from rich.traceback import install
 from db_url import compose_postgres_url
 from graph.context_loader import make_context_loader_node
 from graph.freeform import build_freeform_subgraph
+from graph.router import make_top_router_node
 from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
 
@@ -360,10 +361,28 @@ def create_agent(
     # graph shape works for any tool subset selection.
     context_loader = make_context_loader_node(tool_set=tool_set)
 
+    # Top-level router: classifies every request into one of four buckets
+    # and writes state["route"]. Until Tier 2 subgraphs land, every route
+    # value dispatches to the existing freeform leaf — wiring only, no
+    # behaviour change for end users. The router uses the same LLM as the
+    # leaf (single-provider strategy per master Decision 4).
+    top_router = make_top_router_node(llm)
+
     builder = StateGraph(AgentState)
     builder.add_node("context_loader", context_loader)
+    builder.add_node("top_router", top_router)
     builder.add_node("freeform", freeform)
     builder.add_edge(START, "context_loader")
-    builder.add_edge("context_loader", "freeform")
+    builder.add_edge("context_loader", "top_router")
+    builder.add_conditional_edges(
+        "top_router",
+        lambda state: state["route"],
+        {
+            "phenotyping": "freeform",
+            "scrna": "freeform",
+            "analysis": "freeform",
+            "freeform": "freeform",
+        },
+    )
     builder.add_edge("freeform", END)
     return builder.compile(checkpointer=checkpointer)

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -16,6 +16,7 @@ import logging
 from rich.logging import RichHandler
 from rich.traceback import install
 from db_url import compose_postgres_url
+from graph.analysis import build_analysis_subgraph
 from graph.context_loader import make_context_loader_node
 from graph.freeform import build_freeform_subgraph
 from graph.router import make_top_router_node
@@ -368,9 +369,23 @@ def create_agent(
     # leaf (single-provider strategy per master Decision 4).
     top_router = make_top_router_node(llm)
 
+    # Analysis subgraph: second-level router + analysis_freeform fallback leaf.
+    # Plugged in at the parent's "analysis" route destination. Inside the
+    # subgraph, an LLM sub-classifier writes state["analysis_route"] into one
+    # of 6 sub-buckets (qc, stats, dimred_cluster, viz, correlation,
+    # analysis_freeform); every value currently dispatches to analysis_freeform
+    # until Tier 3 sub-proposals land specialized leaves. The leaf sees only
+    # MCP tools — native scrna/cyl/generic stay in the top-level freeform.
+    analysis_subgraph = build_analysis_subgraph(
+        llm=llm,
+        mcp_tools=mcp_tools or [],
+        pre_model_hook=make_pre_model_hook(provider, llm=llm),
+    )
+
     builder = StateGraph(AgentState)
     builder.add_node("context_loader", context_loader)
     builder.add_node("top_router", top_router)
+    builder.add_node("analysis_subgraph", analysis_subgraph)
     builder.add_node("freeform", freeform)
     builder.add_edge(START, "context_loader")
     builder.add_edge("context_loader", "top_router")
@@ -380,9 +395,10 @@ def create_agent(
         {
             "phenotyping": "freeform",
             "scrna": "freeform",
-            "analysis": "freeform",
+            "analysis": "analysis_subgraph",
             "freeform": "freeform",
         },
     )
+    builder.add_edge("analysis_subgraph", END)
     builder.add_edge("freeform", END)
     return builder.compile(checkpointer=checkpointer)

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -6,8 +6,8 @@ import os
 from typing import Optional, Literal
 
 import httpx
-from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from langgraph.graph import StateGraph, START, END
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import trim_messages, SystemMessage, AIMessage, HumanMessage
 from psycopg_pool import AsyncConnectionPool
@@ -16,6 +16,8 @@ import logging
 from rich.logging import RichHandler
 from rich.traceback import install
 from db_url import compose_postgres_url
+from graph.freeform import build_freeform_subgraph
+from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
 
 install()
@@ -342,10 +344,27 @@ def create_agent(
     if mcp_tools:
         tools = tools + mcp_tools
 
-    return create_react_agent(
-        model=llm,
+    # Tier 0 of the upgrade-agent-architecture roadmap: replace the opaque
+    # `create_react_agent` return with an explicit StateGraph so every
+    # subsequent tier (top router, domain subgraphs, analysis router, MCP
+    # leaves, parallel recipes) has a real graph to attach nodes to.
+    #
+    # Today this graph has one node, `freeform`, which wraps the prebuilt
+    # ReAct agent verbatim — same prompt, same tools, same pre-model hook.
+    # Behavior is byte-for-byte identical to the pre-refactor agent. The
+    # checkpointer lives on the OUTER graph; the inner subgraph stays
+    # checkpointer=None so the parent's `messages` reducer is the single
+    # source of truth for thread state.
+    freeform = build_freeform_subgraph(
+        llm=llm,
         tools=tools,
-        prompt=SYSTEM_PROMPT,
-        checkpointer=checkpointer,
+        system_prompt=SYSTEM_PROMPT,
         pre_model_hook=make_pre_model_hook(provider, llm=llm),
+        checkpointer=None,
     )
+
+    builder = StateGraph(AgentState)
+    builder.add_node("freeform", freeform)
+    builder.add_edge(START, "freeform")
+    builder.add_edge("freeform", END)
+    return builder.compile(checkpointer=checkpointer)

--- a/langchain/graph/__init__.py
+++ b/langchain/graph/__init__.py
@@ -1,0 +1,10 @@
+"""Graph layer for the Bloom agent runtime.
+
+Submodules:
+    state    — typed state schema (`AgentState`) shared across nodes
+    freeform — factory for the freeform leaf subgraph (today's behavior)
+
+Subsequent sub-proposals (top router, domain subgraphs, MCP analysis leaves,
+parallel recipes) will add their own modules here. The package is intentionally
+shallow so each future addition is a small reviewable file.
+"""

--- a/langchain/graph/analysis.py
+++ b/langchain/graph/analysis.py
@@ -1,0 +1,187 @@
+"""Analysis subgraph: second-level router + analysis_freeform fallback leaf.
+
+Plugged in at the parent graph's "analysis" route destination. Mirrors the
+top-router pattern at the second level: an LLM classifier writes
+state["analysis_route"] into one of 6 sub-buckets and a conditional edge
+dispatches to the matching leaf.
+
+Until Tier 3 sub-proposals land specialized leaves (qc, stats, dimred_cluster,
+viz, correlation), every analysis classification dispatches to
+`analysis_freeform`. Wiring only — zero behavior change vs. PR #201's pre-this
+state, since the parent graph routed "analysis" → "freeform" before, and now
+routes "analysis" → "analysis_subgraph" → ... → analysis_freeform leaf, which
+is functionally the same scope (all MCP tools) under a different prompt.
+
+When Tier 3 leaves land, each replaces one destination value in the conditional
+edge here. The router's contract never changes.
+"""
+import logging
+from typing import Literal
+
+from langchain_core.messages import HumanMessage
+from langgraph.graph import StateGraph, START, END
+from langgraph.prebuilt import create_react_agent
+from pydantic import BaseModel, Field
+
+from graph.state import AgentState
+from prompts.analysis_freeform import ANALYSIS_FREEFORM_PROMPT
+from prompts.analysis_router import (
+    ANALYSIS_ROUTER_FEW_SHOTS,
+    ANALYSIS_ROUTER_PROMPT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisRouteDecision(BaseModel):
+    """LLM-emitted second-level analysis classification."""
+
+    route: Literal[
+        "qc",
+        "stats",
+        "dimred_cluster",
+        "viz",
+        "correlation",
+        "analysis_freeform",
+    ] = Field(
+        description=(
+            "qc = data quality + cleanup + outlier detection; "
+            "stats = descriptive stats, ANOVA, heritability; "
+            "dimred_cluster = PCA, clustering, dimensionality reduction; "
+            "viz = plots and visualizations; "
+            "correlation = cross-experiment correlation; "
+            "analysis_freeform = ambiguous or multi-bucket analysis requests."
+        )
+    )
+
+
+ANALYSIS_FALLBACK_ROUTE: Literal["analysis_freeform"] = "analysis_freeform"
+
+_VALID_ANALYSIS_ROUTES = (
+    "qc",
+    "stats",
+    "dimred_cluster",
+    "viz",
+    "correlation",
+    "analysis_freeform",
+)
+
+
+def _build_classifier_messages(user_text: str) -> list[dict]:
+    messages: list[dict] = [{"role": "system", "content": ANALYSIS_ROUTER_PROMPT}]
+    for example_user, example_route in ANALYSIS_ROUTER_FEW_SHOTS:
+        messages.append({"role": "user", "content": example_user})
+        messages.append({"role": "assistant", "content": example_route})
+    messages.append({"role": "user", "content": user_text})
+    return messages
+
+
+def _latest_user_text(messages: list) -> str | None:
+    for msg in reversed(messages):
+        if isinstance(msg, HumanMessage):
+            content = msg.content
+            return content if isinstance(content, str) else str(content)
+    return None
+
+
+def make_analysis_router_node(llm):
+    """Build the analysis_router node bound to a specific LLM instance.
+
+    Same closure pattern as `make_top_router_node` — keeps the node signature
+    `(state) -> dict` while the LLM is captured at construction time. Three-way
+    fallback to `analysis_freeform` on any error path.
+    """
+    classifier = llm.with_structured_output(AnalysisRouteDecision)
+
+    async def analysis_router_node(state) -> dict:
+        user_text = _latest_user_text(state.get("messages", []) or [])
+        if user_text is None:
+            logger.warning(
+                "analysis_router: no HumanMessage in state, falling back to %s",
+                ANALYSIS_FALLBACK_ROUTE,
+            )
+            return {"analysis_route": ANALYSIS_FALLBACK_ROUTE}
+
+        try:
+            messages = _build_classifier_messages(user_text)
+            decision = await classifier.ainvoke(messages)
+        except Exception as exc:
+            logger.warning(
+                "analysis_router: classifier raised %s, falling back to %s",
+                type(exc).__name__,
+                ANALYSIS_FALLBACK_ROUTE,
+            )
+            return {"analysis_route": ANALYSIS_FALLBACK_ROUTE}
+
+        route = getattr(decision, "route", None)
+        if route not in _VALID_ANALYSIS_ROUTES:
+            logger.warning(
+                "analysis_router: classifier returned unknown route %r, falling back to %s",
+                route,
+                ANALYSIS_FALLBACK_ROUTE,
+            )
+            return {"analysis_route": ANALYSIS_FALLBACK_ROUTE}
+
+        return {"analysis_route": route}
+
+    return analysis_router_node
+
+
+def build_analysis_subgraph(llm, mcp_tools: list, pre_model_hook=None):
+    """Build the compiled analysis subgraph.
+
+    Args:
+        llm: Chat model used by both the analysis_router and the inner
+            analysis_freeform leaf (single-provider strategy per master).
+        mcp_tools: MCP tools the analysis_freeform leaf can invoke. The leaf
+            sees only MCP tools (no native scrna/cyl/generic tools) — the top
+            level `freeform` leaf is the catch-all for those.
+        pre_model_hook: Optional pre-LLM-call hook (token trim / summarize /
+            single-SystemMessage merge) applied to the inner ReAct loop.
+
+    Topology inside the subgraph:
+
+        START
+          ↓
+        analysis_router  (LLM call, writes state["analysis_route"])
+          ↓
+        conditional edge: state["analysis_route"] → leaf name
+          ↓ (every value currently → "analysis_freeform")
+        analysis_freeform  (ReAct loop, MCP tools only)
+          ↓
+        END
+
+    The compiled subgraph is plugged in as a node in the parent graph; the
+    parent's checkpointer owns thread state, so this subgraph runs with
+    checkpointer=None (set implicitly by the caller in agent.py).
+    """
+    analysis_router = make_analysis_router_node(llm)
+
+    # Inner ReAct loop with MCP-only tools and the analysis-focused prompt.
+    # checkpointer=None — parent graph in agent.py owns thread state.
+    analysis_freeform = create_react_agent(
+        model=llm,
+        tools=mcp_tools or [],
+        prompt=ANALYSIS_FREEFORM_PROMPT,
+        pre_model_hook=pre_model_hook,
+        checkpointer=None,
+    )
+
+    builder = StateGraph(AgentState)
+    builder.add_node("analysis_router", analysis_router)
+    builder.add_node("analysis_freeform", analysis_freeform)
+    builder.add_edge(START, "analysis_router")
+    builder.add_conditional_edges(
+        "analysis_router",
+        lambda state: state["analysis_route"],
+        {
+            "qc": "analysis_freeform",
+            "stats": "analysis_freeform",
+            "dimred_cluster": "analysis_freeform",
+            "viz": "analysis_freeform",
+            "correlation": "analysis_freeform",
+            "analysis_freeform": "analysis_freeform",
+        },
+    )
+    builder.add_edge("analysis_freeform", END)
+    return builder.compile()

--- a/langchain/graph/context_loader.py
+++ b/langchain/graph/context_loader.py
@@ -1,0 +1,44 @@
+"""Deterministic context-loader node.
+
+Runs at the start of every graph invocation, before any LLM call. Calls the
+existing `get_agent_context` tool deterministically and injects the result as a
+`SystemMessage` into state via the `add_messages` reducer.
+
+Replaces the pre-model-hook reminder hack (a string instruction telling the
+LLM to *"remember"* to call `get_agent_context`) with a graph-level guarantee:
+every leaf subgraph in the routed architecture inherits this property without
+re-implementing it.
+
+Idempotency is enforced by tagging the injected SystemMessage with
+`CONTEXT_MARKER`. On follow-up turns within the same thread, the node detects
+the prior tagged message in state and returns `{}` — no duplicate injection.
+"""
+from typing import Optional
+
+from langchain_core.messages import SystemMessage
+
+from tools.context_tools import get_agent_context
+
+# Marker substring distinguishing context-loader output from other SystemMessages
+# (e.g. conversation summaries written by the pre-model hook).
+CONTEXT_MARKER = "<!-- agent-context -->"
+
+
+def make_context_loader_node(tool_set: str = "all"):
+    """Build a context_loader node bound to a specific tool_set.
+
+    The closure pattern keeps the node signature `(state) -> dict` while
+    letting the parent graph build different agents for different tool_set
+    selections without changing how the graph wires together.
+    """
+
+    def context_loader_node(state) -> dict:
+        for msg in state.get("messages", []) or []:
+            if isinstance(msg, SystemMessage) and CONTEXT_MARKER in str(msg.content):
+                return {}
+
+        context_text = get_agent_context.invoke({"tool_set": tool_set})
+        marked_content = f"{CONTEXT_MARKER}\n{context_text}"
+        return {"messages": [SystemMessage(content=marked_content)]}
+
+    return context_loader_node

--- a/langchain/graph/freeform.py
+++ b/langchain/graph/freeform.py
@@ -1,0 +1,53 @@
+"""Freeform leaf subgraph factory.
+
+The freeform leaf is the safety-valve subgraph that preserves today's
+single-agent behavior. Every router (top-level and analysis-level)
+can fall through to a freeform variant when classification is uncertain,
+so a misclassification can never wedge the agent.
+
+For Tier 0 (`add-stategraph-foundation`) the freeform leaf is the ONLY
+node in the parent graph — every request flows `START → freeform → END`
+and behaves byte-for-byte like the pre-refactor `create_react_agent` call.
+
+The factory is a thin wrapper around LangGraph's prebuilt `create_react_agent`
+so we keep the existing pre-model hook, system prompt, and tool list intact.
+The compiled subgraph it returns is suitable for use as a node in a parent
+StateGraph — see `langchain/agent.py::create_agent`.
+"""
+from typing import Optional
+
+from langgraph.prebuilt import create_react_agent
+
+
+def build_freeform_subgraph(
+    llm,
+    tools: list,
+    system_prompt: str,
+    pre_model_hook=None,
+    checkpointer=None,
+):
+    """Build the compiled freeform subgraph.
+
+    Args:
+        llm: Chat model (already provider/temperature-configured).
+        tools: Tool callables the LLM can invoke, including any MCP tools.
+        system_prompt: Top-level instructions string passed as `prompt=`.
+        pre_model_hook: Optional pre-LLM-call hook (token trim / summarize).
+        checkpointer: Pass `None` here when the subgraph is used as a node
+            inside a parent graph — the parent owns checkpointing in that
+            case so the parent's `messages` field is the canonical history.
+            Pass an `AsyncPostgresSaver` only if calling this subgraph
+            standalone (not via the parent graph).
+
+    Returns:
+        A compiled subgraph (CompiledStateGraph) that exposes `ainvoke` and
+        `astream_events` — drop-in for the previous `create_react_agent`
+        return value.
+    """
+    return create_react_agent(
+        model=llm,
+        tools=tools,
+        prompt=system_prompt,
+        pre_model_hook=pre_model_hook,
+        checkpointer=checkpointer,
+    )

--- a/langchain/graph/router.py
+++ b/langchain/graph/router.py
@@ -1,0 +1,98 @@
+"""Top-level router node — LLM-driven request classifier.
+
+Calls the LLM with structured-output coercion to one of four bucket values
+and writes `state["route"]`. Never wedges the request: any classification
+error (LLM exception, parse failure, missing user message) degrades to the
+`freeform` fallback so subsequent edges can still dispatch the request.
+
+The router uses the same provider/model as the leaf (single-provider
+strategy per the master proposal's Decision 4). The closure pattern lets
+`create_agent` build the node once with its already-configured LLM, then
+hand the resulting node to the StateGraph.
+"""
+import logging
+from typing import Literal
+
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, Field
+
+from prompts.router import ROUTER_FEW_SHOTS, TOP_ROUTER_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+# The classification target. Pydantic model rather than bare Literal so
+# `with_structured_output` accepts it across all backends and the LLM gets
+# field-level metadata (description) to anchor on.
+class TopRouteDecision(BaseModel):
+    """LLM-emitted top-level route classification."""
+
+    route: Literal["phenotyping", "scrna", "analysis", "freeform"] = Field(
+        description=(
+            "phenotyping = cylinder/turface scans + plant traits; "
+            "scrna = single-cell RNA-seq; "
+            "analysis = run a numerical analysis (QC, stats, PCA, viz); "
+            "freeform = anything ambiguous or multi-domain."
+        )
+    )
+
+
+FALLBACK_ROUTE: Literal["freeform"] = "freeform"
+
+
+def _build_classifier_messages(user_text: str) -> list[dict]:
+    """Compose the system prompt + few-shot examples + the new user request."""
+    messages: list[dict] = [{"role": "system", "content": TOP_ROUTER_PROMPT}]
+    for example_user, example_route in ROUTER_FEW_SHOTS:
+        messages.append({"role": "user", "content": example_user})
+        messages.append({"role": "assistant", "content": example_route})
+    messages.append({"role": "user", "content": user_text})
+    return messages
+
+
+def _latest_user_text(messages: list) -> str | None:
+    """Return the content of the most recent HumanMessage, or None."""
+    for msg in reversed(messages):
+        if isinstance(msg, HumanMessage):
+            content = msg.content
+            return content if isinstance(content, str) else str(content)
+    return None
+
+
+def make_top_router_node(llm):
+    """Build the top_router node bound to a specific LLM instance.
+
+    Closure over `llm` so the node signature stays `(state) -> dict` and
+    the parent graph wires it without threading config.
+    """
+    classifier = llm.with_structured_output(TopRouteDecision)
+
+    async def top_router_node(state) -> dict:
+        user_text = _latest_user_text(state.get("messages", []) or [])
+        if user_text is None:
+            logger.warning("top_router: no HumanMessage in state, falling back to %s", FALLBACK_ROUTE)
+            return {"route": FALLBACK_ROUTE}
+
+        try:
+            messages = _build_classifier_messages(user_text)
+            decision = await classifier.ainvoke(messages)
+        except Exception as exc:
+            logger.warning(
+                "top_router: classifier raised %s, falling back to %s",
+                type(exc).__name__,
+                FALLBACK_ROUTE,
+            )
+            return {"route": FALLBACK_ROUTE}
+
+        route = getattr(decision, "route", None)
+        if route not in ("phenotyping", "scrna", "analysis", "freeform"):
+            logger.warning(
+                "top_router: classifier returned unknown route %r, falling back to %s",
+                route,
+                FALLBACK_ROUTE,
+            )
+            return {"route": FALLBACK_ROUTE}
+
+        return {"route": route}
+
+    return top_router_node

--- a/langchain/graph/state.py
+++ b/langchain/graph/state.py
@@ -1,0 +1,49 @@
+"""Typed state schema for the Bloom agent graph.
+
+The state is the shared memory that flows through every node in the graph.
+For Tier 0 it carries only the conversation `messages`; the `route` and
+`analysis_route` fields are reserved here so subsequent tiers (top router,
+analysis sub-router) can write to them without changing the schema.
+
+State-merging notes:
+
+* `messages` uses LangGraph's `add_messages` reducer — without it, every
+  node return would OVERWRITE the message list and we'd lose history.
+* `route` and `analysis_route` are scalar fields with last-write-wins
+  semantics by default. That's acceptable today because no node writes
+  them yet. When the routers land (`add-top-router-with-fallback` and
+  `add-analysis-router-with-fallback`), revisit whether to add a custom
+  reducer that no-ops on `None` so a downstream subgraph can't accidentally
+  clobber a prior router's decision. Tracked as a known issue in
+  `add-stategraph-foundation/proposal.md`.
+"""
+from typing import Annotated, Literal, Optional, TypedDict
+
+from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
+
+
+# Top-level routing destinations. Reserved for `add-top-router-with-fallback`.
+TopRoute = Literal["phenotyping", "scrna", "analysis", "freeform"]
+
+# Analysis sub-router destinations. Reserved for `add-analysis-router-with-fallback`.
+AnalysisRoute = Literal[
+    "qc",
+    "stats",
+    "dimred_cluster",
+    "viz",
+    "correlation",
+    "analysis_freeform",
+]
+
+
+class AgentState(TypedDict):
+    """Shared state for the Bloom agent graph.
+
+    Tier 0 only populates `messages`. Router fields are declared so that
+    later tiers can set them without altering the schema.
+    """
+
+    messages: Annotated[list[BaseMessage], add_messages]
+    route: Optional[TopRoute]
+    analysis_route: Optional[AnalysisRoute]

--- a/langchain/prompts/__init__.py
+++ b/langchain/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt strings for graph nodes — each module exports a single PROMPT constant."""

--- a/langchain/prompts/analysis_freeform.py
+++ b/langchain/prompts/analysis_freeform.py
@@ -1,0 +1,34 @@
+"""Analysis-pool fallback prompt — used when no specialized analysis leaf matches.
+
+The analysis_freeform leaf is the catch-all inside the analysis subgraph. It
+receives requests the analysis_router classified but whose specialized
+destination (qc / stats / dimred_cluster / viz / correlation) hasn't shipped
+yet, OR requests the router itself classified as `analysis_freeform` because
+they span multiple buckets.
+
+Until Tier 3 leaves land, every analysis classification flows here. After Tier
+3 ships, this leaf becomes the genuine multi-bucket fallback only.
+"""
+
+ANALYSIS_FREEFORM_PROMPT = """You are an analysis specialist for the Bloom plant phenotyping platform.
+You have READ access to all SLEAP analysis tools (QC, statistics, dimensionality reduction,
+clustering, outlier detection, visualization, cross-experiment correlation).
+
+The user has an analysis request. You're called either because the request spans multiple
+analysis categories, or as the catch-all fallback for the analysis subgraph.
+
+Workflow rules:
+
+1. ALWAYS call `list_existing_analyses` first to see what's already been computed for the
+   experiment. Avoid redundant work — if a v1 already exists with the right parameters,
+   reference it instead of recomputing.
+
+2. When loading data, prefer the latest cleaned version (default `version="latest"`).
+   The version-aware loader will fall back to raw if no cleaned version exists.
+
+3. Each tool that writes results creates a new versioned directory (`v<N>_<date>[_<label>]`)
+   with a manifest entry. Surface the version_id in your response so the user can cite it.
+
+4. If you're unsure which tool fits, prefer to ask the user a clarifying question over
+   running multiple tools speculatively.
+"""

--- a/langchain/prompts/analysis_router.py
+++ b/langchain/prompts/analysis_router.py
@@ -1,0 +1,50 @@
+"""Sub-router prompt for the analysis subgraph.
+
+Classifies a user's analysis request into one of 6 buckets, mirroring the
+top-level router pattern but scoped to MCP analysis tools. Same calling
+convention: prompt + few-shot pairs + the actual user request, with
+`with_structured_output` enforcing the enum at parse time.
+"""
+
+ANALYSIS_ROUTER_PROMPT = """You are a sub-classifier for analysis requests on a plant phenotyping platform.
+The user has already been classified as wanting an analysis — your job is to choose
+which specialized analysis bucket their request fits.
+Choose `analysis_freeform` whenever the request spans multiple buckets, is exploratory,
+or doesn't clearly fit one of the specific buckets.
+
+Buckets:
+
+- **qc** — Data quality checks, cleanup, outlier detection. Examples: "run a QC report",
+  "clean the data", "find outliers", "inspect data quality", "remove outliers".
+
+- **stats** — Descriptive statistics, ANOVA, heritability. Examples: "compute mean and
+  variance per trait", "run ANOVA by genotype", "calculate heritability for FT22",
+  "diagnose low heritability".
+
+- **dimred_cluster** — PCA, dimensionality reduction, clustering. Examples: "run PCA",
+  "find principal components", "cluster the samples", "K-means", "hierarchical clustering".
+
+- **viz** — Plotting, visualization. Examples: "plot histograms", "make a heatmap",
+  "show a dendrogram", "boxplot trait by genotype", "PCA biplot".
+
+- **correlation** — Cross-experiment correlation. Examples: "correlate trait X across
+  experiments", "compare two waves", "find redundant traits across datasets".
+
+- **analysis_freeform** — Anything ambiguous, multi-bucket, or exploratory. Examples:
+  "explore the data", "what should I do next?", "run a full analysis pipeline",
+  "give me a summary of everything you can do".
+
+Respond with the single chosen bucket value."""
+
+
+# Few-shots in expected production-frequency order (most common first) so the
+# LLM's prior matches real traffic. qc is the most common analysis entry point;
+# correlation is the rarest cross-experiment ask.
+ANALYSIS_ROUTER_FEW_SHOTS = [
+    ("Run a QC report on cylinder_alfalfa_gwas_wave2.csv.", "qc"),
+    ("Plot a histogram of root_length_mm.", "viz"),
+    ("Run PCA on the wave 2 traits.", "dimred_cluster"),
+    ("Calculate heritability for primary_root_length.", "stats"),
+    ("Detect outliers using isolation forest.", "qc"),
+    ("Correlate the same traits across wave 1 and wave 2 datasets.", "correlation"),
+]

--- a/langchain/prompts/router.py
+++ b/langchain/prompts/router.py
@@ -1,0 +1,47 @@
+"""Top-level router prompt.
+
+Classifies an incoming user request into one of four buckets so the
+hierarchical routing topology can dispatch to the appropriate subgraph.
+The classifier is intentionally narrow — when uncertain, choose `freeform`
+so the request still gets answered (just without leaf specialization).
+"""
+
+TOP_ROUTER_PROMPT = """You are a request classifier for a plant phenotyping platform.
+Classify the user's most recent request into exactly one of four buckets.
+Choose `freeform` whenever the request is ambiguous, multi-domain, or doesn't
+fit the other three.
+
+Buckets:
+
+- **phenotyping** — Cylinder/turface scan data, plant traits, root measurements,
+  experiment metadata. Examples: "show me waves for alfalfa", "list cylinder
+  scans from May", "what plants do we have for species X".
+
+- **scrna** — Single-cell RNA-seq data, gene expression, UMAP clusters,
+  cell-type annotations. Examples: "what's the expression of AT1G01010?",
+  "show the UMAP for dataset GSE123", "which clusters are pericycle".
+
+- **analysis** — Any request to RUN a numerical analysis on phenotyping data:
+  QC, outlier detection, descriptive stats, ANOVA, heritability, PCA,
+  clustering, visualization, cross-experiment correlation. Examples: "run a
+  QC report on alfalfa", "do a PCA on the wave 2 traits", "make a heatmap
+  of trait correlations", "find outliers in the foo dataset".
+
+- **freeform** — Anything else: explanations, multi-domain queries, agent
+  meta-questions, ambiguous prompts. Examples: "what can you do?",
+  "explain heritability to me", "compare cylinder vs turface platforms".
+
+Respond with the single chosen bucket value."""
+
+
+# Few-shot examples reinforce the bucket boundaries. Order matters: examples
+# are listed in order of frequency in expected production traffic so the most
+# common patterns dominate the router's prior.
+ROUTER_FEW_SHOTS = [
+    ("List the experiments available for cylinder phenotyping.", "phenotyping"),
+    ("Run a QC report on cylinder_alfalfa_gwas_wave2.csv.", "analysis"),
+    ("What's the expression of AT1G01010 in the dataset?", "scrna"),
+    ("Detect outliers in the wave 2 traits using isolation forest.", "analysis"),
+    ("How does the cylinder platform differ from turface?", "freeform"),
+    ("What plants from species Solanum lycopersicum do we have?", "phenotyping"),
+]

--- a/tests/integration/test_analysis_router.py
+++ b/tests/integration/test_analysis_router.py
@@ -1,0 +1,172 @@
+"""analysis_router_node — second-level classifier with analysis_freeform fallback.
+
+Mirrors the top-level router pattern but scoped to the 6 analysis sub-buckets.
+Tests run against the node directly with a mocked LLM (no live network, no
+compose stack). Per master Decision: every classification error degrades to
+analysis_freeform so the request keeps moving.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+_TMP = tempfile.mkdtemp(prefix="analysis_router_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from langchain_core.messages import HumanMessage  # noqa: E402
+
+from graph.analysis import (  # noqa: E402
+    ANALYSIS_FALLBACK_ROUTE,
+    AnalysisRouteDecision,
+    make_analysis_router_node,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Pin async tests to asyncio only — trio isn't a project dependency."""
+    return "asyncio"
+
+
+def _mock_llm_returning(value):
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(return_value=value)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+def _mock_llm_raising(exc: Exception):
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(side_effect=exc)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+# ─── Success path — one test per real bucket ────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_success_qc():
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="qc"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="run a QC report on alfalfa")]})
+    assert result == {"analysis_route": "qc"}
+
+
+@pytest.mark.anyio
+async def test_router_success_stats():
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="stats"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="calculate heritability")]})
+    assert result == {"analysis_route": "stats"}
+
+
+@pytest.mark.anyio
+async def test_router_success_dimred_cluster():
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="dimred_cluster"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="run PCA on the wave 2 traits")]})
+    assert result == {"analysis_route": "dimred_cluster"}
+
+
+@pytest.mark.anyio
+async def test_router_success_viz():
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="viz"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="plot a histogram of root_length")]})
+    assert result == {"analysis_route": "viz"}
+
+
+@pytest.mark.anyio
+async def test_router_success_correlation():
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="correlation"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="correlate traits across waves")]})
+    assert result == {"analysis_route": "correlation"}
+
+
+@pytest.mark.anyio
+async def test_router_uses_most_recent_user_message():
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="viz"))
+    node = make_analysis_router_node(llm)
+    state = {
+        "messages": [
+            HumanMessage(content="something earlier"),
+            HumanMessage(content="now make a heatmap"),
+        ]
+    }
+    result = await node(state)
+    assert result == {"analysis_route": "viz"}
+
+
+# ─── Fallback paths — every error degrades to analysis_freeform ─────────────
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_llm_exception():
+    llm = _mock_llm_raising(RuntimeError("vLLM unreachable"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="anything")]})
+    assert result == {"analysis_route": ANALYSIS_FALLBACK_ROUTE}
+    assert ANALYSIS_FALLBACK_ROUTE == "analysis_freeform"
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_validation_error():
+    from pydantic import ValidationError as _VE
+    try:
+        AnalysisRouteDecision(route="not_a_real_bucket")
+    except _VE as exc:
+        validation_error = exc
+
+    llm = _mock_llm_raising(validation_error)
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="ambiguous")]})
+    assert result == {"analysis_route": ANALYSIS_FALLBACK_ROUTE}
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_when_no_user_message():
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="qc"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": []})
+    assert result == {"analysis_route": ANALYSIS_FALLBACK_ROUTE}
+
+
+# ─── Determinism + hygiene ───────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_node_returns_only_analysis_route_field():
+    """The node updates only state['analysis_route'], not state['route']
+    or state['messages'] — no clobbering of parent-graph state."""
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="analysis_freeform"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="hi")]})
+    assert set(result.keys()) == {"analysis_route"}
+
+
+@pytest.mark.anyio
+async def test_router_handles_explicit_analysis_freeform_response():
+    """If the LLM itself decides analysis_freeform (not via fallback), pass it through."""
+    llm = _mock_llm_returning(AnalysisRouteDecision(route="analysis_freeform"))
+    node = make_analysis_router_node(llm)
+    result = await node({"messages": [HumanMessage(content="explore the data freely")]})
+    assert result == {"analysis_route": "analysis_freeform"}

--- a/tests/integration/test_context_loader.py
+++ b/tests/integration/test_context_loader.py
@@ -1,0 +1,112 @@
+"""context_loader_node — deterministic agent-context injection before any LLM call.
+
+These tests exercise the context-loader node directly (no LLM, no compose stack).
+They verify the contract:
+  - First call on a fresh state injects a marked SystemMessage.
+  - Subsequent calls within the same thread are no-ops (idempotent).
+  - The closure honours the bound tool_set.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+# Some langchain modules read env vars at import time; provide safe defaults.
+_TMP = tempfile.mkdtemp(prefix="context_loader_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from langchain_core.messages import HumanMessage, SystemMessage  # noqa: E402
+
+from graph.context_loader import (  # noqa: E402
+    CONTEXT_MARKER,
+    make_context_loader_node,
+)
+
+
+def test_context_loader_injects_system_message_on_fresh_state():
+    node = make_context_loader_node(tool_set="all")
+    state = {"messages": [HumanMessage(content="hi")]}
+
+    result = node(state)
+
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert isinstance(msg, SystemMessage)
+    assert CONTEXT_MARKER in msg.content
+    # The actual context content from get_agent_context is a non-empty string
+    assert len(msg.content) > len(CONTEXT_MARKER) + 10
+
+
+def test_context_loader_is_idempotent_on_second_call():
+    """If a marked SystemMessage already exists in state, return {} (no-op)."""
+    node = make_context_loader_node(tool_set="all")
+    state_after_first = {
+        "messages": [
+            HumanMessage(content="hi"),
+            SystemMessage(content=f"{CONTEXT_MARKER}\nsome cached context"),
+        ]
+    }
+    result = node(state_after_first)
+
+    # No new messages appended — node detected prior context-flagged message
+    assert result == {}
+
+
+def test_context_loader_appends_when_only_unmarked_system_message_exists():
+    """A SystemMessage WITHOUT the marker (e.g. summary) doesn't count as
+    prior context — node still injects."""
+    node = make_context_loader_node(tool_set="all")
+    state = {
+        "messages": [
+            SystemMessage(content="Conversation summary so far: ..."),
+            HumanMessage(content="follow-up"),
+        ]
+    }
+    result = node(state)
+
+    assert "messages" in result
+    assert isinstance(result["messages"][0], SystemMessage)
+    assert CONTEXT_MARKER in result["messages"][0].content
+
+
+def test_context_loader_respects_bound_tool_set():
+    """Different tool_set bindings produce different context content."""
+    all_node = make_context_loader_node(tool_set="all")
+    scrna_node = make_context_loader_node(tool_set="scrna")
+
+    state = {"messages": [HumanMessage(content="hi")]}
+    all_result = all_node(state)
+    scrna_result = scrna_node(state)
+
+    all_content = all_result["messages"][0].content
+    scrna_content = scrna_result["messages"][0].content
+
+    # Tool sets differ — content must differ. Both contain the marker.
+    assert CONTEXT_MARKER in all_content
+    assert CONTEXT_MARKER in scrna_content
+    assert all_content != scrna_content
+
+
+def test_context_loader_handles_empty_state():
+    """No messages in state: still inject the marker SystemMessage."""
+    node = make_context_loader_node(tool_set="all")
+    result = node({"messages": []})
+
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    assert CONTEXT_MARKER in result["messages"][0].content

--- a/tests/integration/test_top_router.py
+++ b/tests/integration/test_top_router.py
@@ -1,0 +1,175 @@
+"""top_router_node — LLM-driven request classifier with freeform fallback.
+
+These tests exercise the router node directly with a mocked LLM (no live
+network, no compose stack). They verify the contract:
+
+  - Success: LLM returns a valid Literal value → state["route"] = that value.
+  - LLM exception → fallback to "freeform" + log a warning.
+  - LLM returns an out-of-enum value → fallback to "freeform".
+  - Structured-output parse failure → fallback to "freeform".
+
+Per the "Freeform fallback at every router level" master decision, a
+classification error MUST never wedge the request — it always degrades to
+the freeform leaf so the agent keeps responding.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+_TMP = tempfile.mkdtemp(prefix="top_router_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from langchain_core.messages import HumanMessage  # noqa: E402
+
+from graph.router import (  # noqa: E402
+    FALLBACK_ROUTE,
+    TopRouteDecision,
+    make_top_router_node,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Pin async tests to asyncio only — trio isn't a project dependency."""
+    return "asyncio"
+
+
+def _mock_llm_returning(value):
+    """Build a mock chat model where with_structured_output returns a chain
+    whose ainvoke yields the given value."""
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(return_value=value)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+def _mock_llm_raising(exc: Exception):
+    """Build a mock chat model whose structured-output ainvoke raises exc."""
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(side_effect=exc)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+# ─── Success path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_success_phenotyping():
+    decision = TopRouteDecision(route="phenotyping")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="list cylinder plants from wave 2")]})
+
+    assert result == {"route": "phenotyping"}
+
+
+@pytest.mark.anyio
+async def test_router_success_analysis():
+    decision = TopRouteDecision(route="analysis")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="run a QC report on alfalfa")]})
+
+    assert result == {"route": "analysis"}
+
+
+@pytest.mark.anyio
+async def test_router_uses_most_recent_user_message():
+    """Router should classify based on the latest HumanMessage, not the first."""
+    decision = TopRouteDecision(route="scrna")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    state = {
+        "messages": [
+            HumanMessage(content="something earlier and unrelated"),
+            HumanMessage(content="show me the UMAP for dataset X"),
+        ]
+    }
+    result = await node(state)
+
+    assert result == {"route": "scrna"}
+
+
+# ─── Fallback paths — every error degrades to freeform ───────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_llm_exception():
+    """Network failure or LLM crash should not wedge the request."""
+    llm = _mock_llm_raising(RuntimeError("vLLM unreachable"))
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="anything")]})
+
+    assert result == {"route": FALLBACK_ROUTE}
+    assert FALLBACK_ROUTE == "freeform"
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_parse_error():
+    """If the LLM's structured output can't be parsed (validation error
+    from the wrapping layer), fall back to freeform."""
+    from pydantic import ValidationError as _VE
+    # Construct a real pydantic ValidationError by intentionally validating
+    # an out-of-enum value, so the exception path matches what production
+    # would see when with_structured_output retries fail.
+    try:
+        TopRouteDecision(route="not_a_real_route")
+    except _VE as exc:
+        validation_error = exc
+
+    llm = _mock_llm_raising(validation_error)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="ambiguous prompt")]})
+
+    assert result == {"route": FALLBACK_ROUTE}
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_when_no_user_message():
+    """Defensive: state with no HumanMessage shouldn't crash; route to freeform."""
+    llm = _mock_llm_returning(TopRouteDecision(route="phenotyping"))
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": []})
+
+    # Empty input should not even reach the LLM; freeform fallback.
+    assert result == {"route": FALLBACK_ROUTE}
+
+
+# ─── Determinism ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_node_signature_returns_only_route_field():
+    """The router updates only state['route'], nothing else."""
+    decision = TopRouteDecision(route="freeform")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="hi")]})
+
+    assert set(result.keys()) == {"route"}


### PR DESCRIPTION
## Summary

Adds the **second-level router and analysis_freeform fallback leaf** inside a new analysis subgraph, plugged in at the parent graph's `"analysis"` route destination. **Wiring only** — every analysis sub-route currently dispatches to `analysis_freeform`, so sub-proposals can each replace one destination with a specialized leaf without touching the router contract.

This is the **Tier routing scaffold** from the agent-architecture roadmap. After this lands, every leaf PR (`add-qc-leaf`, `add-stats-leaf`, etc.) is a one-line edit to the analysis subgraph's destinations dict.

## Topology added

Inside the new analysis subgraph:

```
START
  ↓
analysis_router  (LLM call → state["analysis_route"])
  ↓
conditional edge: state["analysis_route"] → leaf name
  ↓ (every value currently → "analysis_freeform")
analysis_freeform  (ReAct loop, MCP tools only)
  ↓
END
```

Parent graph after this PR:

```
START → context_loader → top_router →
   ├─ "phenotyping" → freeform           (still catch-all)
   ├─ "scrna"       → freeform           (still catch-all)
   ├─ "analysis"    → analysis_subgraph  ← NEW
   └─ "freeform"    → freeform
```

## What's in this PR

**New** `langchain/graph/analysis.py` — `build_analysis_subgraph(llm, mcp_tools, pre_model_hook)`

Three pieces:
- `AnalysisRouteDecision` — Pydantic model with `Literal["qc","stats","dimred_cluster","viz","correlation","analysis_freeform"]` for `with_structured_output`
- `make_analysis_router_node(llm)` — closure factory, same shape as `make_top_router_node`. Three-way fallback to `analysis_freeform` (LLM exception / validation error / missing user message)
- `build_analysis_subgraph(...)` — returns a compiled `StateGraph(AgentState)` containing the router + freeform leaf + conditional edges

**New** `langchain/prompts/analysis_router.py` — `ANALYSIS_ROUTER_PROMPT` + 6 few-shot examples in expected-frequency order (qc most common, correlation rarest).

**New** `langchain/prompts/analysis_freeform.py` — `ANALYSIS_FREEFORM_PROMPT` for the fallback leaf. Workflow rules: call `list_existing_analyses` first, prefer latest cleaned version, surface `version_id` in responses.

**Modified** `langchain/agent.py::create_agent` — builds `analysis_subgraph`, registers it as a node, top-level conditional edge now maps `"analysis"` to `"analysis_subgraph"` (other three values still map to `"freeform"`). One-line change to the destinations dict.

## Stacking notes

PR base is `feat/agent-top-router` (PR #201). Logical dependencies:
- **PR #196** — StateGraph foundation (parent graph)
- **PR #195** — system-message merge fix (multi-system-message handling on Qwen)
- **PR #200** — context-loader
- **PR #201** — top-router (provides the `"analysis"` route destination)

When all upstream PRs merge to `staging`, retarget this PR's base for a clean diff.