### PR TITLE
feat(web): forgot/reset password pages

### DIFF
--- a/bloommcp/uv.lock
+++ b/bloommcp/uv.lock
@@ -1967,15 +1967,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]

--- a/langchain/uv.lock
+++ b/langchain/uv.lock
@@ -2117,15 +2117,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]

--- a/web/app/(public)/forgot-password/ForgotPasswordForm.tsx
+++ b/web/app/(public)/forgot-password/ForgotPasswordForm.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import styles from "../login/login.module.css";
+
+const LOCAL_PART = /[^A-Za-z0-9._+\-]/g;
+
+function sanitizeLocalPart(raw: string): string {
+  const atIdx = raw.indexOf("@");
+  const beforeAt = atIdx >= 0 ? raw.slice(0, atIdx) : raw;
+  return beforeAt.replace(LOCAL_PART, "");
+}
+
+export default function ForgotPasswordForm() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const supabase = createClientSupabaseClient();
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    if (!email) {
+      setError("Please enter your Salk login");
+      return;
+    }
+    setSubmitting(true);
+    const fullEmail = email + "@salk.edu";
+    const { error } = await supabase.auth.resetPasswordForEmail(fullEmail, {
+      redirectTo: `${location.origin}/auth/callback?next=/reset-password`,
+    });
+    setSubmitting(false);
+    if (error) {
+      setError(error.message);
+    } else {
+      setSuccess(
+        "If an account exists for that address, a reset link is on its way.",
+      );
+    }
+  };
+
+  return (
+    <form className={styles.formCard} onSubmit={handleSubmit} noValidate>
+      <h2 className={styles.formTitle}>Reset your password</h2>
+      <p className={styles.formHint}>
+        We&apos;ll email you a link to set a new password.{" "}
+        <Link className={styles.modeToggle} href="/login">
+          Back to sign in
+        </Link>
+      </p>
+
+      <label className={styles.label} htmlFor="forgot-email">
+        Salk email
+      </label>
+      <div className={styles.field}>
+        <input
+          id="forgot-email"
+          name="email"
+          inputMode="email"
+          autoComplete="username"
+          autoCapitalize="none"
+          spellCheck={false}
+          placeholder="your-login"
+          value={email}
+          onChange={(e) => setEmail(sanitizeLocalPart(e.target.value))}
+          onPaste={(e) => {
+            e.preventDefault();
+            const text = e.clipboardData.getData("text");
+            setEmail(sanitizeLocalPart(text));
+          }}
+        />
+        <span className={styles.fieldSuffix}>@salk.edu</span>
+      </div>
+
+      {error ? (
+        <div className={`${styles.banner} ${styles.bannerError}`} role="alert">
+          {error}
+        </div>
+      ) : null}
+      {success ? (
+        <div
+          className={`${styles.banner} ${styles.bannerSuccess}`}
+          role="status"
+        >
+          {success}
+        </div>
+      ) : null}
+
+      <button type="submit" className={styles.btnSubmit} disabled={submitting}>
+        {submitting ? "Sending…" : "Send reset link"}
+      </button>
+    </form>
+  );
+}

--- a/web/app/(public)/forgot-password/ForgotPasswordForm.tsx
+++ b/web/app/(public)/forgot-password/ForgotPasswordForm.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 import styles from "../login/login.module.css";
 
 const LOCAL_PART = /[^A-Za-z0-9._+\-]/g;
+const RESEND_COOLDOWN_SECONDS = 30;
 
 function sanitizeLocalPart(raw: string): string {
   const atIdx = raw.indexOf("@");
@@ -13,67 +15,160 @@ function sanitizeLocalPart(raw: string): string {
   return beforeAt.replace(LOCAL_PART, "");
 }
 
+type Stage = "request" | "verify";
+
 export default function ForgotPasswordForm() {
+  const [stage, setStage] = useState<Stage>("request");
   const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
+  const [info, setInfo] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const router = useRouter();
   const supabase = createClientSupabaseClient();
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  useEffect(() => {
+    if (resendCooldown <= 0) return;
+    const t = setTimeout(() => setResendCooldown((s) => s - 1), 1000);
+    return () => clearTimeout(t);
+  }, [resendCooldown]);
+
+  const fullEmail = email + "@salk.edu";
+
+  const sendResetEmail = async () => {
+    const { error } = await supabase.auth.resetPasswordForEmail(fullEmail, {
+      redirectTo: `${location.origin}/auth/callback?next=/reset-password`,
+    });
+    return error;
+  };
+
+  const handleRequest = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
-    setSuccess("");
+    setInfo("");
     if (!email) {
       setError("Please enter your Salk login");
       return;
     }
     setSubmitting(true);
-    const fullEmail = email + "@salk.edu";
-    const { error } = await supabase.auth.resetPasswordForEmail(fullEmail, {
-      redirectTo: `${location.origin}/auth/callback?next=/reset-password`,
+    const err = await sendResetEmail();
+    setSubmitting(false);
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    setStage("verify");
+    setInfo(`We sent a code to ${fullEmail}.`);
+    setResendCooldown(RESEND_COOLDOWN_SECONDS);
+  };
+
+  const handleVerify = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+    setInfo("");
+    if (!code) {
+      setError("Enter the code from your email");
+      return;
+    }
+    setSubmitting(true);
+    const { error } = await supabase.auth.verifyOtp({
+      email: fullEmail,
+      token: code.trim(),
+      type: "recovery",
     });
     setSubmitting(false);
     if (error) {
       setError(error.message);
-    } else {
-      setSuccess(
-        "If an account exists for that address, a reset link is on its way.",
-      );
+      return;
     }
+    router.push("/reset-password");
   };
 
+  const handleResend = async () => {
+    if (resendCooldown > 0) return;
+    setError("");
+    setInfo("");
+    const err = await sendResetEmail();
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    setInfo("Resent. Check your inbox.");
+    setResendCooldown(RESEND_COOLDOWN_SECONDS);
+  };
+
+  if (stage === "request") {
+    return (
+      <form className={styles.formCard} onSubmit={handleRequest} noValidate>
+        <h2 className={styles.formTitle}>Reset your password</h2>
+        <p className={styles.formHint}>
+          We&apos;ll email you a link and a 6-digit code.{" "}
+          <Link className={styles.modeToggle} href="/login">
+            Back to sign in
+          </Link>
+        </p>
+
+        <label className={styles.label} htmlFor="forgot-email">
+          Salk email
+        </label>
+        <div className={styles.field}>
+          <input
+            id="forgot-email"
+            name="email"
+            inputMode="email"
+            autoComplete="username"
+            autoCapitalize="none"
+            spellCheck={false}
+            placeholder="your-login"
+            value={email}
+            onChange={(e) => setEmail(sanitizeLocalPart(e.target.value))}
+            onPaste={(e) => {
+              e.preventDefault();
+              const text = e.clipboardData.getData("text");
+              setEmail(sanitizeLocalPart(text));
+            }}
+          />
+          <span className={styles.fieldSuffix}>@salk.edu</span>
+        </div>
+
+        {error ? (
+          <div className={`${styles.banner} ${styles.bannerError}`} role="alert">
+            {error}
+          </div>
+        ) : null}
+
+        <button type="submit" className={styles.btnSubmit} disabled={submitting}>
+          {submitting ? "Sending…" : "Send reset email"}
+        </button>
+      </form>
+    );
+  }
+
   return (
-    <form className={styles.formCard} onSubmit={handleSubmit} noValidate>
-      <h2 className={styles.formTitle}>Reset your password</h2>
+    <form className={styles.formCard} onSubmit={handleVerify} noValidate>
+      <h2 className={styles.formTitle}>Check your email</h2>
       <p className={styles.formHint}>
-        We&apos;ll email you a link to set a new password.{" "}
-        <Link className={styles.modeToggle} href="/login">
-          Back to sign in
-        </Link>
+        Click the link we sent to <strong>{fullEmail}</strong>, or enter the
+        6-digit code below.
       </p>
 
-      <label className={styles.label} htmlFor="forgot-email">
-        Salk email
+      <label className={styles.label} htmlFor="forgot-code">
+        Verification code
       </label>
       <div className={styles.field}>
         <input
-          id="forgot-email"
-          name="email"
-          inputMode="email"
-          autoComplete="username"
+          id="forgot-code"
+          name="code"
+          inputMode="numeric"
+          autoComplete="one-time-code"
           autoCapitalize="none"
           spellCheck={false}
-          placeholder="your-login"
-          value={email}
-          onChange={(e) => setEmail(sanitizeLocalPart(e.target.value))}
-          onPaste={(e) => {
-            e.preventDefault();
-            const text = e.clipboardData.getData("text");
-            setEmail(sanitizeLocalPart(text));
-          }}
+          placeholder="123456"
+          maxLength={10}
+          value={code}
+          onChange={(e) => setCode(e.target.value.replace(/[^0-9]/g, ""))}
         />
-        <span className={styles.fieldSuffix}>@salk.edu</span>
       </div>
 
       {error ? (
@@ -81,18 +176,40 @@ export default function ForgotPasswordForm() {
           {error}
         </div>
       ) : null}
-      {success ? (
-        <div
-          className={`${styles.banner} ${styles.bannerSuccess}`}
-          role="status"
-        >
-          {success}
+      {info ? (
+        <div className={`${styles.banner} ${styles.bannerSuccess}`} role="status">
+          {info}
         </div>
       ) : null}
 
       <button type="submit" className={styles.btnSubmit} disabled={submitting}>
-        {submitting ? "Sending…" : "Send reset link"}
+        {submitting ? "Verifying…" : "Verify code"}
       </button>
+
+      <div className={styles.row}>
+        <button
+          type="button"
+          className={styles.modeToggle}
+          onClick={handleResend}
+          disabled={resendCooldown > 0}
+        >
+          {resendCooldown > 0
+            ? `Resend in ${resendCooldown}s`
+            : "Resend email"}
+        </button>
+        <button
+          type="button"
+          className={styles.modeToggle}
+          onClick={() => {
+            setStage("request");
+            setCode("");
+            setError("");
+            setInfo("");
+          }}
+        >
+          Use a different email
+        </button>
+      </div>
     </form>
   );
 }

--- a/web/app/(public)/forgot-password/page.tsx
+++ b/web/app/(public)/forgot-password/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/supabase/server";
+import ForgotPasswordForm from "./ForgotPasswordForm";
+import styles from "../login/login.module.css";
+
+export default async function ForgotPasswordPage() {
+  const user = await getUser();
+  if (user) {
+    redirect("/app");
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.bgWash} aria-hidden />
+      <div className={styles.bgGrain} aria-hidden />
+
+      <div className={styles.pageInner}>
+        <div className={styles.middle}>
+          <section className={styles.hero}>
+            <div className={styles.logoRow}>
+              <img
+                src="/login/logo-mark.png"
+                alt="Bloom"
+                width={88}
+                height={88}
+              />
+              <span className={styles.wordmark}>Bloom</span>
+            </div>
+            <p className={styles.kicker}>PASSWORD RESET</p>
+            <h1 className={styles.heroTitle}>
+              Forgot your <em>password</em>?
+            </h1>
+            <p className={styles.heroSub}>
+              Enter your Salk login below and we&apos;ll send a reset link to
+              your inbox.
+            </p>
+          </section>
+
+          <ForgotPasswordForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/(public)/login/LoginForm.tsx
+++ b/web/app/(public)/login/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 import styles from "./login.module.css";
@@ -156,9 +157,9 @@ export default function LoginForm() {
           Keep me signed in
         </label>
         {!isSignUp && (
-          <a className={styles.forgot} href="mailto:dbutler@salk.edu?subject=Bloom%20password%20reset">
+          <Link className={styles.forgot} href="/forgot-password">
             Forgot password?
-          </a>
+          </Link>
         )}
       </div>
 

--- a/web/app/(public)/reset-password/ResetPasswordForm.tsx
+++ b/web/app/(public)/reset-password/ResetPasswordForm.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import styles from "../login/login.module.css";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export default function ResetPasswordForm() {
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const router = useRouter();
+  const supabase = createClientSupabaseClient();
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match");
+      return;
+    }
+    setSubmitting(true);
+    const { error } = await supabase.auth.updateUser({ password });
+    setSubmitting(false);
+    if (error) {
+      setError(error.message);
+      return;
+    }
+    setSuccess("Password updated. Redirecting…");
+    setTimeout(() => router.push("/app"), 800);
+  };
+
+  return (
+    <form className={styles.formCard} onSubmit={handleSubmit} noValidate>
+      <h2 className={styles.formTitle}>Choose a new password</h2>
+      <p className={styles.formHint}>
+        Pick something at least {MIN_PASSWORD_LENGTH} characters long.
+      </p>
+
+      <label className={styles.label} htmlFor="reset-password">
+        New password
+      </label>
+      <div className={styles.field}>
+        <input
+          id="reset-password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+
+      <label className={styles.label} htmlFor="reset-confirm">
+        Confirm new password
+      </label>
+      <div className={styles.field}>
+        <input
+          id="reset-confirm"
+          name="confirm"
+          type="password"
+          autoComplete="new-password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+        />
+      </div>
+
+      {error ? (
+        <div className={`${styles.banner} ${styles.bannerError}`} role="alert">
+          {error}
+        </div>
+      ) : null}
+      {success ? (
+        <div
+          className={`${styles.banner} ${styles.bannerSuccess}`}
+          role="status"
+        >
+          {success}
+        </div>
+      ) : null}
+
+      <button type="submit" className={styles.btnSubmit} disabled={submitting}>
+        {submitting ? "Updating…" : "Update password"}
+      </button>
+    </form>
+  );
+}

--- a/web/app/(public)/reset-password/page.tsx
+++ b/web/app/(public)/reset-password/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/supabase/server";
+import ResetPasswordForm from "./ResetPasswordForm";
+import styles from "../login/login.module.css";
+
+export default async function ResetPasswordPage() {
+  const user = await getUser();
+  if (!user) {
+    redirect("/forgot-password");
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.bgWash} aria-hidden />
+      <div className={styles.bgGrain} aria-hidden />
+
+      <div className={styles.pageInner}>
+        <div className={styles.middle}>
+          <section className={styles.hero}>
+            <div className={styles.logoRow}>
+              <img
+                src="/login/logo-mark.png"
+                alt="Bloom"
+                width={88}
+                height={88}
+              />
+              <span className={styles.wordmark}>Bloom</span>
+            </div>
+            <p className={styles.kicker}>PASSWORD RESET</p>
+            <h1 className={styles.heroTitle}>
+              Set a <em>new</em> password.
+            </h1>
+            <p className={styles.heroSub}>
+              You&apos;re signed in via the reset link. Pick a new password
+              below to finish.
+            </p>
+          </section>
+
+          <ResetPasswordForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/auth/callback/route.ts
+++ b/web/app/auth/callback/route.ts
@@ -23,6 +23,7 @@ export async function GET(request: Request) {
 
   console.log(`requestUrl.origin ${requestUrl.origin}`);
 
-  // URL to redirect to after sign in process completes
-  return NextResponse.redirect(requestUrl.origin);
+  const nextParam = requestUrl.searchParams.get("next");
+  const nextPath = nextParam && nextParam.startsWith("/") ? nextParam : "/";
+  return NextResponse.redirect(new URL(nextPath, requestUrl.origin));
 }

--- a/web/app/verify/route.ts
+++ b/web/app/verify/route.ts
@@ -1,0 +1,42 @@
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import type { EmailOtpType } from "@supabase/supabase-js";
+
+const ALLOWED_TYPES: EmailOtpType[] = [
+  "signup",
+  "recovery",
+  "invite",
+  "magiclink",
+  "email_change",
+  "email",
+];
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  const type = url.searchParams.get("type") as EmailOtpType | null;
+  const redirectTo = url.searchParams.get("redirect_to");
+
+  if (!token || !type || !ALLOWED_TYPES.includes(type)) {
+    return NextResponse.redirect(new URL("/login?error=invalid_link", url.origin));
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const { error } = await supabase.auth.verifyOtp({
+    token_hash: token,
+    type,
+  });
+
+  if (error) {
+    const msg = encodeURIComponent(error.message);
+    return NextResponse.redirect(new URL(`/login?error=${msg}`, url.origin));
+  }
+
+  if (type === "recovery") {
+    return NextResponse.redirect(new URL("/reset-password", url.origin));
+  }
+
+  const safeRedirect =
+    redirectTo && redirectTo.startsWith(url.origin) ? redirectTo : url.origin;
+  return NextResponse.redirect(safeRedirect);
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -75,6 +75,9 @@ export async function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname
   const isPublic =
     path.startsWith('/login') ||
+    path.startsWith('/forgot-password') ||
+    path.startsWith('/reset-password') ||
+    path.startsWith('/verify') ||
     path.startsWith('/auth') ||
     path.startsWith('/error') ||
     path.startsWith('/api') // allow internal routes


### PR DESCRIPTION
## Summary
- New `/forgot-password` page — two-stage form: 
(1) enter Salk email → send reset, 
(2) enter 6-digit OTP from email + Resend / Use-different-email actions
- New `/reset-password` page — set a new password (min 8 chars, confirm field), redirects to `/app` on success
- New `/verify` route handler — exchanges the magic-link `token` with GoTrue and lands the user on `/reset-password` 
- `LoginForm` "Forgot password?" link swapped from `mailto:` to `Link href="/forgot-password"`
- Middleware allowlist updated so `/forgot-password`, `/reset-password`, `/verify` aren't bounced to `/login`

PR #235 wired GoTrue SMTP via Salk MTA — staging/prod now actually send recovery emails. This is the frontend half: the UI users need to request the email, validate the code or link, and set a new password.