### PR TITLE
fix(caddy): add dns_challenge_override_domain for CNAME delegation

### DIFF
--- a/_WIKI/CADDY/README.md
+++ b/_WIKI/CADDY/README.md
@@ -42,6 +42,8 @@ When Let's Encrypt does the DNS-01 lookup at `_acme-challenge.bloom-dev.salk.edu
 
 Both the apex (`bloom-dev.salk.edu`) and the wildcard (`*.bloom-dev.salk.edu`) ACME challenges land at the same name (`_acme-challenge.bloom-dev.salk.edu`), so **one** Salk CNAME covers both prod and staging.
 
+> **`dns_challenge_override_domain` is required for CNAME delegation to work.** Without it, the `caddy-dns/cloudflare` plugin walks up from the challenged name (`_acme-challenge.bloom-dev.salk.edu`), can't find `salk.edu` in our Cloudflare account, and fails with `expected 1 zone, got 0 for salk.edu.` The override tells Caddy to write the TXT at `bloom-acme.talmolab.org` directly (the zone we actually control), bypassing the plugin's zone-lookup walk. See the `tls { ... dns_challenge_override_domain bloom-acme.talmolab.org }` directive in [caddy/Caddyfile](../../caddy/Caddyfile).
+
 ## Site addresses
 
 The Caddyfile site block opens with `{$CADDY_SITE_ADDRESSES}`, which expands per-environment to a comma-separated, scheme-prefixed list:

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -53,8 +53,11 @@
 	# One wildcard SAN cert covering apex + *.bloom-dev.salk.edu via ACME
 	# DNS-01 against Cloudflare's API. For http://-scheme addresses (CI mode)
 	# the tls block is parsed but inert — Caddy does not request a cert.
+	#
+	# `dns_challenge_override_domain` is what makes the CNAME delegation work.
 	tls {
 		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+		dns_challenge_override_domain bloom-acme.talmolab.org
 	}
 
 	# -------------------


### PR DESCRIPTION
## Summary

One-line Caddyfile fix for the failure that hit the PR #254 staging deploy. `caddy-dns/cloudflare` needs `dns_challenge_override_domain bloom-acme.talmolab.org` inside the `tls { }` block. The CNAME resolves but Caddy doesn't follow it directly. Without this directive the plugin walks up from _acme-challenge.bloom-dev.salk.edu looking for salk.edu in our Cloudflare account, doesn't find it, and fails with:

With the override, Caddy writes the TXT at `_acme-challenge.bloom-acme.talmolab.org` directly. Salk's existing CNAME from `_acme-challenge.bloom-dev.salk.edu` brings Let's Encrypt to that TXT, validates, issues the cert.

## Verified preflight

Before opening this PR, ran the exact write Caddy will perform:

- ✅ Cloudflare token authenticates (`/user/tokens/verify` → `active`)
- ✅ POST to `/zones/<id>/dns_records` with name `_acme-challenge.bloom-acme.talmolab.org` succeeds (test record written + deleted cleanly)
- ✅ Salk CNAME at `_acme-challenge.bloom-dev.salk.edu` resolves to `_acme-challenge.bloom-acme.talmolab.org.`
- ✅ `dns_challenge_override_domain` is the correct Caddyfile directive (Caddy docs confirmed)

## Files

- `caddy/Caddyfile` — add directive + one-line comment
- `_WIKI/CADDY/README.md` — callout block in "Why CNAME delegation" explaining the directive and the exact error you hit without it

## Known limitation — tracked separately

The Cloudflare token currently has write access to the entire `talmolab.org` zone instead of just `bloom-acme.talmolab.org` (Cloudflare API tokens scope by zone, and `bloom-acme.talmolab.org` is not its own zone yet). This works for staging but is broader than the PR #254 design intent.

**Tracked in #282** — production deploy of the PR #254 architecture should block on that issue closing.

