### PR TITLE
fix(plate-phenotypes): read images from bloom-storage backend + TIFF→JPG

### DIFF
--- a/web/components/recent-phenotypes-by-plate-scanner/PlateImage.tsx
+++ b/web/components/recent-phenotypes-by-plate-scanner/PlateImage.tsx
@@ -9,19 +9,55 @@ interface PlateImageProps {
   className?: string;
 }
 
+// Plate-scanner objects live under the storage-api backend bucket at
+//   bloom-storage/storage-single-tenant/graviscan-images/<gravi_images.object_path>
+// so the front-end reads directly from `bloom-storage` and prepends the
+// tenant + logical-bucket prefix to the object_path from postgres
+// (which already starts with `gravi-images/<filename>.tif`).
+//
+// Scanner uploads are TIFF; browsers can't render TIFF natively, so both
+// views go through the image transformer (imgproxy + libvips) with
+// `format: "jpg"` to re-encode on the fly. `format` accepts jpg/png/webp
+// on self-hosted even though supabase-js's type only declares "origin";
+// cast around the incomplete type.
+
+const BACKEND_BUCKET = "bloom-storage";
+const STORAGE_PREFIX = "storage-single-tenant/graviscan-images";
+
+function backendPath(objectPath: string): string {
+  return `${STORAGE_PREFIX}/${objectPath}`;
+}
+
+type TransformOpts = {
+  width?: number;
+  height?: number;
+  quality?: number;
+  format?: "origin" | "jpg" | "png" | "webp";
+};
+
 async function getThumbUrl(path: string): Promise<string> {
   const supabase = createClientSupabaseClient();
   const { data } = await supabase.storage
-    .from("graviscan-images")
-    .createSignedUrl(path, 3600, { transform: { width: 480, quality: 80 } });
+    .from(BACKEND_BUCKET)
+    .createSignedUrl(backendPath(path), 3600, {
+      transform: { width: 480, quality: 80, format: "jpg" } as TransformOpts as {
+        width: number;
+        quality: number;
+      },
+    });
   return data?.signedUrl ?? "";
 }
 
 async function getFullUrl(path: string): Promise<string> {
   const supabase = createClientSupabaseClient();
   const { data } = await supabase.storage
-    .from("graviscan-images")
-    .createSignedUrl(path, 3600);
+    .from(BACKEND_BUCKET)
+    .createSignedUrl(backendPath(path), 3600, {
+      transform: { width: 2400, quality: 85, format: "jpg" } as TransformOpts as {
+        width: number;
+        quality: number;
+      },
+    });
   return data?.signedUrl ?? "";
 }
 


### PR DESCRIPTION
Follow-up to PR #259 — plate-scan thumbnails on `/app/plate-phenotypes/[species]/[experiment]/[plate]` render as "missing" on staging because (a) the front-end was asking the storage-api for the wrong logical bucket and (b) the files are TIFFs the browser can't render.

## Cause

Scanner uploads land in the storage-api backend bucket at `bloom-storage/storage-single-tenant/graviscan-images/...`, not in a top-level `graviscan-images` bucket. `.from("graviscan-images")` didn't resolve. Even if it had, `.tif` doesn't render in Chrome/Firefox.

## Fix

`PlateImage.tsx` now:

- Calls `.from("bloom-storage")` and prepends `storage-single-tenant/graviscan-images/` to `gravi_images.object_path` (which already starts with `gravi-images/<filename>.tif`). Resulting URL points at the actual on-disk location.
- Passes `transform: { format: "jpg", ... }` on both the thumbnail (480 px) and lightbox (2400 px) so imgproxy re-encodes the TIFF to JPEG on the fly. `format: "jpg"` isn't in supabase-js's declared type (only `"origin"`), so options are cast through a local `TransformOpts`.

## Test plan

- [ ] On staging: thumbnails on the plate detail page render JPEGs instead of "missing"
- [ ] Click a thumbnail — lightbox opens with the 2400 px JPEG
- [ ] Network tab: `Content-Type: image/jpeg`, URL path is `.../bloom-storage/storage-single-tenant/graviscan-images/gravi-images/...`