### PR TITLE
feat(caddy): wire Let's Encrypt cert for bloom-dev.salk.edu

### DIFF
--- a/.env.prod.defaults
+++ b/.env.prod.defaults
@@ -31,7 +31,13 @@ DOMAIN_MINIO=minio.bloom-dev.salk.edu
 CADDY_HTTP_LISTEN_PORT=80
 CADDY_HTTPS_LISTEN_PORT=443
 CADDY_HTTP_PORT=
-CADDY_TLS_DIRECTIVE=tls internal
+# Primary: Let's Encrypt cert from /data/bloom/production/caddy/certs/
+CADDY_TLS_DIRECTIVE=tls /etc/caddy/certs/fullchain.pem /etc/caddy/certs/privkey.pem
+
+# Fallback if certs are missing/expired — swap manually and restart caddy:
+#   sed -i 's|^CADDY_TLS_DIRECTIVE=.*|CADDY_TLS_DIRECTIVE=tls internal|' .env.prod
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate caddy
+# CADDY_TLS_DIRECTIVE=tls internal
 
 # Database
 POSTGRES_DB=postgres

--- a/caddy/certs/.gitignore
+++ b/caddy/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,6 +46,7 @@ services:
       CADDY_TLS_DIRECTIVE: ${CADDY_TLS_DIRECTIVE}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy/certs:/etc/caddy/certs:ro
       - caddy-data:/data
       - caddy-config:/config
     depends_on:


### PR DESCRIPTION
Replaces Caddy's `tls internal` (self-signed) with a real Let's Encrypt cert covering `bloom-dev.salk.edu` + wildcard `*.bloom-dev.salk.edu`. Cert was issued via DNS-01 ACME (Salk IT added the TXT record)

## Changes
- `docker-compose.prod.yml`: mount `./caddy/certs:/etc/caddy/certs:ro` into caddy container
- `.env.prod.defaults`: `CADDY_TLS_DIRECTIVE` points at the LE cert paths; commented fallback to `tls internal` documented in-file for emergency use
- `caddy/certs/.gitignore`: keep cert PEMs out of git

## Cert files location
On the deploy host: `/data/bloom/production/caddy/certs/{fullchain.pem,privkey.pem}`

## Fallback
If certs go missing or expire before renewal, swap to self-signed:

## Verified
- `curl https://bloom-dev.salk.edu` → Let's Encrypt issuer, verify ok
- `curl https://studio.bloom-dev.salk.edu` →  verify ok
- `curl https://minio.bloom-dev.salk.edu` → verify ok

## Renewal
Cert expires **2026-08-18** (90 days). Manual renewal via certbot for now — auto-renewal needs DNS API access from Salk IT (separate follow-up).

