### PR TITLE
feat(agent): ask_user clarification + runtime safety net

### DIFF
--- a/langchain/agent.py
+++ b/langchain/agent.py
@@ -3,13 +3,20 @@ Bloom LangChain Agent - Uses PostgREST (Supabase) for data queries
 Supports multiple LLM providers: OpenAI, Local (vLLM)
 """
 import os
+import uuid
 from typing import Optional, Literal
 
 import httpx
 from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import trim_messages, SystemMessage, AIMessage, HumanMessage
+from langchain_core.messages import (
+    trim_messages,
+    SystemMessage,
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+)
 from psycopg_pool import AsyncConnectionPool
 
 import logging
@@ -214,6 +221,134 @@ def make_pre_model_hook(provider: str = "openai", llm=None):
     return pre_model_hook
 
 
+#################################################### Runtime Safety Net (Empty AIMessage Detection) ####################################################
+
+
+# Recovery question templates for the runtime safety net. The post_model_hook
+# uses these deterministic templates indexed by consecutive forced-clarification
+# count. Three rounds before bail. We do NOT call an LLM to generate recovery
+# text — recovery is the failure boundary; predictable text is more useful
+# than generated text.
+RECOVERY_QUESTIONS = (
+    "I'm not sure how to proceed with that question. Could you tell me more "
+    "about what you're looking for?",
+    "I'm still having trouble. Could you give me more specifics — like the "
+    "experiment name, trait name, or what kind of answer you're after?",
+    "I'm not making progress on this. Could you rephrase the question, or "
+    "break it into a smaller part?",
+)
+
+# Final terminal message after 3 forced clarifications without progress.
+# The graph terminates normally with this as a content-only AIMessage.
+FAILURE_MESSAGE = (
+    "I'm having trouble processing this request. Could you try rephrasing it, "
+    "or start a new conversation?"
+)
+
+# Bound on consecutive forced clarifications before the runtime gives up.
+# Tunable via env if the production data suggests a different value.
+MAX_FORCED_CLARIFICATIONS = int(os.getenv("MAX_FORCED_CLARIFICATIONS", "3"))
+
+# Tool-call id prefix used to mark forced asks. Walk-back logic distinguishes
+# forced asks (auto-emitted by the runtime) from LLM-driven asks (the LLM
+# explicitly chose to ask). Only forced asks count toward the bound.
+FORCED_ASK_ID_PREFIX = "forced-"
+
+
+def _count_consecutive_forced_asks(messages) -> int:
+    """Walk back through messages and count consecutive forced ask_user
+    tool_calls since the last non-forced AIMessage.
+
+    The chain breaks on:
+      - any AIMessage with content (a normal final answer)
+      - any AIMessage with tool_calls that are NOT all forced asks (the LLM
+        chose to call a real tool, indicating recovery)
+
+    The chain extends through forced-ask tool_calls and their corresponding
+    ToolMessage results (the user's reply) — we count one bump per AIMessage
+    that emitted a forced ask.
+
+    Returns the count of consecutive forced asks. Used to index
+    RECOVERY_QUESTIONS and to decide whether to bail.
+    """
+    count = 0
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage):
+            # Any normal AIMessage breaks the chain
+            if msg.content:
+                return count
+            if not msg.tool_calls:
+                # An empty AIMessage (the very one we're inspecting on the
+                # current turn) doesn't extend the chain by itself; we extend
+                # only when a forced ask was actually emitted.
+                continue
+            # Check if all tool_calls are forced (forced-* prefix)
+            ids = [str(tc.get("id", "")) for tc in msg.tool_calls]
+            all_forced = all(i.startswith(FORCED_ASK_ID_PREFIX) for i in ids)
+            if not all_forced:
+                # The LLM emitted a real tool_call → chain breaks
+                return count
+            count += 1
+        # HumanMessage / ToolMessage / SystemMessage are part of the chain
+        # only when they sit between forced-ask AIMessages; they don't bump
+        # the count themselves. Continue walking back.
+    return count
+
+
+def make_post_model_hook():
+    """Create a post-model hook that prevents silent termination.
+
+    Guarantees: no leaf or react agent can produce a terminal AIMessage
+    with empty content AND empty tool_calls. Every empty AIMessage gets
+    replaced with one of two things:
+      (a) a forced ask_user tool_call, if we haven't bailed yet, OR
+      (b) a final AIMessage with FAILURE_MESSAGE, if we've already forced
+          MAX_FORCED_CLARIFICATIONS consecutive asks.
+
+    Forced asks are marked with tool_call.id prefix "forced-N-<uuid>" so
+    the walk-back counter can distinguish them from LLM-driven asks. Only
+    forced asks count toward the bound.
+
+    The hook returns a partial state update with a RemoveMessage for the
+    empty AIMessage and the replacement message. The add_messages reducer
+    handles RemoveMessage by removing the matching id from state.
+    """
+    async def post_model_hook(state):
+        messages = state.get("messages") or []
+        if not messages:
+            return None
+        last = messages[-1]
+        if not isinstance(last, AIMessage):
+            return None
+        if last.content or last.tool_calls:
+            return None  # normal turn, leave alone
+
+        # Empty AIMessage detected — apply the safety net.
+        # Walk back over the message list to count consecutive forced asks
+        # already in the history (excluding the empty one we just produced).
+        forced_so_far = _count_consecutive_forced_asks(messages[:-1])
+
+        if forced_so_far >= MAX_FORCED_CLARIFICATIONS:
+            # Bound hit. Replace empty with a real failure message and let
+            # the graph terminate normally (no tool_calls = END).
+            replacement = AIMessage(content=FAILURE_MESSAGE)
+        else:
+            # Force a clarification with the next-indexed recovery question.
+            question = RECOVERY_QUESTIONS[forced_so_far]
+            forced_id = f"{FORCED_ASK_ID_PREFIX}{forced_so_far + 1}-{uuid.uuid4().hex[:8]}"
+            replacement = AIMessage(
+                content="",
+                tool_calls=[{
+                    "name": "ask_user",
+                    "args": {"question": question},
+                    "id": forced_id,
+                }],
+            )
+        return {"messages": [RemoveMessage(id=last.id), replacement]}
+
+    return post_model_hook
+
+
 #################################################### LLM Setup ####################################################
 
 
@@ -302,7 +437,36 @@ def get_llm(
 
 SYSTEM_PROMPT = """You are a helpful assistant for the Bloom plant phenotyping platform.
 You have READ-ONLY access. You cannot create, update, or delete data.
-Call get_agent_context at the start of a conversation to learn about available data sources and schema."""
+Call get_agent_context at the start of a conversation to learn about available data sources and schema.
+
+# Handling uncertainty
+
+When the user references something by everyday name (a trait, an
+experiment, an accession, a species), and the schema-side identifier is
+ambiguous or unknown, FIRST call the corresponding discovery tool to
+translate or disambiguate:
+  - For traits, call list_traits_tool to see schema names like
+    'primary_length' before using them in compare_waves_trait_tool or
+    similar.
+  - For experiments, call list_experiments_tool when the user names an
+    experiment and you don't know its id.
+  - For species, call list_species_tool similarly.
+
+Only after discovery has been attempted and ambiguity remains
+unresolvable should you call ask_user. Discovery first, ask second.
+
+# No silent termination
+
+NEVER respond with empty content. If you cannot answer a question — for
+any reason — call the ask_user tool with a specific, focused question
+explaining what you need. The user prefers a visible follow-up question
+to a blank reply.
+
+If you've already asked for clarification 1-2 times without progress, the
+runtime will surface a graceful failure message — but you should not rely
+on that fallback. Make every clarification question count: be specific,
+list the options you found via discovery, and ask the smallest possible
+follow-up that lets you proceed."""
 
 
 def create_agent(
@@ -342,10 +506,17 @@ def create_agent(
     if mcp_tools:
         tools = tools + mcp_tools
 
+    # post_model_hook is the runtime safety net: any AIMessage with empty
+    # content AND empty tool_calls gets replaced with a forced ask_user
+    # tool_call (or, after MAX_FORCED_CLARIFICATIONS consecutive forced asks,
+    # a graceful failure AIMessage). Combined with the SYSTEM_PROMPT rules
+    # (discover-then-ask, no-silent-termination), this guarantees the loop
+    # never terminates with empty content escaping back to the user.
     return create_react_agent(
         model=llm,
         tools=tools,
         prompt=SYSTEM_PROMPT,
         checkpointer=checkpointer,
         pre_model_hook=make_pre_model_hook(provider, llm=llm),
+        post_model_hook=make_post_model_hook(),
     )

--- a/langchain/routes/chat.py
+++ b/langchain/routes/chat.py
@@ -6,10 +6,11 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from langchain_core.messages import AIMessage
+from langgraph.types import Command
 
 import deps
 from agent import AVAILABLE_MODELS
-from schemas import ChatRequest, ChatResponse
+from schemas import ChatRequest, ChatResponse, ChatResumeRequest
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -58,6 +59,31 @@ def _resolve_agent(body: ChatRequest, checkpointer) -> tuple[object, str, str]:
         checkpointer=checkpointer,
     )
     return agent, provider, model
+
+
+async def _get_pending_clarification(agent, config) -> str | None:
+    """If the graph is paused on an `ask_user` interrupt, return the question
+    string. Otherwise return None.
+
+    Walks the post-stream graph state via `aget_state`. An interrupt sets
+    `state.tasks[i].interrupts[j].value` to the dict we passed into
+    `interrupt(...)` from the `ask_user` tool — `{"type": "clarification",
+    "question": "..."}`. We surface only the question text to the client.
+    """
+    try:
+        state = await agent.aget_state(config)
+    except Exception:
+        logger.exception("Failed to read graph state for interrupt detection")
+        return None
+    if not getattr(state, "tasks", None):
+        return None
+    for task in state.tasks:
+        interrupts = getattr(task, "interrupts", None) or []
+        for interrupt in interrupts:
+            value = getattr(interrupt, "value", None)
+            if isinstance(value, dict) and value.get("type") == "clarification":
+                return value.get("question")
+    return None
 
 
 async def _upsert_thread_metadata(checkpointer, user_id: str, thread_id: str, prompt: str) -> None:
@@ -144,6 +170,10 @@ async def chat_stream(
         tool       - tool call started (content = tool name)
         tool_done  - tool call completed (content = tool name)
         token      - incremental LLM output chunk (content = token text)
+        ask_user   - graph paused on a clarification interrupt; client should
+                     show the question to the user and POST the reply to
+                     /langchain/chat/resume (content = question, thread_id
+                     = same id originally sent)
         done       - stream completed (tools_used = list of tool names)
         error      - terminal error (content = error message)
 
@@ -162,13 +192,14 @@ async def chat_stream(
                 return
 
             scoped_thread = f"{user_id}:{body.thread_id}"
+            config = {"configurable": {"thread_id": scoped_thread}}
             tools_used: list[str] = []
 
             yield f"data: {json.dumps({'type': 'status', 'content': 'Thinking...'})}\n\n"
 
             async for event in agent.astream_events(
                 {"messages": [("user", body.prompt)]},
-                config={"configurable": {"thread_id": scoped_thread}},
+                config=config,
                 version="v2",
             ):
                 kind = event.get("event", "")
@@ -187,12 +218,113 @@ async def chat_stream(
                     if chunk and isinstance(getattr(chunk, "content", None), str) and chunk.content:
                         yield f"data: {json.dumps({'type': 'token', 'content': chunk.content})}\n\n"
 
+            # If the graph paused on an ask_user interrupt, surface the question
+            # so the client can prompt the user. The graph state is checkpointed
+            # at the interrupt; the user reply will arrive via /chat/resume and
+            # continue the same thread_id.
+            question = await _get_pending_clarification(agent, config)
+            if question:
+                yield (
+                    f"data: {json.dumps({'type': 'ask_user', 'content': question, 'thread_id': body.thread_id})}\n\n"
+                )
+
             yield f"data: {json.dumps({'type': 'done', 'tools_used': tools_used})}\n\n"
 
             await _upsert_thread_metadata(checkpointer, user_id, body.thread_id, body.prompt)
 
         except Exception:
             logger.exception(f"Stream error for user {user_id}")
+            yield f"data: {json.dumps({'type': 'error', 'content': 'An internal error has occurred.'})}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+# ─── Resume from clarification ────────────────────────────────────────────────
+
+@router.post("/langchain/chat/resume")
+async def chat_resume(
+    body: ChatResumeRequest,
+    request: Request,
+    user_id: str = Depends(deps.get_current_user),
+):
+    """Resume a chat that paused on an `ask_user` clarification.
+
+    Body carries the user's reply plus enough info to re-resolve the same
+    agent factory used for the original chat (same provider / model /
+    tool_set / mcp_tool_names). The resume call advances the paused graph
+    via `Command(resume=reply)`; the `ask_user` tool returns the reply
+    string to the LLM, which then continues the conversation.
+
+    Same SSE event vocabulary as `/chat/stream` — including a fresh
+    `ask_user` event if the LLM asks a follow-up clarification.
+
+    Authentication: same Bearer-JWT check as `/chat/stream`. The thread is
+    namespaced as `f"{user_id}:{thread_id}"`, so a different user posting
+    the same `thread_id` reads from a different namespace and gets no
+    paused state to resume.
+    """
+    async def event_stream():
+        try:
+            checkpointer = getattr(request.app.state, 'checkpointer', None)
+            # Reuse the same _resolve_agent path as /chat/stream by building
+            # a ChatRequest-shaped object. We don't need a `prompt` here —
+            # the agent factory only uses provider/model/tool_set/mcp_tool_names.
+            resolve_body = ChatRequest(
+                prompt="",  # unused by _resolve_agent
+                provider=body.provider,
+                model=body.model,
+                tool_set=body.tool_set,
+                mcp_tool_names=body.mcp_tool_names,
+                thread_id=body.thread_id,
+            )
+            try:
+                agent, _provider, _model = _resolve_agent(resolve_body, checkpointer)
+            except ValueError as e:
+                logger.warning("Invalid chat resume request for user %s: %s", user_id, e)
+                yield f"data: {json.dumps({'type': 'error', 'content': 'Invalid request.'})}\n\n"
+                return
+
+            scoped_thread = f"{user_id}:{body.thread_id}"
+            config = {"configurable": {"thread_id": scoped_thread}}
+            tools_used: list[str] = []
+
+            yield f"data: {json.dumps({'type': 'status', 'content': 'Thinking...'})}\n\n"
+
+            # Command(resume=reply) feeds `body.reply` back into the paused
+            # interrupt. The ask_user tool returns this string to the LLM,
+            # which then continues the ReAct loop.
+            async for event in agent.astream_events(
+                Command(resume=body.reply),
+                config=config,
+                version="v2",
+            ):
+                kind = event.get("event", "")
+
+                if kind == "on_tool_start":
+                    tool_name = event.get("name", "")
+                    tools_used.append(tool_name)
+                    yield f"data: {json.dumps({'type': 'tool', 'content': tool_name})}\n\n"
+
+                elif kind == "on_tool_end":
+                    tool_name = event.get("name", "")
+                    yield f"data: {json.dumps({'type': 'tool_done', 'content': tool_name})}\n\n"
+
+                elif kind == "on_chat_model_stream":
+                    chunk = event.get("data", {}).get("chunk")
+                    if chunk and isinstance(getattr(chunk, "content", None), str) and chunk.content:
+                        yield f"data: {json.dumps({'type': 'token', 'content': chunk.content})}\n\n"
+
+            # Resume can produce another interrupt (multi-turn clarification).
+            question = await _get_pending_clarification(agent, config)
+            if question:
+                yield (
+                    f"data: {json.dumps({'type': 'ask_user', 'content': question, 'thread_id': body.thread_id})}\n\n"
+                )
+
+            yield f"data: {json.dumps({'type': 'done', 'tools_used': tools_used})}\n\n"
+
+        except Exception:
+            logger.exception(f"Resume error for user {user_id}")
             yield f"data: {json.dumps({'type': 'error', 'content': 'An internal error has occurred.'})}\n\n"
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/langchain/schemas.py
+++ b/langchain/schemas.py
@@ -20,6 +20,22 @@ class ChatResponse(BaseModel):
     model: str
 
 
+class ChatResumeRequest(BaseModel):
+    """Resume a chat that paused on an ask_user clarification.
+
+    Symmetric with ChatRequest minus `prompt` (replaced with `reply`).
+    Frontend should keep provider/model/tool_set/mcp_tool_names in sync
+    with the original chat session — same agent factory must be reused
+    so the resumed graph picks up where it paused.
+    """
+    thread_id: str
+    reply: str
+    provider: str = "openai"
+    model: Optional[str] = None
+    tool_set: str = "all"
+    mcp_tool_names: list[str] = Field(default_factory=list)
+
+
 class CreateThreadRequest(BaseModel):
     thread_id: str
     title: Optional[str] = None

--- a/langchain/server.py
+++ b/langchain/server.py
@@ -39,7 +39,13 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage MCP client and PostgresSaver: connect on startup, close on shutdown."""
-    # Initialize PostgresSaver checkpointer
+    # Initialize PostgresSaver checkpointer.
+    # The checkpointer is required for HITL clarification flows: when the
+    # agent calls `ask_user`, `interrupt()` snapshots state to the
+    # checkpointer so a later POST /chat/resume can wake it up. Without a
+    # checkpointer, `interrupt()` raises `InvalidUpdateError`. We log a
+    # loud warning here so missing-checkpointer is visible at boot rather
+    # than surfacing as a non-obvious runtime error mid-conversation.
     try:
         checkpointer = await setup_checkpointer()
         app.state.checkpointer = checkpointer
@@ -47,6 +53,11 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to initialize PostgresSaver: {e}. Conversations will not persist.")
         app.state.checkpointer = None
+        logger.warning(
+            "Agent HITL clarification flow (ask_user tool) is DISABLED — "
+            "interrupt() requires a checkpointer. Fix the Postgres connection "
+            "to enable clarifications."
+        )
 
     # Connect to MCP servers (with retry — bloommcp may still be starting)
     mcp_client = None

--- a/langchain/tools/context_tools.py
+++ b/langchain/tools/context_tools.py
@@ -5,6 +5,7 @@ Provides on-demand schema, rules, and tool discovery so the system prompt
 stays minimal and tokens are only spent when needed.
 """
 from langchain_core.tools import tool
+from langgraph.types import interrupt
 
 
 # ==================== Context Payloads ====================
@@ -150,6 +151,42 @@ def list_available_tools() -> list[dict]:
     ]
 
 
+@tool
+def ask_user(question: str) -> str:
+    """Ask the user a clarifying question when you cannot proceed without more information.
+
+    Use this when:
+      - The user's request is ambiguous and discovery tools (list_traits_tool,
+        list_experiments_tool, list_species_tool, etc.) cannot resolve it on
+        their own. For example: "compare experiments" with no specific
+        experiment named when several exist.
+      - You are missing essential information that no tool can supply.
+      - You have tried discovery tools and the ambiguity remains.
+
+    Do NOT use this as a first response to uncertainty. Always exhaust
+    deterministic discovery (list_*) tools first — clarifying through tools
+    is faster and less disruptive than bouncing the question back to the user.
+
+    NEVER respond with empty content when you cannot answer. Call ask_user
+    with a specific question instead.
+
+    Args:
+        question: A specific, focused question that the user can answer in
+            one sentence. Avoid open-ended phrasing like "what do you want?"
+            — be concrete: "Which alfalfa experiment did you mean — Wave
+            Series 1 (id=1) or Wave Series 2 (id=2)?".
+
+    Returns:
+        The user's reply as a string. Use this reply to continue the
+        conversation as if the user had provided the information up front.
+    """
+    return interrupt({"type": "clarification", "question": question})
+
+
 # ==================== Tool List ====================
 
-context_tools = [get_agent_context, list_available_tools]
+# ask_user is part of context_tools so every leaf and route includes it —
+# clarification is universal, not domain-specific. The runtime safety net
+# in agent.py (post_model_hook) also forces ask_user on empty AIMessages
+# regardless of whether the LLM follows the prompt rule.
+context_tools = [get_agent_context, list_available_tools, ask_user]


### PR DESCRIPTION
## Problem

The agent's ReAct loop has only two terminal states per turn — emit a tool_call, or emit a final answer (no tool_calls). When the LLM hits ambiguity it cannot resolve from the tool surface, it has no architectural path to ask the user a clarifying question. In practice it emits an empty AIMessage and the loop ends silently. The user sees nothing under the bot avatar.

## Fix

Two layers added to remove silent termination as a failure mode entirely.

### Layer 1 — LLM-driven clarification

- New `ask_user(question: str) -> str` tool wraps `langgraph.types.interrupt()`. When the LLM calls it, the graph pauses, the chat handler emits an `ask_user` SSE event with the question, and a separate `POST /langchain/chat/resume` endpoint receives the user's reply and continues the graph via `Command(resume=reply)`.
- `ask_user` registered in `context_tools` so every tool_set includes it.
- `SYSTEM_PROMPT` updated with two rules: discover-then-ask (use `list_traits_tool` / `list_experiments_tool` for translation BEFORE asking) and no-silent-termination (NEVER emit empty content; call `ask_user` instead).

### Layer 2 — Runtime safety net

`create_react_agent` is now passed a `post_model_hook` that detects every empty AIMessage (`content == ""` AND `tool_calls == []`) and replaces it with either:
- A forced `ask_user` tool_call with a deterministic recovery question (count-indexed templates), `tool_call.id` prefixed `forced-N-<uuid>` so subsequent walk-back can identify forced asks, OR
- After 3 consecutive forced asks (`MAX_FORCED_CLARIFICATIONS`, env-tunable), a final AIMessage with `FAILURE_MESSAGE` content. The graph then terminates normally with a clear failure message instead of looping or hanging.

## Files

- `langchain/tools/context_tools.py` — `ask_user` tool, added to `context_tools`.
- `langchain/agent.py` — `RECOVERY_QUESTIONS`, `FAILURE_MESSAGE`, `MAX_FORCED_CLARIFICATIONS`, `FORCED_ASK_ID_PREFIX` constants; `_count_consecutive_forced_asks` helper; `make_post_model_hook` factory; `SYSTEM_PROMPT` rule additions; wired into `create_react_agent` call.
- `langchain/routes/chat.py` — `chat_stream` detects pending `ask_user` interrupts via `aget_state` after astream completes, emits `ask_user` SSE event; new `POST /langchain/chat/resume` endpoint feeds `Command(resume=reply)` back to the paused graph.
- `langchain/schemas.py` — `ChatResumeRequest` model.
- `langchain/server.py` — startup logs a loud warning if the checkpointer fails to initialize (silently disabled without it).