### PR TITLE
fix(web): traits/phenotypes empty pages on prod data

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -49,3 +49,14 @@ CVE-2026-31789
 # Reassess on next python:3.11-slim SHA bump or when Debian publishes a fix.
 # Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-33845
 CVE-2026-33845
+
+# libssh2-1t64 (Debian 13.4 in python:3.11-slim) — affects: langchain-agent
+# Integer overflow via large username or password during SSH client
+# authentication. The langchain agent never initiates SSH connections —
+# libssh2 is a transitive base-image package (pulled by curl/git), not
+# linked or invoked by application code. Exploit requires acting as an SSH
+# client against a malicious server with attacker-controlled credentials,
+# which never happens in our runtime path.
+# Reassess on next python:3.11-slim SHA bump or when Debian publishes a fix.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-7598
+CVE-2026-7598

--- a/bloommcp/uv.lock
+++ b/bloommcp/uv.lock
@@ -1557,11 +1557,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]

--- a/langchain/uv.lock
+++ b/langchain/uv.lock
@@ -675,10 +675,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -687,9 +688,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
 ]
 
 [[package]]
@@ -731,6 +732,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/f5/b1a56f703fb90952b07ff9fb5507123a39df1267d62a7f2bb821c5dbb628/langchain_openai-1.1.14.tar.gz", hash = "sha256:71b4262932fabe506ce79c175dbc956cc48f24d81e20b27662df493147750643", size = 1115195, upload-time = "2026-04-16T14:55:24.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/fa/8c33befbc0cf81b21371cc1dab4e7bf94a80b8116194f263a5021ec02529/langchain_openai-1.1.14-py3-none-any.whl", hash = "sha256:cb525d2011f9813fc15a7dcfd4bca5b87badcbcb2c113a7fbe45d1b8a1bbb69c", size = 88705, upload-time = "2026-04-16T14:55:23.159Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
 ]
 
 [[package]]
@@ -1738,11 +1751,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]
@@ -2333,11 +2346,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/services/video-worker/uv.lock
+++ b/services/video-worker/uv.lock
@@ -311,9 +311,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/web/app/app/phenotypes/[speciesId]/page.tsx
+++ b/web/app/app/phenotypes/[speciesId]/page.tsx
@@ -226,7 +226,7 @@ async function getSpeciesWithExperiments(speciesId: number) {
       "*, cyl_experiments!inner(*, people(*), cyl_waves(*, cyl_plants(*, accessions(*))))"
     )
     .eq("id", speciesId)
-    .neq("cyl_experiments.deleted", true)
+    .is("cyl_experiments.deleted_at", null)
     .single();
 
   return data;

--- a/web/app/app/phenotypes/page.tsx
+++ b/web/app/app/phenotypes/page.tsx
@@ -98,7 +98,7 @@ async function getSpeciesList(): Promise<SpeciesWithExperiments[] | null> {
   const { data } = await supabase
     .from("species")
     .select("*, cyl_experiments!inner(id, name)")
-    .neq("cyl_experiments.deleted", true);
+    .is("cyl_experiments.deleted_at", null);
 
   const typedData = data as SpeciesWithExperiments[] | null;
 

--- a/web/app/app/traits/[speciesId]/[experimentId]/[accessionName]/page.tsx
+++ b/web/app/app/traits/[speciesId]/[experimentId]/[accessionName]/page.tsx
@@ -6,15 +6,16 @@ import PlantImage from '@/components/plant-image';
 import { Key } from 'react';
 
 
-export default async function Accession({ params }: { params: { experimentId: number, accessionName: string } }) {
+export default async function Accession({ params }: { params: Promise<{ experimentId: number, accessionName: string }> }) {
 
-  const experiment : any = await getExperimentWithSpecies(params.experimentId)
+  const { experimentId, accessionName } = await params;
+  const experiment : any = await getExperimentWithSpecies(experimentId)
   const species = experiment?.species
   const experimentName = capitalizeFirstLetter(experiment?.name.replaceAll('-', ' ') ?? '')
   const speciesName = species?.common_name ?? ''
 
-  const lineNameUnescaped = params.accessionName.replaceAll('%20', ' ')
-  const plants: any  = await getPlants(lineNameUnescaped, params.experimentId)  
+  const lineNameUnescaped = accessionName.replaceAll('%20', ' ')
+  const plants: any  = await getPlants(lineNameUnescaped, experimentId)
 
   return (
     <div className=''>
@@ -59,7 +60,7 @@ export default async function Accession({ params }: { params: { experimentId: nu
                     {scan.cyl_images.map((image: { id: Key | null | undefined; object_path: string | null; }) => (
                       <div key={image.id} className='text-center'>
                         <div className='pb-1'>Day {scan.plant_age_days}</div>
-                        <Link href={`/app/phenotypes/${species?.id}/${experiment?.id}/${params.accessionName}/${image.id}`}>
+                        <Link href={`/app/phenotypes/${species?.id}/${experiment?.id}/${accessionName}/${image.id}`}>
                           <PlantImage path={image.object_path} thumb={true} />
                         </Link>
                       </div>

--- a/web/app/app/traits/[speciesId]/page.tsx
+++ b/web/app/app/traits/[speciesId]/page.tsx
@@ -9,9 +9,10 @@ import { Key } from "react";
 export default async function Species({
   params,
 }: {
-  params: { speciesId: number };
+  params: Promise<{ speciesId: number }>;
 }) {
-  const species: any  = await getSpeciesWithExperiments(params.speciesId);
+  const { speciesId } = await params;
+  const species: any  = await getSpeciesWithExperiments(speciesId);
 
   const user = await getUser();
 
@@ -21,7 +22,7 @@ export default async function Species({
 
   mixpanel?.track("Page view", {
     distinct_id: user?.email,
-    url: `/app/traits/${params.speciesId}`,
+    url: `/app/traits/${speciesId}`,
   });
 
   return (
@@ -99,7 +100,7 @@ async function getSpeciesWithExperiments(speciesId: number) {
       "*, cyl_experiments!inner(*, cyl_waves(*, cyl_plants(*, accessions(*))))"
     )
     .eq("id", speciesId)
-    .neq("cyl_experiments.deleted", true)
+    .is("cyl_experiments.deleted_at", null)
     .single();
 
   return data;

--- a/web/app/app/traits/page.tsx
+++ b/web/app/app/traits/page.tsx
@@ -98,7 +98,7 @@ async function getSpeciesList(): Promise<SpeciesWithExperiments[] | null> {
   const { data } = await supabase
     .from("species")
     .select("*, cyl_experiments!inner(id, name)")
-    .neq("cyl_experiments.deleted", true);
+    .is("cyl_experiments.deleted_at", null);
 
   const typedData = data as SpeciesWithExperiments[] | null;
 


### PR DESCRIPTION
Two bugs surfaced when V1 bloom prod data was loaded into V2 bloom:

1. **Next.js 16 async params** — Dynamic route handlers in `traits/[speciesId]` and `traits/[speciesId]/[experimentId]/[accessionName]` were reading `params` synchronously. Since Next.js 16 made `params` a `Promise`, `params.speciesId` resolved to `undefined`, sending `id=eq.undefined` to PostgREST and returning 400.

2. **Schema rename `deleted` → `deleted_at`** — V2 renamed the boolean `cyl_experiments.deleted` column to a `deleted_at` timestamp. Five server components still filtered on the old column, silently returning empty results for traits/phenotypes listings.