### PR TITLE
deploy: staging → prod (Let's Encrypt cert)

### DIFF
--- a/.env.prod.defaults
+++ b/.env.prod.defaults
@@ -31,7 +31,13 @@ DOMAIN_MINIO=minio.bloom-dev.salk.edu
 CADDY_HTTP_LISTEN_PORT=80
 CADDY_HTTPS_LISTEN_PORT=443
 CADDY_HTTP_PORT=
-CADDY_TLS_DIRECTIVE=tls internal
+# Primary: Let's Encrypt cert from /data/bloom/production/caddy/certs/
+CADDY_TLS_DIRECTIVE=tls /etc/caddy/certs/fullchain.pem /etc/caddy/certs/privkey.pem
+
+# Fallback if certs are missing/expired — swap manually and restart caddy:
+#   sed -i 's|^CADDY_TLS_DIRECTIVE=.*|CADDY_TLS_DIRECTIVE=tls internal|' .env.prod
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate caddy
+# CADDY_TLS_DIRECTIVE=tls internal
 
 # Database
 POSTGRES_DB=postgres

--- a/caddy/certs/.gitignore
+++ b/caddy/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,6 +46,7 @@ services:
       CADDY_TLS_DIRECTIVE: ${CADDY_TLS_DIRECTIVE}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy/certs:/etc/caddy/certs:ro
       - caddy-data:/data
       - caddy-config:/config
     depends_on:


### PR DESCRIPTION
Promote `staging` → `main` (prod deploy).

## Summary
- **Let's Encrypt cert wired into Caddy** (#233) — replaces `tls internal` self-signed with a real cert covering `bloom-dev.salk.edu` + `*.bloom-dev.salk.edu`. Cert files already on the deploy host at `/data/bloom/production/caddy/certs/` (out of git). Expires 2026-08-18.

## Renewal reminder
Cert expires **Aug 18, 2026**. Schedule manual DNS-01 renewal with Salk IT for ~late July.

