### PR TITLE
fix(ci): apply migrations before starting realtime/kong to avoid lock deadlock

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -388,30 +388,15 @@ jobs:
           timeout 180 bash -c 'until docker compose -f docker-compose.prod.yml --env-file .env.ci ps db-prod --format json | jq -e "select(.Health == \"healthy\")" > /dev/null 2>&1; do sleep 2; echo "  waiting..."; done'
           echo "Database is healthy!"
 
-      - name: Start remaining services
-        run: docker compose -f docker-compose.prod.yml --env-file .env.ci up -d --build
-
-      - name: Wait for services to be healthy
-        run: |
-          echo "Waiting for services to become healthy..."
-          TIMEOUT=180
-          ELAPSED=0
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            UNHEALTHY=$(docker compose -f docker-compose.prod.yml --env-file .env.ci ps --format json | jq -r '.[] | select(.Health == "unhealthy" or .Health == "starting") | .Name' 2>/dev/null | wc -l)
-            EXITED=$(docker compose -f docker-compose.prod.yml --env-file .env.ci ps --format json | jq -r '.[] | select(.State == "exited" and .ExitCode != 0) | .Name' 2>/dev/null | wc -l)
-            if [ "$UNHEALTHY" -eq 0 ] && [ "$EXITED" -eq 0 ]; then
-              echo "All services healthy!"
-              docker compose -f docker-compose.prod.yml --env-file .env.ci ps
-              exit 0
-            fi
-            echo "Waiting... (${ELAPSED}s / ${TIMEOUT}s) — ${UNHEALTHY} unhealthy, ${EXITED} failed"
-            sleep 5
-            ELAPSED=$((ELAPSED + 5))
-          done
-          echo "::error::Services did not become healthy within ${TIMEOUT}s"
-          docker compose -f docker-compose.prod.yml --env-file .env.ci ps
-          docker compose -f docker-compose.prod.yml --env-file .env.ci logs --tail=50
-          exit 1
+      # Start only the storage service first so it can create the storage.*
+      # schema (storage.buckets, storage.objects, etc.) that our migrations
+      # need. Holding back realtime + kong + auth + web prevents them from
+      # doing pg_publication / storage.objects introspection concurrently with
+      # `supabase db push`'s AccessExclusiveLocks — which caused intermittent
+      # deadlocks in CI (SQLSTATE 40P01) on otherwise-unchanged migrations
+      # like 20230711213534's `DROP POLICY ... ON cyl_scans`.
+      - name: Start storage service (for storage.* schema)
+        run: docker compose -f docker-compose.prod.yml --env-file .env.ci up -d --build storage
 
       - name: Wait for storage schema
         env:
@@ -434,6 +419,9 @@ jobs:
       # Apply migrations via Supabase CLI — same code path as the prod and staging deploys.
       # Creates `supabase_migrations.schema_migrations` on first run, skips already-applied
       # migrations, wraps each in a transaction, takes an advisory lock.
+      #
+      # Runs BEFORE kong/realtime/auth/web come up so migrations don't fight
+      # those services' background queries for locks.
       - name: Apply database migrations
         run: |
           # Extract only the Postgres connection vars we need. Avoids
@@ -459,6 +447,33 @@ jobs:
             echo "::error title=Migration failed (CI)::See 'Migration status on failure' step and the Migration summary at top of run for applied vs pending state."
             exit 1
           }
+
+      # Bring up everything else (kong, realtime, auth, web, langchain, etc.).
+      # db-prod and storage are already running; `up -d` is idempotent for them.
+      - name: Start remaining services
+        run: docker compose -f docker-compose.prod.yml --env-file .env.ci up -d --build
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for services to become healthy..."
+          TIMEOUT=180
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            UNHEALTHY=$(docker compose -f docker-compose.prod.yml --env-file .env.ci ps --format json | jq -r '.[] | select(.Health == "unhealthy" or .Health == "starting") | .Name' 2>/dev/null | wc -l)
+            EXITED=$(docker compose -f docker-compose.prod.yml --env-file .env.ci ps --format json | jq -r '.[] | select(.State == "exited" and .ExitCode != 0) | .Name' 2>/dev/null | wc -l)
+            if [ "$UNHEALTHY" -eq 0 ] && [ "$EXITED" -eq 0 ]; then
+              echo "All services healthy!"
+              docker compose -f docker-compose.prod.yml --env-file .env.ci ps
+              exit 0
+            fi
+            echo "Waiting... (${ELAPSED}s / ${TIMEOUT}s) — ${UNHEALTHY} unhealthy, ${EXITED} failed"
+            sleep 5
+            ELAPSED=$((ELAPSED + 5))
+          done
+          echo "::error::Services did not become healthy within ${TIMEOUT}s"
+          docker compose -f docker-compose.prod.yml --env-file .env.ci ps
+          docker compose -f docker-compose.prod.yml --env-file .env.ci logs --tail=50
+          exit 1
 
       # Layer B — runs only on failure. Prints applied-vs-pending state so an
       # on-call engineer can see which migration broke without digging through


### PR DESCRIPTION
# PR: fix(ci): apply migrations before starting realtime/kong to avoid lock deadlock

**Branch:** `fix/ci-migration-deadlock` (already pushed to origin)
**Base:** `staging`
**Status:** branch + commit ready, PR not opened yet

---

## How to open this PR when you're ready

```bash
gh pr create --base staging --head fix/ci-migration-deadlock \
  --title "fix(ci): apply migrations before starting realtime/kong to avoid lock deadlock" \
  --body-file /tmp/pr-body-ci-migration-deadlock.md
```

(If you do that, strip the first three lines + this section first — only the body below is the actual PR description.)

---

## Why

The `Docker Compose Health Check` job has been intermittently failing at
`supabase db push` with:

```
ERROR: deadlock detected (SQLSTATE 40P01)
At statement: 2
DROP POLICY IF EXISTS "Authenticated users can insert cyl_scans" ON cyl_scans
```

— on an **unchanged 2023 migration** (`20230711213534_create_cyl_scans_table.sql`).
Surfaced during review of [PR #247](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/247).

## Root cause

The CI workflow previously did:

1. Start MinIO
2. Start `db-prod`
3. **Start ALL remaining services** (realtime, storage, kong, auth, web, langchain-agent, …)
4. Wait for services to be healthy
5. Wait for storage schema
6. **Apply database migrations**

Realtime polls `pg_publication` for replication slots; storage-api / kong
introspect `storage.objects`. Those processes take `ShareLock` /
`AccessShareLock` on system + app relations in the background while `supabase
db push` is taking `AccessExclusiveLock` on the same tables for `DROP POLICY`
/ `ALTER TABLE` statements. With three+ concurrent processes touching
overlapping objects, Postgres detects a lock cycle and aborts the migration.

Lock detail from the failing run:

```
Process 588 waits for AccessExclusiveLock on relation 17332 of database 5;
  blocked by process 580.
Process 580 waits for ShareLock on virtual transaction 9/30;
  blocked by process 589.
Process 589 waits for AccessShareLock on relation 16529 of database 5;
  blocked by process 588.
```

## Fix

Reorder the steps so migrations apply **before** any introspecting service
comes up:

1. Start MinIO + buckets
2. Start `db-prod`
3. **Start `storage` service only** (creates `storage.*` schema)
4. Wait for `storage.buckets` to exist
5. **Apply database migrations**
6. Start remaining services (kong, realtime, auth, web, langchain, …)
7. Wait for services to be healthy

`storage` has to come up before migrations because our
`20260527180800_create_graviscan_images_bucket.sql` INSERTs into
`storage.buckets` and needs the table to exist. After storage-api creates its
schema once, its steady-state load is much lower than realtime's continuous
publication polling — small enough to not deadlock with the migration apply.

`db-prod` and `storage` are already running when step 6 fires, so
`docker compose up -d` is idempotent for them — only kong/realtime/auth/web
actually start in step 6.

## Test plan

- This PR's own CI run on `fix/ci-migration-deadlock` should pass the
  `Docker Compose Health Check` step
- Once merged to `staging`, PR #247 (`staging → main`) re-runs and should
  unblock that promotion

## Scope

- Only `.github/workflows/pr-checks.yml` is touched
- No migration content change
- No docker-compose change
- No effect on prod or staging deploy workflows (those don't run from scratch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
