### PR TITLE
fix(agent): fixes in the top router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ docker-compose.prod copy.yml
 DOCUMENTATION.md
 TROUBLESHOOTING.md
 prompts/
+# Re-include the langchain agent's prompt module (the gitignore rule above
+# catches Claude-Code planning folders named `prompts/`; this re-includes
+# the production code path the agent uses for graph-node prompts).
+!langchain/prompts/
+!langchain/prompts/**
 .claude/settings.local.json
 .claude/draft-pr/
 langchain/ANALYSIS_OUTPUT/

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -16,6 +16,7 @@ import logging
 from rich.logging import RichHandler
 from rich.traceback import install
 from db_url import compose_postgres_url
+from graph.context_loader import make_context_loader_node
 from graph.freeform import build_freeform_subgraph
 from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
@@ -82,16 +83,6 @@ async def setup_checkpointer() -> AsyncPostgresSaver:
 def _count_tokens(messages) -> int:
     """Approximate token count (~4 chars per token)."""
     return sum(len(str(m.content)) for m in messages) // 4
-
-
-def _has_context_call(messages) -> bool:
-    """Check if get_agent_context was already called in the conversation."""
-    for msg in messages:
-        if isinstance(msg, AIMessage) and msg.tool_calls:
-            for tc in msg.tool_calls:
-                if tc.get("name") == "get_agent_context":
-                    return True
-    return False
 
 
 SUMMARIZATION_PROMPT = """Summarize the following conversation between a user and an AI assistant on a plant biology platform.
@@ -174,12 +165,10 @@ def make_pre_model_hook(provider: str = "openai", llm=None):
 
     async def pre_model_hook(state):
         messages = state["messages"]
-        # Safety net: remind to call get_agent_context on first turn
-        if len(messages) <= 2 and not _has_context_call(messages):
-                reminder = SystemMessage(
-                    content="Remember: call get_agent_context to learn about available data sources before answering."
-                )
-                messages = [messages[0], reminder] + messages[1:] if messages else [reminder]
+        # Reminder injection removed — `graph.context_loader.context_loader_node`
+        # injects the agent context deterministically as a SystemMessage at the
+        # start of every graph invocation, so the LLM no longer needs a hint to
+        # remember to call get_agent_context.
         total_tokens = _count_tokens(messages)
         if total_tokens > thresholds["summarize_at"]:
             # Find the split point: keep the last N tokens of messages
@@ -363,8 +352,18 @@ def create_agent(
         checkpointer=None,
     )
 
+    # Deterministic context-loader runs before the ReAct loop on every
+    # invocation. Replaces the prior reminder-injection branch in
+    # make_pre_model_hook — the LLM no longer needs to be told to call
+    # get_agent_context because the context is already in state.messages
+    # by the time freeform runs. Closure over tool_set so the same parent
+    # graph shape works for any tool subset selection.
+    context_loader = make_context_loader_node(tool_set=tool_set)
+
     builder = StateGraph(AgentState)
+    builder.add_node("context_loader", context_loader)
     builder.add_node("freeform", freeform)
-    builder.add_edge(START, "freeform")
+    builder.add_edge(START, "context_loader")
+    builder.add_edge("context_loader", "freeform")
     builder.add_edge("freeform", END)
     return builder.compile(checkpointer=checkpointer)

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -18,6 +18,7 @@ from rich.traceback import install
 from db_url import compose_postgres_url
 from graph.context_loader import make_context_loader_node
 from graph.freeform import build_freeform_subgraph
+from graph.router import make_top_router_node
 from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
 
@@ -360,10 +361,28 @@ def create_agent(
     # graph shape works for any tool subset selection.
     context_loader = make_context_loader_node(tool_set=tool_set)
 
+    # Top-level router: classifies every request into one of four buckets
+    # and writes state["route"]. Until Tier 2 subgraphs land, every route
+    # value dispatches to the existing freeform leaf — wiring only, no
+    # behaviour change for end users. The router uses the same LLM as the
+    # leaf (single-provider strategy per master Decision 4).
+    top_router = make_top_router_node(llm)
+
     builder = StateGraph(AgentState)
     builder.add_node("context_loader", context_loader)
+    builder.add_node("top_router", top_router)
     builder.add_node("freeform", freeform)
     builder.add_edge(START, "context_loader")
-    builder.add_edge("context_loader", "freeform")
+    builder.add_edge("context_loader", "top_router")
+    builder.add_conditional_edges(
+        "top_router",
+        lambda state: state["route"],
+        {
+            "phenotyping": "freeform",
+            "scrna": "freeform",
+            "analysis": "freeform",
+            "freeform": "freeform",
+        },
+    )
     builder.add_edge("freeform", END)
     return builder.compile(checkpointer=checkpointer)

--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -6,8 +6,8 @@ import os
 from typing import Optional, Literal
 
 import httpx
-from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from langgraph.graph import StateGraph, START, END
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import trim_messages, SystemMessage, AIMessage, HumanMessage
 from psycopg_pool import AsyncConnectionPool
@@ -16,6 +16,8 @@ import logging
 from rich.logging import RichHandler
 from rich.traceback import install
 from db_url import compose_postgres_url
+from graph.freeform import build_freeform_subgraph
+from graph.state import AgentState
 from tools import all_tools, generic_tools, scrna_tools, cyl_tools, context_tools
 
 install()
@@ -342,10 +344,27 @@ def create_agent(
     if mcp_tools:
         tools = tools + mcp_tools
 
-    return create_react_agent(
-        model=llm,
+    # Tier 0 of the upgrade-agent-architecture roadmap: replace the opaque
+    # `create_react_agent` return with an explicit StateGraph so every
+    # subsequent tier (top router, domain subgraphs, analysis router, MCP
+    # leaves, parallel recipes) has a real graph to attach nodes to.
+    #
+    # Today this graph has one node, `freeform`, which wraps the prebuilt
+    # ReAct agent verbatim — same prompt, same tools, same pre-model hook.
+    # Behavior is byte-for-byte identical to the pre-refactor agent. The
+    # checkpointer lives on the OUTER graph; the inner subgraph stays
+    # checkpointer=None so the parent's `messages` reducer is the single
+    # source of truth for thread state.
+    freeform = build_freeform_subgraph(
+        llm=llm,
         tools=tools,
-        prompt=SYSTEM_PROMPT,
-        checkpointer=checkpointer,
+        system_prompt=SYSTEM_PROMPT,
         pre_model_hook=make_pre_model_hook(provider, llm=llm),
+        checkpointer=None,
     )
+
+    builder = StateGraph(AgentState)
+    builder.add_node("freeform", freeform)
+    builder.add_edge(START, "freeform")
+    builder.add_edge("freeform", END)
+    return builder.compile(checkpointer=checkpointer)

--- a/langchain/graph/__init__.py
+++ b/langchain/graph/__init__.py
@@ -1,0 +1,10 @@
+"""Graph layer for the Bloom agent runtime.
+
+Submodules:
+    state    — typed state schema (`AgentState`) shared across nodes
+    freeform — factory for the freeform leaf subgraph (today's behavior)
+
+Subsequent sub-proposals (top router, domain subgraphs, MCP analysis leaves,
+parallel recipes) will add their own modules here. The package is intentionally
+shallow so each future addition is a small reviewable file.
+"""

--- a/langchain/graph/context_loader.py
+++ b/langchain/graph/context_loader.py
@@ -1,0 +1,44 @@
+"""Deterministic context-loader node.
+
+Runs at the start of every graph invocation, before any LLM call. Calls the
+existing `get_agent_context` tool deterministically and injects the result as a
+`SystemMessage` into state via the `add_messages` reducer.
+
+Replaces the pre-model-hook reminder hack (a string instruction telling the
+LLM to *"remember"* to call `get_agent_context`) with a graph-level guarantee:
+every leaf subgraph in the routed architecture inherits this property without
+re-implementing it.
+
+Idempotency is enforced by tagging the injected SystemMessage with
+`CONTEXT_MARKER`. On follow-up turns within the same thread, the node detects
+the prior tagged message in state and returns `{}` — no duplicate injection.
+"""
+from typing import Optional
+
+from langchain_core.messages import SystemMessage
+
+from tools.context_tools import get_agent_context
+
+# Marker substring distinguishing context-loader output from other SystemMessages
+# (e.g. conversation summaries written by the pre-model hook).
+CONTEXT_MARKER = "<!-- agent-context -->"
+
+
+def make_context_loader_node(tool_set: str = "all"):
+    """Build a context_loader node bound to a specific tool_set.
+
+    The closure pattern keeps the node signature `(state) -> dict` while
+    letting the parent graph build different agents for different tool_set
+    selections without changing how the graph wires together.
+    """
+
+    def context_loader_node(state) -> dict:
+        for msg in state.get("messages", []) or []:
+            if isinstance(msg, SystemMessage) and CONTEXT_MARKER in str(msg.content):
+                return {}
+
+        context_text = get_agent_context.invoke({"tool_set": tool_set})
+        marked_content = f"{CONTEXT_MARKER}\n{context_text}"
+        return {"messages": [SystemMessage(content=marked_content)]}
+
+    return context_loader_node

--- a/langchain/graph/freeform.py
+++ b/langchain/graph/freeform.py
@@ -1,0 +1,53 @@
+"""Freeform leaf subgraph factory.
+
+The freeform leaf is the safety-valve subgraph that preserves today's
+single-agent behavior. Every router (top-level and analysis-level)
+can fall through to a freeform variant when classification is uncertain,
+so a misclassification can never wedge the agent.
+
+For Tier 0 (`add-stategraph-foundation`) the freeform leaf is the ONLY
+node in the parent graph — every request flows `START → freeform → END`
+and behaves byte-for-byte like the pre-refactor `create_react_agent` call.
+
+The factory is a thin wrapper around LangGraph's prebuilt `create_react_agent`
+so we keep the existing pre-model hook, system prompt, and tool list intact.
+The compiled subgraph it returns is suitable for use as a node in a parent
+StateGraph — see `langchain/agent.py::create_agent`.
+"""
+from typing import Optional
+
+from langgraph.prebuilt import create_react_agent
+
+
+def build_freeform_subgraph(
+    llm,
+    tools: list,
+    system_prompt: str,
+    pre_model_hook=None,
+    checkpointer=None,
+):
+    """Build the compiled freeform subgraph.
+
+    Args:
+        llm: Chat model (already provider/temperature-configured).
+        tools: Tool callables the LLM can invoke, including any MCP tools.
+        system_prompt: Top-level instructions string passed as `prompt=`.
+        pre_model_hook: Optional pre-LLM-call hook (token trim / summarize).
+        checkpointer: Pass `None` here when the subgraph is used as a node
+            inside a parent graph — the parent owns checkpointing in that
+            case so the parent's `messages` field is the canonical history.
+            Pass an `AsyncPostgresSaver` only if calling this subgraph
+            standalone (not via the parent graph).
+
+    Returns:
+        A compiled subgraph (CompiledStateGraph) that exposes `ainvoke` and
+        `astream_events` — drop-in for the previous `create_react_agent`
+        return value.
+    """
+    return create_react_agent(
+        model=llm,
+        tools=tools,
+        prompt=system_prompt,
+        pre_model_hook=pre_model_hook,
+        checkpointer=checkpointer,
+    )

--- a/langchain/graph/router.py
+++ b/langchain/graph/router.py
@@ -1,0 +1,98 @@
+"""Top-level router node — LLM-driven request classifier.
+
+Calls the LLM with structured-output coercion to one of four bucket values
+and writes `state["route"]`. Never wedges the request: any classification
+error (LLM exception, parse failure, missing user message) degrades to the
+`freeform` fallback so subsequent edges can still dispatch the request.
+
+The router uses the same provider/model as the leaf (single-provider
+strategy per the master proposal's Decision 4). The closure pattern lets
+`create_agent` build the node once with its already-configured LLM, then
+hand the resulting node to the StateGraph.
+"""
+import logging
+from typing import Literal
+
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, Field
+
+from prompts.router import ROUTER_FEW_SHOTS, TOP_ROUTER_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+# The classification target. Pydantic model rather than bare Literal so
+# `with_structured_output` accepts it across all backends and the LLM gets
+# field-level metadata (description) to anchor on.
+class TopRouteDecision(BaseModel):
+    """LLM-emitted top-level route classification."""
+
+    route: Literal["phenotyping", "scrna", "analysis", "freeform"] = Field(
+        description=(
+            "phenotyping = cylinder/turface scans + plant traits; "
+            "scrna = single-cell RNA-seq; "
+            "analysis = run a numerical analysis (QC, stats, PCA, viz); "
+            "freeform = anything ambiguous or multi-domain."
+        )
+    )
+
+
+FALLBACK_ROUTE: Literal["freeform"] = "freeform"
+
+
+def _build_classifier_messages(user_text: str) -> list[dict]:
+    """Compose the system prompt + few-shot examples + the new user request."""
+    messages: list[dict] = [{"role": "system", "content": TOP_ROUTER_PROMPT}]
+    for example_user, example_route in ROUTER_FEW_SHOTS:
+        messages.append({"role": "user", "content": example_user})
+        messages.append({"role": "assistant", "content": example_route})
+    messages.append({"role": "user", "content": user_text})
+    return messages
+
+
+def _latest_user_text(messages: list) -> str | None:
+    """Return the content of the most recent HumanMessage, or None."""
+    for msg in reversed(messages):
+        if isinstance(msg, HumanMessage):
+            content = msg.content
+            return content if isinstance(content, str) else str(content)
+    return None
+
+
+def make_top_router_node(llm):
+    """Build the top_router node bound to a specific LLM instance.
+
+    Closure over `llm` so the node signature stays `(state) -> dict` and
+    the parent graph wires it without threading config.
+    """
+    classifier = llm.with_structured_output(TopRouteDecision)
+
+    async def top_router_node(state) -> dict:
+        user_text = _latest_user_text(state.get("messages", []) or [])
+        if user_text is None:
+            logger.warning("top_router: no HumanMessage in state, falling back to %s", FALLBACK_ROUTE)
+            return {"route": FALLBACK_ROUTE}
+
+        try:
+            messages = _build_classifier_messages(user_text)
+            decision = await classifier.ainvoke(messages)
+        except Exception as exc:
+            logger.warning(
+                "top_router: classifier raised %s, falling back to %s",
+                type(exc).__name__,
+                FALLBACK_ROUTE,
+            )
+            return {"route": FALLBACK_ROUTE}
+
+        route = getattr(decision, "route", None)
+        if route not in ("phenotyping", "scrna", "analysis", "freeform"):
+            logger.warning(
+                "top_router: classifier returned unknown route %r, falling back to %s",
+                route,
+                FALLBACK_ROUTE,
+            )
+            return {"route": FALLBACK_ROUTE}
+
+        return {"route": route}
+
+    return top_router_node

--- a/langchain/graph/state.py
+++ b/langchain/graph/state.py
@@ -1,0 +1,49 @@
+"""Typed state schema for the Bloom agent graph.
+
+The state is the shared memory that flows through every node in the graph.
+For Tier 0 it carries only the conversation `messages`; the `route` and
+`analysis_route` fields are reserved here so subsequent tiers (top router,
+analysis sub-router) can write to them without changing the schema.
+
+State-merging notes:
+
+* `messages` uses LangGraph's `add_messages` reducer — without it, every
+  node return would OVERWRITE the message list and we'd lose history.
+* `route` and `analysis_route` are scalar fields with last-write-wins
+  semantics by default. That's acceptable today because no node writes
+  them yet. When the routers land (`add-top-router-with-fallback` and
+  `add-analysis-router-with-fallback`), revisit whether to add a custom
+  reducer that no-ops on `None` so a downstream subgraph can't accidentally
+  clobber a prior router's decision. Tracked as a known issue in
+  `add-stategraph-foundation/proposal.md`.
+"""
+from typing import Annotated, Literal, Optional, TypedDict
+
+from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
+
+
+# Top-level routing destinations. Reserved for `add-top-router-with-fallback`.
+TopRoute = Literal["phenotyping", "scrna", "analysis", "freeform"]
+
+# Analysis sub-router destinations. Reserved for `add-analysis-router-with-fallback`.
+AnalysisRoute = Literal[
+    "qc",
+    "stats",
+    "dimred_cluster",
+    "viz",
+    "correlation",
+    "analysis_freeform",
+]
+
+
+class AgentState(TypedDict):
+    """Shared state for the Bloom agent graph.
+
+    Tier 0 only populates `messages`. Router fields are declared so that
+    later tiers can set them without altering the schema.
+    """
+
+    messages: Annotated[list[BaseMessage], add_messages]
+    route: Optional[TopRoute]
+    analysis_route: Optional[AnalysisRoute]

--- a/langchain/prompts/__init__.py
+++ b/langchain/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt strings for graph nodes — each module exports a single PROMPT constant."""

--- a/langchain/prompts/router.py
+++ b/langchain/prompts/router.py
@@ -1,0 +1,47 @@
+"""Top-level router prompt.
+
+Classifies an incoming user request into one of four buckets so the
+hierarchical routing topology can dispatch to the appropriate subgraph.
+The classifier is intentionally narrow — when uncertain, choose `freeform`
+so the request still gets answered (just without leaf specialization).
+"""
+
+TOP_ROUTER_PROMPT = """You are a request classifier for a plant phenotyping platform.
+Classify the user's most recent request into exactly one of four buckets.
+Choose `freeform` whenever the request is ambiguous, multi-domain, or doesn't
+fit the other three.
+
+Buckets:
+
+- **phenotyping** — Cylinder/turface scan data, plant traits, root measurements,
+  experiment metadata. Examples: "show me waves for alfalfa", "list cylinder
+  scans from May", "what plants do we have for species X".
+
+- **scrna** — Single-cell RNA-seq data, gene expression, UMAP clusters,
+  cell-type annotations. Examples: "what's the expression of AT1G01010?",
+  "show the UMAP for dataset GSE123", "which clusters are pericycle".
+
+- **analysis** — Any request to RUN a numerical analysis on phenotyping data:
+  QC, outlier detection, descriptive stats, ANOVA, heritability, PCA,
+  clustering, visualization, cross-experiment correlation. Examples: "run a
+  QC report on alfalfa", "do a PCA on the wave 2 traits", "make a heatmap
+  of trait correlations", "find outliers in the foo dataset".
+
+- **freeform** — Anything else: explanations, multi-domain queries, agent
+  meta-questions, ambiguous prompts. Examples: "what can you do?",
+  "explain heritability to me", "compare cylinder vs turface platforms".
+
+Respond with the single chosen bucket value."""
+
+
+# Few-shot examples reinforce the bucket boundaries. Order matters: examples
+# are listed in order of frequency in expected production traffic so the most
+# common patterns dominate the router's prior.
+ROUTER_FEW_SHOTS = [
+    ("List the experiments available for cylinder phenotyping.", "phenotyping"),
+    ("Run a QC report on cylinder_alfalfa_gwas_wave2.csv.", "analysis"),
+    ("What's the expression of AT1G01010 in the dataset?", "scrna"),
+    ("Detect outliers in the wave 2 traits using isolation forest.", "analysis"),
+    ("How does the cylinder platform differ from turface?", "freeform"),
+    ("What plants from species Solanum lycopersicum do we have?", "phenotyping"),
+]

--- a/langchain/prompts/router.py
+++ b/langchain/prompts/router.py
@@ -11,21 +11,38 @@ Classify the user's most recent request into exactly one of four buckets.
 Choose `freeform` whenever the request is ambiguous, multi-domain, or doesn't
 fit the other three.
 
+Rule of thumb — operational distinction, not linguistic:
+  If the request can be answered by a SINGLE database query against
+  pre-aggregated Supabase data → `phenotyping` (or `scrna`, depending on
+  data type). If it requires LOADING an experiment dataframe and running
+  a numerical algorithm on it → `analysis`. The same request worded as
+  a "comparison" can fall on either side — what matters is whether the
+  answer comes from a database lookup or from a compute pipeline.
+
 Buckets:
 
-- **phenotyping** — Cylinder/turface scan data, plant traits, root measurements,
-  experiment metadata. Examples: "show me waves for alfalfa", "list cylinder
-  scans from May", "what plants do we have for species X".
+- **phenotyping** — Cylinder/turface scan data, plant traits, root
+  measurements, experiment metadata, AND pre-aggregated trait statistics
+  served directly by Supabase queries (wave-to-wave comparisons,
+  per-experiment trait summaries, descriptive stats over the database).
+  These are answered by a single round-trip query — no dataframe loading.
+  Examples: "show me waves for alfalfa", "list cylinder scans from May",
+  "what plants do we have for species X", "how does primary root length
+  differ between waves", "what's the mean height per wave".
 
 - **scrna** — Single-cell RNA-seq data, gene expression, UMAP clusters,
   cell-type annotations. Examples: "what's the expression of AT1G01010?",
   "show the UMAP for dataset GSE123", "which clusters are pericycle".
 
-- **analysis** — Any request to RUN a numerical analysis on phenotyping data:
-  QC, outlier detection, descriptive stats, ANOVA, heritability, PCA,
-  clustering, visualization, cross-experiment correlation. Examples: "run a
-  QC report on alfalfa", "do a PCA on the wave 2 traits", "make a heatmap
-  of trait correlations", "find outliers in the foo dataset".
+- **analysis** — Requests that RUN a heavy numerical pipeline on a LOADED
+  experiment dataframe: QC reports, outlier detection (mahalanobis,
+  isolation forest, PCA-based), ANOVA, heritability, PCA decomposition,
+  clustering, visualization, cross-experiment correlation. Triggered when
+  the user wants an algorithm executed on a dataset that has to be loaded
+  first. Phrases: "run QC", "detect outliers", "compute PCA", "make a
+  heatmap", "find outliers in the foo dataset". If the answer can come
+  from a single Supabase query without loading a dataframe, classify as
+  `phenotyping` instead.
 
 - **freeform** — Anything else: explanations, multi-domain queries, agent
   meta-questions, ambiguous prompts. Examples: "what can you do?",
@@ -36,7 +53,9 @@ Respond with the single chosen bucket value."""
 
 # Few-shot examples reinforce the bucket boundaries. Order matters: examples
 # are listed in order of frequency in expected production traffic so the most
-# common patterns dominate the router's prior.
+# common patterns dominate the router's prior. Boundary examples (linguistically
+# in one bucket, operationally in another) are interleaved so the model learns
+# the operational distinction, not just surface vocabulary.
 ROUTER_FEW_SHOTS = [
     ("List the experiments available for cylinder phenotyping.", "phenotyping"),
     ("Run a QC report on cylinder_alfalfa_gwas_wave2.csv.", "analysis"),
@@ -44,4 +63,14 @@ ROUTER_FEW_SHOTS = [
     ("Detect outliers in the wave 2 traits using isolation forest.", "analysis"),
     ("How does the cylinder platform differ from turface?", "freeform"),
     ("What plants from species Solanum lycopersicum do we have?", "phenotyping"),
+    # Boundary cases — Supabase pre-aggregated stats that sound analytical
+    # but operationally are single-query lookups. These belong in `phenotyping`,
+    # NOT `analysis`, because no dataframe loading or compute pipeline runs.
+    ("How does primary root length differ between wave 1 and wave 2?", "phenotyping"),
+    ("Compare trait means across waves for the alfalfa experiment.", "phenotyping"),
+    ("Show the distribution of trait X across waves.", "phenotyping"),
+    # Boundary case in the other direction — descriptive language but
+    # operationally requires loading a dataframe and running compute.
+    ("Get a quality summary of the loaded experiment data.", "analysis"),
+    ("Run PCA on the loaded dataset traits.", "analysis"),
 ]

--- a/tests/integration/test_context_loader.py
+++ b/tests/integration/test_context_loader.py
@@ -1,0 +1,112 @@
+"""context_loader_node — deterministic agent-context injection before any LLM call.
+
+These tests exercise the context-loader node directly (no LLM, no compose stack).
+They verify the contract:
+  - First call on a fresh state injects a marked SystemMessage.
+  - Subsequent calls within the same thread are no-ops (idempotent).
+  - The closure honours the bound tool_set.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+# Some langchain modules read env vars at import time; provide safe defaults.
+_TMP = tempfile.mkdtemp(prefix="context_loader_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from langchain_core.messages import HumanMessage, SystemMessage  # noqa: E402
+
+from graph.context_loader import (  # noqa: E402
+    CONTEXT_MARKER,
+    make_context_loader_node,
+)
+
+
+def test_context_loader_injects_system_message_on_fresh_state():
+    node = make_context_loader_node(tool_set="all")
+    state = {"messages": [HumanMessage(content="hi")]}
+
+    result = node(state)
+
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert isinstance(msg, SystemMessage)
+    assert CONTEXT_MARKER in msg.content
+    # The actual context content from get_agent_context is a non-empty string
+    assert len(msg.content) > len(CONTEXT_MARKER) + 10
+
+
+def test_context_loader_is_idempotent_on_second_call():
+    """If a marked SystemMessage already exists in state, return {} (no-op)."""
+    node = make_context_loader_node(tool_set="all")
+    state_after_first = {
+        "messages": [
+            HumanMessage(content="hi"),
+            SystemMessage(content=f"{CONTEXT_MARKER}\nsome cached context"),
+        ]
+    }
+    result = node(state_after_first)
+
+    # No new messages appended — node detected prior context-flagged message
+    assert result == {}
+
+
+def test_context_loader_appends_when_only_unmarked_system_message_exists():
+    """A SystemMessage WITHOUT the marker (e.g. summary) doesn't count as
+    prior context — node still injects."""
+    node = make_context_loader_node(tool_set="all")
+    state = {
+        "messages": [
+            SystemMessage(content="Conversation summary so far: ..."),
+            HumanMessage(content="follow-up"),
+        ]
+    }
+    result = node(state)
+
+    assert "messages" in result
+    assert isinstance(result["messages"][0], SystemMessage)
+    assert CONTEXT_MARKER in result["messages"][0].content
+
+
+def test_context_loader_respects_bound_tool_set():
+    """Different tool_set bindings produce different context content."""
+    all_node = make_context_loader_node(tool_set="all")
+    scrna_node = make_context_loader_node(tool_set="scrna")
+
+    state = {"messages": [HumanMessage(content="hi")]}
+    all_result = all_node(state)
+    scrna_result = scrna_node(state)
+
+    all_content = all_result["messages"][0].content
+    scrna_content = scrna_result["messages"][0].content
+
+    # Tool sets differ — content must differ. Both contain the marker.
+    assert CONTEXT_MARKER in all_content
+    assert CONTEXT_MARKER in scrna_content
+    assert all_content != scrna_content
+
+
+def test_context_loader_handles_empty_state():
+    """No messages in state: still inject the marker SystemMessage."""
+    node = make_context_loader_node(tool_set="all")
+    result = node({"messages": []})
+
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    assert CONTEXT_MARKER in result["messages"][0].content

--- a/tests/integration/test_top_router.py
+++ b/tests/integration/test_top_router.py
@@ -1,0 +1,175 @@
+"""top_router_node — LLM-driven request classifier with freeform fallback.
+
+These tests exercise the router node directly with a mocked LLM (no live
+network, no compose stack). They verify the contract:
+
+  - Success: LLM returns a valid Literal value → state["route"] = that value.
+  - LLM exception → fallback to "freeform" + log a warning.
+  - LLM returns an out-of-enum value → fallback to "freeform".
+  - Structured-output parse failure → fallback to "freeform".
+
+Per the "Freeform fallback at every router level" master decision, a
+classification error MUST never wedge the request — it always degrades to
+the freeform leaf so the agent keeps responding.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_LANGCHAIN_DIR = Path(__file__).resolve().parents[2] / "langchain"
+if str(_LANGCHAIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_LANGCHAIN_DIR))
+
+_TMP = tempfile.mkdtemp(prefix="top_router_test_")
+os.environ.setdefault("BLOOM_TRAITS_DIR", _TMP)
+os.environ.setdefault("BLOOM_OUTPUT_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_DIR", _TMP)
+os.environ.setdefault("BLOOM_PLOTS_URL", "http://test.invalid")
+os.environ.setdefault("FRONTEND_URL", "http://test.invalid")
+os.environ.setdefault("SUPABASE_URL", "http://test.invalid")
+os.environ.setdefault("BLOOM_AGENT_KEY", "test-token-not-real")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-key-not-real")
+os.environ.setdefault("NEXT_PUBLIC_APP_URL", "http://test.invalid")
+
+from langchain_core.messages import HumanMessage  # noqa: E402
+
+from graph.router import (  # noqa: E402
+    FALLBACK_ROUTE,
+    TopRouteDecision,
+    make_top_router_node,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Pin async tests to asyncio only — trio isn't a project dependency."""
+    return "asyncio"
+
+
+def _mock_llm_returning(value):
+    """Build a mock chat model where with_structured_output returns a chain
+    whose ainvoke yields the given value."""
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(return_value=value)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+def _mock_llm_raising(exc: Exception):
+    """Build a mock chat model whose structured-output ainvoke raises exc."""
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(side_effect=exc)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm
+
+
+# ─── Success path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_success_phenotyping():
+    decision = TopRouteDecision(route="phenotyping")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="list cylinder plants from wave 2")]})
+
+    assert result == {"route": "phenotyping"}
+
+
+@pytest.mark.anyio
+async def test_router_success_analysis():
+    decision = TopRouteDecision(route="analysis")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="run a QC report on alfalfa")]})
+
+    assert result == {"route": "analysis"}
+
+
+@pytest.mark.anyio
+async def test_router_uses_most_recent_user_message():
+    """Router should classify based on the latest HumanMessage, not the first."""
+    decision = TopRouteDecision(route="scrna")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    state = {
+        "messages": [
+            HumanMessage(content="something earlier and unrelated"),
+            HumanMessage(content="show me the UMAP for dataset X"),
+        ]
+    }
+    result = await node(state)
+
+    assert result == {"route": "scrna"}
+
+
+# ─── Fallback paths — every error degrades to freeform ───────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_llm_exception():
+    """Network failure or LLM crash should not wedge the request."""
+    llm = _mock_llm_raising(RuntimeError("vLLM unreachable"))
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="anything")]})
+
+    assert result == {"route": FALLBACK_ROUTE}
+    assert FALLBACK_ROUTE == "freeform"
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_on_parse_error():
+    """If the LLM's structured output can't be parsed (validation error
+    from the wrapping layer), fall back to freeform."""
+    from pydantic import ValidationError as _VE
+    # Construct a real pydantic ValidationError by intentionally validating
+    # an out-of-enum value, so the exception path matches what production
+    # would see when with_structured_output retries fail.
+    try:
+        TopRouteDecision(route="not_a_real_route")
+    except _VE as exc:
+        validation_error = exc
+
+    llm = _mock_llm_raising(validation_error)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="ambiguous prompt")]})
+
+    assert result == {"route": FALLBACK_ROUTE}
+
+
+@pytest.mark.anyio
+async def test_router_falls_back_when_no_user_message():
+    """Defensive: state with no HumanMessage shouldn't crash; route to freeform."""
+    llm = _mock_llm_returning(TopRouteDecision(route="phenotyping"))
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": []})
+
+    # Empty input should not even reach the LLM; freeform fallback.
+    assert result == {"route": FALLBACK_ROUTE}
+
+
+# ─── Determinism ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_router_node_signature_returns_only_route_field():
+    """The router updates only state['route'], nothing else."""
+    decision = TopRouteDecision(route="freeform")
+    llm = _mock_llm_returning(decision)
+    node = make_top_router_node(llm)
+
+    result = await node({"messages": [HumanMessage(content="hi")]})
+
+    assert set(result.keys()) == {"route"}


### PR DESCRIPTION
## Problem

The top router classifies wave-comparison prompts (e.g. *"how does primary root length differ between wave 1 and wave 2"*) as `analysis`, dispatching them to the analysis subgraph. 

But `compare_waves_trait_tool` is a Supabase pre-aggregated query that lives in `cyl_tools` — i.e., it belongs in the `phenotyping` route. 
The router miss leaves the prompt routed to a subgraph that doesn't have the right tool in scope.

Root cause is in the prompt itself: the `analysis` bucket description includes "descriptive stats", which captures any wave-to-wave comparison phrasing — even though operationally those are a single Supabase query, not a dataframe-loading compute pipeline.

## Fix

Sharpen the operational distinction in `langchain/prompts/router.py`:

- Add a rule-of-thumb line at the top: *single Supabase query → phenotyping; load-a-dataframe-and-run-compute → analysis*.
- Refine the `phenotyping` description to explicitly include pre-aggregated Supabase stats (wave comparisons, per-experiment summaries).
- Add boundary-case few-shots in both directions — Supabase stats that sound analytical, and MCP compute that sounds descriptive.