### PR TITLE
fix(ci): add missing test deps + docs(scrna): cell_count null caveat

### DIFF
--- a/langchain/tools/scrna_tools.py
+++ b/langchain/tools/scrna_tools.py
@@ -111,7 +111,7 @@ def get_clusters_by_dataset_tool(dataset_id: int) -> list | str:
                 "name": c.get("name"),
                 "color": c.get("color"),
                 "ordinal": c.get("ordinal"),
-                "cell_count": counts.get(c["cluster_id"]),
+                "cell_count": counts.get(c["cluster_id"]),  # null until scrna_cluster_stats backfill lands
             }
             for c in clusters
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ requires-python = ">=3.11"
 test = [
     "pytest>=8.3,<9",
     "psycopg[binary]==3.3.3",
+    # required by tests/integration/* — they sys.path-import langchain agent
+    # and bloommcp modules and need these resolvable at collection time.
+    "langchain-core>=0.3.0",
+    "langgraph>=0.2.0",
+    "pydantic>=2.0.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Two small changes bundled together — the second one's needed to unblock CI on every other open PR against staging.

### 1. `fix(ci)` — add `langchain-core`, `langgraph`, `pydantic` to root test extra

This unblocks PRs #210, #211, #212, #213, #214 — once #215 lands on staging, those rebase and re-run CI clean.

### 2. `docs(scrna)` — note cell_count is null until backfill


## Test plan

- [x] Local: `uv run --extra test pytest tests/integration/ -v` collects all 5 newly-blocked test files without `ModuleNotFoundError`.
- [x] CI: compose-health-check passes on this PR.