### PR TITLE
feat(web): chat UI handler for ask_user clarification events

### DIFF
--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -149,6 +149,15 @@ export default function MCPChat() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeThreadId, setActiveThreadId] = useState<string>("default");
 
+  // When the agent calls ask_user, the SSE stream emits an `ask_user` event
+  // with a question. The graph is paused until the user replies. We track
+  // the paused thread here so the next prompt submission goes to
+  // /chat/resume instead of /chat/stream. Cleared when the user submits a
+  // reply (or starts a new thread).
+  const [pendingClarification, setPendingClarification] = useState<{
+    threadId: string;
+  } | null>(null);
+
   // Thread history
   const [threads, setThreads] = useState<ThreadInfo[]>([]);
   const [historyCollapsed, setHistoryCollapsed] = useState(false);
@@ -276,6 +285,10 @@ export default function MCPChat() {
     setActiveThreadId(newThreadId);
     saveThreadId(newThreadId);
     setMessages([]);
+    // Pending clarification belongs to the previous thread — clear it so a
+    // new conversation doesn't accidentally route the next prompt to /resume
+    // against the wrong thread_id.
+    setPendingClarification(null);
     // Refresh thread list so it stays current
     fetchThreads();
   }
@@ -291,6 +304,9 @@ export default function MCPChat() {
     saveThreadId(threadId);
     const savedMessages = loadMessagesForThread(threadId);
     setMessages(savedMessages);
+    // Pending clarification is bound to the previous thread; clear it so the
+    // next submission doesn't try to resume against the wrong graph.
+    setPendingClarification(null);
   }
 
   async function handleDeleteThread(threadId: string) {
@@ -317,7 +333,16 @@ export default function MCPChat() {
     const text = prompt.trim();
     setMessages((m) => [...m, { from: "user", text }]);
     setPrompt("");
-    startRequest(text);
+    // If the agent is paused on an `ask_user` interrupt, route the next
+    // submission to /chat/resume so the typed text feeds back into the
+    // paused graph as the tool's return value. Otherwise it's a fresh prompt.
+    if (pendingClarification) {
+      const paused = pendingClarification;
+      setPendingClarification(null);
+      resumeRequest(text, paused.threadId);
+    } else {
+      startRequest(text);
+    }
   }
 
   function startRequest(text: string) {
@@ -371,7 +396,7 @@ export default function MCPChat() {
 
           for (const line of lines) {
             if (!line.startsWith("data: ")) continue;
-            let event: { type?: string; content?: string };
+            let event: { type?: string; content?: string; thread_id?: string };
             try {
               event = JSON.parse(line.slice(6));
             } catch {
@@ -406,12 +431,164 @@ export default function MCPChat() {
                 }
                 return copy;
               });
+            } else if (event.type === "ask_user" && event.content) {
+              // Backend pauses the graph on `interrupt()` and surfaces the
+              // question here. We render it as the bot's most recent message
+              // and flag the thread as awaiting a reply — the next prompt
+              // submission will POST to /chat/resume instead of /chat/stream.
+              accumulatedText = event.content;
+              setMessages((msgs) => {
+                const copy = [...msgs];
+                const last = copy[copy.length - 1];
+                if (last && last.from === "bot") {
+                  copy[copy.length - 1] = { from: "bot", text: accumulatedText };
+                } else {
+                  copy.push({ from: "bot", text: accumulatedText });
+                }
+                return copy;
+              });
+              setPendingClarification({
+                threadId: event.thread_id || activeThreadId,
+              });
             }
             // 'done' is handled implicitly when the reader finishes
           }
         }
 
         // Refresh thread list after message (new thread may appear, timestamps update)
+        fetchThreads();
+      } catch (err: unknown) {
+        const errMsg = `Error contacting agent: ${err instanceof Error ? err.message : String(err)}`;
+        setMessages((msgs) => {
+          const copy = [...msgs];
+          const last = copy.slice(-1)[0];
+          if (last && last.from === "bot") {
+            copy[copy.length - 1] = { from: "bot", text: errMsg };
+          } else {
+            copy.push({ from: "bot", text: errMsg });
+          }
+          return copy;
+        });
+      } finally {
+        setStreaming(false);
+        setStreamStatus("");
+        setActiveTools([]);
+      }
+    })();
+  }
+
+  // Resume a chat that paused on an `ask_user` interrupt. Sends the user's
+  // reply to /chat/resume; the backend feeds it back into the paused graph
+  // via Command(resume=reply), and streams the continuation. The event
+  // vocabulary is identical to /chat/stream — including a fresh `ask_user`
+  // event if the agent asks a follow-up.
+  function resumeRequest(reply: string, threadId: string) {
+    setStreaming(true);
+    setStreamStatus("Thinking...");
+    setActiveTools([]);
+    setMessages((m) => [...m, { from: "bot", text: "" }]);
+    const resumeUrl = `${API_BASE_URL}/langchain/chat/resume`;
+
+    (async () => {
+      try {
+        const token = await getAuthToken();
+        if (!token) throw new Error("Please log in to use the Bloom Assistant.");
+
+        const resp = await fetch(resumeUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            thread_id: threadId,
+            reply,
+            provider: settings.provider,
+            model: settings.model,
+            tool_set: settings.toolSet || "generic",
+            mcp_tool_names: settings.mcpToolNames || [],
+          }),
+        });
+
+        if (!resp.ok) {
+          const errBody = await resp.text();
+          throw new Error(`Agent resume failed ${resp.status}: ${errBody}`);
+        }
+        if (!resp.body) throw new Error("No response body");
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedText = "";
+        let buffer = "";
+        const toolsUsed: string[] = [];
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            let event: { type?: string; content?: string; thread_id?: string };
+            try {
+              event = JSON.parse(line.slice(6));
+            } catch {
+              continue;
+            }
+
+            if (event.type === "status") {
+              setStreamStatus(event.content ?? "");
+            } else if (event.type === "tool" && event.content) {
+              toolsUsed.push(event.content);
+              setActiveTools([...toolsUsed]);
+              setStreamStatus(`Using ${event.content}...`);
+            } else if (event.type === "tool_done") {
+              setStreamStatus("Thinking...");
+            } else if (event.type === "token" && event.content) {
+              accumulatedText += event.content;
+              setMessages((msgs) => {
+                const copy = [...msgs];
+                const last = copy[copy.length - 1];
+                if (last && last.from === "bot") {
+                  copy[copy.length - 1] = { from: "bot", text: accumulatedText };
+                }
+                return copy;
+              });
+            } else if (event.type === "error" && event.content) {
+              accumulatedText += `\n\nError: ${event.content}`;
+              setMessages((msgs) => {
+                const copy = [...msgs];
+                const last = copy[copy.length - 1];
+                if (last && last.from === "bot") {
+                  copy[copy.length - 1] = { from: "bot", text: accumulatedText };
+                }
+                return copy;
+              });
+            } else if (event.type === "ask_user" && event.content) {
+              // Multi-turn clarification: the agent asked another question
+              // after the previous reply. Render and arm pendingClarification
+              // again so the next prompt submission also routes to /resume.
+              accumulatedText = event.content;
+              setMessages((msgs) => {
+                const copy = [...msgs];
+                const last = copy[copy.length - 1];
+                if (last && last.from === "bot") {
+                  copy[copy.length - 1] = { from: "bot", text: accumulatedText };
+                } else {
+                  copy.push({ from: "bot", text: accumulatedText });
+                }
+                return copy;
+              });
+              setPendingClarification({
+                threadId: event.thread_id || threadId,
+              });
+            }
+          }
+        }
+
         fetchThreads();
       } catch (err: unknown) {
         const errMsg = `Error contacting agent: ${err instanceof Error ? err.message : String(err)}`;
@@ -1072,7 +1249,11 @@ export default function MCPChat() {
                   sendPrompt();
                 }
               }}
-              placeholder="Ask about datasets, genes, or run analysis..."
+              placeholder={
+                pendingClarification
+                  ? "Type your answer to the agent's question..."
+                  : "Ask about datasets, genes, or run analysis..."
+              }
               style={{
                 flex: 1,
                 padding: "14px 16px",

--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -144,6 +144,8 @@ export default function MCPChat() {
   const [prompt, setPrompt] = useState("");
   const [messages, setMessages] = useState<Message[]>([]);
   const [streaming, setStreaming] = useState(false);
+  const [streamStatus, setStreamStatus] = useState<string>("");
+  const [activeTools, setActiveTools] = useState<string[]>([]);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeThreadId, setActiveThreadId] = useState<string>("default");
 
@@ -320,81 +322,99 @@ export default function MCPChat() {
 
   function startRequest(text: string) {
     setStreaming(true);
+    setStreamStatus("Thinking...");
+    setActiveTools([]);
     setMessages((m) => [...m, { from: "bot", text: "" }]);
-    const url = `${API_BASE_URL}/langchain/chat`;
+    const streamUrl = `${API_BASE_URL}/langchain/chat/stream`;
 
     (async () => {
       try {
-        const body: any = {
-          prompt: text,
-          provider: settings.provider,
-          model: settings.model,
-          tool_set: settings.toolSet || "generic",
-          mcp_tool_names: settings.mcpToolNames || [],
-          thread_id: activeThreadId,
-        };
-
         const token = await getAuthToken();
-        if (!token) {
-          throw new Error("Please log in to use the Bloom Assistant.");
-        }
+        if (!token) throw new Error("Please log in to use the Bloom Assistant.");
 
-        const resp = await fetch(url, {
+        const resp = await fetch(streamUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": `Bearer ${token}`,
+            Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify(body),
+          body: JSON.stringify({
+            prompt: text,
+            provider: settings.provider,
+            model: settings.model,
+            tool_set: settings.toolSet || "generic",
+            mcp_tool_names: settings.mcpToolNames || [],
+            thread_id: activeThreadId,
+          }),
         });
-        const rawBody = await resp.text();
+
         if (!resp.ok) {
-          throw new Error(`Agent request failed ${resp.status}: ${rawBody}`);
+          const errBody = await resp.text();
+          throw new Error(`Agent request failed ${resp.status}: ${errBody}`);
         }
-        let data: any = null;
-        try {
-          data = JSON.parse(rawBody);
-        } catch {
-          // rawBody already captured above
-        }
+        if (!resp.body) throw new Error("No response body");
 
-        const parts: string[] = [];
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedText = "";
+        let buffer = "";
+        const toolsUsed: string[] = [];
 
-        if (data && data.answer) {
-          parts.push(data.answer);
-        }
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
 
-        if (data && data.tools_used && data.tools_used.length > 0) {
-          parts.push("\nTools: " + data.tools_used.join(", "));
-        }
+          buffer += decoder.decode(value, { stream: true });
+          // SSE lines are separated by \n; events end with a blank line.
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
 
-        if (data && data.error) {
-          parts.push(`Error: ${data.error}`);
-          if (data.detail) {
-            parts.push(`Details: ${data.detail}`);
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            let event: { type?: string; content?: string };
+            try {
+              event = JSON.parse(line.slice(6));
+            } catch {
+              continue; // skip malformed SSE line
+            }
+
+            if (event.type === "status") {
+              setStreamStatus(event.content ?? "");
+            } else if (event.type === "tool" && event.content) {
+              toolsUsed.push(event.content);
+              setActiveTools([...toolsUsed]);
+              setStreamStatus(`Using ${event.content}...`);
+            } else if (event.type === "tool_done") {
+              setStreamStatus("Thinking...");
+            } else if (event.type === "token" && event.content) {
+              accumulatedText += event.content;
+              setMessages((msgs) => {
+                const copy = [...msgs];
+                const last = copy[copy.length - 1];
+                if (last && last.from === "bot") {
+                  copy[copy.length - 1] = { from: "bot", text: accumulatedText };
+                }
+                return copy;
+              });
+            } else if (event.type === "error" && event.content) {
+              accumulatedText += `\n\nError: ${event.content}`;
+              setMessages((msgs) => {
+                const copy = [...msgs];
+                const last = copy[copy.length - 1];
+                if (last && last.from === "bot") {
+                  copy[copy.length - 1] = { from: "bot", text: accumulatedText };
+                }
+                return copy;
+              });
+            }
+            // 'done' is handled implicitly when the reader finishes
           }
         }
-
-        if (rawBody) {
-          parts.push("--- Raw response body (non-JSON) ---\n" + rawBody);
-        }
-
-        const textOut = parts.join("\n\n");
-        setMessages((msgs) => {
-          const copy = [...msgs];
-          const last = copy.slice(-1)[0];
-          if (last && last.from === "bot") {
-            copy[copy.length - 1] = { from: "bot", text: textOut };
-          } else {
-            copy.push({ from: "bot", text: textOut });
-          }
-          return copy;
-        });
 
         // Refresh thread list after message (new thread may appear, timestamps update)
         fetchThreads();
-      } catch (err: any) {
-        const errMsg = `Error contacting agent: ${err?.message ?? String(err)}`;
+      } catch (err: unknown) {
+        const errMsg = `Error contacting agent: ${err instanceof Error ? err.message : String(err)}`;
         setMessages((msgs) => {
           const copy = [...msgs];
           const last = copy.slice(-1)[0];
@@ -407,6 +427,8 @@ export default function MCPChat() {
         });
       } finally {
         setStreaming(false);
+        setStreamStatus("");
+        setActiveTools([]);
       }
     })();
   }
@@ -985,23 +1007,47 @@ export default function MCPChat() {
               <div
                 style={{
                   display: "flex",
-                  alignItems: "center",
-                  gap: 10,
+                  flexDirection: "column",
+                  gap: 8,
                   padding: "12px 0",
                 }}
               >
-                <span
-                  style={{
-                    width: 20,
-                    height: 20,
-                    border: "3px solid rgba(0,0,0,0.12)",
-                    borderTopColor: "#0ea5a4",
-                    borderRadius: "50%",
-                    display: "inline-block",
-                    animation: "mcp-spin 0.9s linear infinite",
-                  }}
-                />
-                <span style={{ color: "#64748b", fontSize: 14 }}>Thinking...</span>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <span
+                    style={{
+                      width: 20,
+                      height: 20,
+                      border: "3px solid rgba(0,0,0,0.12)",
+                      borderTopColor: "#0ea5a4",
+                      borderRadius: "50%",
+                      display: "inline-block",
+                      animation: "mcp-spin 0.9s linear infinite",
+                    }}
+                  />
+                  <span style={{ color: "#64748b", fontSize: 14 }}>
+                    {streamStatus || "Thinking..."}
+                  </span>
+                </div>
+                {activeTools.length > 0 && (
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 6, paddingLeft: 30 }}>
+                    {activeTools.map((toolName, idx) => (
+                      <span
+                        key={`${toolName}-${idx}`}
+                        style={{
+                          background: "#e0f2f1",
+                          color: "#0d9695",
+                          padding: "4px 10px",
+                          borderRadius: 12,
+                          fontSize: 12,
+                          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                          border: "1px solid #b2dfdb",
+                        }}
+                      >
+                        {toolName}
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
             )}
             <div ref={messagesEndRef} />


### PR DESCRIPTION
## Problem

When the agent calls the `ask_user` tool (PR #208 — backend), the SSE stream emits a new event type `ask_user` with the question text and the paused thread_id. The chat client today doesn't recognize this event type — the event is silently dropped, the user sees nothing, and the conversation appears to stall.

## Fix

Wire `ask_user` events into the chat client.

- New state `pendingClarification: { threadId } | null` tracks whether the active thread is paused on a clarification interrupt.
- When the SSE stream emits `{ type: "ask_user", content: <question>, thread_id }`, the chat client renders the question as the bot's most recent message and arms `pendingClarification`.
- `sendPrompt` checks `pendingClarification`: if set, the typed text routes to `POST /langchain/chat/resume` (with `reply: text`); otherwise it goes to `/langchain/chat/stream` as before.
- `resumeRequest` mirrors `startRequest`'s SSE consumption — including handling another `ask_user` event mid-resume so multi-turn clarifications work without UI changes.
- Input placeholder switches to `"Type your answer to the agent's question..."` while a clarification is pending, so the affordance is obvious.
- `pendingClarification` clears when the user creates a new conversation or switches threads, so a paused state never leaks across thread boundaries.