### PR TITLE
feat(orthobrowser): Nolan  HPI OrthoBrowser

### DIFF
--- a/web/app/app/layout.tsx
+++ b/web/app/app/layout.tsx
@@ -35,7 +35,10 @@ const navSections = [
   },
   {
     heading: "Tools",
-    items: [{ name: "Bloom Assistant", href: "/chat" }],
+    items: [
+      { name: "Bloom Assistant", href: "/chat" },
+      { name: "OrthoBrowser", href: "/app/orthofinder" },
+    ],
   },
 ];
 

--- a/web/app/app/orthofinder/page.tsx
+++ b/web/app/app/orthofinder/page.tsx
@@ -1,0 +1,40 @@
+import { getUser } from "@/lib/supabase/server";
+import Mixpanel from "mixpanel";
+
+const ORTHOBROWSER_URL =
+  "https://resources.michael.salk.edu/misc/hpi_orthobrowser/index.html";
+
+export default async function OrthofinderPage() {
+  const user = await getUser();
+  const mixpanel = process.env.MIXPANEL_TOKEN
+    ? Mixpanel.init(process.env.MIXPANEL_TOKEN)
+    : null;
+  mixpanel?.track("Page view", {
+    distinct_id: user?.email,
+    url: "/app/orthofinder",
+  });
+
+  return (
+    <div className="w-full h-screen flex flex-col">
+      <div className="flex items-center justify-between px-4 py-2 bg-white rounded-lg border border-stone-200 mb-3 text-sm">
+        <span className="text-neutral-600">
+          Maintained by Nolan Hartwick{" "}
+          <span className="font-bold text-neutral-500">(Michael Lab)</span>
+        </span>
+        <a
+          href="mailto:nhartwick@salk.edu"
+          className="text-lime-700 hover:text-lime-800 hover:underline transition-colors"
+        >
+          nhartwick@salk.edu
+        </a>
+      </div>
+
+      <iframe
+        src={ORTHOBROWSER_URL}
+        className="w-full border-0 rounded-lg flex-grow"
+        title="HPI OrthoBrowser"
+        allowFullScreen
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds `/app/orthofinder` — a thin iframe of Nolan Hartwick's [HPI OrthoBrowser](https://resources.michael.salk.edu/misc/hpi_orthobrowser/index.html) with a "Maintained by Nolan Hartwick (Michael Lab)"

Adds a corresponding **OrthoBrowser** entry in the Tools section of the dashboard nav.

Extracted from PR #47 — pulls only the iframe mirror, **not** the EmbedTreeTab / embedding-phylogenomics work (that branch is 447 commits behind staging and would require its own rebase + ingest work). Once this lands, PR #47 can stays open as a  larger workstream or be closed after the EmbedTreeTab is merged to main.

## Files changed

| File | Change |
|---|---|
| `web/app/app/orthofinder/page.tsx` (new) | Server-component page with credit row + iframe |
| `web/app/app/layout.tsx` | Add OrthoBrowser entry under Tools |