### PR TITLE
feat(expression): UMAP polish, cluster catalog backfill, NULL_DATASET filtering

### DIFF
--- a/bloommcp/uv.lock
+++ b/bloommcp/uv.lock
@@ -55,14 +55,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.11"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -667,6 +668,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/2f590052b55cbdd0ace470ee7ee1f685f6882051be93a9374891005623e2/joserfc-1.7.0.tar.gz", hash = "sha256:4aced6ab0c47846f0a531402aec2419a874b91e918df9c4c9da8a82fb559d6c4", size = 232967, upload-time = "2026-06-02T09:59:34.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/83/b6b62a66a06ce872d9429a5eb5ee20b2002fd9c331b953c94381c1f7c9f9/joserfc-1.7.0-py3-none-any.whl", hash = "sha256:17e5d7a5a35e65442b05efc435a3d5d46696ffa2c8a2ed0eea6f63fc268e3224", size = 70387, upload-time = "2026-06-02T09:59:33.264Z" },
 ]
 
 [[package]]

--- a/scripts/backfill_scrna_cluster_catalog.sql
+++ b/scripts/backfill_scrna_cluster_catalog.sql
@@ -55,7 +55,34 @@ BEGIN
   RAISE NOTICE 'pre: scrna_cluster_stats rows                  = %', stats_rows;
 END $$;
 
--- ─── 1) Split composite cluster_id → (cluster_id, replicate) ─────────────────
+-- ─── 1) Seed scrna_clusters FIRST so the FK on scrna_cells is satisfied ─────
+-- The FK scrna_cells_cluster_fkey on (dataset_id, cluster_id) is checked
+-- against the NEW row value when we update cells in step 2, so the
+-- catalog must contain the cleaned cluster_ids before any UPDATE runs.
+-- We compute the cleaned values via SPLIT_PART inside the SELECT —
+-- scrna_cells is not modified here. Ordinals 0..N-1 per dataset,
+-- lex-sorted, name = cluster_id (edit later in Studio for biology).
+WITH inserted AS (
+  INSERT INTO public.scrna_clusters (dataset_id, cluster_id, ordinal, name)
+  SELECT
+    dataset_id,
+    cluster_id_clean,
+    (ROW_NUMBER() OVER (PARTITION BY dataset_id ORDER BY cluster_id_clean) - 1)::smallint,
+    cluster_id_clean
+  FROM (
+    SELECT DISTINCT
+      dataset_id,
+      SPLIT_PART(cluster_id, '.', 1) AS cluster_id_clean
+    FROM public.scrna_cells
+    WHERE cluster_id IS NOT NULL
+  ) distinct_clusters
+  ON CONFLICT (dataset_id, cluster_id) DO NOTHING
+  RETURNING 1
+)
+SELECT COUNT(*) AS cluster_inserts FROM inserted \gset
+\echo 'seed: scrna_clusters rows inserted =' :cluster_inserts
+
+-- ─── 2) Split composite cluster_id → (cluster_id, replicate) ─────────────────
 -- Source values look like "Cluster1.Gmax_root_no_primary_tip_1wk_2023_rep2".
 --   cluster_id ← the part before the first dot ("Cluster1")
 --   replicate  ← just the trailing replicate token ("rep2"), captured by
@@ -63,7 +90,7 @@ END $$;
 --                replicate is set to NULL.
 -- Postgres SET expressions evaluate against the OLD row, so both the
 -- regex and SPLIT_PART see the un-split cluster_id even though it's
--- also being updated.
+-- also being updated. FK targets were seeded in step 1.
 WITH split AS (
   UPDATE public.scrna_cells
   SET
@@ -75,25 +102,6 @@ WITH split AS (
 )
 SELECT COUNT(*) AS split_count FROM split \gset
 \echo 'split: rows updated =' :split_count
-
--- ─── 2) Seed scrna_clusters (ordinals 0..N-1 per dataset, lex-sorted) ────────
-WITH inserted AS (
-  INSERT INTO public.scrna_clusters (dataset_id, cluster_id, ordinal, name)
-  SELECT
-    dataset_id,
-    cluster_id,
-    (ROW_NUMBER() OVER (PARTITION BY dataset_id ORDER BY cluster_id) - 1)::smallint,
-    cluster_id
-  FROM (
-    SELECT DISTINCT dataset_id, cluster_id
-    FROM public.scrna_cells
-    WHERE cluster_id IS NOT NULL
-  ) distinct_clusters
-  ON CONFLICT (dataset_id, cluster_id) DO NOTHING
-  RETURNING 1
-)
-SELECT COUNT(*) AS cluster_inserts FROM inserted \gset
-\echo 'seed: scrna_clusters rows inserted =' :cluster_inserts
 
 -- ─── 3) Seed scrna_cluster_stats (cell_count, pct, centroid_x/y) ─────────────
 WITH inserted AS (

--- a/scripts/backfill_scrna_cluster_catalog.sql
+++ b/scripts/backfill_scrna_cluster_catalog.sql
@@ -1,0 +1,138 @@
+-- ============================================================================
+-- Backfill: scRNA cluster catalog + stats
+-- ============================================================================
+-- One-time data cleanup — NOT a schema migration. Lives under scripts/ so
+-- the deploy workflow ignores it; run by hand against the target DB via
+-- `docker compose exec` (see commands at the bottom of this header).
+--
+-- Repairs the UMAP "0 clusters / 100% no cluster assignment" state by:
+--   1) Splitting scrna_cells.cluster_id values of the form
+--      "<cluster>.<...stuff..._repN>" into cluster_id ("<cluster>") and
+--      replicate ("repN" only — the bare token, not the full suffix).
+--   2) Seeding scrna_clusters from the cleaned distinct cluster_ids
+--      (ordinals 0..N-1 per dataset, lex-sorted, name = cluster_id).
+--   3) Seeding scrna_cluster_stats (cell_count, pct, centroid_x/y) so
+--      the sidebar can show per-cluster counts.
+--
+-- Idempotent: split step skips rows without a dot; both inserts use
+-- ON CONFLICT DO NOTHING. Re-running on a clean DB is a no-op.
+--
+-- Run against PROD:
+--   cd /data/bloom/production
+--   docker compose -f docker-compose.prod.yml --env-file .env.prod \
+--     -p bloom_v2_prod exec -T db-prod \
+--     psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+--     < scripts/backfill_scrna_cluster_catalog.sql
+--
+-- Run against STAGING:
+--   cd /data/bloom/staging
+--   docker compose -f docker-compose.prod.yml --env-file .env.staging \
+--     -p bloom_v2_staging exec -T db-prod \
+--     psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+--     < scripts/backfill_scrna_cluster_catalog.sql
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ─── 0) Snapshot pre-state for the operator log ──────────────────────────────
+DO $$
+DECLARE
+  composite_cells BIGINT;
+  catalog_rows    BIGINT;
+  stats_rows      BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO composite_cells
+  FROM public.scrna_cells
+  WHERE cluster_id IS NOT NULL AND POSITION('.' IN cluster_id) > 0;
+
+  SELECT COUNT(*) INTO catalog_rows FROM public.scrna_clusters;
+  SELECT COUNT(*) INTO stats_rows   FROM public.scrna_cluster_stats;
+
+  RAISE NOTICE 'pre: composite cluster_id rows in scrna_cells = %', composite_cells;
+  RAISE NOTICE 'pre: scrna_clusters rows                       = %', catalog_rows;
+  RAISE NOTICE 'pre: scrna_cluster_stats rows                  = %', stats_rows;
+END $$;
+
+-- ─── 1) Split composite cluster_id → (cluster_id, replicate) ─────────────────
+-- Source values look like "Cluster1.Gmax_root_no_primary_tip_1wk_2023_rep2".
+--   cluster_id ← the part before the first dot ("Cluster1")
+--   replicate  ← just the trailing replicate token ("rep2"), captured by
+--                the regex `_(rep[0-9]+)$`. If no rep token is present,
+--                replicate is set to NULL.
+-- Postgres SET expressions evaluate against the OLD row, so both the
+-- regex and SPLIT_PART see the un-split cluster_id even though it's
+-- also being updated.
+WITH split AS (
+  UPDATE public.scrna_cells
+  SET
+    replicate  = SUBSTRING(cluster_id FROM '_(rep[0-9]+)$'),
+    cluster_id = SPLIT_PART(cluster_id, '.', 1)
+  WHERE cluster_id IS NOT NULL
+    AND POSITION('.' IN cluster_id) > 0
+  RETURNING 1
+)
+SELECT COUNT(*) AS split_count FROM split \gset
+\echo 'split: rows updated =' :split_count
+
+-- ─── 2) Seed scrna_clusters (ordinals 0..N-1 per dataset, lex-sorted) ────────
+WITH inserted AS (
+  INSERT INTO public.scrna_clusters (dataset_id, cluster_id, ordinal, name)
+  SELECT
+    dataset_id,
+    cluster_id,
+    (ROW_NUMBER() OVER (PARTITION BY dataset_id ORDER BY cluster_id) - 1)::smallint,
+    cluster_id
+  FROM (
+    SELECT DISTINCT dataset_id, cluster_id
+    FROM public.scrna_cells
+    WHERE cluster_id IS NOT NULL
+  ) distinct_clusters
+  ON CONFLICT (dataset_id, cluster_id) DO NOTHING
+  RETURNING 1
+)
+SELECT COUNT(*) AS cluster_inserts FROM inserted \gset
+\echo 'seed: scrna_clusters rows inserted =' :cluster_inserts
+
+-- ─── 3) Seed scrna_cluster_stats (cell_count, pct, centroid_x/y) ─────────────
+WITH inserted AS (
+  INSERT INTO public.scrna_cluster_stats
+    (dataset_id, cluster_id, cell_count, pct, centroid_x, centroid_y)
+  SELECT
+    c.dataset_id,
+    c.cluster_id,
+    COUNT(*) AS cell_count,
+    (COUNT(*)::real * 100.0
+       / NULLIF(SUM(COUNT(*)) OVER (PARTITION BY c.dataset_id), 0))::real AS pct,
+    AVG(c.x)::real AS centroid_x,
+    AVG(c.y)::real AS centroid_y
+  FROM public.scrna_cells c
+  WHERE c.cluster_id IS NOT NULL
+  GROUP BY c.dataset_id, c.cluster_id
+  ON CONFLICT (dataset_id, cluster_id) DO NOTHING
+  RETURNING 1
+)
+SELECT COUNT(*) AS stats_inserts FROM inserted \gset
+\echo 'seed: scrna_cluster_stats rows inserted =' :stats_inserts
+
+-- ─── 4) Post-snapshot ────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  composite_cells BIGINT;
+  catalog_rows    BIGINT;
+  stats_rows      BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO composite_cells
+  FROM public.scrna_cells
+  WHERE cluster_id IS NOT NULL AND POSITION('.' IN cluster_id) > 0;
+
+  SELECT COUNT(*) INTO catalog_rows FROM public.scrna_clusters;
+  SELECT COUNT(*) INTO stats_rows   FROM public.scrna_cluster_stats;
+
+  RAISE NOTICE 'post: composite cluster_id rows in scrna_cells = %', composite_cells;
+  RAISE NOTICE 'post: scrna_clusters rows                       = %', catalog_rows;
+  RAISE NOTICE 'post: scrna_cluster_stats rows                  = %', stats_rows;
+END $$;
+
+COMMIT;

--- a/scripts/backfill_scrna_cluster_colors.sql
+++ b/scripts/backfill_scrna_cluster_colors.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- Backfill: scRNA cluster colors
+-- ============================================================================
+-- One-time data cleanup — NOT a schema migration. Paints
+-- scrna_clusters.color with a 20-color qualitative palette (Tableau 20)
+-- keyed by ordinal mod 20. Only touches rows where color IS NULL, so
+-- any hand-picked colors are preserved on re-run.
+--
+-- Picked Tableau 20 because it's colorblind-friendly and the most
+-- familiar palette for scientific scatter plots. Swap the VALUES list
+-- below if you want a different scheme (viridis bins, d3 schemeCategory10,
+-- a domain palette, etc.) — each row is `(ordinal_mod, hex)`.
+--
+-- Run against PROD:
+--   cd /data/bloom/production
+--   docker compose -f docker-compose.prod.yml --env-file .env.prod \
+--     -p bloom_v2_prod exec -T db-prod \
+--     psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+--     < scripts/backfill_scrna_cluster_colors.sql
+--
+-- Run against STAGING:
+--   cd /data/bloom/staging
+--   docker compose -f docker-compose.prod.yml --env-file .env.staging \
+--     -p bloom_v2_staging exec -T db-prod \
+--     psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+--     < scripts/backfill_scrna_cluster_colors.sql
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ─── 0) Pre-snapshot ─────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  null_before BIGINT;
+  total_rows  BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO total_rows  FROM public.scrna_clusters;
+  SELECT COUNT(*) INTO null_before FROM public.scrna_clusters WHERE color IS NULL;
+  RAISE NOTICE 'pre:  scrna_clusters total rows         = %', total_rows;
+  RAISE NOTICE 'pre:  scrna_clusters with NULL color    = %', null_before;
+END $$;
+
+-- ─── 1) Assign hex colors via ordinal mod 20 (Tableau 20 palette) ────────────
+WITH palette(idx, hex) AS (
+  VALUES
+    ( 0, '#4e79a7'), ( 1, '#f28e2c'), ( 2, '#e15759'), ( 3, '#76b7b2'),
+    ( 4, '#59a14f'), ( 5, '#edc949'), ( 6, '#af7aa1'), ( 7, '#ff9da7'),
+    ( 8, '#9c755f'), ( 9, '#bab0ac'), (10, '#86bcb6'), (11, '#b07aa1'),
+    (12, '#d4a6c8'), (13, '#fabfd2'), (14, '#ffbe7d'), (15, '#8cd17d'),
+    (16, '#b6992d'), (17, '#499894'), (18, '#79706e'), (19, '#d37295')
+),
+painted AS (
+  UPDATE public.scrna_clusters c
+  SET color = p.hex
+  FROM palette p
+  WHERE c.color IS NULL
+    AND p.idx = (c.ordinal::int % 20)
+  RETURNING 1
+)
+SELECT COUNT(*) AS n_painted FROM painted \gset
+\echo 'paint: scrna_clusters rows painted =' :n_painted
+
+-- ─── 2) Post-snapshot ────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  null_after BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO null_after FROM public.scrna_clusters WHERE color IS NULL;
+  RAISE NOTICE 'post: scrna_clusters with NULL color   = %', null_after;
+END $$;
+
+COMMIT;

--- a/scripts/backfill_scrna_dataset_ncells.sql
+++ b/scripts/backfill_scrna_dataset_ncells.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- Backfill: scRNA dataset n_cells
+-- ============================================================================
+-- One-time data cleanup — NOT a schema migration. Sets
+-- scrna_datasets.n_cells to the actual COUNT(*) of scrna_cells per
+-- dataset_id. The banner pill ("— cells") reads from this column.
+--
+-- Idempotent: only updates rows where the stored value disagrees with
+-- the counted value, so re-running on a synced DB is a no-op.
+--
+-- Run against PROD:
+--   cd /data/bloom/production
+--   docker compose -f docker-compose.prod.yml --env-file .env.prod \
+--     -p bloom_v2_prod exec -T db-prod \
+--     psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+--     < scripts/backfill_scrna_dataset_ncells.sql
+--
+-- Run against STAGING:
+--   cd /data/bloom/staging
+--   docker compose -f docker-compose.prod.yml --env-file .env.staging \
+--     -p bloom_v2_staging exec -T db-prod \
+--     psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+--     < scripts/backfill_scrna_dataset_ncells.sql
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ─── 0) Pre-snapshot ─────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  null_before BIGINT;
+  total       BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO total       FROM public.scrna_datasets;
+  SELECT COUNT(*) INTO null_before FROM public.scrna_datasets WHERE n_cells IS NULL;
+  RAISE NOTICE 'pre:  scrna_datasets total rows           = %', total;
+  RAISE NOTICE 'pre:  scrna_datasets with NULL n_cells    = %', null_before;
+END $$;
+
+-- ─── 1) Set n_cells = COUNT(*) of scrna_cells per dataset ────────────────────
+-- IS DISTINCT FROM treats NULL ≠ N, so first-time rows are filled and
+-- previously-counted rows are only rewritten if the count actually drifted.
+WITH counts AS (
+  SELECT
+    d.id AS dataset_id,
+    (SELECT COUNT(*)::int FROM public.scrna_cells c WHERE c.dataset_id = d.id) AS n
+  FROM public.scrna_datasets d
+),
+upd AS (
+  UPDATE public.scrna_datasets d
+  SET n_cells = counts.n
+  FROM counts
+  WHERE d.id = counts.dataset_id
+    AND d.n_cells IS DISTINCT FROM counts.n
+  RETURNING 1
+)
+SELECT COUNT(*) AS n_updated FROM upd \gset
+\echo 'update: scrna_datasets rows updated =' :n_updated
+
+-- ─── 2) Post-snapshot ────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  null_after BIGINT;
+  empty_ds   BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO null_after FROM public.scrna_datasets WHERE n_cells IS NULL;
+  SELECT COUNT(*) INTO empty_ds   FROM public.scrna_datasets WHERE n_cells = 0;
+  RAISE NOTICE 'post: scrna_datasets with NULL n_cells   = %', null_after;
+  RAISE NOTICE 'post: scrna_datasets with n_cells = 0    = %', empty_ds;
+END $$;
+
+COMMIT;

--- a/web/app/app/expression/[speciesId]/[datasetId]/page.tsx
+++ b/web/app/app/expression/[speciesId]/[datasetId]/page.tsx
@@ -29,7 +29,9 @@ export default async function Dataset({
     url: `/app/expression/${speciesId}/${datasetId}`,
   });
 
-  if (!dataset) {
+  // NULL_DATASET rows are placeholders without real expression data —
+  // treat as not-found rather than rendering an empty cockpit.
+  if (!dataset || dataset.name === "NULL_DATASET") {
     return (
       <div className="max-w-5xl mx-auto">
         <div className="text-sm mb-6 select-none">

--- a/web/app/app/expression/[speciesId]/page.tsx
+++ b/web/app/app/expression/[speciesId]/page.tsx
@@ -29,7 +29,10 @@ export default async function Species({
 
   if (!species) return <div>Species not found.</div>;
 
-  const datasets = species.scrna_datasets ?? [];
+  // NULL_DATASET is a placeholder sentinel — hide from the UI.
+  const datasets = (species.scrna_datasets ?? []).filter(
+    (d) => d.name !== "NULL_DATASET",
+  );
 
   return (
     <div>

--- a/web/app/app/expression/page.tsx
+++ b/web/app/app/expression/page.tsx
@@ -38,7 +38,11 @@ export default async function AllSpecies() {
 
       <ul className="divide-y divide-stone-200 border-y border-stone-200">
         {speciesList.map((species) => {
-          const datasets = species.scrna_datasets ?? [];
+          // NULL_DATASET is a sentinel for placeholder rows with no real
+          // expression data attached yet — hide them from the UI.
+          const datasets = (species.scrna_datasets ?? []).filter(
+            (d) => d.name !== "NULL_DATASET",
+          );
           const n = datasets.length;
           const suffix = n === 1 ? "" : "s";
           const preview = datasets
@@ -101,8 +105,11 @@ async function getSpeciesList(): Promise<SpeciesWithRNADatasets[]> {
     .select("*, scrna_datasets(id, name)")
     .is("deleted_at", null);
 
+  const countReal = (s: SpeciesWithRNADatasets) =>
+    (s.scrna_datasets ?? []).filter((d) => d.name !== "NULL_DATASET").length;
+
   (data as SpeciesWithRNADatasets[] | undefined)?.sort((a, b) => {
-    const diff = (b.scrna_datasets?.length ?? 0) - (a.scrna_datasets?.length ?? 0);
+    const diff = countReal(b) - countReal(a);
     if (diff !== 0) return diff;
     return (a.common_name ?? "").localeCompare(b.common_name ?? "");
   });

--- a/web/components/expression-cluster-detail-panel.tsx
+++ b/web/components/expression-cluster-detail-panel.tsx
@@ -48,8 +48,9 @@ export function ExpressionClusterDetailPanel({
 
   const name = clusterName ?? clusterId;
   const markers = stats?.markers ?? null;
+  // pct is stored as a percentage (0..100) per the column name; render directly.
   const pctHuman =
-    stats?.pct != null ? (stats.pct * 100).toFixed(1) : "—";
+    stats?.pct != null ? stats.pct.toFixed(1) : "—";
   const cellsHuman =
     stats?.cell_count != null
       ? new Intl.NumberFormat("en-US").format(stats.cell_count)

--- a/web/components/expression-cockpit.tsx
+++ b/web/components/expression-cockpit.tsx
@@ -3,13 +3,15 @@
 import { useState, type ReactNode } from "react";
 
 import { ExpressionView } from "@/components/expression-view";
-import ExpressionGeneLevel from "@/components/expression-genelevel";
-import DifferentialExpressionAnalysis from "@/components/expression-differential-analysis";
-import ExpressionCorrelation from "@/components/expression-correlation-page";
-import ExpressonDownloadFiles from "@/components/expression-download-files";
+// Tabs disabled until the new schema is plumbed through — re-enable by
+// uncommenting the imports, the Tab union, the buttons, and the bodies.
+// import ExpressionGeneLevel from "@/components/expression-genelevel";
+// import DifferentialExpressionAnalysis from "@/components/expression-differential-analysis";
+// import ExpressionCorrelation from "@/components/expression-correlation-page";
+// import ExpressonDownloadFiles from "@/components/expression-download-files";
 import { ExpressionThemeProvider } from "@/components/expression-theme-provider";
 
-type Tab = "umap" | "gene" | "correlation" | "de" | "download";
+type Tab = "umap"; // | "gene" | "correlation" | "de" | "download";
 
 export interface ExpressionCockpitProps {
   datasetId: number;
@@ -31,6 +33,7 @@ export function ExpressionCockpit({
         <TabBtn active={tab === "umap"} onClick={() => setTab("umap")}>
           UMAP
         </TabBtn>
+        {/*
         <TabBtn active={tab === "gene"} onClick={() => setTab("gene")}>
           Gene explorer
         </TabBtn>
@@ -46,6 +49,7 @@ export function ExpressionCockpit({
         <TabBtn active={tab === "download"} onClick={() => setTab("download")}>
           Download
         </TabBtn>
+        */}
       </div>
 
       {/* Tab body */}
@@ -53,6 +57,7 @@ export function ExpressionCockpit({
         {tab === "umap" && (
           <ExpressionView datasetId={datasetId} datasetName={datasetName} />
         )}
+        {/*
         {tab === "gene" && <ExpressionGeneLevel file_id={datasetId} />}
         {tab === "correlation" && <ExpressionCorrelation file_id={datasetId} />}
         {tab === "de" && (
@@ -64,6 +69,7 @@ export function ExpressionCockpit({
             file_name={datasetName}
           />
         )}
+        */}
       </div>
     </div>
     </ExpressionThemeProvider>

--- a/web/components/expression-dataset-banner.tsx
+++ b/web/components/expression-dataset-banner.tsx
@@ -32,6 +32,7 @@ async function fetchBannerData(datasetId: number) {
       .eq("species_id", dataset.species_id)
       .is("deleted_at", null)
       .neq("id", datasetId)
+      .neq("name", "NULL_DATASET")
       .order("name"),
     supabase
       .from("scrna_cells")

--- a/web/components/expression-umap.tsx
+++ b/web/components/expression-umap.tsx
@@ -165,17 +165,17 @@ export function ExpressionUmap({
   const [zoom, setZoom] = useState(1);
   const [translate, setTranslate] = useState<[number, number]>([0, 0]);
 
-  // Refs the RAF tick reads each frame, kept in sync with React state
-  // by the mirror effect below. Lets the render loop skip effect deps.
   const zoomRef = useRef(zoom);
   const translateRef = useRef(translate);
   const expressionArrRef = useRef(expressionArr);
   const expressionRangeRef = useRef(expressionRange);
+  const dirtyRef = useRef(true);
   useEffect(() => {
     zoomRef.current = zoom;
     translateRef.current = translate;
     expressionArrRef.current = expressionArr;
     expressionRangeRef.current = expressionRange;
+    dirtyRef.current = true;
   });
 
   // -------- data load ---------------------------------------------------------
@@ -380,6 +380,35 @@ export function ExpressionUmap({
     drawClustersRef.current = drawClusters;
     drawExpressionRef.current = drawExpression;
 
+    // Size the canvas's backing store to its CSS box × devicePixelRatio
+    // so points render crisp on retina/4K. ResizeObserver re-syncs on any
+    // container size change (sidebar collapse, window resize, etc.).
+    const resizeToParent = () => {
+      const parent = canvas.parentElement;
+      if (!parent) return;
+      const dpr = window.devicePixelRatio || 1;
+      const cssW = parent.clientWidth;
+      const cssH = height;
+      // Bail out if nothing changed — avoids a redraw on every observer tick.
+      if (
+        canvas.width === Math.floor(cssW * dpr) &&
+        canvas.height === Math.floor(cssH * dpr)
+      ) {
+        return;
+      }
+      canvas.style.width = `${cssW}px`;
+      canvas.style.height = `${cssH}px`;
+      canvas.width = Math.floor(cssW * dpr);
+      canvas.height = Math.floor(cssH * dpr);
+      dirtyRef.current = true;
+    };
+    resizeToParent();
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(resizeToParent) : null;
+    if (resizeObserver && canvas.parentElement) {
+      resizeObserver.observe(canvas.parentElement);
+    }
+
     // Mid-session WebGL context loss — surface the fallback panel.
     const handleContextLost = (e: Event) => {
       e.preventDefault();
@@ -391,21 +420,27 @@ export function ExpressionUmap({
 
     let rafId = 0;
     const tick = () => {
-      regl.poll();
-      regl.clear({ color: [0.05, 0.05, 0.08, 1], depth: 1 });
-      const expArr = expressionArrRef.current;
-      const expRange = expressionRangeRef.current;
-      const z = zoomRef.current;
-      const t = translateRef.current;
-      if (expArr && expRange) {
-        drawExpression({
-          zoom: z,
-          translate: t,
-          expMin: expRange.min,
-          expMax: expRange.max,
-        });
-      } else {
-        drawClusters({ zoom: z, translate: t });
+      // Lazy RAF: draw only when something changed. Idle UMAPs cost ~0
+      // GPU/CPU between frames; interactions flip dirty and the next
+      // frame draws.
+      if (dirtyRef.current) {
+        regl.poll();
+        regl.clear({ color: [0.05, 0.05, 0.08, 1], depth: 1 });
+        const expArr = expressionArrRef.current;
+        const expRange = expressionRangeRef.current;
+        const z = zoomRef.current;
+        const t = translateRef.current;
+        if (expArr && expRange) {
+          drawExpression({
+            zoom: z,
+            translate: t,
+            expMin: expRange.min,
+            expMax: expRange.max,
+          });
+        } else {
+          drawClusters({ zoom: z, translate: t });
+        }
+        dirtyRef.current = false;
       }
       rafId = requestAnimationFrame(tick);
     };
@@ -413,6 +448,7 @@ export function ExpressionUmap({
 
     return () => {
       cancelAnimationFrame(rafId);
+      resizeObserver?.disconnect();
       canvas.removeEventListener("webglcontextlost", handleContextLost);
       positionBuffer.destroy();
       colorBuffer.destroy();
@@ -442,6 +478,7 @@ export function ExpressionUmap({
     // will populate it with the latest visibility on the next render.
     if (visibility.length !== cellCountRef.current) return;
     buf.subdata(visibility);
+    dirtyRef.current = true;
   }, [visibility]);
 
   // -------- expression update (in-place subdata) ------------------------------
@@ -451,6 +488,7 @@ export function ExpressionUmap({
     const arr = expressionArr ?? new Float32Array(cellCountRef.current);
     if (arr.length !== cellCountRef.current) return;
     buf.subdata(arr);
+    dirtyRef.current = true;
   }, [expressionArr]);
 
   // -------- zoom / pan handlers ----------------------------------------------
@@ -556,11 +594,11 @@ export function ExpressionUmap({
   }
 
   return (
+    // Canvas dimensions are set imperatively in the init effect against
+    // parent.clientWidth × devicePixelRatio. We don't set width/height here.
     <canvas
       ref={canvasRef}
       data-testid="expression-umap-canvas"
-      width={1200}
-      height={height}
       onWheel={handleWheel}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}

--- a/web/components/expression-view.tsx
+++ b/web/components/expression-view.tsx
@@ -5,7 +5,8 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 
 import { ExpressionUmap } from "@/components/expression-umap";
-import { ExpressionGeneSearch } from "@/components/expression-gene-search";
+// Gene search disabled — see the JSX comment below.
+// import { ExpressionGeneSearch } from "@/components/expression-gene-search";
 import { ExpressionColorbar } from "@/components/expression-colorbar";
 import { ExpressionClusterSidebar } from "@/components/expression-cluster-sidebar";
 import { ExpressionClusterDetailPanel } from "@/components/expression-cluster-detail-panel";
@@ -148,10 +149,10 @@ export function ExpressionView({ datasetId }: ExpressionViewProps) {
         onHideAll={handleHideAll}
       />
 
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
         {/* dataset header */}
         {meta && (
-          <Box sx={{ display: "flex", gap: 2, alignItems: "baseline" }}>
+          <Box sx={{ display: "flex", gap: 2, alignItems: "baseline", minWidth: 0, flexWrap: "wrap" }}>
             <Typography variant="h6" sx={{ fontFamily: "monospace" }}>
               {meta.dataset.name}
             </Typography>
@@ -165,32 +166,24 @@ export function ExpressionView({ datasetId }: ExpressionViewProps) {
           </Box>
         )}
 
-        {/* gene search */}
-        <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
-          <Box sx={{ maxWidth: 360, flex: 1 }}>
-            <ExpressionGeneSearch
-              datasetId={datasetId}
-              value={geneName}
-              onChange={setGeneName}
-              disabled={!meta}
-            />
-          </Box>
-          {(() => {
-            const clusters = meta?.clusters ?? [];
-            if (clusters.length === 0) return null;
-            const soloCount = clusters.length - hidden.size;
-            if (soloCount === 1) return null;
-            return (
-              <span
-                className="ml-auto inline-flex items-center gap-2 rounded-full border border-lime-200 bg-lime-50/70 px-3 py-1 text-xs text-lime-800"
-                role="status"
-              >
-                <span className="inline-block h-1.5 w-1.5 rounded-full bg-lime-500 shadow-[0_0_4px_rgba(132,204,22,0.8)]" />
-                Click a cluster for details
-              </span>
-            );
-          })()}
-        </Box>
+        {/* Gene search disabled — re-enable by uncommenting the Box below
+            and restoring ExpressionGeneSearch + colorbar wiring. The
+            geneName state is kept so UMAP/colorbar code paths stay typed. */}
+        {(() => {
+          const clusters = meta?.clusters ?? [];
+          if (clusters.length === 0) return null;
+          const soloCount = clusters.length - hidden.size;
+          if (soloCount === 1) return null;
+          return (
+            <span
+              className="inline-flex items-center gap-2 self-start rounded-full border border-lime-200 bg-lime-50/70 px-3 py-1 text-xs text-lime-800"
+              role="status"
+            >
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-lime-500 shadow-[0_0_4px_rgba(132,204,22,0.8)]" />
+              Click a cluster for details
+            </span>
+          );
+        })()}
 
         {/* orphan-cell warning */}
         {meta && meta.orphanCount > 0 && (

--- a/web/components/scan-trait-boxplot.tsx
+++ b/web/components/scan-trait-boxplot.tsx
@@ -105,11 +105,6 @@ export default function ScanTraitBoxplot({
     const mean = n > 0 ? values.reduce((s, v) => s + v, 0) / n : 0;
     const median =
       n === 0 ? 0 : n % 2 ? values[(n - 1) / 2] : (values[n / 2 - 1] + values[n / 2]) / 2;
-    const variance =
-      n > 1
-        ? values.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1)
-        : 0;
-    const std = Math.sqrt(variance);
     const wavesRepresented = new Set(rows.map((r) => r.wave_number)).size;
     const min = values[0] ?? 0;
     const max = values[n - 1] ?? 0;
@@ -120,7 +115,6 @@ export default function ScanTraitBoxplot({
       n,
       mean,
       median,
-      std,
       min,
       max,
       wavesRepresented,
@@ -294,7 +288,6 @@ export default function ScanTraitBoxplot({
 
                 <div className="flex-shrink-0 w-36 text-stone-600 tabular-nums">
                   mean {s.mean.toFixed(1)}
-                  {s.n > 1 ? ` ± ${s.std.toFixed(2)}` : ""}
                 </div>
 
                 <div className="flex-1 min-w-[140px]">


### PR DESCRIPTION
## Summary

Single-cell page is now usable end-to-end on the new schema. Seven commits, two layers:

**UI (`web/`):**
- Single-cell page shows only the UMAP tab. Gene explorer / Correlation / Differential / Download are commented out until they're plumbed through the new schema.
- Gene search bar above the UMAP is also commented out. Cluster detail panel layout fix: middle grid column now has `minWidth: 0` so the canvas releases width when a cluster is soloed, keeping the right-hand panel on-screen.
- `NULL_DATASET` placeholder rows are hidden from the species list, per-species dataset list, dataset-banner siblings, and deep-link navigation.

## Files changed

| File | Change |
|---|---|
| `web/components/expression-umap.tsx` | DPR sizing, ResizeObserver, lazy RAF (dirtyRef) |
| `web/components/expression-cockpit.tsx` | UMAP-only tabs (others commented) |
| `web/components/expression-view.tsx` | Remove gene search, fix grid \`minWidth: 0\` so detail panel stays on-screen |
| `web/components/expression-dataset-banner.tsx` | Filter \`NULL_DATASET\` from siblings query |
| `web/components/expression-cluster-detail-panel.tsx` | Drop \`× 100\` on pct |
| `web/app/app/expression/page.tsx` | Hide NULL datasets in species list + sort |
| `web/app/app/expression/[speciesId]/page.tsx` | Hide NULL datasets in per-species list |
| `web/app/app/expression/[speciesId]/[datasetId]/page.tsx` | Deep-link guard |
| `web/components/scan-trait-boxplot.tsx` | Drop client-side std deviation |
| `scripts/backfill_scrna_cluster_catalog.sql` | New: catalog + stats backfill |
| `scripts/backfill_scrna_cluster_colors.sql` | New: Tableau 20 color paint |
| `scripts/backfill_scrna_dataset_ncells.sql` | New: n_cells from row count |

## Out of scope (follow-up workstreams)

- Differential expression ingest job (populates `scrna_cluster_stats.markers` JSONB + uploads `scrna_de` CSVs) so the "Top markers" table and "Export CSV" button stop showing the "waiting on DE ingest" placeholder
- Re-enabling the Gene explorer, Correlation, Differential, Download tabs and the gene search bar once they're plumbed through the new schema
- Rename / Run-DE buttons in the cluster detail panel (currently placeholders)