### PR TITLE
fix(web,env): public Storage URLs + vLLM LAN IP

### DIFF
--- a/.env.prod.defaults
+++ b/.env.prod.defaults
@@ -92,9 +92,8 @@ JWT_EXPIRY=3600
 LANGCHAIN_TRACING_V2=false
 LANGCHAIN_PROJECT=bloom-prod
 
-# Local LLM (vLLM) — Spark host on Tailscale internal network.
-# Reachable only from prod/staging hosts that have joined the Tailnet.
-LOCAL_LLM_URL=http://100.104.65.54:8000/v1
+# Local LLM (vLLM) — Spark host on Salk LAN.
+LOCAL_LLM_URL=http://10.1.38.28:8000/v1
 LOCAL_LLM_MODEL=Qwen/Qwen3.5-9B
 
 # Browser-facing langchain agent endpoint. Caddy routes /langchain/* on

--- a/.env.staging.defaults
+++ b/.env.staging.defaults
@@ -84,9 +84,8 @@ JWT_EXPIRY=3600
 LANGCHAIN_TRACING_V2=false
 LANGCHAIN_PROJECT=bloom-staging
 
-# Local LLM (vLLM) — Spark host on Tailscale internal network.
-# Reachable only from prod/staging hosts that have joined the Tailnet.
-LOCAL_LLM_URL=http://100.104.65.54:8000/v1
+# Local LLM (vLLM) — Spark host on Salk LAN.
+LOCAL_LLM_URL=http://10.1.38.28:8000/v1
 LOCAL_LLM_MODEL=Qwen/Qwen3.5-9B
 
 # Browser-facing langchain agent endpoint. Caddy routes /langchain/* on

--- a/web/components/illustration.tsx
+++ b/web/components/illustration.tsx
@@ -1,6 +1,7 @@
-export const revalidate = 60 // revalidate this page every 60 seconds
+export const revalidate = 60 
 
 import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { toPublicStorageUrl } from '@/lib/supabase/storage-url'
 import { promises as fs } from 'fs'
 import path from 'path'
 
@@ -18,7 +19,7 @@ async function getObjectUrl(storagePath: string): Promise<string | null> {
     console.log('Illustration error:', error)
     return null
   }
-  return data?.signedUrl ?? null
+  return toPublicStorageUrl(data?.signedUrl)
 }
 
 function slugify(value: string | null | undefined): string {

--- a/web/lib/supabase/storage-url.ts
+++ b/web/lib/supabase/storage-url.ts
@@ -1,0 +1,9 @@
+
+const INTERNAL_HOST = /^https?:\/\/kong:\d+/
+
+export function toPublicStorageUrl(url: string | null | undefined): string | null {
+  if (!url) return null
+  const publicBase = process.env.NEXT_PUBLIC_SUPABASE_URL
+  if (!publicBase) return url
+  return url.replace(INTERNAL_HOST, publicBase)
+}


### PR DESCRIPTION
- Rewrites server-side signed Storage URLs from `kong:8000` to `NEXT_PUBLIC_SUPABASE_URL` so the browser can load species illustrations.
- Points vLLM at Spark's IP