### PR TITLE
fix(bloommcp): hard-fail on missing BLOOMMCP_API_KEY (closes #29 pt. 3)

### DIFF
--- a/bloommcp/server.py
+++ b/bloommcp/server.py
@@ -45,8 +45,32 @@ from tools.workflows import (
 logger = logging.getLogger(__name__)
 
 # --- Authentication ---
+#
+# Server refuses to start when BLOOMMCP_API_KEY is unset, unless the caller
+# explicitly opts out via BLOOMMCP_ALLOW_NO_AUTH=1. The opt-out exists so
+# local dev workflows (where MCP traffic stays on the docker network) can
+# run without a key; staging/prod must always set a real key. Closes the
+# silent-auth-disable gap flagged in #29.
 
 API_KEY = os.getenv("BLOOMMCP_API_KEY")
+ALLOW_NO_AUTH = os.getenv("BLOOMMCP_ALLOW_NO_AUTH", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+if not API_KEY:
+    if not ALLOW_NO_AUTH:
+        raise RuntimeError(
+            "BLOOMMCP_API_KEY is not set. The server refuses to start "
+            "without authentication. Set BLOOMMCP_API_KEY to a strong "
+            "secret, or — for local development only — opt out explicitly "
+            "with BLOOMMCP_ALLOW_NO_AUTH=1."
+        )
+    logger.warning(
+        "BLOOMMCP_ALLOW_NO_AUTH is set — server running without "
+        "authentication. DO NOT use this in staging or production."
+    )
 
 auth_provider = None
 if API_KEY:
@@ -98,5 +122,9 @@ if __name__ == "__main__":
     if API_KEY:
         print("Bloom MCP Server starting with API key authentication")
     else:
-        print("Bloom MCP Server starting without authentication (dev mode)")
+        print(
+            "Bloom MCP Server starting WITHOUT authentication "
+            "(BLOOMMCP_ALLOW_NO_AUTH=1). Local dev only — never use in "
+            "staging or production."
+        )
     mcp.run(transport="streamable-http", host="0.0.0.0", port=8811)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,6 +85,11 @@ services:
       BLOOM_PLOTS_DIR: /app/data/PLOTS_DIR
       BLOOM_PLOTS_URL: ${BLOOM_PLOTS_URL}
       BLOOMMCP_API_KEY: ${BLOOMMCP_API_KEY}
+      # Allow the bloommcp server to start without an API key for local dev.
+      # Staging/prod compose files must NOT set this — the server's startup
+      # check (bloommcp/server.py) hard-fails when the key is missing without
+      # this flag. See #29.
+      BLOOMMCP_ALLOW_NO_AUTH: "1"
       # Kept in sync with docker-compose.prod.yml for dev/prod parity, even
       # though dev has a writable root FS. See the prod compose for rationale.
       NUMBA_CACHE_DIR: /tmp/numba


### PR DESCRIPTION
Closes #29 (point 3 only — points 1 and 2 already shipped; see the issue's comment thread for the audit).

## Problem

`bloommcp/server.py` guarded auth with `if API_KEY:` and fell through to `auth_provider = None` when the env var was unset, printing "starting without authentication (dev mode)" — but with no actual environment gating. A staging/prod rollout that forgot to inject `BLOOMMCP_API_KEY` (e.g. a missing GH secret) would silently run unauthenticated.

## Fix

Deny-by-default. The server now raises `RuntimeError` at module import if `BLOOMMCP_API_KEY` is unset, unless the caller explicitly opts out with `BLOOMMCP_ALLOW_NO_AUTH=1`. Local dev keeps working out of the box because `docker-compose.dev.yml` sets the opt-out for the `bloommcp` service.

Staging and prod compose files are intentionally **not** changed — the deploy workflow already injects `BLOOMMCP_API_KEY` from GitHub Secrets (`STAGING_BLOOMMCP_API_KEY` / `PROD_BLOOMMCP_API_KEY`). With a valid secret the new check passes silently, so happy-path behaviour is unchanged. The win is in failure mode: if the secret is ever missing, bloommcp now refuses to start instead of running open.