### PR TITLE
fix(scrna): handle orphan cells explicitly in UMAP view

### DIFF
--- a/supabase/migrations/20260504000003_scrna_cell_arrays_orphan_handling.sql
+++ b/supabase/migrations/20260504000003_scrna_cell_arrays_orphan_handling.sql
@@ -1,0 +1,68 @@
+-- Migration: scrna_cell_arrays_orphan_handling
+--
+-- Three changes that close a class of silent scientific-correctness bugs in
+-- the scRNA UMAP view when a cell's cluster_id has no matching catalog row
+-- in scrna_clusters.
+--
+-- 1. Reserve cluster ordinal 255 as the orphan sentinel via a CHECK
+--    constraint on scrna_clusters.ordinal. Real clusters get 0..254.
+-- 2. Recreate scrna_cell_arrays() so orphan cells return ordinal=255 from
+--    the RPC instead of NULL. The frontend then handles 255 explicitly
+--    (gray + warning) rather than relying on JS null-coercion.
+-- 3. Add a NOT VALID composite foreign key from scrna_cells (dataset_id,
+--    cluster_id) to scrna_clusters (dataset_id, cluster_id). NOT VALID
+--    applies to new writes only and skips validation of existing rows, so
+--    the migration is safe to run against data that may already contain
+--    orphans. A future VALIDATE CONSTRAINT step can run after a one-time
+--    cleanup once we know prod state.
+
+BEGIN;
+
+-- 1. Reserve ordinal 255 as the orphan sentinel. NOT VALID so the migration
+--    cannot fail on legacy rows; new writes are still checked.
+ALTER TABLE public.scrna_clusters
+  DROP CONSTRAINT IF EXISTS scrna_clusters_ordinal_below_sentinel;
+ALTER TABLE public.scrna_clusters
+  ADD CONSTRAINT scrna_clusters_ordinal_below_sentinel
+  CHECK (ordinal < 255) NOT VALID;
+
+-- 2. RPC returns 255 for orphan cells instead of NULL.
+CREATE OR REPLACE FUNCTION public.scrna_cell_arrays(
+  ds_id BIGINT
+)
+RETURNS TABLE (
+  x               REAL,
+  y               REAL,
+  cluster_ordinal SMALLINT
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT
+    c.x::REAL,
+    c.y::REAL,
+    COALESCE(cl.ordinal, 255::SMALLINT) AS cluster_ordinal
+  FROM public.scrna_cells c
+  LEFT JOIN public.scrna_clusters cl
+    ON cl.dataset_id = c.dataset_id
+   AND cl.cluster_id = c.cluster_id
+  WHERE c.dataset_id = ds_id
+  ORDER BY c.cell_number ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.scrna_cell_arrays(BIGINT)
+  TO anon, authenticated, bloom_user, bloom_admin, bloom_agent;
+
+-- 3. NOT VALID composite FK on (dataset_id, cluster_id).
+ALTER TABLE public.scrna_cells
+  DROP CONSTRAINT IF EXISTS scrna_cells_cluster_fkey;
+ALTER TABLE public.scrna_cells
+  ADD CONSTRAINT scrna_cells_cluster_fkey
+  FOREIGN KEY (dataset_id, cluster_id)
+  REFERENCES public.scrna_clusters (dataset_id, cluster_id)
+  ON DELETE RESTRICT
+  ON UPDATE CASCADE
+  NOT VALID;
+
+COMMIT;

--- a/supabase/rollbacks/20260504000003_scrna_cell_arrays_orphan_handling_rollback.sql
+++ b/supabase/rollbacks/20260504000003_scrna_cell_arrays_orphan_handling_rollback.sql
@@ -1,0 +1,38 @@
+-- Rollback for 20260504000003_scrna_cell_arrays_orphan_handling.sql
+
+BEGIN;
+
+ALTER TABLE public.scrna_cells
+  DROP CONSTRAINT IF EXISTS scrna_cells_cluster_fkey;
+
+ALTER TABLE public.scrna_clusters
+  DROP CONSTRAINT IF EXISTS scrna_clusters_ordinal_below_sentinel;
+
+CREATE OR REPLACE FUNCTION public.scrna_cell_arrays(
+  ds_id BIGINT
+)
+RETURNS TABLE (
+  x               REAL,
+  y               REAL,
+  cluster_ordinal SMALLINT
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT
+    c.x::REAL,
+    c.y::REAL,
+    cl.ordinal AS cluster_ordinal
+  FROM public.scrna_cells c
+  LEFT JOIN public.scrna_clusters cl
+    ON cl.dataset_id = c.dataset_id
+   AND cl.cluster_id = c.cluster_id
+  WHERE c.dataset_id = ds_id
+  ORDER BY c.cell_number ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.scrna_cell_arrays(BIGINT)
+  TO anon, authenticated, bloom_user, bloom_admin, bloom_agent;
+
+COMMIT;

--- a/web/components/expression-lib/scrna-client.ts
+++ b/web/components/expression-lib/scrna-client.ts
@@ -10,12 +10,20 @@ const DEFAULT_STORAGE_URL = "http://localhost:9100";
 const STORAGE_BUCKET = "scrna";
 const GENE_SEARCH_DEFAULT_LIMIT = 20;
 
-/** Row returned by the `scrna_cell_arrays` RPC. */
+/** Row returned by the `scrna_cell_arrays` RPC.
+ *
+ * `cluster_ordinal === 255` is the orphan sentinel: the cell's `cluster_id`
+ * does not appear in `scrna_clusters` for this dataset. Real clusters are
+ * 0..254 (CHECK constraint on `scrna_clusters.ordinal`).
+ */
 export interface CellArraysRow {
   x: number;
   y: number;
   cluster_ordinal: number;
 }
+
+/** Cluster ordinal returned by the RPC for cells with no matching catalog row. */
+export const ORPHAN_CLUSTER_ORDINAL = 255;
 
 /** Storage base URL for `.bin` fetches, from NEXT_PUBLIC_STORAGE_URL. */
 function getStorageBaseUrl(): string {

--- a/web/components/expression-umap.tsx
+++ b/web/components/expression-umap.tsx
@@ -8,6 +8,7 @@ import {
   fetchClusters,
   fetchDataset,
   fetchGeneBin,
+  ORPHAN_CLUSTER_ORDINAL,
   type CellArraysRow,
 } from "@/components/expression-lib/scrna-client";
 import {
@@ -24,6 +25,8 @@ type Cluster = Database["public"]["Tables"]["scrna_clusters"]["Row"];
 const DEFAULT_POINT_SIZE = 4.0;
 const NORMALIZE_PADDING = 1.05; // give a small border around the UMAP bbox
 
+const ORPHAN_GRAY: [number, number, number] = [0.6, 0.6, 0.6];
+
 export interface ExpressionUmapProps {
   datasetId: number;
   /** Currently-selected gene for expression overlay; null = color by cluster */
@@ -37,6 +40,8 @@ export interface ExpressionUmapProps {
     dataset: Dataset;
     clusters: Cluster[];
     cellCount: number;
+    /** Cells whose `cluster_id` had no row in `scrna_clusters` (sentinel ordinal 255). */
+    orphanCount: number;
   }) => void;
   /** Fires whenever the currently-overlaid gene's min/max changes */
   onExpressionRangeChanged?: (range: { min: number; max: number } | null) => void;
@@ -74,7 +79,11 @@ function packClusterColors(
   }
   const out = new Float32Array(cells.length * 4);
   for (let i = 0; i < cells.length; i++) {
-    const rgb = paletteRgb.get(cells[i].cluster_ordinal) ?? [0.5, 0.5, 0.5];
+    const ord = cells[i].cluster_ordinal;
+    const rgb =
+      ord === ORPHAN_CLUSTER_ORDINAL
+        ? ORPHAN_GRAY
+        : paletteRgb.get(ord) ?? ORPHAN_GRAY;
     out[i * 4] = rgb[0];
     out[i * 4 + 1] = rgb[1];
     out[i * 4 + 2] = rgb[2];
@@ -192,8 +201,10 @@ export function ExpressionUmap({
         const visibility = new Float32Array(cells.length);
         visibility.fill(1.0);
         const clusterOrdinals = new Uint8Array(cells.length);
+        let orphanCount = 0;
         for (let i = 0; i < cells.length; i++) {
           clusterOrdinals[i] = cells[i].cluster_ordinal;
+          if (cells[i].cluster_ordinal === ORPHAN_CLUSTER_ORDINAL) orphanCount++;
         }
         const loaded: LoadedData = {
           dataset,
@@ -208,7 +219,12 @@ export function ExpressionUmap({
           normCenterY,
         };
         setData(loaded);
-        onDataLoaded?.({ dataset, clusters, cellCount: cells.length });
+        onDataLoaded?.({
+          dataset,
+          clusters,
+          cellCount: cells.length,
+          orphanCount,
+        });
       } catch (err) {
         if (!cancelled) {
           setLoadError(err instanceof Error ? err.message : String(err));

--- a/web/components/expression-view.tsx
+++ b/web/components/expression-view.tsx
@@ -26,6 +26,8 @@ interface LoadedMeta {
   dataset: Dataset;
   clusters: Cluster[];
   cellCount: number;
+  /** Cells whose `cluster_id` had no row in `scrna_clusters` (sentinel ordinal 255). */
+  orphanCount: number;
   /** from scrna_cluster_stats.cell_count, keyed by ordinal */
   counts: Record<number, number>;
 }
@@ -73,11 +75,17 @@ export function ExpressionView({ datasetId }: ExpressionViewProps) {
   }, [datasetId]);
 
   const handleDataLoaded = useCallback(
-    (ctx: { dataset: Dataset; clusters: Cluster[]; cellCount: number }) => {
+    (ctx: {
+      dataset: Dataset;
+      clusters: Cluster[];
+      cellCount: number;
+      orphanCount: number;
+    }) => {
       setMeta((prev) => ({
         dataset: ctx.dataset,
         clusters: ctx.clusters,
         cellCount: ctx.cellCount,
+        orphanCount: ctx.orphanCount,
         counts: prev?.counts ?? {},
       }));
     },
@@ -183,6 +191,20 @@ export function ExpressionView({ datasetId }: ExpressionViewProps) {
             );
           })()}
         </Box>
+
+        {/* orphan-cell warning */}
+        {meta && meta.orphanCount > 0 && (
+          <span
+            className="inline-flex items-center gap-2 self-start rounded-full border border-amber-200 bg-amber-50/70 px-3 py-1 text-xs text-amber-900"
+            role="status"
+          >
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
+            {meta.orphanCount.toLocaleString()} cell
+            {meta.orphanCount === 1 ? "" : "s"} (
+            {((meta.orphanCount / meta.cellCount) * 100).toFixed(1)}%) have no
+            cluster assignment — shown in gray
+          </span>
+        )}
 
         {/* canvas */}
         <ExpressionUmap


### PR DESCRIPTION
## Summary

The `scrna_cell_arrays` RPC LEFT-JOINs `scrna_clusters` and returns `cluster_ordinal=NULL` for orphan cells. The frontend `Uint8Array` packing coerced `NULL → 0`, so orphans got hidden along with cluster-0 when the user toggled visibility. The TS type also lied about nullability. Flagged as a Blocking finding in #195 review.

## Fix

- **SQL**: new migration adds a `NOT VALID` `CHECK (ordinal < 255)` reserving `255` as the orphan sentinel, recreates `scrna_cell_arrays()` to `COALESCE` NULL → 255, and adds a `NOT VALID` composite FK from `scrna_cells(dataset_id, cluster_id)` → `scrna_clusters` to block future orphan writes.
- **Frontend**: explicit `ORPHAN_CLUSTER_ORDINAL = 255` handling in `packClusterColors`, orphan count surfaced through `onDataLoaded`, amber warning banner in `expression-view` when count > 0.