### PR TITLE
fix(web): magic link now lands users on the reset password page

### DIFF
--- a/web/app/verify/route.ts
+++ b/web/app/verify/route.ts
@@ -1,51 +1,13 @@
-import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
-import type { EmailOtpType } from "@supabase/supabase-js";
-
-const ALLOWED_TYPES: EmailOtpType[] = [
-  "signup",
-  "recovery",
-  "invite",
-  "magiclink",
-  "email_change",
-  "email",
-];
-
-function externalOrigin(request: Request): string {
-  const url = new URL(request.url);
-  const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || url.host;
-  const proto =
-    request.headers.get("x-forwarded-proto") || url.protocol.replace(":", "");
-  return `${proto}://${host}`;
-}
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const token = url.searchParams.get("token");
-  const type = url.searchParams.get("type") as EmailOtpType | null;
-  const redirectTo = url.searchParams.get("redirect_to");
-  const origin = externalOrigin(request);
-
-  if (!token || !type || !ALLOWED_TYPES.includes(type)) {
-    return NextResponse.redirect(new URL("/login?error=invalid_link", origin));
-  }
-
-  const supabase = await createServerSupabaseClient();
-  const { error } = await supabase.auth.verifyOtp({
-    token_hash: token,
-    type,
-  });
-
-  if (error) {
-    const msg = encodeURIComponent(error.message);
-    return NextResponse.redirect(new URL(`/login?error=${msg}`, origin));
-  }
-
-  if (type === "recovery") {
-    return NextResponse.redirect(new URL("/reset-password", origin));
-  }
-
-  const safeRedirect =
-    redirectTo && redirectTo.startsWith(origin) ? redirectTo : origin;
-  return NextResponse.redirect(safeRedirect);
+  const host =
+    request.headers.get("x-forwarded-host") ||
+    request.headers.get("host") ||
+    url.host;
+  const proto =
+    request.headers.get("x-forwarded-proto") || url.protocol.replace(":", "");
+  const goTrueVerify = `${proto}://${host}/api/auth/v1/verify${url.search}`;
+  return NextResponse.redirect(goTrueVerify);
 }


### PR DESCRIPTION
**Fix:** Magic link in the recovery email didn't land the user on the reset password page.

**Change:** /verify now forwards the request to Supabase auth (/api/auth/v1/verify) instead of trying to validate the token in Next. After Supabase verifies the token, the user is landed on /reset-password where they can set a new password.