### PR TITLE
Staging -> Prod

### DIFF
--- a/web/app/app/layout.tsx
+++ b/web/app/app/layout.tsx
@@ -35,7 +35,10 @@ const navSections = [
   },
   {
     heading: "Tools",
-    items: [{ name: "Bloom Assistant", href: "/chat" }],
+    items: [
+      { name: "Bloom Assistant", href: "/chat" },
+      { name: "OrthoBrowser", href: "/app/orthofinder" },
+    ],
   },
 ];
 

--- a/web/app/app/orthofinder/page.tsx
+++ b/web/app/app/orthofinder/page.tsx
@@ -1,0 +1,40 @@
+import { getUser } from "@/lib/supabase/server";
+import Mixpanel from "mixpanel";
+
+const ORTHOBROWSER_URL =
+  "https://resources.michael.salk.edu/misc/hpi_orthobrowser/index.html";
+
+export default async function OrthofinderPage() {
+  const user = await getUser();
+  const mixpanel = process.env.MIXPANEL_TOKEN
+    ? Mixpanel.init(process.env.MIXPANEL_TOKEN)
+    : null;
+  mixpanel?.track("Page view", {
+    distinct_id: user?.email,
+    url: "/app/orthofinder",
+  });
+
+  return (
+    <div className="w-full h-screen flex flex-col">
+      <div className="flex items-center justify-between px-4 py-2 bg-white rounded-lg border border-stone-200 mb-3 text-sm">
+        <span className="text-neutral-600">
+          Maintained by Nolan Hartwick{" "}
+          <span className="font-bold text-neutral-500">(Michael Lab)</span>
+        </span>
+        <a
+          href="mailto:nhartwick@salk.edu"
+          className="text-lime-700 hover:text-lime-800 hover:underline transition-colors"
+        >
+          nhartwick@salk.edu
+        </a>
+      </div>
+
+      <iframe
+        src={ORTHOBROWSER_URL}
+        className="w-full border-0 rounded-lg flex-grow"
+        title="HPI OrthoBrowser"
+        allowFullScreen
+      />
+    </div>
+  );
+}

--- a/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/[plateId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/[plateId]/page.tsx
@@ -130,9 +130,9 @@ export default async function PlateDetail({
 
       <div className="mb-8">
         <h2 className="mb-2 text-sm uppercase tracking-widest text-stone-500">
-          Growth time-lapse
+          Time points
         </h2>
-        <PlateVideo objectPath={video?.object_path ?? null} />
+        <PlateTimeSeries points={timePoints} />
       </div>
 
       {sections.length > 0 && (
@@ -171,9 +171,9 @@ export default async function PlateDetail({
 
       <div className="mb-8">
         <h2 className="mb-2 text-sm uppercase tracking-widest text-stone-500">
-          Time points
+          Growth time-lapse
         </h2>
-        <PlateTimeSeries points={timePoints} />
+        <PlateVideo objectPath={video?.object_path ?? null} />
       </div>
     </div>
   );

--- a/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/page.tsx
@@ -80,7 +80,12 @@ export default async function PlateExperiment({
   }
 
   const plates = groupByPlate(experiment.gravi_scans ?? []);
-  const totalTimepoints = experiment.gravi_scans?.length ?? 0;
+  // Per-plate timepoint count. Plates in the same experiment typically share
+  // a cadence, so showing the max is honest ("up to N"); falls back to 0 when
+  // there are no scans.
+  const perPlateTimepoints = plates.length
+    ? Math.max(...plates.map((p) => p.scans.length))
+    : 0;
 
   return (
     <div>
@@ -107,8 +112,8 @@ export default async function PlateExperiment({
         </div>
         <div className="mt-2 text-lg font-medium text-stone-700">
           {plates.length} plate{plates.length === 1 ? "" : "s"} ·{" "}
-          {totalTimepoints} time point{totalTimepoints === 1 ? "" : "s"} across
-          all plates
+          {perPlateTimepoints} time point
+          {perPlateTimepoints === 1 ? "" : "s"}
         </div>
       </div>
 
@@ -284,8 +289,20 @@ function groupByPlate(scans: ScanRow[]): PlateGroup[] {
     });
   }
 
-  groups.sort((a, b) => a.plate_id.localeCompare(b.plate_id));
+  // Natural sort: extract the trailing integer so Plate_2 < Plate_10.
+  // Lex tiebreak keeps order stable when plate_ids share the same suffix.
+  groups.sort((a, b) => {
+    const an = plateSortKey(a.plate_id);
+    const bn = plateSortKey(b.plate_id);
+    if (an !== bn) return an - bn;
+    return a.plate_id.localeCompare(b.plate_id);
+  });
   return groups;
+}
+
+function plateSortKey(plate_id: string): number {
+  const match = plate_id.match(/(\d+)$/);
+  return match ? parseInt(match[1], 10) : Number.POSITIVE_INFINITY;
 }
 
 async function getExperiment(

--- a/web/app/app/plate-phenotypes/[speciesId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/page.tsx
@@ -88,7 +88,10 @@ export default async function PlateSpecies({
           const duration = formatDuration(
             latest?.actual_duration_seconds ?? latest?.duration_seconds ?? null,
           );
-          const cycles = latest?.total_cycles ?? null;
+          // Per-plate timepoint count derived from gravi_scans, matching the
+          // experiment detail page (total_cycles from the session config can
+          // disagree with the recorded scan count by ±1).
+          const timepoints = perPlateTimepointCount(experiment.gravi_scans);
           const sessionCount = experiment.gravi_scan_sessions?.length ?? 0;
           const plateCount = uniquePlateCount(experiment.gravi_scans);
           const phenotypers = uniquePhenotyperNames(
@@ -96,10 +99,10 @@ export default async function PlateSpecies({
           );
 
           const timeSeries =
-            cycles !== null && duration
-              ? `${cycles} time point${cycles === 1 ? "" : "s"} collected over ${duration}`
-              : cycles !== null
-                ? `${cycles} time point${cycles === 1 ? "" : "s"}`
+            timepoints > 0 && duration
+              ? `${timepoints} time point${timepoints === 1 ? "" : "s"} collected over ${duration}`
+              : timepoints > 0
+                ? `${timepoints} time point${timepoints === 1 ? "" : "s"}`
                 : duration
                   ? `Collected over ${duration}`
                   : null;
@@ -241,6 +244,18 @@ function uniquePlateCount(scans: ScanRow[] | null | undefined): number {
     if (s.plate_id) set.add(s.plate_id);
   }
   return set.size;
+}
+
+function perPlateTimepointCount(
+  scans: ScanRow[] | null | undefined,
+): number {
+  if (!scans || scans.length === 0) return 0;
+  const counts = new Map<string, number>();
+  for (const s of scans) {
+    if (!s.plate_id) continue;
+    counts.set(s.plate_id, (counts.get(s.plate_id) ?? 0) + 1);
+  }
+  return counts.size === 0 ? 0 : Math.max(...counts.values());
 }
 
 function uniquePhenotyperNames(


### PR DESCRIPTION
## Highlights

- Plate phenotypes: natural plate sort, per-plate timepoint count consistent across species/experiment pages (fixes the 85 vs 86 mismatch), plate detail page reordered so time-point images sit above the time-lapse section (#273)
- OrthoBrowser: Nolan HPI OrthoBrowser embedded at `/app/orthofinder`, accessible from the Tools nav (#274)

## Post-deploy ops (prod server)

None required for this batch — both PRs are UI-only.