### PR TITLE
fix(ci): trivyignore CVE-2026-33845 (libgnutls30t64 DTLS, unreachable in langchain-agent)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -39,3 +39,13 @@ CVE-2026-30836
 # not yet rebuilt with it. Reassess on next node:20-alpine SHA bump.
 # Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-31789
 CVE-2026-31789
+
+# libgnutls30t64 (Debian 13.4 in python:3.11-slim) — affects: langchain-agent
+# DTLS handshake parsing — out-of-bounds read on malformed fragments,
+# DoS-only (Red Hat CVSS A:H, C:N, I:N). The langchain agent runs uvicorn/
+# FastAPI over TCP only (port 5002), exposes no UDP listener, and has no
+# DTLS client code; libgnutls30t64 is a transitive Debian base package,
+# not used by the application. None of the three exploit preconditions hold.
+# Reassess on next python:3.11-slim SHA bump or when Debian publishes a fix.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-33845
+CVE-2026-33845


### PR DESCRIPTION
## Summary

Trivy's database picked up `CVE-2026-33845` around 2026-05-05T17:35Z, causing the `Build Docker Images & Scan for CVEs` job to fail on every new PR.

## Why it doesn't actually affect Bloom

The CVE is a GnuTLS DTLS handshake parser bug — out-of-bounds read on malformed fragments.

For this bug to fire, the application would need at least one of:
- A DTLS server (received malformed handshake from a client)
- A UDP listener exposed  (only TCP/5002)
- Outbound DTLS calls (Python `ssl` / OpenSSL only)

`libgnutls30t64` is a transitive Debian base package, never invoked by application code.

## What this PR does

Appends a `.trivyignore` entry following the existing pattern (`CVE-2026-31789` libcrypto3 in node:20-alpine).

## Closes

#217 — filed by @eberrigan with this exact suggested resolution.