### PR TITLE
fix(plate-phenotypes): natural plate sort + per-plate timepoint count + detail layout

### DIFF
--- a/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/[plateId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/[plateId]/page.tsx
@@ -130,9 +130,9 @@ export default async function PlateDetail({
 
       <div className="mb-8">
         <h2 className="mb-2 text-sm uppercase tracking-widest text-stone-500">
-          Growth time-lapse
+          Time points
         </h2>
-        <PlateVideo objectPath={video?.object_path ?? null} />
+        <PlateTimeSeries points={timePoints} />
       </div>
 
       {sections.length > 0 && (
@@ -171,9 +171,9 @@ export default async function PlateDetail({
 
       <div className="mb-8">
         <h2 className="mb-2 text-sm uppercase tracking-widest text-stone-500">
-          Time points
+          Growth time-lapse
         </h2>
-        <PlateTimeSeries points={timePoints} />
+        <PlateVideo objectPath={video?.object_path ?? null} />
       </div>
     </div>
   );

--- a/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/page.tsx
@@ -80,7 +80,12 @@ export default async function PlateExperiment({
   }
 
   const plates = groupByPlate(experiment.gravi_scans ?? []);
-  const totalTimepoints = experiment.gravi_scans?.length ?? 0;
+  // Per-plate timepoint count. Plates in the same experiment typically share
+  // a cadence, so showing the max is honest ("up to N"); falls back to 0 when
+  // there are no scans.
+  const perPlateTimepoints = plates.length
+    ? Math.max(...plates.map((p) => p.scans.length))
+    : 0;
 
   return (
     <div>
@@ -107,8 +112,8 @@ export default async function PlateExperiment({
         </div>
         <div className="mt-2 text-lg font-medium text-stone-700">
           {plates.length} plate{plates.length === 1 ? "" : "s"} ·{" "}
-          {totalTimepoints} time point{totalTimepoints === 1 ? "" : "s"} across
-          all plates
+          {perPlateTimepoints} time point
+          {perPlateTimepoints === 1 ? "" : "s"}
         </div>
       </div>
 
@@ -284,8 +289,20 @@ function groupByPlate(scans: ScanRow[]): PlateGroup[] {
     });
   }
 
-  groups.sort((a, b) => a.plate_id.localeCompare(b.plate_id));
+  // Natural sort: extract the trailing integer so Plate_2 < Plate_10.
+  // Lex tiebreak keeps order stable when plate_ids share the same suffix.
+  groups.sort((a, b) => {
+    const an = plateSortKey(a.plate_id);
+    const bn = plateSortKey(b.plate_id);
+    if (an !== bn) return an - bn;
+    return a.plate_id.localeCompare(b.plate_id);
+  });
   return groups;
+}
+
+function plateSortKey(plate_id: string): number {
+  const match = plate_id.match(/(\d+)$/);
+  return match ? parseInt(match[1], 10) : Number.POSITIVE_INFINITY;
 }
 
 async function getExperiment(

--- a/web/app/app/plate-phenotypes/[speciesId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/page.tsx
@@ -88,7 +88,10 @@ export default async function PlateSpecies({
           const duration = formatDuration(
             latest?.actual_duration_seconds ?? latest?.duration_seconds ?? null,
           );
-          const cycles = latest?.total_cycles ?? null;
+          // Per-plate timepoint count derived from gravi_scans, matching the
+          // experiment detail page (total_cycles from the session config can
+          // disagree with the recorded scan count by ±1).
+          const timepoints = perPlateTimepointCount(experiment.gravi_scans);
           const sessionCount = experiment.gravi_scan_sessions?.length ?? 0;
           const plateCount = uniquePlateCount(experiment.gravi_scans);
           const phenotypers = uniquePhenotyperNames(
@@ -96,10 +99,10 @@ export default async function PlateSpecies({
           );
 
           const timeSeries =
-            cycles !== null && duration
-              ? `${cycles} time point${cycles === 1 ? "" : "s"} collected over ${duration}`
-              : cycles !== null
-                ? `${cycles} time point${cycles === 1 ? "" : "s"}`
+            timepoints > 0 && duration
+              ? `${timepoints} time point${timepoints === 1 ? "" : "s"} collected over ${duration}`
+              : timepoints > 0
+                ? `${timepoints} time point${timepoints === 1 ? "" : "s"}`
                 : duration
                   ? `Collected over ${duration}`
                   : null;
@@ -241,6 +244,18 @@ function uniquePlateCount(scans: ScanRow[] | null | undefined): number {
     if (s.plate_id) set.add(s.plate_id);
   }
   return set.size;
+}
+
+function perPlateTimepointCount(
+  scans: ScanRow[] | null | undefined,
+): number {
+  if (!scans || scans.length === 0) return 0;
+  const counts = new Map<string, number>();
+  for (const s of scans) {
+    if (!s.plate_id) continue;
+    counts.set(s.plate_id, (counts.get(s.plate_id) ?? 0) + 1);
+  }
+  return counts.size === 0 ? 0 : Math.max(...counts.values());
 }
 
 function uniquePhenotyperNames(


### PR DESCRIPTION
## Summary

Four related plate-phenotypes UI fixes:

- **Plate list sort** — lex sort produced `Plate_1, Plate_10, Plate_11, …, Plate_2`. Sort by trailing integer.
- **Experiment header** — was summing every plate's scans (`1720 time points across all plates`). Show the per-plate max (`86 time points`) — that's the cadence users compare against.
- **Species page vs experiment page mismatch (85 vs 86)** — species page read `gravi_scan_sessions.total_cycles` (the scanner's *planned* cycle count); experiment page counted actual `gravi_scans` rows. Scanners record ±1 vs the plan. Both pages now use the same derivation (max per-plate scan count).
- **Plate detail layout** — Time points (plate image carousel) moves above the Growth time-lapse section. Sections stays between them.

## Files changed

| File | Change |
|---|---|
| `web/app/app/plate-phenotypes/[speciesId]/page.tsx` | Replace `total_cycles` source with per-plate scan count |
| `web/app/app/plate-phenotypes/[speciesId]/[experimentId]/page.tsx` | Natural plate sort + per-plate timepoint header |
| `web/app/app/plate-phenotypes/[speciesId]/[experimentId]/[plateId]/page.tsx` | Reorder: Time points → Sections → Time-lapse video |