### PR TITLE
feat(agent): qc_leaf — first Tier 3 specialized leaf (QC + outlier detection)

### DIFF
--- a/langchain/graph/analysis.py
+++ b/langchain/graph/analysis.py
@@ -23,6 +23,7 @@ from langgraph.graph import StateGraph, START, END
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
+from graph.leaves.qc import build_qc_leaf
 from graph.state import AgentState
 from prompts.analysis_freeform import ANALYSIS_FREEFORM_PROMPT
 from prompts.analysis_router import (
@@ -158,7 +159,9 @@ def build_analysis_subgraph(llm, mcp_tools: list, pre_model_hook=None):
     analysis_router = make_analysis_router_node(llm)
 
     # Inner ReAct loop with MCP-only tools and the analysis-focused prompt.
-    # checkpointer=None — parent graph in agent.py owns thread state.
+    # Catch-all for analysis requests that don't fit one of the specialized
+    # Tier 3 leaves (and the destination for analysis_router's
+    # `analysis_freeform` classification).
     analysis_freeform = create_react_agent(
         model=llm,
         tools=mcp_tools or [],
@@ -167,15 +170,27 @@ def build_analysis_subgraph(llm, mcp_tools: list, pre_model_hook=None):
         checkpointer=None,
     )
 
+    # qc leaf — Tier 3 specialized leaf for data quality + outlier detection.
+    # Sees only the 11 QC + outlier tools (plus list_existing_analyses) under
+    # the QC_PROMPT, so the LLM reasons over a tight surface and the leaf's
+    # workflow rules (check existing analyses first, surface source labels,
+    # pick the right outlier method) anchor the decision-making.
+    qc_leaf = build_qc_leaf(
+        llm=llm,
+        mcp_tools=mcp_tools or [],
+        pre_model_hook=pre_model_hook,
+    )
+
     builder = StateGraph(AgentState)
     builder.add_node("analysis_router", analysis_router)
     builder.add_node("analysis_freeform", analysis_freeform)
+    builder.add_node("qc_leaf", qc_leaf)
     builder.add_edge(START, "analysis_router")
     builder.add_conditional_edges(
         "analysis_router",
         lambda state: state["analysis_route"],
         {
-            "qc": "analysis_freeform",
+            "qc": "qc_leaf",
             "stats": "analysis_freeform",
             "dimred_cluster": "analysis_freeform",
             "viz": "analysis_freeform",
@@ -183,5 +198,6 @@ def build_analysis_subgraph(llm, mcp_tools: list, pre_model_hook=None):
             "analysis_freeform": "analysis_freeform",
         },
     )
+    builder.add_edge("qc_leaf", END)
     builder.add_edge("analysis_freeform", END)
     return builder.compile()

--- a/langchain/graph/leaves/__init__.py
+++ b/langchain/graph/leaves/__init__.py
@@ -1,0 +1,12 @@
+"""Tier 3 specialized analysis leaves.
+
+Each leaf is a focused ReAct loop with a narrow tool surface and a dedicated
+prompt. Leaves plug into the analysis subgraph at the destinations of the
+analysis_router's conditional edge.
+
+Today: only qc. Future leaves (stats, dimred_cluster, viz, correlation) follow
+the same factory + prompt + filter pattern.
+"""
+from .qc import QC_LEAF_TOOL_NAMES, build_qc_leaf, filter_qc_tools
+
+__all__ = ["QC_LEAF_TOOL_NAMES", "build_qc_leaf", "filter_qc_tools"]

--- a/langchain/graph/leaves/qc.py
+++ b/langchain/graph/leaves/qc.py
@@ -1,0 +1,79 @@
+"""QC leaf — Tier 3 specialized analysis leaf for data quality + outlier detection.
+
+Provides:
+  - QC_LEAF_TOOL_NAMES: the explicit set of tool names the leaf exposes (12 total:
+    6 qc_tools + 5 outlier_tools + list_existing_analyses)
+  - filter_qc_tools(mcp_tools): filter the full MCP tool list down to the QC subset
+  - build_qc_leaf(llm, mcp_tools, pre_model_hook): factory returning a compiled
+    ReAct subgraph with the narrowed tool surface and the QC prompt
+
+Plugged into the analysis subgraph at the "qc" destination (replaces the
+placeholder edge `"qc" -> "analysis_freeform"` from PR #202).
+"""
+from langgraph.prebuilt import create_react_agent
+
+from prompts.qc import QC_PROMPT
+
+
+# The exact tool surface the QC leaf exposes. Hardcoded by name rather than
+# heuristic-matched against bloommcp module structure so:
+#   1. The leaf's surface is auditable from one place
+#   2. Reordering bloommcp modules doesn't accidentally expand or contract scope
+#   3. Tests can assert the set without depending on a live MCP catalog
+QC_LEAF_TOOL_NAMES = frozenset(
+    {
+        # qc_tools (6) — discovery + inspection + cleanup
+        "list_available_experiments",
+        "inspect_experiment_columns",
+        "load_experiment_data",
+        "inspect_data_quality",
+        "clean_experiment_data",
+        "list_trait_columns",
+        # outlier_tools (5) — detection + removal
+        "detect_outliers_mahalanobis",
+        "detect_outliers_isolation_forest",
+        "detect_outliers_pca",
+        "run_consensus_outlier_detection",
+        "remove_detected_outliers",
+        # storage introspection (1) — required for the prompt's
+        # "check existing analyses first" rule
+        "list_existing_analyses",
+    }
+)
+
+
+def filter_qc_tools(mcp_tools):
+    """Return only the MCP tools whose names are in the QC leaf's surface.
+
+    Tools missing from the input list are silently dropped — the leaf works
+    with whatever subset of QC tools the agent actually loaded. Unknown tool
+    names in the input list are also dropped (defensive against drift).
+    """
+    if not mcp_tools:
+        return []
+    return [t for t in mcp_tools if getattr(t, "name", None) in QC_LEAF_TOOL_NAMES]
+
+
+def build_qc_leaf(llm, mcp_tools, pre_model_hook=None):
+    """Build the compiled QC leaf — a ReAct loop over the narrowed tool surface.
+
+    Args:
+        llm: Chat model instance, same as the leaf's parent (single-provider
+            strategy per master Decision 4).
+        mcp_tools: The full MCP tool list. Filtered to QC + outlier internally.
+        pre_model_hook: Optional pre-LLM-call hook (token trim / summarize /
+            single-SystemMessage merge) applied to every LLM call in the loop.
+
+    Returns:
+        A compiled subgraph (CompiledStateGraph) suitable for use as a node
+        in the analysis subgraph. checkpointer=None — the parent graph in
+        agent.py owns thread state.
+    """
+    qc_tools = filter_qc_tools(mcp_tools)
+    return create_react_agent(
+        model=llm,
+        tools=qc_tools,
+        prompt=QC_PROMPT,
+        pre_model_hook=pre_model_hook,
+        checkpointer=None,
+    )

--- a/langchain/prompts/qc.py
+++ b/langchain/prompts/qc.py
@@ -1,0 +1,46 @@
+"""QC leaf prompt — focused on data quality + outlier detection workflow.
+
+This is the system prompt the qc_leaf's ReAct loop sees. It scopes the LLM's
+behaviour to QC tasks and bakes in the workflow rules from the QC sub-proposal:
+
+  - Check existing analyses first (list_existing_analyses)
+  - Inspect before cleaning
+  - Surface source labels (raw vs v<N>_cleaned) on every numerical report
+  - Pick the right outlier method based on the data's distribution
+  - Out-of-domain signal: bow out cleanly when the request isn't QC
+
+The LLM only sees the 11 QC + outlier tools (plus foundational), so a
+misclassified non-QC request can't accidentally execute the wrong tool.
+"""
+
+QC_PROMPT = """You are the QC specialist for the Bloom plant phenotyping platform.
+You handle data quality inspection, cleanup, and outlier detection on phenotyping CSV files.
+
+## Workflow
+
+For every QC request, follow this sequence:
+
+1. **Check existing analyses first.** Call `list_existing_analyses(experiment_filename)` to see what's already been computed. If a recent QC version (v1, v2, ...) exists with the right parameters, reference it instead of recomputing. Save the user time and disk space.
+
+2. **Inspect before acting.** Call `inspect_data_quality(filename)` to surface the issues (NaN samples, zero-inflated traits, low-sample traits) before suggesting cleanup. Don't clean blindly — show the user what you'll filter and why.
+
+3. **Cleanup is destructive in spirit.** `clean_experiment_data` writes a new versioned `_cleaned.csv` and the manifest's `latest` pointer moves. Subsequent loads in this leaf and other leaves prefer the cleaned version silently. **Always surface the source label** (`"raw"` / `"legacy_cleaned"` / `"v<N>_cleaned"`) when reporting any numerical result so the user knows which dataset version produced a number.
+
+4. **Outlier detection — pick the right method.** When asked to detect outliers, choose based on the data:
+   - `detect_outliers_mahalanobis` — assumes multivariate normality. Good for trait sets with linear correlations and roughly Gaussian distribution.
+   - `detect_outliers_isolation_forest` — non-parametric, no distribution assumption. Good when traits are non-linear, non-Gaussian, or when you can estimate the contamination fraction.
+   - `detect_outliers_pca` — high-dimensional reconstruction error. Good when many traits are highly correlated and you want to flag samples that don't fit the principal subspace.
+   - `run_consensus_outlier_detection` — runs all three and reports samples flagged by ≥ 2 methods. The most robust default. Use this when you're unsure which single method fits.
+
+   A misapplied method produces misleading scientific output. When the user doesn't specify, default to `run_consensus_outlier_detection`.
+
+## Output discipline
+
+- Report numerical values **verbatim from tool outputs**. No LLM rounding of NaN counts, outlier IDs, descriptive statistics. The agent's job is to surface, not to summarize-with-loss.
+- Always cite the `version_id` (v1, v2, ...) the cleanup or outlier tool created so the user can reference it later.
+- When loading data, surface the `source` label from `load_experiment_data` so the user knows whether they're seeing raw or cleaned data.
+
+## Out-of-domain requests
+
+If the user's request is clearly NOT QC (e.g., "make a heatmap", "compute heritability", "run PCA", "correlate across experiments"), respond with a brief note that the request belongs to a different leaf (`viz` / `stats` / `dimred_cluster` / `correlation`) and suggest they rephrase or that the agent re-route. Do NOT attempt the request with QC tools — you don't have the right tool surface.
+"""

--- a/tests/integration/test_qc_leaf.py
+++ b/tests/integration/test_qc_leaf.py
@@ -1,0 +1,181 @@
+"""qc_leaf — Tier 3 specialized analysis leaf for QC + outlier detection.
+
+Verifies the leaf's tool-filtering contract: only QC + outlier tools (plus
+foundational MCP tools) reach the leaf. Non-QC analysis tools (stats, dimred,
+viz, correlation) are excluded so the LLM reasons over a tight surface.
+
+Tests run against the leaf factory and helpers directly. The compiled
+ReAct subgraph itself is exercised via the prebuilt `create_react_agent`
+machinery in upstream LangGraph; we don't re-test that here.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+_TMP = tempfile.mkdtemp(prefix="qc_leaf_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from graph.leaves.qc import (  # noqa: E402
+    QC_LEAF_TOOL_NAMES,
+    build_qc_leaf,
+    filter_qc_tools,
+)
+
+
+def _mock_tool(name: str):
+    """Build a stub object with a `.name` attribute mimicking a LangChain tool."""
+    tool = MagicMock()
+    tool.name = name
+    return tool
+
+
+def _mock_llm():
+    """Bare-minimum mock that satisfies create_react_agent's bind path."""
+    llm = MagicMock()
+    # create_react_agent calls llm.bind_tools or llm.with_config; return self.
+    llm.bind_tools = MagicMock(return_value=llm)
+    llm.with_config = MagicMock(return_value=llm)
+    return llm
+
+
+# ─── Tool filtering ──────────────────────────────────────────────────────────
+
+
+def test_filter_qc_tools_includes_all_expected_tool_names():
+    """Every QC + outlier + foundational tool name in the registry passes through."""
+    fake_tools = [_mock_tool(n) for n in QC_LEAF_TOOL_NAMES]
+    filtered = filter_qc_tools(fake_tools)
+    assert {t.name for t in filtered} == QC_LEAF_TOOL_NAMES
+
+
+def test_filter_qc_tools_excludes_non_qc_analysis_tools():
+    """stats / dimred / clustering / viz / correlation tools are filtered out."""
+    out_of_scope = [
+        "get_trait_statistics",
+        "run_anova_by_genotype",
+        "calculate_heritability",
+        "run_pca",
+        "get_pca_feature_contributions",
+        "run_kmeans_clustering",
+        "plot_trait_histograms",
+        "plot_correlation_heatmap",
+        "run_cross_experiment_correlations",
+    ]
+    in_scope = list(QC_LEAF_TOOL_NAMES)
+    fake_tools = [_mock_tool(n) for n in out_of_scope + in_scope]
+
+    filtered = filter_qc_tools(fake_tools)
+
+    # Only in-scope tools come through
+    assert {t.name for t in filtered} == set(in_scope)
+    # Nothing from out-of-scope leaks
+    for name in out_of_scope:
+        assert name not in {t.name for t in filtered}
+
+
+def test_filter_qc_tools_handles_empty_input():
+    assert filter_qc_tools([]) == []
+    assert filter_qc_tools(None) == []
+
+
+def test_filter_qc_tools_handles_unknown_tool_names_gracefully():
+    """Tool names not in the QC registry are dropped without error."""
+    fake_tools = [_mock_tool("totally_made_up_tool"), _mock_tool("inspect_data_quality")]
+    filtered = filter_qc_tools(fake_tools)
+    assert {t.name for t in filtered} == {"inspect_data_quality"}
+
+
+# ─── Foundational tools — always present ─────────────────────────────────────
+
+
+def test_qc_leaf_tool_set_includes_all_foundational_tools():
+    """The four ALWAYS_INCLUDE_MCP_TOOLS must be in the QC tool set so a fresh
+    chat session can self-orient even before any QC-specific tool runs."""
+    foundational = {
+        "list_available_experiments",
+        "load_experiment_data",
+        "inspect_data_quality",
+        "list_existing_analyses",
+    }
+    assert foundational.issubset(QC_LEAF_TOOL_NAMES)
+
+
+# ─── Leaf factory ────────────────────────────────────────────────────────────
+
+
+def test_build_qc_leaf_returns_a_compiled_subgraph():
+    """The factory returns the result of create_react_agent (a compiled subgraph)."""
+    llm = _mock_llm()
+    fake_mcp_tools = [_mock_tool(n) for n in QC_LEAF_TOOL_NAMES]
+
+    with patch("graph.leaves.qc.create_react_agent") as mock_react:
+        mock_react.return_value = MagicMock(name="compiled_subgraph")
+        leaf = build_qc_leaf(llm, fake_mcp_tools)
+
+    assert leaf is not None
+    assert mock_react.called
+
+
+def test_build_qc_leaf_filters_unrelated_tools_before_passing_to_react_agent():
+    """The factory passes the FILTERED tool list to create_react_agent — out-of-scope
+    tools never reach the prebuilt ReAct loop."""
+    llm = _mock_llm()
+    fake_mcp_tools = [
+        _mock_tool("clean_experiment_data"),       # QC, in-scope
+        _mock_tool("detect_outliers_pca"),         # outlier, in-scope
+        _mock_tool("run_pca"),                      # dimred, OUT-of-scope
+        _mock_tool("plot_correlation_heatmap"),     # viz, OUT-of-scope
+        _mock_tool("list_existing_analyses"),       # foundational, in-scope
+    ]
+
+    with patch("graph.leaves.qc.create_react_agent") as mock_react:
+        mock_react.return_value = MagicMock()
+        build_qc_leaf(llm, fake_mcp_tools)
+
+    # Inspect the tools= kwarg passed to create_react_agent
+    call_kwargs = mock_react.call_args.kwargs
+    passed_tools = call_kwargs["tools"]
+    passed_names = {t.name for t in passed_tools}
+
+    assert passed_names == {
+        "clean_experiment_data",
+        "detect_outliers_pca",
+        "list_existing_analyses",
+    }
+    assert "run_pca" not in passed_names
+    assert "plot_correlation_heatmap" not in passed_names
+
+
+def test_build_qc_leaf_handles_empty_mcp_tools_without_error():
+    """Defensive: leaf still compiles even if no MCP tools are loaded."""
+    llm = _mock_llm()
+    with patch("graph.leaves.qc.create_react_agent") as mock_react:
+        mock_react.return_value = MagicMock()
+        leaf = build_qc_leaf(llm, [])
+    assert leaf is not None
+
+
+# ─── Tool count sanity check ─────────────────────────────────────────────────
+
+
+def test_qc_leaf_tool_set_has_expected_count():
+    """The proposal targets ~11 specialized tools (6 qc + 5 outlier) plus
+    foundational. Today's count: 11 (foundational already overlap with qc_tools)."""
+    # 6 qc_tools + 5 outlier_tools = 11 (list_existing_analyses is added once)
+    assert len(QC_LEAF_TOOL_NAMES) == 12  # 11 + list_existing_analyses


### PR DESCRIPTION
## Summary

Replaces the placeholder `analysis_router` edge for `state['analysis_route'] == 'qc'` with a real specialized leaf. The QC leaf is a ReAct loop over a tight **12-tool surface** (6 qc_tools + 5 outlier_tools + `list_existing_analyses`) under a dedicated prompt that bakes in the QC workflow rules.

**This is the first Tier 3 leaf.** It's also the one the parallel-recipes demo headline depends on — the QC-report fan-out (qc + outlier + stats in parallel via `Send`) lives inside this leaf.

## Topology delta

Inside the analysis subgraph (PR #202), the conditional-edge dispatch table changes one entry:

```diff
 {
-    "qc":             "analysis_freeform",   # placeholder
+    "qc":             "qc_leaf",             # specialized
     "stats":          "analysis_freeform",
     "dimred_cluster": "analysis_freeform",
     "viz":            "analysis_freeform",
     "correlation":    "analysis_freeform",
     "analysis_freeform": "analysis_freeform",
 }
```

Plus the new `qc_leaf` node and `qc_leaf → END` edge. That's the ENTIRE wiring change. The remaining Tier 3 leaves follow the same pattern — one-line edit each.

## What's in this PR

**New** `langchain/graph/leaves/qc.py` — `build_qc_leaf(llm, mcp_tools, pre_model_hook)` + `filter_qc_tools` + `QC_LEAF_TOOL_NAMES`

```python
QC_LEAF_TOOL_NAMES = frozenset({
    # qc_tools (6)
    "list_available_experiments", "inspect_experiment_columns",
    "load_experiment_data", "inspect_data_quality",
    "clean_experiment_data", "list_trait_columns",
    # outlier_tools (5)
    "detect_outliers_mahalanobis", "detect_outliers_isolation_forest",
    "detect_outliers_pca", "run_consensus_outlier_detection",
    "remove_detected_outliers",
    # storage introspection (1)
    "list_existing_analyses",
})

def build_qc_leaf(llm, mcp_tools, pre_model_hook=None):
    qc_tools = filter_qc_tools(mcp_tools)
    return create_react_agent(model=llm, tools=qc_tools, prompt=QC_PROMPT, ...)
```

The tool surface is hardcoded by name rather than heuristic-matched against bloommcp module structure. Three reasons:
1. The leaf's exact surface is auditable from one place
2. Reordering bloommcp modules can't accidentally expand or contract scope
3. Tests can assert the set without depending on a live MCP catalog

**New** `langchain/prompts/qc.py` — `QC_PROMPT`

Four data-integrity rules baked into the prompt:

1. **Check existing analyses first** via `list_existing_analyses` — avoids redundant computation when a recent QC version already exists
2. **Inspect before cleaning** — surface NaN counts, zero-inflated traits, low-sample traits before suggesting cleanup
3. **Surface source labels** (`raw` / `legacy_cleaned` / `v<N>_cleaned`) on every numerical report so the user knows which dataset version produced each number
4. **Pick the right outlier method**:
   - `mahalanobis` — multivariate normality assumed
   - `isolation_forest` — non-parametric
   - `pca` — high-dimensional correlated traits
   - `consensus` — most robust default (runs all three, reports samples flagged by ≥2)

Plus an out-of-domain instruction: if the user asks for stats / viz / dimred / correlation, bow out cleanly instead of attempting with the wrong tool surface.

**New** `langchain/graph/leaves/__init__.py` — package marker, future Tier 3 leaves drop in here

**Modified** `langchain/graph/analysis.py` — register `qc_leaf` as a node, change `"qc": "analysis_freeform"` → `"qc": "qc_leaf"`, add edge `qc_leaf → END`

## Tests

`tests/integration/test_qc_leaf.py` — 9 cases:

| Category | Tests |
|---|---|
| Tool filtering | All in-scope tools pass through; out-of-scope (stats/dimred/viz/correlation) excluded; empty input handled; unknown names dropped silently |
| Foundational tools always present | The 4 `ALWAYS_INCLUDE_MCP_TOOLS` (`list_available_experiments`, `load_experiment_data`, `inspect_data_quality`, `list_existing_analyses`) are in `QC_LEAF_TOOL_NAMES` |
| Factory hygiene | `build_qc_leaf` returns a compiled subgraph; passes the FILTERED tool list to `create_react_agent` (not the full mcp_tools); handles empty mcp_tools without error |
| Sanity | Tool count is 12 (matches the proposal) |

**9/9 green** with mocked LLM + mocked `create_react_agent`. Combined: 32/32 across context_loader (5) + top_router (7) + analysis_router (11) + qc_leaf (9). All filesystem/mock — no live LLM, no compose stack.

## Why it matters

This PR is the first time the agent's tool surface gets meaningfully narrower for a specific request type:

- Before this PR: a "run QC on alfalfa" request lands in `analysis_freeform` with **40 MCP tools** in scope
- After this PR: lands in `qc_leaf` with **12 tools** in scope
- The LLM's tool-pick search space shrinks 3.3× for QC requests, with a prompt specialized for QC workflow

This is exactly the architectural payoff the routing track promised — and it's where Phase B-1's storage layer pays off, because the QC leaf's prompt explicitly leverages `list_existing_analyses` to avoid redundant work.

## File-change footprint

3 new + 1 modified = 4 files. Within the ~5 estimate from the proposal.

## Stacking notes

PR base is `feat/agent-analysis-router` (PR #202). Logical dependencies:
- **PR #196** — StateGraph foundation
- **PR #195** — system-message merge fix
- **PR #200** — context-loader
- **PR #201** — top-router
- **PR #202** — analysis subgraph (provides the `"qc"` route destination)

Plus an implicit dependency on **PR #198 + #199** (storage Phase A + B-1) at runtime, because the QC prompt instructs the LLM to call `list_existing_analyses` and use versioned writes.

When all upstream PRs merge to `staging`, retarget this PR's base for a clean diff.

## What's next

Each of the remaining 4 Tier 3 leaves (`add-stats-leaf`, `add-dimred-cluster-leaf`, `add-viz-leaf`, `add-correlation-leaf`) is a copy of this PR's shape with a different tool list and prompt:

```python
# langchain/graph/leaves/stats.py
STATS_LEAF_TOOL_NAMES = frozenset({"get_trait_statistics", "run_anova_by_genotype", ...})
def build_stats_leaf(llm, mcp_tools, pre_model_hook=None): ...

# langchain/graph/analysis.py — one-line dict edit
"stats": "stats_leaf",
```

Each ~5 files, ~1 day of work. They can ship in parallel after this PR.

The critical-path PR after this one is **`add-parallel-recipes`** (the demo headline) which uses qc_leaf + Storage Phase B-1's `with_snapshot` to fan out the QC report.
