### PR TITLE
fix(plate-phenotypes): image rendering on staging + add video backfill

### DIFF
--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -265,24 +265,15 @@ def upload_video(
 # ─── Encoding ────────────────────────────────────────────────────────────────
 
 
-def _ffmpeg_binary() -> str:
-    """System ffmpeg if on PATH, otherwise the static binary bundled with imageio-ffmpeg."""
-    sys_ffmpeg = shutil.which("ffmpeg")
-    if sys_ffmpeg:
-        return sys_ffmpeg
-    try:
-        import imageio_ffmpeg
-    except ImportError as e:
-        raise RuntimeError(
-            "ffmpeg not on PATH and imageio-ffmpeg not installed. "
-            "Install one: `apt-get install ffmpeg` OR `pip install imageio-ffmpeg`."
-        ) from e
-    return imageio_ffmpeg.get_ffmpeg_exe()
-
-
 def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
-    """Run ffmpeg to glob all frames in frames_dir into a web-friendly MP4."""
-    ffmpeg = _ffmpeg_binary()
+    """Run ffmpeg to glob all frames in frames_dir into a web-friendly MP4.
+
+    Uses the static ffmpeg binary bundled with the imageio-ffmpeg pip package,
+    so no system install (and no admin) is required.
+    """
+    import imageio_ffmpeg
+
+    ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
     # frames are named frame_NNNN.<ext>; glob input keeps ffmpeg flexible on extension
     cmd = [
         ffmpeg,
@@ -431,12 +422,11 @@ def main(argv: list[str]) -> int:
     if args.env_file.exists():
         load_dotenv(args.env_file)
 
-    # Pre-flight ffmpeg lookup so we fail fast with a clear message.
+    # Pre-flight: confirm the bundled ffmpeg is available.
     try:
-        ffmpeg = _ffmpeg_binary()
-        logger.debug("using ffmpeg: %s", ffmpeg)
-    except RuntimeError as e:
-        logger.error("%s", e)
+        import imageio_ffmpeg  # noqa: F401
+    except ImportError:
+        logger.error("imageio-ffmpeg not installed (`pip install imageio-ffmpeg`)")
         return 2
 
     cfg = Config.from_env(framerate=args.framerate)

--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -5,6 +5,7 @@
 #   "psycopg[binary]>=3.2",
 #   "httpx>=0.27",
 #   "python-dotenv>=1.0",
+#   "imageio-ffmpeg>=0.5",
 # ]
 # ///
 """
@@ -18,8 +19,10 @@ per-plate detail page can render it.
 
 REQUIREMENTS
 ------------
-- ffmpeg on PATH (`brew install ffmpeg` / `apt-get install ffmpeg`)
-- uv (or run with `python -m` and install the deps from the script header)
+- ffmpeg: either on PATH, or the bundled binary that ships with the
+  `imageio-ffmpeg` pip package (the script falls back to that automatically,
+  so no admin install is required).
+- uv (or run with `python -m` and install the deps from the script header).
 
 USAGE
 -----
@@ -262,11 +265,27 @@ def upload_video(
 # ─── Encoding ────────────────────────────────────────────────────────────────
 
 
+def _ffmpeg_binary() -> str:
+    """System ffmpeg if on PATH, otherwise the static binary bundled with imageio-ffmpeg."""
+    sys_ffmpeg = shutil.which("ffmpeg")
+    if sys_ffmpeg:
+        return sys_ffmpeg
+    try:
+        import imageio_ffmpeg
+    except ImportError as e:
+        raise RuntimeError(
+            "ffmpeg not on PATH and imageio-ffmpeg not installed. "
+            "Install one: `apt-get install ffmpeg` OR `pip install imageio-ffmpeg`."
+        ) from e
+    return imageio_ffmpeg.get_ffmpeg_exe()
+
+
 def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
     """Run ffmpeg to glob all frames in frames_dir into a web-friendly MP4."""
+    ffmpeg = _ffmpeg_binary()
     # frames are named frame_NNNN.<ext>; glob input keeps ffmpeg flexible on extension
     cmd = [
-        "ffmpeg",
+        ffmpeg,
         "-y",
         "-framerate",
         str(framerate),
@@ -293,23 +312,11 @@ def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
         )
 
 
-def probe_duration_seconds(path: Path) -> int:
-    """Use ffprobe to read duration in seconds (rounded)."""
-    cmd = [
-        "ffprobe",
-        "-v",
-        "error",
-        "-show_entries",
-        "format=duration",
-        "-of",
-        "default=noprint_wrappers=1:nokey=1",
-        str(path),
-    ]
-    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip()
-    try:
-        return int(round(float(out)))
-    except ValueError:
+def estimate_duration_seconds(frame_count: int, framerate: int) -> int:
+    """Duration is just frames / fps — no need to ffprobe."""
+    if framerate <= 0:
         return 0
+    return max(1, round(frame_count / framerate))
 
 
 # ─── Orchestration ───────────────────────────────────────────────────────────
@@ -385,7 +392,9 @@ def render_one(
             plate_id=job.plate_id,
             session_id=job.session_id,
             object_path=target_path,
-            duration_seconds=probe_duration_seconds(out_path),
+            duration_seconds=estimate_duration_seconds(
+                len(job.frame_paths), cfg.framerate
+            ),
             frame_count=len(job.frame_paths),
             file_size_bytes=out_path.stat().st_size,
         )
@@ -422,8 +431,12 @@ def main(argv: list[str]) -> int:
     if args.env_file.exists():
         load_dotenv(args.env_file)
 
-    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
-        logger.error("ffmpeg/ffprobe not on PATH — install ffmpeg first")
+    # Pre-flight ffmpeg lookup so we fail fast with a clear message.
+    try:
+        ffmpeg = _ffmpeg_binary()
+        logger.debug("using ffmpeg: %s", ffmpeg)
+    except RuntimeError as e:
+        logger.error("%s", e)
         return 2
 
     cfg = Config.from_env(framerate=args.framerate)

--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -89,9 +89,10 @@ class Config:
     source_bucket: str = "graviscan-images"
     target_bucket: str = "graviscan-videos"
     framerate: int = 4
+    max_width: int = 720
 
     @classmethod
-    def from_env(cls, framerate: int) -> "Config":
+    def from_env(cls, framerate: int, max_width: int) -> "Config":
         missing = [
             k
             for k in ("SUPABASE_URL", "SERVICE_ROLE_KEY", "POSTGRES_DSN")
@@ -107,6 +108,7 @@ class Config:
             service_role_key=os.environ["SERVICE_ROLE_KEY"],
             postgres_dsn=os.environ["POSTGRES_DSN"],
             framerate=framerate,
+            max_width=max_width,
         )
 
 
@@ -265,7 +267,9 @@ def upload_video(
 # ─── Encoding ────────────────────────────────────────────────────────────────
 
 
-def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
+def encode_mp4(
+    frames_dir: Path, out_path: Path, framerate: int, max_width: int
+) -> None:
     """Run ffmpeg to encode all frames in frames_dir into a web-friendly MP4.
 
     Uses the static ffmpeg binary bundled with imageio-ffmpeg (no admin
@@ -283,9 +287,11 @@ def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
     ext = frames[0].suffix or ".bin"
     input_pattern = str(frames_dir / f"frame_%04d{ext}")
 
-    # Preserve source aspect — plate scanner TIFFs are tall (≈5:7 portrait
-    # for the staging dataset). The only required transform is rounding
-    # both dimensions to even numbers, which libx264 + yuv420p need.
+    # Preserve source aspect (plate scanner TIFFs are ≈5:7 portrait) but
+    # cap the long edge so the resulting MP4 is web-sized — TIFFs are
+    # 4960x6850 native, way too big for an in-page preview. Cap width at
+    # max_width and let height float (-2 rounds to even, which libx264
+    # + yuv420p require).
     cmd = [
         ffmpeg,
         "-y",
@@ -300,7 +306,7 @@ def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
         "-movflags",
         "+faststart",
         "-vf",
-        "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+        f"scale='min({max_width},iw)':-2",
         str(out_path),
     ]
     logger.debug("ffmpeg: %s", " ".join(cmd))
@@ -367,7 +373,7 @@ def render_one(
             cfg.framerate,
             out_path.name,
         )
-        encode_mp4(frames_dir, out_path, cfg.framerate)
+        encode_mp4(frames_dir, out_path, cfg.framerate, cfg.max_width)
 
         # 3. Upload
         logger.info(
@@ -407,6 +413,12 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--plate", type=str, default=None, help="optional plate_id filter")
     ap.add_argument("--framerate", type=int, default=4, help="output fps (default 4)")
     ap.add_argument(
+        "--max-width",
+        type=int,
+        default=720,
+        help="cap output width in px; height scales to preserve aspect (default 720)",
+    )
+    ap.add_argument(
         "--force", action="store_true", help="re-render even if row already matches"
     )
     ap.add_argument(
@@ -437,7 +449,7 @@ def main(argv: list[str]) -> int:
         logger.error("imageio-ffmpeg not installed (`pip install imageio-ffmpeg`)")
         return 2
 
-    cfg = Config.from_env(framerate=args.framerate)
+    cfg = Config.from_env(framerate=args.framerate, max_width=args.max_width)
 
     failures: list[str] = []
     with psycopg.connect(cfg.postgres_dsn) as conn, storage_client(cfg) as client:

--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -266,24 +266,30 @@ def upload_video(
 
 
 def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
-    """Run ffmpeg to glob all frames in frames_dir into a web-friendly MP4.
+    """Run ffmpeg to encode all frames in frames_dir into a web-friendly MP4.
 
-    Uses the static ffmpeg binary bundled with the imageio-ffmpeg pip package,
-    so no system install (and no admin) is required.
+    Uses the static ffmpeg binary bundled with imageio-ffmpeg (no admin
+    install required). Inputs are passed as a printf-style sequence
+    (`frame_%04d.<ext>`) — the imageio-ffmpeg build doesn't support
+    `-pattern_type glob`.
     """
     import imageio_ffmpeg
 
     ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
-    # frames are named frame_NNNN.<ext>; glob input keeps ffmpeg flexible on extension
+
+    frames = sorted(frames_dir.iterdir())
+    if not frames:
+        raise RuntimeError("encode_mp4: no frames found in {frames_dir}")
+    ext = frames[0].suffix or ".bin"
+    input_pattern = str(frames_dir / f"frame_%04d{ext}")
+
     cmd = [
         ffmpeg,
         "-y",
         "-framerate",
         str(framerate),
-        "-pattern_type",
-        "glob",
         "-i",
-        str(frames_dir / "frame_*"),
+        input_pattern,
         "-c:v",
         "libx264",
         "-pix_fmt",

--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -283,6 +283,9 @@ def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
     ext = frames[0].suffix or ".bin"
     input_pattern = str(frames_dir / f"frame_%04d{ext}")
 
+    # Preserve source aspect — plate scanner TIFFs are tall (≈5:7 portrait
+    # for the staging dataset). The only required transform is rounding
+    # both dimensions to even numbers, which libx264 + yuv420p need.
     cmd = [
         ffmpeg,
         "-y",
@@ -296,7 +299,6 @@ def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
         "yuv420p",
         "-movflags",
         "+faststart",
-        # libx264 needs even dimensions; scale to nearest-even width keeping aspect
         "-vf",
         "scale=trunc(iw/2)*2:trunc(ih/2)*2",
         str(out_path),

--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "psycopg[binary]>=3.2",
+#   "httpx>=0.27",
+#   "python-dotenv>=1.0",
+# ]
+# ///
+"""
+render_plate_videos.py — backfill time-lapse MP4s for plate-scanner experiments.
+
+Reads gravi_scans + gravi_images for each (experiment_id, plate_id) pair, pulls
+the TIFFs out of the graviscan-images bucket, encodes a sorted-by-capture_date
+MP4 with ffmpeg, uploads the result to the graviscan-videos bucket at
+{experiment_id}/{plate_id}.mp4, and upserts a row in gravi_plate_videos so the
+per-plate detail page can render it.
+
+REQUIREMENTS
+------------
+- ffmpeg on PATH (`brew install ffmpeg` / `apt-get install ffmpeg`)
+- uv (or run with `python -m` and install the deps from the script header)
+
+USAGE
+-----
+Set these env vars (or put them in a .env file next to this script):
+
+    SUPABASE_URL=https://staging-bloom-dev.salk.edu:8443/api
+    SERVICE_ROLE_KEY=<staging service_role JWT>
+    POSTGRES_DSN=postgres://supabase_admin:<pass>@host:port/postgres
+
+Then:
+
+    # all plates for one experiment
+    uv run scripts/render_plate_videos.py --experiment 1
+
+    # one specific plate
+    uv run scripts/render_plate_videos.py --experiment 1 --plate PLATE_011
+
+    # dry-run: list what would be done without writing anything
+    uv run scripts/render_plate_videos.py --experiment 1 --dry-run
+
+    # force re-render even if gravi_plate_videos already has a row
+    uv run scripts/render_plate_videos.py --experiment 1 --force
+
+DESIGN NOTES
+------------
+- Idempotent by default: skips a plate whose `gravi_plate_videos.frame_count`
+  matches the current count of `gravi_images` rows for that plate.
+- Conservative on errors: a failure on one plate logs and continues; the
+  process exits non-zero if any plate failed so cron can detect it.
+- TIFF → MP4: ffmpeg reads each TIFF as a frame; framerate is configurable
+  via --framerate (default 4 fps).
+- Auth: uses SERVICE_ROLE_KEY for both DB queries and storage I/O. Never
+  bake this script into a request path; it's a back-office job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import httpx
+import psycopg
+from dotenv import load_dotenv
+
+logger = logging.getLogger("render_plate_videos")
+
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Config:
+    supabase_url: str
+    service_role_key: str
+    postgres_dsn: str
+    source_bucket: str = "graviscan-images"
+    target_bucket: str = "graviscan-videos"
+    framerate: int = 4
+
+    @classmethod
+    def from_env(cls, framerate: int) -> "Config":
+        missing = [
+            k
+            for k in ("SUPABASE_URL", "SERVICE_ROLE_KEY", "POSTGRES_DSN")
+            if not os.getenv(k)
+        ]
+        if missing:
+            raise SystemExit(
+                f"Missing env var(s): {', '.join(missing)}. Set them or put them "
+                "in a .env file next to this script."
+            )
+        return cls(
+            supabase_url=os.environ["SUPABASE_URL"].rstrip("/"),
+            service_role_key=os.environ["SERVICE_ROLE_KEY"],
+            postgres_dsn=os.environ["POSTGRES_DSN"],
+            framerate=framerate,
+        )
+
+
+# ─── DB helpers ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class PlateJob:
+    experiment_id: int
+    plate_id: str
+    session_id: int | None
+    frame_paths: list[str]  # object_paths from gravi_images, ordered by capture_date
+
+
+def list_plate_jobs(
+    conn: psycopg.Connection, experiment_id: int, plate_id: str | None
+) -> list[PlateJob]:
+    """Return one job per (experiment, plate) with the ordered list of frame paths."""
+    sql = """
+        SELECT
+            s.experiment_id,
+            s.plate_id,
+            MAX(s.session_id)   AS session_id,
+            ARRAY_AGG(i.object_path ORDER BY s.capture_date) AS frame_paths
+        FROM gravi_scans s
+        JOIN gravi_images i ON i.scan_id = s.id
+        WHERE s.experiment_id = %s
+          AND s.plate_id IS NOT NULL
+          {plate_filter}
+        GROUP BY s.experiment_id, s.plate_id
+        HAVING COUNT(*) >= 1
+        ORDER BY s.plate_id
+    """
+    if plate_id:
+        sql = sql.format(plate_filter="AND s.plate_id = %s")
+        params: tuple = (experiment_id, plate_id)
+    else:
+        sql = sql.format(plate_filter="")
+        params = (experiment_id,)
+
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+    return [
+        PlateJob(
+            experiment_id=r[0], plate_id=r[1], session_id=r[2], frame_paths=list(r[3])
+        )
+        for r in rows
+    ]
+
+
+def existing_video_row(
+    conn: psycopg.Connection, experiment_id: int, plate_id: str
+) -> dict | None:
+    sql = """
+        SELECT id, object_path, frame_count
+        FROM gravi_plate_videos
+        WHERE experiment_id = %s AND plate_id = %s
+        LIMIT 1
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (experiment_id, plate_id))
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {"id": row[0], "object_path": row[1], "frame_count": row[2]}
+
+
+def upsert_video_row(
+    conn: psycopg.Connection,
+    *,
+    experiment_id: int,
+    plate_id: str,
+    session_id: int | None,
+    object_path: str,
+    duration_seconds: int,
+    frame_count: int,
+    file_size_bytes: int,
+) -> None:
+    """Upsert a row in gravi_plate_videos keyed on (experiment, plate, session?)."""
+    sql = """
+        INSERT INTO gravi_plate_videos
+          (experiment_id, plate_id, session_id, object_path,
+           duration_seconds, frame_count, file_size_bytes, generated_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, now())
+        ON CONFLICT (experiment_id, plate_id, COALESCE(session_id, -1)) DO UPDATE
+          SET object_path     = EXCLUDED.object_path,
+              duration_seconds = EXCLUDED.duration_seconds,
+              frame_count     = EXCLUDED.frame_count,
+              file_size_bytes = EXCLUDED.file_size_bytes,
+              generated_at    = EXCLUDED.generated_at
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            sql,
+            (
+                experiment_id,
+                plate_id,
+                session_id,
+                object_path,
+                duration_seconds,
+                frame_count,
+                file_size_bytes,
+            ),
+        )
+
+
+# ─── Storage helpers ─────────────────────────────────────────────────────────
+
+
+def storage_client(cfg: Config) -> httpx.Client:
+    return httpx.Client(
+        base_url=cfg.supabase_url,
+        headers={
+            "apikey": cfg.service_role_key,
+            "Authorization": f"Bearer {cfg.service_role_key}",
+        },
+        timeout=60.0,
+        verify=False,  # staging uses tls internal; in prod swap for verify=True
+    )
+
+
+def download_frame(
+    client: httpx.Client, bucket: str, object_path: str, dest: Path
+) -> None:
+    """Pull a single object's raw bytes via the storage-api authenticated endpoint."""
+    url = f"/storage/v1/object/{bucket}/{object_path}"
+    with client.stream("GET", url) as r:
+        r.raise_for_status()
+        with dest.open("wb") as fh:
+            for chunk in r.iter_bytes():
+                fh.write(chunk)
+
+
+def upload_video(
+    client: httpx.Client,
+    bucket: str,
+    object_path: str,
+    source: Path,
+    overwrite: bool,
+) -> None:
+    """Upload (or overwrite) an MP4 to the storage bucket."""
+    url = f"/storage/v1/object/{bucket}/{object_path}"
+    method = "PUT" if overwrite else "POST"
+    headers = {"Content-Type": "video/mp4"}
+    if overwrite:
+        headers["x-upsert"] = "true"
+    with source.open("rb") as fh:
+        r = client.request(method, url, headers=headers, content=fh.read())
+    if r.status_code >= 400:
+        raise RuntimeError(
+            f"Upload failed {r.status_code} for {object_path}: {r.text[:300]}"
+        )
+
+
+# ─── Encoding ────────────────────────────────────────────────────────────────
+
+
+def encode_mp4(frames_dir: Path, out_path: Path, framerate: int) -> None:
+    """Run ffmpeg to glob all frames in frames_dir into a web-friendly MP4."""
+    # frames are named frame_NNNN.<ext>; glob input keeps ffmpeg flexible on extension
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-framerate",
+        str(framerate),
+        "-pattern_type",
+        "glob",
+        "-i",
+        str(frames_dir / "frame_*"),
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        # libx264 needs even dimensions; scale to nearest-even width keeping aspect
+        "-vf",
+        "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+        str(out_path),
+    ]
+    logger.debug("ffmpeg: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg failed (rc={result.returncode}): {result.stderr[-500:]}"
+        )
+
+
+def probe_duration_seconds(path: Path) -> int:
+    """Use ffprobe to read duration in seconds (rounded)."""
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(path),
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip()
+    try:
+        return int(round(float(out)))
+    except ValueError:
+        return 0
+
+
+# ─── Orchestration ───────────────────────────────────────────────────────────
+
+
+def render_one(
+    cfg: Config,
+    conn: psycopg.Connection,
+    client: httpx.Client,
+    job: PlateJob,
+    force: bool,
+    dry_run: bool,
+) -> None:
+    target_path = f"{job.experiment_id}/{job.plate_id}.mp4"
+
+    existing = existing_video_row(conn, job.experiment_id, job.plate_id)
+    if existing and existing["frame_count"] == len(job.frame_paths) and not force:
+        logger.info(
+            "  skip — gravi_plate_videos already at %d frames; use --force to redo",
+            existing["frame_count"],
+        )
+        return
+    if dry_run:
+        logger.info(
+            "  DRY-RUN would render %d frames → %s/%s",
+            len(job.frame_paths),
+            cfg.target_bucket,
+            target_path,
+        )
+        return
+
+    with tempfile.TemporaryDirectory(prefix="gravi-render-") as tmp:
+        tmp_dir = Path(tmp)
+        frames_dir = tmp_dir / "frames"
+        frames_dir.mkdir()
+        out_path = tmp_dir / "out.mp4"
+
+        # 1. Download frames in order
+        for idx, object_path in enumerate(job.frame_paths):
+            suffix = Path(object_path).suffix or ".tif"
+            local = frames_dir / f"frame_{idx:04d}{suffix}"
+            logger.debug("  download %s → %s", object_path, local.name)
+            download_frame(client, cfg.source_bucket, object_path, local)
+
+        # 2. Encode MP4
+        logger.info(
+            "  encode %d frames @ %d fps → %s",
+            len(job.frame_paths),
+            cfg.framerate,
+            out_path.name,
+        )
+        encode_mp4(frames_dir, out_path, cfg.framerate)
+
+        # 3. Upload
+        logger.info(
+            "  upload → %s/%s (%.1f MiB)",
+            cfg.target_bucket,
+            target_path,
+            out_path.stat().st_size / (1024 * 1024),
+        )
+        upload_video(
+            client,
+            cfg.target_bucket,
+            target_path,
+            out_path,
+            overwrite=bool(existing),
+        )
+
+        # 4. Upsert DB row
+        upsert_video_row(
+            conn,
+            experiment_id=job.experiment_id,
+            plate_id=job.plate_id,
+            session_id=job.session_id,
+            object_path=target_path,
+            duration_seconds=probe_duration_seconds(out_path),
+            frame_count=len(job.frame_paths),
+            file_size_bytes=out_path.stat().st_size,
+        )
+        conn.commit()
+        logger.info("  ✓ committed gravi_plate_videos row")
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--experiment", type=int, required=True, help="gravi_experiments.id")
+    ap.add_argument("--plate", type=str, default=None, help="optional plate_id filter")
+    ap.add_argument("--framerate", type=int, default=4, help="output fps (default 4)")
+    ap.add_argument(
+        "--force", action="store_true", help="re-render even if row already matches"
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="list jobs without writing"
+    )
+    ap.add_argument(
+        "--env-file",
+        type=Path,
+        default=Path(__file__).with_name(".env.render-plate-videos"),
+        help="env file with SUPABASE_URL / SERVICE_ROLE_KEY / POSTGRES_DSN",
+    )
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if args.env_file.exists():
+        load_dotenv(args.env_file)
+
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        logger.error("ffmpeg/ffprobe not on PATH — install ffmpeg first")
+        return 2
+
+    cfg = Config.from_env(framerate=args.framerate)
+
+    failures: list[str] = []
+    with psycopg.connect(cfg.postgres_dsn) as conn, storage_client(cfg) as client:
+        jobs = list_plate_jobs(conn, args.experiment, args.plate)
+        logger.info("Found %d plate(s) to consider for experiment %d", len(jobs), args.experiment)
+        for job in jobs:
+            logger.info(
+                "[%s] %d frames%s",
+                job.plate_id,
+                len(job.frame_paths),
+                " (DRY-RUN)" if args.dry_run else "",
+            )
+            try:
+                render_one(cfg, conn, client, job, force=args.force, dry_run=args.dry_run)
+            except Exception as e:  # noqa: BLE001 — keep going on a single-plate failure
+                logger.error("[%s] FAILED: %s", job.plate_id, e)
+                conn.rollback()
+                failures.append(job.plate_id)
+
+    if failures:
+        logger.error("%d plate(s) failed: %s", len(failures), ", ".join(failures))
+        return 1
+    logger.info("done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/web/components/recent-phenotypes-by-plate-scanner/PlateImage.tsx
+++ b/web/components/recent-phenotypes-by-plate-scanner/PlateImage.tsx
@@ -9,41 +9,26 @@ interface PlateImageProps {
   className?: string;
 }
 
-// Plate-scanner objects live under the storage-api backend bucket at
-//   bloom-storage/storage-single-tenant/graviscan-images/<gravi_images.object_path>
-// so the front-end reads directly from `bloom-storage` and prepends the
-// tenant + logical-bucket prefix to the object_path from postgres
-// (which already starts with `gravi-images/<filename>.tif`).
+// Plate-scanner objects live in the `graviscan-images` logical bucket;
+// `gravi_images.object_path` already stores the path inside that bucket
+// (e.g. `gravi-images/<filename>.tif`). Storage-api handles the tenant +
+// backend-bucket translation internally — the front-end only owns the
+// logical bucket name.
 //
-// Scanner uploads are TIFF; browsers can't render TIFF natively, so both
-// views go through the image transformer (imgproxy + libvips) with
-// `format: "jpg"` to re-encode on the fly. `format` accepts jpg/png/webp
-// on self-hosted even though supabase-js's type only declares "origin";
-// cast around the incomplete type.
+// Scanner uploads are TIFF; the browser can't decode TIFF natively. We
+// rely on the transform layer (imgproxy / libvips) auto-converting to a
+// web-renderable format based on the Accept header. The `format` field
+// on the transform options is restricted by the staging storage-api
+// version, so we leave it off and let the transformer pick.
 
-const BACKEND_BUCKET = "bloom-storage";
-const STORAGE_PREFIX = "storage-single-tenant/graviscan-images";
-
-function backendPath(objectPath: string): string {
-  return `${STORAGE_PREFIX}/${objectPath}`;
-}
-
-type TransformOpts = {
-  width?: number;
-  height?: number;
-  quality?: number;
-  format?: "origin" | "jpg" | "png" | "webp";
-};
+const STORAGE_BUCKET = "graviscan-images";
 
 async function getThumbUrl(path: string): Promise<string> {
   const supabase = createClientSupabaseClient();
   const { data } = await supabase.storage
-    .from(BACKEND_BUCKET)
-    .createSignedUrl(backendPath(path), 3600, {
-      transform: { width: 480, quality: 80, format: "jpg" } as TransformOpts as {
-        width: number;
-        quality: number;
-      },
+    .from(STORAGE_BUCKET)
+    .createSignedUrl(path, 3600, {
+      transform: { width: 480, quality: 80 },
     });
   return data?.signedUrl ?? "";
 }
@@ -51,12 +36,9 @@ async function getThumbUrl(path: string): Promise<string> {
 async function getFullUrl(path: string): Promise<string> {
   const supabase = createClientSupabaseClient();
   const { data } = await supabase.storage
-    .from(BACKEND_BUCKET)
-    .createSignedUrl(backendPath(path), 3600, {
-      transform: { width: 2400, quality: 85, format: "jpg" } as TransformOpts as {
-        width: number;
-        quality: number;
-      },
+    .from(STORAGE_BUCKET)
+    .createSignedUrl(path, 3600, {
+      transform: { width: 2400, quality: 85 },
     });
   return data?.signedUrl ?? "";
 }

--- a/web/components/recent-phenotypes-by-plate-scanner/PlateVideo.tsx
+++ b/web/components/recent-phenotypes-by-plate-scanner/PlateVideo.tsx
@@ -49,7 +49,7 @@ export function PlateVideo({ objectPath }: PlateVideoProps) {
 
   if (state.status === "loading") {
     return (
-      <div className="flex aspect-[3/1] w-full animate-pulse items-center justify-center rounded-md border border-stone-200 bg-stone-100 text-sm text-stone-400">
+      <div className="flex aspect-[5/7] w-full animate-pulse items-center justify-center rounded-md border border-stone-200 bg-stone-100 text-sm text-stone-400">
         loading…
       </div>
     );
@@ -57,7 +57,7 @@ export function PlateVideo({ objectPath }: PlateVideoProps) {
 
   if (state.status === "missing") {
     return (
-      <div className="flex aspect-[3/1] w-full items-center justify-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-stone-400">
+      <div className="flex aspect-[5/7] w-full items-center justify-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-stone-400">
         No time-lapse video available for this plate yet.
       </div>
     );
@@ -67,7 +67,7 @@ export function PlateVideo({ objectPath }: PlateVideoProps) {
     <video
       controls
       preload="metadata"
-      className="aspect-[3/1] w-full rounded-md border border-stone-200 bg-black object-cover"
+      className="aspect-[5/7] w-full rounded-md border border-stone-200 bg-black object-cover"
       onError={() => setState({ status: "missing" })}
     >
       <source src={state.url} type="video/mp4" />

--- a/web/components/recent-phenotypes-by-plate-scanner/PlateVideo.tsx
+++ b/web/components/recent-phenotypes-by-plate-scanner/PlateVideo.tsx
@@ -49,7 +49,7 @@ export function PlateVideo({ objectPath }: PlateVideoProps) {
 
   if (state.status === "loading") {
     return (
-      <div className="flex aspect-[5/7] w-full animate-pulse items-center justify-center rounded-md border border-stone-200 bg-stone-100 text-sm text-stone-400">
+      <div className="flex h-[60vh] aspect-[5/7] mx-auto animate-pulse items-center justify-center rounded-md border border-stone-200 bg-stone-100 text-sm text-stone-400">
         loading…
       </div>
     );
@@ -57,7 +57,7 @@ export function PlateVideo({ objectPath }: PlateVideoProps) {
 
   if (state.status === "missing") {
     return (
-      <div className="flex aspect-[5/7] w-full items-center justify-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-stone-400">
+      <div className="flex h-[60vh] aspect-[5/7] mx-auto items-center justify-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-stone-400">
         No time-lapse video available for this plate yet.
       </div>
     );
@@ -67,7 +67,7 @@ export function PlateVideo({ objectPath }: PlateVideoProps) {
     <video
       controls
       preload="metadata"
-      className="aspect-[5/7] w-full rounded-md border border-stone-200 bg-black object-cover"
+      className="h-[60vh] aspect-[5/7] mx-auto rounded-md border border-stone-200 bg-black object-cover"
       onError={() => setState({ status: "missing" })}
     >
       <source src={state.url} type="video/mp4" />


### PR DESCRIPTION

Two related changes that finally get plate-scan rendering working on staging end-to-end.

## 1. PR #266 — change the  bucket + unsupported transform option

PR #266 made the front-end mimic the on-disk MinIO layout instead of talking to storage-api the way storage-api expects:

- Used `.from("bloom-storage")` — `bloom-storage` is the storage-api backend bucket on disk, not a registered logical bucket. The actual logical bucket is `graviscan-images` Storage-api handles the tenant + backend path translation internally.


## 2. Add `scripts/render_plate_videos.py` — time-lapse MP4 backfill

Standalone backfill that reads `gravi_scans` + `gravi_images` for an experiment, downloads frames in capture-date order, encodes a portrait MP4 with ffmpeg, uploads to the `graviscan-videos` bucket at `{experiment_id}/{plate_id}.mp4`, and upserts a row into `gravi_plate_videos` so the per-plate page can render it.

## 3. PlateVideo.tsx layout updates

After confirming the video pipeline end-to-end on staging:

- Plate TIFFs are portrait (≈5:7).
- Cap the player height at `60vh` so the portrait video doesn't push the rest of the page below the fold on wide monitors.

## Follow-ups

- The script should be wired into a scheduled job once we're sure about cadence. Manual run is fine for now.
- Real plant-scan data will replace the staging checkerboard test pattern once a non-`Test_Uploads` experiment runs.
