### PR TITLE
feat: add bloom_writer role for Bloom Desktop writes

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -49,3 +49,23 @@ CVE-2026-31789
 # Reassess on next python:3.11-slim SHA bump or when Debian publishes a fix.
 # Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-33845
 CVE-2026-33845
+
+# libgnutls30t64 (Debian 13.4 in python:3.11-slim) — affects: langchain-agent
+# GnuTLS authentication bypass via NUL character in username. The langchain
+# agent does not authenticate clients via GnuTLS (FastAPI uses Supabase JWT
+# over plain TCP), so the affected code path is not reachable. Transitive
+# Debian base package, no fix available upstream. Reassess on next SHA bump.
+CVE-2026-42010
+
+# libpython3.13 / python3.13 (Debian 13.4 in python:3.11-slim) — affects: langchain-agent
+# xml.parsers.expat / xml.etree.ElementTree insufficient hash randomization
+# entropy. The agent runs python3.11 (not 3.13); python3.13 ships as a base
+# Debian package but is never executed. Agent input is JSON via FastAPI, no
+# untrusted XML parsing. No fix available. Reassess on next SHA bump.
+CVE-2026-7210
+
+# libssh2-1t64 (Debian 13.4 in python:3.11-slim) — affects: langchain-agent
+# Integer overflow on large username/password arguments. The agent does not
+# use libssh2 / SSH at runtime; transitive Debian base package. No fix
+# available upstream. Reassess on next SHA bump.
+CVE-2026-7598

--- a/bloommcp/uv.lock
+++ b/bloommcp/uv.lock
@@ -596,11 +596,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -1557,11 +1557,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]

--- a/langchain/uv.lock
+++ b/langchain/uv.lock
@@ -500,11 +500,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -675,10 +675,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -687,9 +688,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
 ]
 
 [[package]]
@@ -731,6 +732,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/f5/b1a56f703fb90952b07ff9fb5507123a39df1267d62a7f2bb821c5dbb628/langchain_openai-1.1.14.tar.gz", hash = "sha256:71b4262932fabe506ce79c175dbc956cc48f24d81e20b27662df493147750643", size = 1115195, upload-time = "2026-04-16T14:55:24.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/fa/8c33befbc0cf81b21371cc1dab4e7bf94a80b8116194f263a5021ec02529/langchain_openai-1.1.14-py3-none-any.whl", hash = "sha256:cb525d2011f9813fc15a7dcfd4bca5b87badcbcb2c113a7fbe45d1b8a1bbb69c", size = 88705, upload-time = "2026-04-16T14:55:23.159Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
 ]
 
 [[package]]
@@ -806,7 +819,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.32"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -819,9 +832,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/eb/8883d1158c743d0aac350f09df7880714d27283497e8c80bb9fe3480f165/langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c", size = 4462348, upload-time = "2026-05-15T21:31:41.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/968c88a63e32a59b3e5c68afd2fe114ce0708a125db0be1a85efc25fb2ea/langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae", size = 399564, upload-time = "2026-05-15T21:31:39.046Z" },
 ]
 
 [[package]]
@@ -1738,11 +1751,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -2333,11 +2346,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/services/video-worker/uv.lock
+++ b/services/video-worker/uv.lock
@@ -311,9 +311,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/supabase/migrations/20260519130000_add_bloom_writer_role.sql
+++ b/supabase/migrations/20260519130000_add_bloom_writer_role.sql
@@ -1,0 +1,135 @@
+-- bloom_writer role: INSERT/UPDATE/SELECT for users flagged is_writer=true.
+--
+-- Adds a fourth Postgres role alongside bloom_admin, bloom_user, bloom_agent.
+-- Routed via the custom_access_token_hook based on
+-- auth.users.raw_user_meta_data->>'is_writer'. Inherits bloom_user, so all
+-- existing bloom_user RLS policies in 20260506000001_bloom_role_rls_policies.sql
+-- continue to apply via Postgres role membership.
+--
+-- Initial use case: Bloom Desktop writes scans + images to production from
+-- approved scientist accounts. The role is intentionally generic ("writer")
+-- so additional write-capable clients can reuse it.
+--
+-- Idempotent — safe to re-apply on environments where this was applied manually.
+
+BEGIN;
+
+-- 1. Create role if missing
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'bloom_writer') THEN
+    CREATE ROLE bloom_writer NOLOGIN;
+  END IF;
+END$$;
+
+-- 2. Membership: inherit bloom_user (RLS policies on bloom_user apply via membership)
+GRANT bloom_user TO bloom_writer;
+-- Supabase machinery can SET ROLE to bloom_writer when JWT claim says so
+GRANT bloom_writer TO authenticator;
+GRANT bloom_writer TO postgres;
+
+-- 3. public schema grants
+GRANT USAGE ON SCHEMA public TO bloom_writer;
+GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA public TO bloom_writer;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bloom_writer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE ON TABLES TO bloom_writer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO bloom_writer;
+
+-- 4. auth schema — needed for auth.uid() in RLS policies + lookups
+GRANT USAGE ON SCHEMA auth TO bloom_writer;
+GRANT SELECT ON auth.users TO bloom_writer;
+
+-- 5. storage schema — image uploads write storage.objects + companion .info rows
+GRANT USAGE ON SCHEMA storage TO bloom_writer;
+GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA storage TO bloom_writer;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA storage TO bloom_writer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA storage
+  GRANT SELECT, INSERT, UPDATE ON TABLES TO bloom_writer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA storage
+  GRANT USAGE, SELECT ON SEQUENCES TO bloom_writer;
+
+-- 6. JWT hook — adds is_writer branch. Hierarchy: admin > writer > user.
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  claims    JSONB;
+  is_admin  BOOLEAN;
+  is_writer BOOLEAN;
+BEGIN
+  claims := event->'claims';
+
+  SELECT COALESCE(
+    (SELECT (raw_user_meta_data->>'is_admin')::boolean
+     FROM auth.users WHERE id = (claims->>'sub')::uuid),
+    false
+  ) INTO is_admin;
+
+  SELECT COALESCE(
+    (SELECT (raw_user_meta_data->>'is_writer')::boolean
+     FROM auth.users WHERE id = (claims->>'sub')::uuid),
+    false
+  ) INTO is_writer;
+
+  -- Note: bloom_agent is NOT set here. The LangChain agent uses a pre-generated
+  -- static JWT with role=bloom_agent (stored in BLOOM_AGENT_KEY env var) rather
+  -- than going through GoTrue. Do not add a bloom_agent branch to this hook.
+  IF is_admin THEN
+    claims := jsonb_set(claims, '{role}', '"bloom_admin"');
+  ELSIF is_writer THEN
+    claims := jsonb_set(claims, '{role}', '"bloom_writer"');
+  ELSE
+    claims := jsonb_set(claims, '{role}', '"bloom_user"');
+  END IF;
+
+  event := jsonb_set(event, '{claims}', claims);
+  RETURN event;
+END;
+$function$;
+
+-- 7. RLS policies on every public table for bloom_writer.
+-- Role membership grants table privileges, but RLS policies are checked
+-- separately by current_role. Add writer_<verb>_<table> mirroring the
+-- existing user_<verb>_<table> naming. INSERT and UPDATE use
+-- WITH CHECK (true) — bloom_writer is trusted, no ownership filter.
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS writer_select_%I ON public.%I', r.tablename, r.tablename);
+    EXECUTE format('CREATE POLICY writer_select_%I ON public.%I FOR SELECT TO bloom_writer USING (true)', r.tablename, r.tablename);
+
+    EXECUTE format('DROP POLICY IF EXISTS writer_insert_%I ON public.%I', r.tablename, r.tablename);
+    EXECUTE format('CREATE POLICY writer_insert_%I ON public.%I FOR INSERT TO bloom_writer WITH CHECK (true)', r.tablename, r.tablename);
+
+    EXECUTE format('DROP POLICY IF EXISTS writer_update_%I ON public.%I', r.tablename, r.tablename);
+    EXECUTE format('CREATE POLICY writer_update_%I ON public.%I FOR UPDATE TO bloom_writer USING (true) WITH CHECK (true)', r.tablename, r.tablename);
+  END LOOP;
+END$$;
+
+-- 8. RLS policies on storage.objects + storage.buckets for bloom_writer.
+-- Image uploads via Supabase Storage API hit storage.objects directly; without
+-- a matching INSERT policy the storage-api returns 403. buckets is SELECT-only
+-- for bucket config lookup.
+DROP POLICY IF EXISTS writer_select_objects ON storage.objects;
+CREATE POLICY writer_select_objects ON storage.objects
+  FOR SELECT TO bloom_writer USING (true);
+
+DROP POLICY IF EXISTS writer_insert_objects ON storage.objects;
+CREATE POLICY writer_insert_objects ON storage.objects
+  FOR INSERT TO bloom_writer WITH CHECK (true);
+
+DROP POLICY IF EXISTS writer_update_objects ON storage.objects;
+CREATE POLICY writer_update_objects ON storage.objects
+  FOR UPDATE TO bloom_writer USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS writer_select_buckets ON storage.buckets;
+CREATE POLICY writer_select_buckets ON storage.buckets
+  FOR SELECT TO bloom_writer USING (true);
+
+COMMIT;

--- a/web/components/illustration.tsx
+++ b/web/components/illustration.tsx
@@ -1,7 +1,6 @@
 export const revalidate = 60 // revalidate this page every 60 seconds
 
 import { createServerSupabaseClient } from '@/lib/supabase/server'
-import Image from 'next/image'
 import { promises as fs } from 'fs'
 import path from 'path'
 
@@ -60,11 +59,10 @@ export default async function Illustration({
 
   if (objectUrl) {
     return (
-      <Image
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
         alt={commonName ?? 'Species illustration'}
         src={objectUrl}
-        width={192}
-        height={192}
         className="w-full h-full object-contain"
       />
     )


### PR DESCRIPTION
## Summary
- Adds a generic `bloom_writer` Postgres role for clients needing INSERT + UPDATE
- JWT hook routes users with `auth.users.raw_user_meta_data.is_writer = true` to this role
- Initial use case: Bloom Desktop; designed to be reused for future write-capable clients
- Already applied manually to `bloom_v2_prod` on 2026-05-19 for live testing — migration is idempotent so CI re-run is a no-op

## What's in the migration
1. `CREATE ROLE bloom_writer NOLOGIN` (idempotent)
2. Role hierarchy: inherits `bloom_user`, granted to `authenticator` + `postgres`
3. `public` schema: SELECT/INSERT/UPDATE on all tables + future defaults
4. `auth` schema: USAGE + SELECT on `auth.users` (needed for `auth.uid()` in RLS)
5. `storage` schema: SELECT/INSERT/UPDATE on `storage.*` (image uploads)
6. `custom_access_token_hook`: adds `is_writer` branch (hierarchy: admin > writer > user)
7. RLS policies: `writer_select/insert/update_<table>` on every public table
8. RLS policies: `writer_select/insert/update_objects` + `writer_select_buckets` on storage

## Companion PRs (in `bloom-desktop-pilot`)
- [#55 — trust Caddy's root CA for bloom-dev TLS](https://github.com/eberrigan/bloom-desktop-pilot/pull/55)
- [#56 — inject ws as Supabase Realtime transport](https://github.com/eberrigan/bloom-desktop-pilot/pull/56)