### PR TITLE
fix(web): use X-Forwarded-Host for forgot/reset redirects

### DIFF
--- a/web/app/auth/callback/route.ts
+++ b/web/app/auth/callback/route.ts
@@ -23,7 +23,15 @@ export async function GET(request: Request) {
 
   console.log(`requestUrl.origin ${requestUrl.origin}`);
 
+  const host =
+    request.headers.get("x-forwarded-host") ||
+    request.headers.get("host") ||
+    requestUrl.host;
+  const proto =
+    request.headers.get("x-forwarded-proto") || requestUrl.protocol.replace(":", "");
+  const origin = `${proto}://${host}`;
+
   const nextParam = requestUrl.searchParams.get("next");
   const nextPath = nextParam && nextParam.startsWith("/") ? nextParam : "/";
-  return NextResponse.redirect(new URL(nextPath, requestUrl.origin));
+  return NextResponse.redirect(new URL(nextPath, origin));
 }

--- a/web/app/verify/route.ts
+++ b/web/app/verify/route.ts
@@ -11,14 +11,23 @@ const ALLOWED_TYPES: EmailOtpType[] = [
   "email",
 ];
 
+function externalOrigin(request: Request): string {
+  const url = new URL(request.url);
+  const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || url.host;
+  const proto =
+    request.headers.get("x-forwarded-proto") || url.protocol.replace(":", "");
+  return `${proto}://${host}`;
+}
+
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const token = url.searchParams.get("token");
   const type = url.searchParams.get("type") as EmailOtpType | null;
   const redirectTo = url.searchParams.get("redirect_to");
+  const origin = externalOrigin(request);
 
   if (!token || !type || !ALLOWED_TYPES.includes(type)) {
-    return NextResponse.redirect(new URL("/login?error=invalid_link", url.origin));
+    return NextResponse.redirect(new URL("/login?error=invalid_link", origin));
   }
 
   const supabase = await createServerSupabaseClient();
@@ -29,14 +38,14 @@ export async function GET(request: Request) {
 
   if (error) {
     const msg = encodeURIComponent(error.message);
-    return NextResponse.redirect(new URL(`/login?error=${msg}`, url.origin));
+    return NextResponse.redirect(new URL(`/login?error=${msg}`, origin));
   }
 
   if (type === "recovery") {
-    return NextResponse.redirect(new URL("/reset-password", url.origin));
+    return NextResponse.redirect(new URL("/reset-password", origin));
   }
 
   const safeRedirect =
-    redirectTo && redirectTo.startsWith(url.origin) ? redirectTo : url.origin;
+    redirectTo && redirectTo.startsWith(origin) ? redirectTo : origin;
   return NextResponse.redirect(safeRedirect);
 }


### PR DESCRIPTION
## Summary
Follow-up to #237. The recovery email link lands on `https://0.0.0.0:3000/login?error=...` on staging instead of the public host.

`/verify` and `/auth/callback` built redirect URLs from `request.url`'s origin, which inside the container is the Next address (`0.0.0.0:3000`). Fix: use `X-Forwarded-Host` / `X-Forwarded-Proto` from Caddy, fall back to `Host`, then to the URL host.