### PR TITLE
fix(home): null-guard recent-phenotypes timestamp formatting

### DIFF
--- a/web/components/recent-phenotypes-by-cyl-scanner/RelativeTime.tsx
+++ b/web/components/recent-phenotypes-by-cyl-scanner/RelativeTime.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from "react";
 import { formatRelativeAndAbsolute } from "./format-times";
 
 interface RelativeTimeProps {
-  iso: string;
+  iso: string | null | undefined;
 }
 
 export function RelativeTime({ iso }: RelativeTimeProps) {

--- a/web/components/recent-phenotypes-by-cyl-scanner/format-times.ts
+++ b/web/components/recent-phenotypes-by-cyl-scanner/format-times.ts
@@ -12,17 +12,17 @@
  * empty string if the input isn't a valid date.
  */
 export function formatRelative(
-  iso: string | Date,
+  iso: string | Date | null | undefined,
   now: Date = new Date(),
   locale: string | undefined = undefined,
 ): string {
+  if (iso == null) return "";
   const date = typeof iso === "string" ? new Date(iso) : iso;
   if (Number.isNaN(date.getTime())) return "";
 
   const diffSeconds = (date.getTime() - now.getTime()) / 1000;
   const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
 
-  // Pick the largest unit that gives a non-trivial number.
   const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
     ["year", 60 * 60 * 24 * 365],
     ["month", 60 * 60 * 24 * 30],
@@ -46,9 +46,10 @@ export function formatRelative(
  * empty string if the input isn't a valid date.
  */
 export function formatAbsolute(
-  iso: string | Date,
+  iso: string | Date | null | undefined,
   locale: string | undefined = undefined,
 ): string {
+  if (iso == null) return "";
   const date = typeof iso === "string" ? new Date(iso) : iso;
   if (Number.isNaN(date.getTime())) return "";
 
@@ -63,7 +64,7 @@ export function formatAbsolute(
  * line. Skips the bullet if either half is empty.
  */
 export function formatRelativeAndAbsolute(
-  iso: string | Date,
+  iso: string | Date | null | undefined,
   now: Date = new Date(),
   locale: string | undefined = undefined,
 ): string {

--- a/web/lib/queries/recent-phenotypes-by-cyl-scanner.ts
+++ b/web/lib/queries/recent-phenotypes-by-cyl-scanner.ts
@@ -39,7 +39,7 @@ export interface CylScanRow {
   plant_age_days: number | null;
   phenotyper_first_name: string | null;
   phenotyper_last_name: string | null;
-  latest_upload_on_this_scanner_at: string; // ISO timestamp
+  latest_upload_on_this_scanner_at: string | null; // ISO timestamp; null if no underlying scan has uploaded_at set
   rank_on_scanner: number;
 }
 

--- a/web/lib/queries/recent-phenotypes-by-plate-scanner.ts
+++ b/web/lib/queries/recent-phenotypes-by-plate-scanner.ts
@@ -37,7 +37,7 @@ export interface PlateScanRow {
   plate_id: string | null;
   phenotyper_first_name: string | null;
   phenotyper_last_name: string | null;
-  latest_upload_on_this_scanner_at: string; // ISO timestamp
+  latest_upload_on_this_scanner_at: string | null; // ISO timestamp; null if no underlying gravi_image has uploaded_at
   rank_on_scanner: number;
 }
 


### PR DESCRIPTION
Updates to the staging homepage.

\`latest_upload_on_this_scanner_at\` can be \`null\` when an underlying scan has no \`uploaded_at\` set. The formatter assumed \`string | Date\`, so \`null.getTime()\` threw on first paint, React kept retrying, the renderer crashed → "This page couldn't load."

- Loosen \`formatRelative\` / \`formatAbsolute\` / \`formatRelativeAndAbsolute\` to accept \`null | undefined\` and return \`""\` early.

Card behaviour with a null timestamp: the time text is silently empty; the rest of the card (experiment name, wave/age/phenotyper line, "View" pill) renders normally.