### PR TITLE
fix(agent): hide router's classification stream from chat UI

### DIFF
--- a/langchain/graph/router.py
+++ b/langchain/graph/router.py
@@ -75,7 +75,9 @@ def make_top_router_node(llm):
 
         try:
             messages = _build_classifier_messages(user_text)
-            decision = await classifier.ainvoke(messages)
+            decision = await classifier.ainvoke(
+                messages, config={"tags": ["router_internal"]}
+            )
         except Exception as exc:
             logger.warning(
                 "top_router: classifier raised %s, falling back to %s",

--- a/langchain/routes/chat.py
+++ b/langchain/routes/chat.py
@@ -183,6 +183,8 @@ async def chat_stream(
                     yield f"data: {json.dumps({'type': 'tool_done', 'content': tool_name})}\n\n"
 
                 elif kind == "on_chat_model_stream":
+                    if "router_internal" in (event.get("tags") or []):
+                        continue
                     chunk = event.get("data", {}).get("chunk")
                     if chunk and isinstance(getattr(chunk, "content", None), str) and chunk.content:
                         yield f"data: {json.dumps({'type': 'token', 'content': chunk.content})}\n\n"


### PR DESCRIPTION
The top router's LLM call (which classifies a request as phenotyping/scrna/analysis/freeform) was streaming its structured-output JSON to the SSE handler, which then rendered it in the chat UI as the assistant's reply. `{"route": "phenotyping"}` showed up as the answer; the actual freeform leaf response never reached the user because the browser disconnected.

Fix: tag the router's `ainvoke` with `router_internal`, skip `on_chat_model_stream` events with that tag in the SSE handler. Two-line change in `router.py` + `chat.py`.