### PR TITLE
fix(deploy): pass LOCAL_LLM_MODEL through docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       LOCAL_LLM_URL: ${LOCAL_LLM_URL}
+      LOCAL_LLM_MODEL: ${LOCAL_LLM_MODEL}
       CORS_ORIGINS: "http://localhost:3000"
     volumes:
       - ./langchain:/app


### PR DESCRIPTION
## Summary
- `docker-compose.dev.yml` was forwarding only `LOCAL_LLM_URL` to the langchain-agent service. The agent fell back to auto-detecting the model from `/v1/models` at startup, which works but is fragile and doesn't match `docker-compose.prod.yml`.
- Add `LOCAL_LLM_MODEL: ${LOCAL_LLM_MODEL}` to dev compose so dev/prod parity is restored and the agent sees the model name explicitly.

## Test plan
- [x] Local: `docker compose --env-file .env.dev -f docker-compose.dev.yml exec langchain-agent printenv | grep LOCAL_LLM` shows both `LOCAL_LLM_URL` and `LOCAL_LLM_MODEL`; chat UI smoke test against Spark Qwen3.5-9B passes.