### PR TITLE
feat(auth): wire SMTP relay via Salk MTA

### DIFF
--- a/.env.prod.defaults
+++ b/.env.prod.defaults
@@ -94,6 +94,13 @@ ENABLE_EMAIL_AUTOCONFIRM=true
 DISABLE_SIGNUP=false
 JWT_EXPIRY=3600
 
+# SMTP relay via Salk's neoemex1 MTA (TLS 1.2 on port 25, IP-whitelisted; no auth)
+SMTP_HOST=neoemex1.salk.edu
+SMTP_PORT=25
+SMTP_ADMIN_EMAIL=noreply@bloom-dev.salk.edu
+SMTP_SENDER_NAME=Bloom
+SMTP_MAX_FREQUENCY=60s
+
 # LangChain / LangSmith
 LANGCHAIN_TRACING_V2=false
 LANGCHAIN_PROJECT=bloom-prod

--- a/.env.staging.defaults
+++ b/.env.staging.defaults
@@ -80,6 +80,13 @@ ENABLE_EMAIL_AUTOCONFIRM=true
 DISABLE_SIGNUP=false
 JWT_EXPIRY=3600
 
+# SMTP relay via Salk's neoemex1 MTA (TLS 1.2 on port 25, IP-whitelisted; no auth)
+SMTP_HOST=neoemex1.salk.edu
+SMTP_PORT=25
+SMTP_ADMIN_EMAIL=noreply@bloom-dev.salk.edu
+SMTP_SENDER_NAME=Bloom
+SMTP_MAX_FREQUENCY=60s
+
 # LangChain / LangSmith
 LANGCHAIN_TRACING_V2=false
 LANGCHAIN_PROJECT=bloom-staging

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -306,6 +306,11 @@ jobs:
           echo "ENABLE_EMAIL_SIGNUP=true" >> .env.ci
           echo "ENABLE_EMAIL_AUTOCONFIRM=true" >> .env.ci
           echo "DISABLE_SIGNUP=false" >> .env.ci
+          echo "SMTP_HOST=localhost" >> .env.ci
+          echo "SMTP_PORT=25" >> .env.ci
+          echo "SMTP_ADMIN_EMAIL=noreply@bloom-ci.local" >> .env.ci
+          echo "SMTP_SENDER_NAME=Bloom CI" >> .env.ci
+          echo "SMTP_MAX_FREQUENCY=60s" >> .env.ci
           echo "API_EXTERNAL_URL=http://localhost:9999" >> .env.ci
           echo "ADDITIONAL_REDIRECT_URLS=http://localhost" >> .env.ci
           echo "SITE_URL=http://localhost" >> .env.ci

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -288,6 +288,13 @@ services:
       GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: ${ENABLE_ANONYMOUS_USERS}
       GOTRUE_MAILER_AUTOCONFIRM: ${ENABLE_EMAIL_AUTOCONFIRM}
 
+      # SMTP relay via Salk MTA
+      GOTRUE_SMTP_HOST: ${SMTP_HOST}
+      GOTRUE_SMTP_PORT: ${SMTP_PORT}
+      GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
+      GOTRUE_SMTP_SENDER_NAME: ${SMTP_SENDER_NAME}
+      GOTRUE_SMTP_MAX_FREQUENCY: ${SMTP_MAX_FREQUENCY}
+
       # Custom access token hook — assigns bloom_user/bloom_admin role via JWT
       GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: "true"
       GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI: "pg-functions://postgres/public/custom_access_token_hook"


### PR DESCRIPTION
## Summary

- Wires `GOTRUE_SMTP_*` env vars on the auth service to Salk's neoemex1.salk.edu MTA
- Adds matching `SMTP_*` defaults to `.env.prod.defaults` and `.env.staging.defaults`
- Password-reset and other Bloom related emails now actually send

## Why

Prod's auth service had no SMTP wired, "forgot password" does nothing for users. 
Tried two MTA through Salk, helix.salk.edu. and neoemex1.salk.edu.

The helix.salk.edu only supports TLS 1.0 — incompatible with with our auth container and its GoTrue client. So using neoemex1.salk.edu, which supports TLS 1.2.

## Verification

- TLS 1.2 negotiation confirmed via `openssl s_client -starttls smtp -tls1_2 neoemex1.salk.edu:25` — `*.salk.edu` cert, AES-256-GCM, OK
- send-test from bloom-dev → inbox delivery confirmed

## Out of scope

- `ENABLE_EMAIL_AUTOCONFIRM=false` flip — kept `true` This would change the sign - up page to be based on email confirmation is a deliberate separate change.

