### PR TITLE
fix(plate-phenotypes): treat gravi_images embed as single object, not array

### DIFF
--- a/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/[plateId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/[plateId]/page.tsx
@@ -34,7 +34,7 @@ interface ScanRow {
   id: number;
   cycle_number: number | null;
   capture_date: string;
-  gravi_images: { object_path: string }[];
+  gravi_images: { object_path: string } | null;
 }
 
 interface ExperimentRow {
@@ -92,7 +92,7 @@ export default async function PlateDetail({
     scan_id: s.id,
     capture_date: s.capture_date,
     cycle_number: s.cycle_number,
-    object_path: s.gravi_images?.[0]?.object_path ?? null,
+    object_path: s.gravi_images?.object_path ?? null,
   }));
 
   return (

--- a/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/page.tsx
@@ -30,7 +30,7 @@ interface ScanRow {
   plate_index: string | null;
   wave_number: number | null;
   capture_date: string;
-  gravi_images: { object_path: string }[];
+  gravi_images: { object_path: string } | null;
   gravi_scan_metadata_accession: MetadataAccession | null;
 }
 
@@ -125,7 +125,7 @@ export default async function PlateExperiment({
             >
               <div className="flex gap-5">
                 <PlateImage
-                  path={plate.latestScan.gravi_images?.[0]?.object_path ?? null}
+                  path={plate.latestScan.gravi_images?.object_path ?? null}
                   alt={plate.plate_id}
                   className="w-[160px] h-[160px] shrink-0"
                 />


### PR DESCRIPTION
PostgREST returns `gravi_images` as a single object (not an array) because the table has `UNIQUE (scan_id)` — one-to-one. The page code treated it as an array (`gravi_images?.[0]?.object_path`), so `path` resolved to null and every `PlateImage` rendered "no image" without firing a request. Fixes both plate-phenotypes pages to access `gravi_images?.object_path` directly.