### PR TITLE
feat(traits): polish Traits pages + draggable split-pane explorer

### DIFF
--- a/web/app/app/traits/[speciesId]/[experimentId]/TraitExplorer.tsx
+++ b/web/app/app/traits/[speciesId]/[experimentId]/TraitExplorer.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+/**
+ * Interactive trait-exploration island for the experiment page.
+ *
+ * Owns the trait / wave / plant-age dropdowns and the boxplot rendering.
+ * Fetches per-trait data on demand from `get_scan_traits` RPC. The
+ * surrounding server component (page.tsx) handles the breadcrumb + scientist
+ * badge so the first paint doesn't wait on a client-side roundtrip.
+ */
+
+import { useEffect, useState } from "react";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import ScanTraitBoxplot from "@/components/scan-trait-boxplot";
+import type { TraitData } from "@/lib/custom.types";
+
+interface TraitExplorerProps {
+  experimentId: number;
+  traitNames: string[];
+  defaultTraitName?: string;
+}
+
+interface WaveOption {
+  waveNumber: number;
+  earliestDate: Date;
+  latestDate: Date;
+}
+
+export default function TraitExplorer({
+  experimentId,
+  traitNames,
+  defaultTraitName = "primary_length_mean",
+}: TraitExplorerProps) {
+  const [selectedTraitName, setSelectedTraitName] = useState<string>(
+    traitNames.includes(defaultTraitName)
+      ? defaultTraitName
+      : (traitNames[0] ?? defaultTraitName),
+  );
+  const [traitData, setTraitData] = useState<TraitData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [waves, setWaves] = useState<WaveOption[]>([]);
+  const [plantAges, setPlantAges] = useState<number[]>([]);
+  const [waveNumber, setWaveNumber] = useState<number>(0);
+  const [plantAge, setPlantAge] = useState<number>(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setTraitData(null);
+
+    (async () => {
+      const data = await getTraitData(experimentId, selectedTraitName);
+      if (cancelled) return;
+
+      setTraitData(data);
+
+      const plantAgeDays = data.map((row) => row.plant_age_days);
+      const plantAgeDaysUnique = [...new Set(plantAgeDays)].sort(
+        (a, b) => a - b,
+      );
+
+      const waveNumbers = data.map((row) => row.wave_number);
+      const wavesUnique = [...new Set(waveNumbers)].sort((a, b) => a - b);
+      const waveOptions: WaveOption[] = wavesUnique.map((wave) => {
+        const rows = data.filter((row) => row.wave_number === wave);
+        const dates = rows.map((row) => new Date(row.date_scanned).getTime());
+        return {
+          waveNumber: wave,
+          earliestDate: new Date(Math.min(...dates)),
+          latestDate: new Date(Math.max(...dates)),
+        };
+      });
+
+      setPlantAges(plantAgeDaysUnique);
+      setPlantAge(plantAgeDaysUnique[plantAgeDaysUnique.length - 1] ?? 0);
+      setWaves(waveOptions);
+      setWaveNumber(wavesUnique[wavesUnique.length - 1] ?? 0);
+      setIsLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [experimentId, selectedTraitName]);
+
+  const filteredData = traitData?.filter(
+    (row) =>
+      row.plant_age_days === plantAge && row.wave_number === waveNumber,
+  );
+
+  const traitMax = (traitData ?? []).reduce(
+    (max, row) => (isNaN(row.trait_value) ? max : Math.max(max, row.trait_value)),
+    0,
+  );
+
+  return (
+    <div className="mt-6">
+      <div className="flex flex-wrap items-end gap-4 mb-6">
+        <Field label="Trait">
+          <select
+            className="block w-72 rounded-md border-gray-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50"
+            value={selectedTraitName}
+            onChange={(e) => setSelectedTraitName(e.target.value)}
+          >
+            {traitNames.map((traitName) => (
+              <option key={traitName} value={traitName}>
+                {traitName}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Wave">
+          <select
+            className="block w-72 rounded-md border-gray-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50 disabled:opacity-50"
+            value={waveNumber}
+            onChange={(e) => setWaveNumber(parseInt(e.target.value))}
+            disabled={waves.length === 0}
+          >
+            {waves.map((wave) => (
+              <option key={wave.waveNumber} value={wave.waveNumber}>
+                {wave.waveNumber} ({wave.earliestDate.toLocaleDateString()} –{" "}
+                {wave.latestDate.toLocaleDateString()})
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Plant age">
+          <select
+            className="block w-36 rounded-md border-gray-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50 disabled:opacity-50"
+            value={plantAge}
+            onChange={(e) => setPlantAge(parseInt(e.target.value))}
+            disabled={plantAges.length === 0}
+          >
+            {plantAges.map((i) => (
+              <option key={i} value={i}>
+                {i} days
+              </option>
+            ))}
+          </select>
+        </Field>
+      </div>
+
+      {isLoading ? (
+        <LoadingState />
+      ) : !filteredData || filteredData.length === 0 ? (
+        <EmptyState
+          message={`No "${selectedTraitName}" measurements for wave ${waveNumber} at ${plantAge} days.`}
+        />
+      ) : (
+        <ScanTraitBoxplot traitData={filteredData} traitMax={traitMax} />
+      )}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col">
+      <label className="text-xs uppercase tracking-wide text-stone-500 mb-1">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="h-72 rounded-md border border-stone-200 bg-stone-50 animate-pulse" />
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-md border border-dashed border-stone-300 bg-stone-50 p-6 text-sm text-stone-500">
+      {message}
+    </div>
+  );
+}
+
+async function getTraitData(
+  experimentId: number,
+  traitName: string,
+): Promise<TraitData> {
+  const supabase = createClientSupabaseClient();
+  const { data, error } = await supabase.rpc("get_scan_traits", {
+    experiment_id_: experimentId,
+    trait_name_: traitName,
+  });
+  if (error) console.error(error);
+  return (data ?? []) as TraitData;
+}

--- a/web/app/app/traits/[speciesId]/[experimentId]/[accessionName]/[imageId]/page.tsx
+++ b/web/app/app/traits/[speciesId]/[experimentId]/[accessionName]/[imageId]/page.tsx
@@ -1,85 +1,99 @@
-import Link from 'next/link'
-import { createServerSupabaseClient } from '@/lib/supabase/server'
+import Link from "next/link";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import PlantImage from "@/components/plant-image";
 
-import PlantImage from '@/components/plant-image';
+export default async function Image({
+  params,
+}: {
+  params: Promise<{
+    speciesId: string;
+    experimentId: string;
+    accessionName: string;
+    imageId: string;
+  }>;
+}) {
+  const { speciesId, experimentId, accessionName, imageId } = await params;
+  const experiment = await getExperimentWithSpecies(Number(experimentId));
+  const species = experiment?.species;
+  const experimentName = capitalizeFirstLetter(
+    experiment?.name?.replaceAll("-", " ") ?? "",
+  );
+  const speciesName = species?.common_name ?? "";
 
-
-export default async function Image({ params }: { params: Promise<{ experimentId: number, accessionName: string, imageId: string }> }) {
-
-  const { experimentId, accessionName, imageId } = await params;
-  const experiment : any = await getExperimentWithSpecies(experimentId)
-  const species = experiment?.species
-  const experimentName = capitalizeFirstLetter(experiment?.name.replaceAll('-', ' ') ?? '')
-  const speciesName = species?.common_name ?? ''
-
-  const lineNameUnescaped = accessionName.replaceAll('%20', ' ')
-  const image : any  = await getImage(imageId)
+  const lineNameUnescaped = accessionName.replaceAll("%20", " ");
+  const image = await getImage(imageId);
 
   return (
-    <div className=''>
-      <div className='text-xl mb-8 select-none'>
-        <span className='text-stone-400'>
-          <span className='hover:underline'><Link href='/app/phenotypes'>All species</Link></span>
+    <div>
+      <div className="text-xl mb-8 select-none">
+        <span className="text-stone-400">
+          <span className="hover:underline">
+            <Link href="/app/traits">All species</Link>
+          </span>
           &nbsp;▸&nbsp;
-          <span className='hover:underline capitalize'>
-            <Link href={`/app/phenotypes/${species?.id}`}>
-                {speciesName}
+          <span className="hover:underline capitalize">
+            <Link href={`/app/traits/${speciesId}`}>{speciesName}</Link>
+          </span>
+          &nbsp;▸&nbsp;
+          <span className="hover:underline">
+            <Link href={`/app/traits/${speciesId}/${experimentId}`}>
+              {experimentName}
             </Link>
           </span>
           &nbsp;▸&nbsp;
-          <span className='hover:underline'>
-            <Link href={`/app/phenotypes/${species?.id}/${experiment?.id}`}>
-                {experimentName}
-            </Link>
-          </span>
-          &nbsp;▸&nbsp;
-          <span className='hover:underline'>
-            <Link href={`/app/phenotypes/${species?.id}/${experiment?.id}/${accessionName}`}>
-                {lineNameUnescaped}
+          <span className="hover:underline">
+            <Link
+              href={`/app/traits/${speciesId}/${experimentId}/${accessionName}`}
+            >
+              {lineNameUnescaped}
             </Link>
           </span>
           &nbsp;▸&nbsp;
         </span>
-        <span className='select-all'>
-          Replicate <span className='font-light'>{image?.cyl_scans?.cyl_plants?.qr_code}</span> (Day {image?.cyl_scans?.plant_age_days})
+        <span className="select-all">
+          Replicate{" "}
+          <span className="font-light">
+            {image?.cyl_scans?.cyl_plants?.qr_code}
+          </span>{" "}
+          (Day {image?.cyl_scans?.plant_age_days})
         </span>
       </div>
-      <div className='table-auto select-none pr-8 pb-8'>
-        <PlantImage path={image?.object_path || ''} thumb={false} />
-      </div>
+
+      {!image ? (
+        <div className="text-neutral-500 italic">Image not found.</div>
+      ) : (
+        <div className="table-auto select-none pr-8 pb-8">
+          <PlantImage path={image.object_path || ""} thumb={false} />
+        </div>
+      )}
     </div>
-  )
+  );
 }
 
-function capitalizeFirstLetter(string: String) {
+function capitalizeFirstLetter(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-
 async function getExperimentWithSpecies(experimentId: number) {
-
-  const supabase = await createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient();
 
   const { data } = await supabase
-    .from('cyl_experiments')
-    .select('*, species(*)')
-    .eq('id', experimentId)
-    .single()
-  
+    .from("cyl_experiments")
+    .select("*, species(*)")
+    .eq("id", experimentId)
+    .single();
+
   return data;
-  
 }
 
 async function getImage(imageId: string) {
-
-  const supabase = await createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient();
 
   const { data } = await supabase
-    .from('cyl_images')
-    .select('*, cyl_scans(*, cyl_plants(*))')
-    .eq('id', Number(imageId))
-    .single()
-    
+    .from("cyl_images")
+    .select("*, cyl_scans(*, cyl_plants(*))")
+    .eq("id", Number(imageId))
+    .single();
+
   return data;
-  
 }

--- a/web/app/app/traits/[speciesId]/[experimentId]/[accessionName]/page.tsx
+++ b/web/app/app/traits/[speciesId]/[experimentId]/[accessionName]/page.tsx
@@ -1,109 +1,148 @@
-import Link from 'next/link'
-import { createServerSupabaseClient } from '@/lib/supabase/server'
+import Link from "next/link";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import PlantImage from "@/components/plant-image";
+import { Key } from "react";
 
-import PlantImage from '@/components/plant-image';
-// import type { Database } from "@/lib/database.types";
-import { Key } from 'react';
+export default async function Accession({
+  params,
+}: {
+  params: Promise<{ speciesId: string; experimentId: string; accessionName: string }>;
+}) {
+  const { speciesId, experimentId, accessionName } = await params;
+  const experimentIdNum = Number(experimentId);
 
+  const experiment = await getExperimentWithSpecies(experimentIdNum);
+  const species = experiment?.species;
+  const experimentName = capitalizeFirstLetter(
+    experiment?.name?.replaceAll("-", " ") ?? "",
+  );
+  const speciesName = species?.common_name ?? "";
 
-export default async function Accession({ params }: { params: { experimentId: number, accessionName: string } }) {
-
-  const experiment : any = await getExperimentWithSpecies(params.experimentId)
-  const species = experiment?.species
-  const experimentName = capitalizeFirstLetter(experiment?.name.replaceAll('-', ' ') ?? '')
-  const speciesName = species?.common_name ?? ''
-
-  const lineNameUnescaped = params.accessionName.replaceAll('%20', ' ')
-  const plants: any  = await getPlants(lineNameUnescaped, params.experimentId)  
+  const lineNameUnescaped = accessionName.replaceAll("%20", " ");
+  const plants = await getPlants(lineNameUnescaped, experimentIdNum);
 
   return (
-    <div className=''>
-      <div className='text-xl mb-8 select-none'>
-        <span className='text-stone-400'>
-          <span className='hover:underline'><Link href='/app/phenotypes'>All species</Link></span>
-          &nbsp;▸&nbsp;
-          <span className='hover:underline capitalize'>
-            <Link href={`/app/phenotypes/${species?.id}`}>
-                {speciesName}
-            </Link>
+    <div>
+      <div className="text-xl mb-8 select-none">
+        <span className="text-stone-400">
+          <span className="hover:underline">
+            <Link href="/app/traits">All species</Link>
           </span>
           &nbsp;▸&nbsp;
-          <span className='hover:underline'>
-            <Link href={`/app/phenotypes/${species?.id}/${experiment?.id}`}>
-                {experimentName}
+          <span className="hover:underline capitalize">
+            <Link href={`/app/traits/${speciesId}`}>{speciesName}</Link>
+          </span>
+          &nbsp;▸&nbsp;
+          <span className="hover:underline">
+            <Link href={`/app/traits/${speciesId}/${experimentId}`}>
+              {experimentName}
             </Link>
           </span>
           &nbsp;▸&nbsp;
         </span>
-        <span className='select-all'>
-          {lineNameUnescaped}
-        </span>
+        <span className="select-all">{lineNameUnescaped}</span>
       </div>
-      <div className='table-auto select-none'>
-        {plants?.map((plant: { id: Key | null | undefined; qr_code: any; cyl_scans: any[]; }, index: number) => (
-          <div className='table-row' key={plant.id}>
-            <div className='table-cell text-lg align-middle pb-4 pr-4'>
-              <div className='align-middle'>
-                <div className='text-sm text-neutral-700'>
-                  <span className='text-neutral-500'>Replicate {index + 1}</span>
-                  <br/>
-                  <span className='text-neutral-500'>ID:</span>&nbsp;
-                  <span className='text-neutral-400 select-all'>{plant?.qr_code ?? ''}</span>
+
+      {!plants || plants.length === 0 ? (
+        <div className="text-neutral-500 italic">
+          No replicates found for this accession in this experiment.
+        </div>
+      ) : (
+        <div className="table-auto select-none">
+          {plants.map(
+            (
+              plant: {
+                id: Key | null | undefined;
+                qr_code: string | null;
+                cyl_scans: {
+                  id: number;
+                  plant_age_days: number | null;
+                  cyl_images: {
+                    id: Key | null | undefined;
+                    object_path: string | null;
+                  }[];
+                }[];
+              },
+              index: number,
+            ) => (
+              <div className="table-row" key={plant.id}>
+                <div className="table-cell text-lg align-middle pb-4 pr-4">
+                  <div className="align-middle">
+                    <div className="text-sm text-neutral-700">
+                      <span className="text-neutral-500">
+                        Replicate {index + 1}
+                      </span>
+                      <br />
+                      <span className="text-neutral-500">ID:</span>&nbsp;
+                      <span className="text-neutral-400 select-all">
+                        {plant?.qr_code ?? ""}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div className="table-cell text-lg align-middle pb-4">
+                  <div className="text-sm mt-2 text-neutral-400 flex flex-row">
+                    {plant.cyl_scans
+                      .sort(
+                        (a, b) =>
+                          (a.plant_age_days ?? 0) - (b.plant_age_days ?? 0),
+                      )
+                      .map((scan) => (
+                        <div key={scan.id} className="mr-4">
+                          {scan.cyl_images.map((image) => (
+                            <div key={image.id} className="text-center">
+                              <div className="pb-1">
+                                Day {scan.plant_age_days}
+                              </div>
+                              <Link
+                                href={`/app/traits/${speciesId}/${experimentId}/${accessionName}/${image.id}`}
+                              >
+                                <PlantImage
+                                  path={image.object_path}
+                                  thumb={true}
+                                />
+                              </Link>
+                            </div>
+                          ))}
+                        </div>
+                      ))}
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className='table-cell text-lg align-middle pb-4'>
-              <div className='text-sm mt-2 text-neutral-400 flex flex-row'>
-                {plant.cyl_scans.sort((a, b) => ((a.plant_age_days ?? 0) - (b.plant_age_days ?? 0))).map((scan) => (
-                  <div key={scan.id} className='mr-4'>
-                    {scan.cyl_images.map((image: { id: Key | null | undefined; object_path: string | null; }) => (
-                      <div key={image.id} className='text-center'>
-                        <div className='pb-1'>Day {scan.plant_age_days}</div>
-                        <Link href={`/app/phenotypes/${species?.id}/${experiment?.id}/${params.accessionName}/${image.id}`}>
-                          <PlantImage path={image.object_path} thumb={true} />
-                        </Link>
-                      </div>
-                    ))}
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
+            ),
+          )}
+        </div>
+      )}
     </div>
-  )
+  );
 }
 
-function capitalizeFirstLetter(string: String) {
+function capitalizeFirstLetter(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-
 async function getExperimentWithSpecies(experimentId: number) {
-
-  const supabase = await createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient();
 
   const { data } = await supabase
-    .from('cyl_experiments')
-    .select('*, species(*)')
-    .eq('id', experimentId)
-    .single()
-  
+    .from("cyl_experiments")
+    .select("*, species(*)")
+    .eq("id", experimentId)
+    .single();
+
   return data;
-  
 }
 
 async function getPlants(lineName: string, experimentId: number) {
-
-  const supabase = await createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient();
 
   const { data } = await supabase
-    .from('cyl_plants')
-    .select('*, cyl_scans(*, cyl_images(*)), cyl_waves(*, cyl_experiments(*, species(*))), accessions!inner(*)')
-    .eq('cyl_scans.cyl_images.frame_number', 1)
-    .eq('accessions.name', lineName)
-    
+    .from("cyl_plants")
+    .select(
+      "*, cyl_scans(*, cyl_images(*)), cyl_waves(*, cyl_experiments(*, species(*))), accessions!inner(*)",
+    )
+    .eq("cyl_scans.cyl_images.frame_number", 1)
+    .eq("accessions.name", lineName);
+
   return data;
-  
 }

--- a/web/app/app/traits/[speciesId]/[experimentId]/page.tsx
+++ b/web/app/app/traits/[speciesId]/[experimentId]/page.tsx
@@ -18,7 +18,7 @@ export default async function Experiment({
   const [user, experiment, traitNames] = await Promise.all([
     getUser(),
     getExperimentWithSpecies(experimentIdNum),
-    getTraitNames(),
+    getTraitNamesForExperiment(experimentIdNum),
   ]);
 
   const mixpanel = process.env.MIXPANEL_TOKEN
@@ -111,15 +111,27 @@ async function getExperimentWithSpecies(experimentId: number) {
   return data;
 }
 
-async function getTraitNames(): Promise<string[]> {
+/**
+ * Trait names that actually have at least one measurement for this
+ * experiment, sourced from the `cyl_trait_by_experiment_wave` view
+ * (one row per experiment × wave × trait). De-duplicated across waves
+ * because Supabase doesn't expose DISTINCT directly.
+ */
+async function getTraitNamesForExperiment(
+  experimentId: number,
+): Promise<string[]> {
   const supabase = await createServerSupabaseClient();
   const { data } = await supabase
-    .from("cyl_scan_trait_names")
-    .select("name")
-    .order("name");
+    .from("cyl_trait_by_experiment_wave")
+    .select("trait_name")
+    .eq("experiment_id", experimentId)
+    .order("trait_name");
 
   if (!data) return [];
-  return (data as { name: string | null }[])
-    .map((row) => row.name)
-    .filter((name): name is string => Boolean(name));
+
+  const names = (data as { trait_name: string | null }[])
+    .map((row) => row.trait_name)
+    .filter((n): n is string => Boolean(n));
+
+  return [...new Set(names)];
 }

--- a/web/app/app/traits/[speciesId]/[experimentId]/page.tsx
+++ b/web/app/app/traits/[speciesId]/[experimentId]/page.tsx
@@ -1,324 +1,125 @@
-"use client";
-
-import { use, useState, useEffect } from "react";
 import Link from "next/link";
-import { createClientSupabaseClient } from "@/lib/supabase/client";
-import ScanTraitBoxplot from "@/components/scan-trait-boxplot";
-
-import { Database } from "@/lib/database.types";
-import { CylExperimentPlus, TraitData } from "@/lib/custom.types";
+import {
+  createServerSupabaseClient,
+  getUser,
+} from "@/lib/supabase/server";
+import Mixpanel from "mixpanel";
 import ScientistBadge from "@/components/scientist-badge";
+import TraitExplorer from "./TraitExplorer";
 
-export default function Experiment({
+export default async function Experiment({
   params,
 }: {
-  params: Promise<{ experimentId: number }>;
+  params: Promise<{ speciesId: string; experimentId: string }>;
 }) {
-  const { experimentId } = use(params);
-  const defaultTraitName = "primary_length_mean";
+  const { speciesId, experimentId } = await params;
+  const experimentIdNum = Number(experimentId);
 
-  const [loginStatusReady, setLoginStatusReady] = useState(false);
-  const [loggedIn, setLoggedIn] = useState(false);
-  const [experiment, setExperiment] = useState<CylExperimentPlus | null>(null);
-  const [plantAge, setPlantAge] = useState<number>(0);
-  const [plantAges, setPlantAges] = useState<number[]>([]);
-  const [traitData, setTraitData] = useState<TraitData | null>(null);
-  const [traitNames, setTraitNames] = useState<string[]>([]);
-  const [selectedTraitName, setSelectedTraitName] =
-    useState<string>(defaultTraitName);
-  const [waves, setWaves] = useState<
-    { waveNumber: number; earliestDate: Date; latestDate: Date }[]
-  >([]);
-  const [waveNumber, setWaveNumber] = useState<number>(0);
+  const [user, experiment, traitNames] = await Promise.all([
+    getUser(),
+    getExperimentWithSpecies(experimentIdNum),
+    getTraitNames(),
+  ]);
 
-  // useEffect(() => {
-  //   console.log("re-rendering Experiment");
-  //   console.log("experiment = ", experiment);
-  //   console.log("traitData = ", traitData);
-  //   console.log("plantAge = ", plantAge);
-  //   console.log("plantAges = ", plantAges);
-  //   console.log("traitNames = ", traitNames);
-  //   console.log("selectedTraitName = ", selectedTraitName);
-  // });
-
-  // get experiment data
-  useEffect(() => {
-    const get = async () => {
-      const data = await getExperiment(experimentId);
-      setExperiment(data);
-    };
-    get();
-  }, [experimentId]);
-
-  // get trait names
-  useEffect(() => {
-    const get = async () => {
-      const traitNames = await getTraitNames();
-      setTraitNames(traitNames);
-    };
-    get();
-  }, [experiment]);
-
-  // get trait data
-  useEffect(() => {
-    const getExperiment = async () => {
-      setTraitData(null);
-      const data = await getTraitData(experimentId, selectedTraitName);
-      setTraitData(data);
-      // set plant ages
-      const plantAgeDays = (data ?? []).map((row) => row.plant_age_days);
-      const plantAgeDaysUnique = [...new Set(plantAgeDays)].sort(
-        (a, b) => a - b
-      );
-      setPlantAge(Math.max(...plantAgeDaysUnique));
-      setPlantAges(plantAgeDaysUnique);
-      // set waves
-      const waves_ = data?.map((row) => row.wave_number) ?? [];
-      const wavesUnique = [...new Set(waves_)].sort((a, b) => a - b);
-      const rowsByWave = wavesUnique.map((wave) =>
-        data?.filter((row) => row.wave_number === wave)
-      );
-      const waveStartEndDates = rowsByWave.map((rows, i) => {
-        const waveNumber = wavesUnique[i];
-        const dates =
-          rows?.map((row) => new Date(row.date_scanned).getTime()) ?? [];
-        const earliestDate = new Date(Math.min(...dates));
-        const latestDate = new Date(Math.max(...dates));
-        return {
-          waveNumber,
-          earliestDate,
-          latestDate,
-        };
-      });
-      setWaveNumber(Math.max(...wavesUnique));
-      setWaves(waveStartEndDates);
-    };
-    getExperiment();
-  }, [experimentId, selectedTraitName]);
+  const mixpanel = process.env.MIXPANEL_TOKEN
+    ? Mixpanel.init(process.env.MIXPANEL_TOKEN)
+    : null;
+  mixpanel?.track("Page view", {
+    distinct_id: user?.email,
+    url: `/app/traits/${speciesId}/${experimentId}`,
+  });
 
   const experimentName = capitalizeFirstLetter(
-    experiment?.name.replaceAll("-", " ") ?? ""
+    experiment?.name?.replaceAll("-", " ") ?? "",
   );
   const speciesName = experiment?.species?.common_name ?? "";
 
-  return (
-    <div className="">
-      <div className="text-xl mb-8 select-none">
-        <span className="text-stone-400">
-          <span className="hover:underline">
-            <Link href="/app/traits">All species</Link>
-          </span>
-          &nbsp;▸&nbsp;
-          <span className="hover:underline capitalize">
-            <Link href={`/app/traits/${experiment?.species?.id}`}>
-              {speciesName}
-            </Link>
-          </span>
-          &nbsp;▸&nbsp;
-        </span>
-        <span className="">{experimentName}</span>
-      </div>
+  if (!experiment) {
+    return (
       <div>
-        {experiment?.people && <ScientistBadge person={experiment.people} />}
+        <Breadcrumbs
+          speciesId={speciesId}
+          speciesName={speciesName}
+          experimentName={experimentName}
+        />
+        <div className="text-neutral-500 italic">Experiment not found.</div>
       </div>
-      <div className="">
-        <div className="mt-4 flex flex-col">
-          <div className="flex flex-col w-96 mb-4">
-            <table>
-              <tbody>
-                {/* Dropdown to select trait name */}
-                <tr>
-                  <td className="text-sm pr-2">Trait</td>
-                  <td>
-                    <select
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50"
-                      value={selectedTraitName}
-                      onChange={(e) => setSelectedTraitName(e.target.value)}
-                    >
-                      {traitNames.map((traitName) => (
-                        <option key={traitName} value={traitName}>
-                          {traitName}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                </tr>
-                {/* Dropdown to select wave */}
-                <tr>
-                  <td className="text-sm pr-2">Wave</td>
-                  <td>
-                    <select
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50"
-                      value={waveNumber}
-                      onChange={(e) => setWaveNumber(parseInt(e.target.value))}
-                    >
-                      {waves.map((wave) => (
-                        <option key={wave.waveNumber} value={wave.waveNumber}>
-                          {wave.waveNumber} (
-                          {wave.earliestDate.toLocaleDateString()} -{" "}
-                          {wave.latestDate.toLocaleDateString()})
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                </tr>
-                {/* Dropdown to select plant age */}
-                <tr>
-                  <td className="text-sm pr-2">Age</td>
-                  <td>
-                    <select
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-neutral-300 focus:ring focus:ring-neutral-200 focus:ring-opacity-50"
-                      value={plantAge}
-                      onChange={(e) => setPlantAge(parseInt(e.target.value))}
-                    >
-                      {plantAges.map((i) => (
-                        <option key={i} value={i}>
-                          {i} days
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          {traitData ? (
-            <ScanTraitBoxplot
-              // traitData={traitData}
-              traitData={traitData.filter(
-                (row) =>
-                  row.plant_age_days === plantAge &&
-                  row.wave_number === waveNumber
-              )}
-              traitMax={traitData.reduce(
-                (max, row) =>
-                  isNaN(row.trait_value) ? max : Math.max(max, row.trait_value),
-                0
-              )}
-            />
-          ) : (
-            <div>Data loading...</div>
-          )}
+    );
+  }
+
+  return (
+    <div>
+      <Breadcrumbs
+        speciesId={speciesId}
+        speciesName={speciesName}
+        experimentName={experimentName}
+      />
+
+      {experiment.people && <ScientistBadge person={experiment.people} />}
+
+      {traitNames.length === 0 ? (
+        <div className="mt-6 rounded-md border border-dashed border-stone-300 bg-stone-50 p-6 text-sm text-stone-500">
+          No trait measurements are available yet for this experiment.
         </div>
-      </div>
+      ) : (
+        <TraitExplorer
+          experimentId={experimentIdNum}
+          traitNames={traitNames}
+        />
+      )}
     </div>
   );
 }
 
-function capitalizeFirstLetter(string: String) {
+function Breadcrumbs({
+  speciesId,
+  speciesName,
+  experimentName,
+}: {
+  speciesId: string;
+  speciesName: string;
+  experimentName: string;
+}) {
+  return (
+    <div className="text-xl mb-8 select-none">
+      <span className="text-stone-400">
+        <span className="hover:underline">
+          <Link href="/app/traits">All species</Link>
+        </span>
+        &nbsp;▸&nbsp;
+        <span className="hover:underline capitalize">
+          <Link href={`/app/traits/${speciesId}`}>{speciesName}</Link>
+        </span>
+        &nbsp;▸&nbsp;
+      </span>
+      <span>{experimentName}</span>
+    </div>
+  );
+}
+
+function capitalizeFirstLetter(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-async function getExperiment(experimentId: number) {
-  const supabase = createClientSupabaseClient();
-
+async function getExperimentWithSpecies(experimentId: number) {
+  const supabase = await createServerSupabaseClient();
   const { data } = await supabase
     .from("cyl_experiments")
-    .select(
-      "*, cyl_waves(*, cyl_plants(*, accessions(*), cyl_scans(*))), species(*), people(*)"
-    )
+    .select("*, species(*), people(*)")
     .eq("id", experimentId)
     .single();
-
   return data;
 }
 
 async function getTraitNames(): Promise<string[]> {
-  const supabase = createClientSupabaseClient();
-
+  const supabase = await createServerSupabaseClient();
   const { data } = await supabase
     .from("cyl_scan_trait_names")
-    .select("name");
+    .select("name")
+    .order("name");
 
   if (!data) return [];
-
-  return (data as { name: string | null }[]).map((row) => row.name || "");
-}
-
-async function getTraitData(
-  experimentId: number,
-  traitName: string
-): Promise<TraitData> {
-  const supabase = createClientSupabaseClient();
-
-  let { data, error } = await supabase.rpc("get_scan_traits", {
-    experiment_id_: experimentId,
-    trait_name_: traitName,
-  } as any);
-
-  if (error) console.error(error);
-
-  return (data ?? []) as TraitData;
-}
-
-function getPlantCount(experiment: any) {
-  let plantCount = 0;
-  experiment.cyl_waves.forEach((wave: any) => {
-    plantCount += wave.cyl_plants.length;
-  });
-  return `${plantCount} plants`;
-}
-
-function getLineCount(experiment: any) {
-  // empty array of strings
-  let lineNames: string[] = [];
-  experiment.cyl_waves.forEach((wave: any) => {
-    wave.cyl_plants.forEach((plant: any) => {
-      lineNames.push(plant.accession_name);
-    });
-  });
-  const lineCount = new Set(lineNames).size;
-  return `${lineCount} lines`;
-}
-
-function countStrings(strings: string[]) {
-  const count: { [key: string]: number } = {};
-  strings.forEach((s) => {
-    count[s] = (count[s] || 0) + 1;
-  });
-  return count;
-}
-
-type Wave = {
-  experiment_id: number | null;
-  id: number;
-  name: string | null;
-  number: number | null;
-  cyl_plants: {
-    created_at: string;
-    germ_day: number | null;
-    germ_day_color: string | null;
-    id: number;
-    line_name: string | null;
-    qr_code: string | null;
-    wave_id: number | null;
-    accessions: {}[];
-  }[];
-};
-
-function getAccessions(experiment: any) {
-  // empty array of strings
-  let lineNames: string[] = [];
-  experiment.cyl_waves.forEach((wave: Wave) => {
-    wave.cyl_plants.forEach((plant: any) => {
-      lineNames.push(plant.accessions.name);
-    });
-  });
-  const plantCountObj = countStrings(lineNames);
-  const plantCountArray = Object.entries(plantCountObj);
-  // sort by name
-  const plantCountArraySorted = plantCountArray.sort((a, b) => {
-    if (a[0] < b[0]) {
-      return -1;
-    }
-    if (a[0] > b[0]) {
-      return 1;
-    }
-    return 0;
-  });
-  const plantNameCountsArray = plantCountArraySorted.map(([name, count]) => ({
-    name,
-    count,
-  }));
-  return plantNameCountsArray;
+  return (data as { name: string | null }[])
+    .map((row) => row.name)
+    .filter((name): name is string => Boolean(name));
 }

--- a/web/app/app/traits/[speciesId]/[experimentId]/page.tsx
+++ b/web/app/app/traits/[speciesId]/[experimentId]/page.tsx
@@ -121,7 +121,20 @@ async function getTraitNamesForExperiment(
   experimentId: number,
 ): Promise<string[]> {
   const supabase = await createServerSupabaseClient();
-  const { data } = await supabase
+  const { data } = await (supabase as unknown as {
+    from: (table: string) => {
+      select: (cols: string) => {
+        eq: (
+          col: string,
+          val: unknown,
+        ) => {
+          order: (
+            col: string,
+          ) => Promise<{ data: { trait_name: string | null }[] | null }>;
+        };
+      };
+    };
+  })
     .from("cyl_trait_by_experiment_wave")
     .select("trait_name")
     .eq("experiment_id", experimentId)
@@ -129,7 +142,7 @@ async function getTraitNamesForExperiment(
 
   if (!data) return [];
 
-  const names = (data as { trait_name: string | null }[])
+  const names = data
     .map((row) => row.trait_name)
     .filter((n): n is string => Boolean(n));
 

--- a/web/app/app/traits/[speciesId]/page.tsx
+++ b/web/app/app/traits/[speciesId]/page.tsx
@@ -86,6 +86,10 @@ export default async function Species({
             slack_channel_url: string | null | undefined;
             people: { email: string | null; id: number; name: string | null } | null;
             description: string | null;
+            cyl_waves: {
+              id: number;
+              cyl_plants: { id: number; accessions: { name: string | null } | null }[];
+            }[];
           }) => (
             <div className="table-row" key={experiment.id}>
               <div className="table-cell text-lg align-middle p-4">
@@ -166,9 +170,17 @@ function capitalizeFirstLetter(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-function getPlantCount(experiment: {
-  cyl_waves?: { cyl_plants?: unknown[] }[];
-}): string {
+interface ExperimentForCount {
+  cyl_waves?:
+    | {
+        cyl_plants?:
+          | { accessions?: { name?: string | null } | null }[]
+          | null;
+      }[]
+    | null;
+}
+
+function getPlantCount(experiment: ExperimentForCount): string {
   if (!experiment?.cyl_waves || !Array.isArray(experiment.cyl_waves)) {
     return "0 replicates";
   }
@@ -182,9 +194,7 @@ function getPlantCount(experiment: {
   return `${plantCount} replicates`;
 }
 
-function getAccessionCount(experiment: {
-  cyl_waves?: { cyl_plants?: { accessions?: { name?: string } }[] }[];
-}): string {
+function getAccessionCount(experiment: ExperimentForCount): string {
   if (!experiment?.cyl_waves || !Array.isArray(experiment.cyl_waves)) {
     return "0 accessions";
   }

--- a/web/app/app/traits/[speciesId]/page.tsx
+++ b/web/app/app/traits/[speciesId]/page.tsx
@@ -9,9 +9,10 @@ import { Key } from "react";
 export default async function Species({
   params,
 }: {
-  params: { speciesId: number };
+  params: Promise<{ speciesId: string }>;
 }) {
-  const species: any  = await getSpeciesWithExperiments(params.speciesId);
+  const { speciesId } = await params;
+  const species = await getSpeciesWithExperiments(Number(speciesId));
 
   const user = await getUser();
 
@@ -21,12 +22,36 @@ export default async function Species({
 
   mixpanel?.track("Page view", {
     distinct_id: user?.email,
-    url: `/app/traits/${params.speciesId}`,
+    url: `/app/traits/${speciesId}`,
   });
 
+  if (
+    !species ||
+    !species.cyl_experiments ||
+    species.cyl_experiments.length === 0
+  ) {
+    return (
+      <div>
+        <div className="text-xl mb-8 select-none">
+          <span className="text-stone-400">
+            <span className="hover:underline">
+              <Link href="/app/traits">All species</Link>
+            </span>
+            &nbsp;▸&nbsp;
+          </span>
+          <span className="capitalize">
+            {species?.common_name || "Unknown Species"}
+          </span>
+        </div>
+        <div className="text-neutral-500 italic">
+          No experiments found for this species.
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <>
-    <div className="">
+    <div>
       <div className="text-xl mb-8 select-none">
         <span className="text-stone-400">
           <span className="hover:underline">
@@ -34,75 +59,179 @@ export default async function Species({
           </span>
           &nbsp;▸&nbsp;
         </span>
-        <span className="capitalize">{species?.common_name}</span>
+        <span className="capitalize">{species.common_name}</span>
       </div>
+
+      <div className="text-sm mb-4 text-stone-500 align-middle max-w-[650px] flex flex-row items-center">
+        <div>
+          <div className="mb-1">
+            Each experiment below has a Slack channel (
+            <img
+              src="/slack.svg"
+              alt="Slack"
+              className="w-8 h-8 inline pb-1 opacity-70 -my-2 -mx-2"
+            />
+            ) and the lead scientist&apos;s email address (
+            <EmailIcon className="w-4 h-4 inline-block -mt-1" />
+            ).
+          </div>
+        </div>
+      </div>
+
       <div className="table-auto select-none">
-        {species?.cyl_experiments.map((experiment: { id: Key | null | undefined; name: string; }) => (
-          <div className="table-row" key={experiment.id}>
-            <div className="table-cell text-lg align-middle p-4">
-              <div className="align-middle">
-                <Link
-                  href={`/app/traits/${species.id}/${experiment.id}`}
-                  key={experiment.id}
-                >
-                  <span className="text-lime-700 hover:underline">
-                    {capitalizeFirstLetter(
-                      experiment.name.replaceAll("-", " ")
-                    )}
-                  </span>
-                </Link>
-                <div className="text-sm mt-2 text-neutral-400">
-                  {getAccessionCount(experiment)}
-                  &nbsp;/&nbsp;
-                  {getPlantCount(experiment)}
+        {species.cyl_experiments.map(
+          (experiment: {
+            id: Key | null | undefined;
+            name: string;
+            slack_channel_url: string | null | undefined;
+            people: { email: string | null; id: number; name: string | null } | null;
+            description: string | null;
+          }) => (
+            <div className="table-row" key={experiment.id}>
+              <div className="table-cell text-lg align-middle p-4">
+                <div className="align-middle">
+                  <Link
+                    href={`/app/traits/${species.id}/${experiment.id}`}
+                    key={experiment.id}
+                    className="mr-4"
+                  >
+                    <span className="text-lime-700 hover:underline">
+                      {capitalizeFirstLetter(
+                        experiment.name.replaceAll("-", " "),
+                      )}
+                    </span>
+                  </Link>
+                  {experiment.slack_channel_url && (
+                    <a
+                      href={experiment.slack_channel_url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <img
+                        src="/slack.svg"
+                        alt="Slack channel"
+                        className="w-8 h-8 inline pb-1 opacity-70 hover:opacity-100 -my-2"
+                      />
+                    </a>
+                  )}
+                  {experiment.people?.email && (
+                    <a href={`mailto:${experiment.people.email}`}>
+                      <EmailIcon className="w-4 h-4 inline-block -mt-1 ml-2 opacity-50 hover:opacity-100" />
+                    </a>
+                  )}
+                  <div className="text-sm mt-2 text-neutral-400">
+                    {getAccessionCount(experiment)}
+                    &nbsp;/&nbsp;
+                    {getPlantCount(experiment)}
+                  </div>
+                  <div>
+                    <span className="text-sm text-neutral-400 italic">
+                      {experiment.description
+                        ? experiment.description.slice(0, 100) +
+                          (experiment.description.length > 100 ? "..." : "")
+                        : "No description provided."}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        ))}
+          ),
+        )}
       </div>
     </div>
-  </>
   );
 }
 
-function capitalizeFirstLetter(string: String) {
+function EmailIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"
+      />
+    </svg>
+  );
+}
+
+function capitalizeFirstLetter(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-function getPlantCount(experiment: any) {
+function getPlantCount(experiment: {
+  cyl_waves?: { cyl_plants?: unknown[] }[];
+}): string {
+  if (!experiment?.cyl_waves || !Array.isArray(experiment.cyl_waves)) {
+    return "0 replicates";
+  }
+
   let plantCount = 0;
-  experiment.cyl_waves.forEach((wave: any) => {
-    plantCount += wave.cyl_plants.length;
+  experiment.cyl_waves.forEach((wave) => {
+    if (wave?.cyl_plants && Array.isArray(wave.cyl_plants)) {
+      plantCount += wave.cyl_plants.length;
+    }
   });
   return `${plantCount} replicates`;
 }
 
-function getAccessionCount(experiment: any) {
-  // empty array of strings
-  let accessionNames: string[] = [];
-  experiment.cyl_waves.forEach((wave: any) => {
-    wave.cyl_plants.forEach((plant: any) => {
-      accessionNames.push(plant.accessions.name);
-    });
+function getAccessionCount(experiment: {
+  cyl_waves?: { cyl_plants?: { accessions?: { name?: string } }[] }[];
+}): string {
+  if (!experiment?.cyl_waves || !Array.isArray(experiment.cyl_waves)) {
+    return "0 accessions";
+  }
+
+  const accessionNames: string[] = [];
+  experiment.cyl_waves.forEach((wave) => {
+    if (wave?.cyl_plants && Array.isArray(wave.cyl_plants)) {
+      wave.cyl_plants.forEach((plant) => {
+        if (plant?.accessions?.name) {
+          accessionNames.push(plant.accessions.name);
+        }
+      });
+    }
   });
   const lineCount = new Set(accessionNames).size;
   return `${lineCount} accessions`;
 }
 
-async function getSpeciesWithExperiments(speciesId: number) {
+interface SpeciesWithExperiments {
+  id: number;
+  common_name: string | null;
+  cyl_experiments: {
+    id: number;
+    name: string;
+    slack_channel_url: string | null;
+    people: { email: string | null; id: number; name: string | null } | null;
+    description: string | null;
+    cyl_waves: {
+      id: number;
+      cyl_plants: { id: number; accessions: { name: string | null } | null }[];
+    }[];
+  }[];
+}
+
+async function getSpeciesWithExperiments(
+  speciesId: number,
+): Promise<SpeciesWithExperiments | null> {
   const supabase = await createServerSupabaseClient();
 
   const { data } = await supabase
     .from("species")
     .select(
-      "*, cyl_experiments!inner(*, cyl_waves(*, cyl_plants(*, accessions(*))))"
+      "*, cyl_experiments!inner(*, people(*), cyl_waves(*, cyl_plants(*, accessions(*))))",
     )
     .eq("id", speciesId)
     .neq("cyl_experiments.deleted", true)
     .single();
 
-  return data;
+  return data as SpeciesWithExperiments | null;
 }
-
-

--- a/web/components/plant-scan.tsx
+++ b/web/components/plant-scan.tsx
@@ -65,20 +65,37 @@ export default function PlantScan({
   const [loading, setLoading] = useState<boolean>(true);
   const [imageIsLoaded, setImageIsLoaded] = useState<boolean>(false);
 
+  // Guard for scans with no attached cyl_images (e.g. demo / seed data,
+  // or a real scan whose images haven't been uploaded yet). Without this,
+  // scan.cyl_images[0].object_path threw "Cannot read properties of
+  // undefined (reading 'object_path')".
+  const firstImagePath = scan?.cyl_images?.[0]?.object_path ?? null;
+
   useEffect(() => {
-    const path = scan.cyl_images[0].object_path;
-    if (path === null) {
+    if (firstImagePath === null) {
       setLoading(false);
       return;
     }
-    getImageUrl(path, thumb, height || defaultHeight).then((url) => {
+    getImageUrl(firstImagePath, thumb, height || defaultHeight).then((url) => {
       setObjectUrl(url);
       setLoading(false);
     });
     getVideoUrl(scan).then((url) => {
       setVideoUrl(url);
     });
-  }, [scan]);
+  }, [scan, firstImagePath]);
+
+  // The scan record carries no cyl_images row, OR the row carries no
+  // object_path. Either way the client can't resolve a signed URL, so we
+  // surface that to the user honestly rather than pretending the image
+  // doesn't exist (it might exist upstream — we just can't fetch it).
+  if (!loading && firstImagePath === null) {
+    return (
+      <div className="rounded-lg border-2 border-dashed border-stone-300 bg-stone-50 px-4 py-6 text-sm text-stone-500 italic">
+        Unable to retrieve scan image.
+      </div>
+    );
+  }
 
   return (
     <div className="group">

--- a/web/components/scan-trait-boxplot.tsx
+++ b/web/components/scan-trait-boxplot.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import {
-  // SupabaseClient,
-  createClientSupabaseClient,
-} from "@/lib/supabase/client";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
 import PlantScan from "@/components/plant-scan";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { Database } from "@/lib/database.types";
 import { TraitData } from "@/lib/custom.types";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 export default function ScanTraitBoxplot({
   traitData,
@@ -18,177 +15,317 @@ export default function ScanTraitBoxplot({
   traitData: TraitData;
   traitMax: number;
 }) {
-  //   // Create a Supabase client configured to use cookies
-  // const supabase = createClientSupabaseClient();
   const supabase = createClientSupabaseClient() as unknown as SupabaseClient<Database>;
 
   const ySpacing = 20;
   const xOrigin = 150;
   const labelOffset = 40;
-  const totalWidth = 500;
   const radius = 4;
+  const validRows = traitData.filter((row) => !isNaN(row.trait_value));
+  const uniqueAccessions = [
+    ...new Set(validRows.map((row) => row.accession_name)),
+  ];
+  const accessionY = uniqueAccessions.map(
+    (_, index) => (index + 0.5) * ySpacing,
+  );
+
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const [chartWidth, setChartWidth] = useState(800);
+
+  useEffect(() => {
+    const el = chartContainerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0].contentRect.width;
+      setChartWidth(Math.max(w, 500));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const xScale = traitMax > 0 ? (chartWidth - xOrigin - 20) / traitMax : 1;
 
   const [scanId, setScanId] = useState<number | null>(null);
   const [scan, setScan] = useState<any | null>(null);
   const [plantId, setPlantId] = useState<number | null>(null);
-  const [imageLoading, setImageLoading] = useState<boolean>(false);
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [offsets, setOffsets] = useState<number[]>([]);
-  const [accessionY, setAccessionY] = useState<number[]>([]);
-  const [accessions, setAccessions] = useState<string[]>([]);
-  const [uniqueAccessions, setUniqueAccessions] = useState<string[]>([]);
-  const [xScale, setXScale] = useState<number>(1);
 
-  // useEffect(() => {
-  //   console.log("re-rendering ScanTraitBoxplot");
-  //   console.log("traitData = ", traitData);
-  // });
+  const [leftWidthPct, setLeftWidthPct] = useState(65);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDraggingRef = useRef(false);
 
   useEffect(() => {
-    const get = async () => {
-      const offsets = traitData
-        .filter((row) => !isNaN(row.trait_value))
-        .map((row) => 0);
-      // .map((row) => Math.random() * 6 - 3);
-      console.log("offsets = ", offsets);
-      const accessions_ = traitData.map((trait) => trait.accession_name);
-      const uniqueAccessions_ = [...new Set(accessions_)];
-      const accessionY = uniqueAccessions_.map((accession, index) => {
-        return (index + 0.5) * ySpacing;
-      });
-      // set scanId if plantId is set
-      if (plantId) {
-        const scanId_ = traitData.find(
-          (row) => row.plant_id === plantId
-        )?.scan_id;
-        if (scanId_) setScanId(scanId_);
-      }
-      // calculate trait max
-      const traitValues = traitData.map((trait) =>
-        isNaN(trait.trait_value) ? 0 : trait.trait_value
-      );
-      const xScale_ = (totalWidth - xOrigin - 20) / traitMax;
-      setXScale(xScale_);
-      setOffsets(offsets);
-      setAccessionY(accessionY);
-      setAccessions(accessions_);
-      setUniqueAccessions(uniqueAccessions_);
+    const onMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const pct = ((e.clientX - rect.left) / rect.width) * 100;
+      setLeftWidthPct(Math.max(25, Math.min(85, pct)));
     };
-    get();
-  }, [traitData]);
+    const onUp = () => {
+      if (!isDraggingRef.current) return;
+      isDraggingRef.current = false;
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, []);
+
+  const startDrag = () => {
+    isDraggingRef.current = true;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+  };
 
   useEffect(() => {
-    const get = async () => {
-      if (scanId) {
-        await getScan(scanId, supabase).then((data) => {
-          setScan(data);
-        });
-      }
+    if (!plantId) return;
+    const match = traitData.find((row) => row.plant_id === plantId);
+    if (match) setScanId(match.scan_id);
+  }, [traitData, plantId]);
+
+  useEffect(() => {
+    if (!scanId) return;
+    let cancelled = false;
+    (async () => {
+      const data = await getScan(scanId, supabase);
+      if (!cancelled) setScan(data);
+    })();
+    return () => {
+      cancelled = true;
     };
-    get();
   }, [scanId, supabase]);
 
+  const perAccessionStats = uniqueAccessions.map((accession) => {
+    const rows = validRows.filter((r) => r.accession_name === accession);
+    const values = rows.map((r) => r.trait_value).sort((a, b) => a - b);
+    const n = values.length;
+    const mean = n > 0 ? values.reduce((s, v) => s + v, 0) / n : 0;
+    const median =
+      n === 0 ? 0 : n % 2 ? values[(n - 1) / 2] : (values[n / 2 - 1] + values[n / 2]) / 2;
+    const variance =
+      n > 1
+        ? values.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1)
+        : 0;
+    const std = Math.sqrt(variance);
+    const wavesRepresented = new Set(rows.map((r) => r.wave_number)).size;
+    const min = values[0] ?? 0;
+    const max = values[n - 1] ?? 0;
+    const medianFrac =
+      max > min ? (median - min) / (max - min) : 0.5;
+    return {
+      accession,
+      n,
+      mean,
+      median,
+      std,
+      min,
+      max,
+      wavesRepresented,
+      medianFrac,
+    };
+  });
+
   return (
-    <div className="flex flex-row h-96">
-      <div className="overflow-scroll mr-4 border-2 p-4">
-        <svg height={uniqueAccessions.length * ySpacing} width={totalWidth}>
-          <g>
-            {uniqueAccessions.map((accession, index) => {
-              const yOffset = accessionY[index];
-              return (
+    <div>
+      <div className="mb-3 flex items-center justify-between gap-3 flex-wrap">
+        <span className="text-xs text-stone-500">
+          {validRows.length} measurement{validRows.length === 1 ? "" : "s"}{" "}
+          across {uniqueAccessions.length} accession
+          {uniqueAccessions.length === 1 ? "" : "s"}
+        </span>
+        <span className="inline-flex items-center gap-2 rounded-full border border-lime-700/40 bg-lime-50 px-3 py-1 text-xs font-medium text-lime-800 shadow-sm">
+          <span className="relative inline-flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-lime-400 opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-lime-600" />
+          </span>
+          Click a dot to view the scan image
+        </span>
+      </div>
+
+      <div
+        ref={containerRef}
+        className="flex flex-col gap-4 lg:flex-row lg:gap-0"
+        style={
+          {
+            ["--left-w" as unknown as string]: `${leftWidthPct}%`,
+            ["--right-w" as unknown as string]: `${100 - leftWidthPct}%`,
+          } as React.CSSProperties
+        }
+      >
+        <div
+          ref={chartContainerRef}
+          className="w-full lg:w-[var(--left-w)] rounded-lg border border-stone-200 bg-white p-4 shadow-sm overflow-hidden"
+        >
+          <svg
+            height={Math.max(uniqueAccessions.length * ySpacing + 10, ySpacing * 2)}
+            width={chartWidth}
+            className="block"
+          >
+            <g>
+              {uniqueAccessions.map((accession, index) => (
                 <g
-                  key={accession}
-                  transform={`translate(${xOrigin - labelOffset}, ${yOffset})`}
+                  key={accession ?? `__null-${index}`}
+                  transform={`translate(${xOrigin - labelOffset}, ${accessionY[index]})`}
                 >
                   <text
-                    key={accession}
                     style={{
                       fontSize: "12px",
                       fontFamily: "Arial, Helvetica, sans-serif",
                       textAnchor: "end",
-                      // transform: "translateX(20px)",
+                      fill: "rgb(68 64 60)",
                     }}
                   >
-                    {accession}
+                    {accession ?? "—"}
                   </text>
                 </g>
-              );
-            })}
-          </g>
-          <g>
-            {traitData
-              .filter((row) => !isNaN(row.trait_value))
-              .map((row, index) => {
-                const accessionIndex = uniqueAccessions?.findIndex(
-                  (a) => a === row.accession_name
+              ))}
+            </g>
+            <g>
+              {validRows.map((row) => {
+                const accessionIndex = uniqueAccessions.indexOf(
+                  row.accession_name,
                 );
+                if (accessionIndex < 0) return null;
+                const cy = accessionY[accessionIndex] - 3;
+                const cx = xOrigin + row.trait_value * xScale;
+                const isSelected =
+                  row.scan_id === scanId || row.plant_id === plantId;
                 return (
                   <circle
                     key={row.scan_id}
                     className={
-                      "opacity-50 hover:fill-red-600 hover:stroke-red-600 hover:opacity-100 hover:stroke-2 cursor-pointer" +
-                      (row.scan_id === scanId || row.plant_id === plantId
-                        ? " fill-red-600 stroke-red-600 opacity-100 stroke-2"
-                        : "")
+                      "cursor-pointer transition-all" +
+                      (isSelected
+                        ? " fill-lime-600 stroke-lime-700 opacity-100 stroke-2"
+                        : " fill-lime-500 stroke-lime-600 opacity-60 hover:opacity-100 hover:stroke-2")
                     }
                     onClick={() => {
-                      console.log(`row.scan_id = ${row.scan_id}`);
-                      setScanId(null);
-                      setImageLoading(true);
                       setScanId(row.scan_id);
                       setPlantId(row.plant_id);
                     }}
-                    cx={xOrigin + row.trait_value * xScale}
-                    cy={accessionY[accessionIndex] - 3 + offsets[index]}
+                    cx={cx}
+                    cy={cy}
                     r={radius}
                   />
                 );
               })}
-          </g>
-        </svg>
-      </div>
-      <div>
-        {scanId ? (
-          scan ? (
-            <PlantScan
-              scan={scan}
-              thumb={true}
-              height={250}
-              href={`/app/phenotypes/${scan.cyl_plants.cyl_waves.cyl_experiments.species.id}/${scan.cyl_plants.cyl_waves.cyl_experiments.id}/${scan.cyl_plants.cyl_waves.id}/${scan.cyl_plants.accessions.id}#scan-${scan.id}`}
-              label={`Plant: ${scan.cyl_plants.qr_code}`}
-              target="_blank"
-            />
+            </g>
+          </svg>
+        </div>
+
+        <div
+          onMouseDown={startDrag}
+          className="hidden lg:flex w-3 mx-1 cursor-col-resize items-stretch shrink-0 group"
+        >
+          <div className="w-0.5 mx-auto h-full bg-stone-300 group-hover:bg-lime-600 transition-colors rounded-full" />
+        </div>
+
+        <div className="w-full lg:w-[var(--right-w)]">
+          {scanId ? (
+            scan ? (
+              <PlantScan
+                scan={scan}
+                thumb={true}
+                height={250}
+                href={`/app/phenotypes/${scan.cyl_plants?.cyl_waves?.cyl_experiments?.species?.id}/${scan.cyl_plants?.cyl_waves?.cyl_experiments?.id}/${scan.cyl_plants?.cyl_waves?.id}/${scan.cyl_plants?.accessions?.id}#scan-${scan.id}`}
+                label={`Plant: ${scan.cyl_plants?.qr_code}`}
+                target="_blank"
+              />
+            ) : (
+              <div className="rounded-lg border-2 border-dashed border-stone-200 bg-stone-50 px-4 py-6 text-sm text-stone-500 italic">
+                Loading scan…
+              </div>
+            )
           ) : (
-            <div>Image loading...</div>
-          )
-        ) : null}
+            <div className="rounded-lg border-2 border-dashed border-stone-200 bg-stone-50 px-4 py-6 text-sm text-stone-500">
+              <div className="font-medium text-stone-600 mb-1">
+                Scan preview
+              </div>
+              <div className="italic">
+                Click any dot in the chart to load the corresponding plant
+                scan.
+              </div>
+            </div>
+          )}
+        </div>
       </div>
+
+      {perAccessionStats.length > 0 && (
+        <div className="mt-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-xs uppercase tracking-wide text-stone-500">
+              Per-accession summary
+            </div>
+            {perAccessionStats.length > 5 && (
+              <div className="text-xs text-stone-400 italic">scroll ↓</div>
+            )}
+          </div>
+          <div
+            className="flex flex-col gap-2 overflow-y-scroll max-h-[26rem] rounded-lg border border-stone-200 bg-stone-50/50 p-2"
+            style={{
+              scrollbarWidth: "thin",
+              scrollbarColor: "rgb(132 204 22 / 0.5) rgb(231 229 228)",
+            }}
+          >
+            {perAccessionStats.map((s) => (
+              <div
+                key={s.accession ?? "__null"}
+                className="rounded-lg border border-stone-200 border-l-4 border-l-lime-500/40 bg-white p-3 text-xs flex items-center gap-4"
+              >
+                <div className="w-40 flex-shrink-0">
+                  <div className="font-semibold text-stone-800 truncate">
+                    {s.accession ?? "—"}
+                  </div>
+                  <div className="mt-0.5 text-stone-500 tabular-nums">
+                    n {s.n} · {s.wavesRepresented} wave
+                    {s.wavesRepresented === 1 ? "" : "s"}
+                  </div>
+                </div>
+
+                <div className="flex-shrink-0 w-28 flex items-baseline gap-1">
+                  <span className="text-xl font-semibold text-stone-900 tabular-nums">
+                    {s.median.toFixed(1)}
+                  </span>
+                  <span className="text-stone-500">median</span>
+                </div>
+
+                <div className="flex-shrink-0 w-36 text-stone-600 tabular-nums">
+                  mean {s.mean.toFixed(1)}
+                  {s.n > 1 ? ` ± ${s.std.toFixed(2)}` : ""}
+                </div>
+
+                <div className="flex-1 min-w-[140px]">
+                  <div className="relative h-1.5 rounded-full bg-stone-200">
+                    <div
+                      className="absolute top-0 h-1.5 w-0.5 bg-lime-700"
+                      style={{ left: `${s.medianFrac * 100}%` }}
+                    />
+                  </div>
+                  <div className="mt-1 flex justify-between text-stone-400 tabular-nums">
+                    <span>{s.min.toFixed(1)}</span>
+                    <span>{s.max.toFixed(1)}</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
-async function getScanThumbnail(
-  scanId: number,
-  supabase: SupabaseClient<Database, "public", "public">
-) {
-  const { data } = await supabase
-    .from("cyl_images")
-    .select("*")
-    .eq("scan_id", scanId)
-    .eq("frame_number", 1)
-    .single();
-
-  return data;
-}
-
 async function getScan(
   scanId: number,
-  supabase: SupabaseClient<Database, "public", "public">
+  supabase: SupabaseClient<Database, "public", "public">,
 ) {
   const { data } = await supabase
     .from("cyl_scans")
     .select(
-      "*, cyl_images(*), cyl_plants(*, accessions(*), cyl_waves(*, cyl_experiments(*, species(*))))"
+      "*, cyl_images(*), cyl_plants(*, accessions(*), cyl_waves(*, cyl_experiments(*, species(*))))",
     )
     .eq("id", scanId)
     .single();


### PR DESCRIPTION
## Summary

Polishes the 5 routes under `/app/traits/*` and adds an interactive split-pane trait explorer.

## What the pages do

- **`/app/traits`** — species list with illustrations.
- **`/app/traits/[speciesId]`** — experiments for the species, each with a Slack channel link, scientist email, description preview, and accession / replicate counts.
- **`/app/traits/[speciesId]/[experimentId]`** — interactive trait explorer:
  - Trait / wave / plant-age dropdowns. Trait list scoped to traits with measurements in this experiment.
  - Boxplot with lime-green dots, one row per accession.
  - Click a dot → side panel shows the corresponding plant scan image.
  - Draggable vertical divider between the chart and the side panel — resize as needed.
  - Per-accession summary list below the chart: median, mean ± std, n + waves, and a range bar with a tick at the median.
- **`/app/traits/[speciesId]/[experimentId]/[accessionName]`** — replicates for an accession, each with thumbnails of every scan day.
- **`/app/traits/[speciesId]/[experimentId]/[accessionName]/[imageId]`** — full-size scan image.