### PR TITLE
fix(migrations): skip non-owned tables in bloom_writer policy loop

### DIFF
--- a/supabase/migrations/20260519130000_add_bloom_writer_role.sql
+++ b/supabase/migrations/20260519130000_add_bloom_writer_role.sql
@@ -91,15 +91,17 @@ END;
 $function$;
 
 -- 7. RLS policies on every public table for bloom_writer.
--- Role membership grants table privileges, but RLS policies are checked
--- separately by current_role. Add writer_<verb>_<table> mirroring the
--- existing user_<verb>_<table> naming. INSERT and UPDATE use
--- WITH CHECK (true) — bloom_writer is trusted, no ownership filter.
+-- Skip tables from Langraph implementation. 
+-- check Postgres applies before allowing CREATE POLICY.
 DO $$
 DECLARE
   r RECORD;
 BEGIN
-  FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+  FOR r IN
+    SELECT tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND pg_has_role(current_user, tableowner, 'MEMBER')
   LOOP
     EXECUTE format('DROP POLICY IF EXISTS writer_select_%I ON public.%I', r.tablename, r.tablename);
     EXECUTE format('CREATE POLICY writer_select_%I ON public.%I FOR SELECT TO bloom_writer USING (true)', r.tablename, r.tablename);


### PR DESCRIPTION
## Summary

Staging deploy of #224 failed with `must be owner of table checkpoint_migrations`. 

The bloom_writer migration loops over every `public` table to add `writer_*` RLS policies — but LangGraph's `checkpoint_*` tables are owned by `supabase_admin`

Add `pg_has_role(current_user, tableowner, 'MEMBER')` filter so the loop only touches tables the migration user can policy. 

The 4 skipped tables are `checkpoint_migrations`, `checkpoints`, `checkpoint_blobs`, `checkpoint_writes, bloom desktop (`bloom_writer`)  doesn't need write access on them.