### PR TITLE
fix(kong): register bloom_agent consumer for PostgREST access

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -158,6 +158,7 @@ services:
       KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      BLOOM_AGENT_KEY: ${BLOOM_AGENT_KEY}
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
     entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -244,6 +244,7 @@ services:
       KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      BLOOM_AGENT_KEY: ${BLOOM_AGENT_KEY}
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
     entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'

--- a/volumes/api/kong.yml
+++ b/volumes/api/kong.yml
@@ -12,6 +12,9 @@ consumers:
   - username: service_role
     keyauth_credentials:
       - key: $SUPABASE_SERVICE_KEY
+  - username: bloom_agent
+    keyauth_credentials:
+      - key: $BLOOM_AGENT_KEY
 
 ###
 ### Access Control List
@@ -21,6 +24,8 @@ acls:
     group: anon
   - consumer: service_role
     group: admin
+  - consumer: bloom_agent
+    group: bloom_agent
 
 ###
 ### Dashboard credentials
@@ -104,6 +109,7 @@ services:
           allow:
             - admin
             - anon
+            - bloom_agent
 
   ## Secure GraphQL routes
   - name: graphql-v1


### PR DESCRIPTION
## Problem

The agent uses `BLOOM_AGENT_KEY` to query PostgREST, but Kong's `key-auth` plugin doesn't know about that key — only `anon` and `service_role` are registered. Every agent request gets rejected at the gateway with `Invalid authentication credentials`. All agent data queries through Kong are silently broken.

## Fix

- `volumes/api/kong.yml` — register `bloom_agent` as a Kong consumer with `BLOOM_AGENT_KEY`, give it its own ACL group, and allow that group on the `rest-v1` route.
- `docker-compose.dev.yml` + `docker-compose.prod.yml` — pass `BLOOM_AGENT_KEY` into the kong container's env so the `$BLOOM_AGENT_KEY` substitution in `kong.yml` resolves at startup.

`.env.dev` already has the key. Prod will pick it up from the deploy environment.