### PR TITLE
feat(db): add cyl_trait_sources provenance + idempotency (sub-project #2, change A)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -83,3 +83,10 @@ CVE-2026-42496
 # package included by python:3.11-slim. No fix available upstream.
 # Reassess on next python:3.11-slim SHA bump.
 CVE-2026-8376
+
+# linux-libc-dev (Debian 13 in python:3.11-slim) — affects: langchain-agent / bloommcp
+# kernel: ksmbd signedness bug. Kernel headers are a build-time-only transitive base
+# package; the container runs no kernel and uses no in-kernel SMB server (ksmbd), so the
+# affected code path is unreachable at runtime. No fix available upstream. Reassess on the
+# next python:3.11-slim SHA bump. Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-43185
+CVE-2026-43185

--- a/openspec/changes/add-cyl-trait-source-provenance/design.md
+++ b/openspec/changes/add-cyl-trait-source-provenance/design.md
@@ -83,6 +83,17 @@ unset key arrives as an empty string, never as SQL `NULL`.
   NULL-escape risk below is the same failure mode as gravi #250 (UNIQUE treats NULLs as
   distinct, so NULL keys do not collide). (#251 was a *client-side* bloom-js upsert fix, a
   different pattern — not the model for D's RPC.)
+- **Open decision for change D — the RPC role model** (raised in #290 review by @blm3886): the
+  repo's existing RPCs (`insert_gravi_*`) are `SECURITY INVOKER` and run as the caller via
+  `bloom_writer` (which holds `INSERT/UPDATE` on all public tables), so logs show *which app*
+  wrote. The roadmap's "service-role" framing implies `SECURITY DEFINER` (the RPC as sole
+  sanctioned writer once E drops the legacy `authenticated` INSERT) — stronger integrity but
+  **no caller attribution**. Three options for D: (a) `SECURITY DEFINER`/service-role (sole
+  writer; loses attribution); (b) `SECURITY INVOKER` as `bloom_writer` (attribution + matches
+  existing RPCs, but not a sole write path, so E's lockdown loses teeth); (c) **hybrid
+  (recommended): `SECURITY DEFINER` + record the caller** (`auth.jwt()` claim / app id /
+  `session_user`) into the source row or an audit column — sole-writer integrity *and*
+  attribution. Decide in D's brainstorming; not an A concern.
 
 ## Migration Plan
 

--- a/openspec/changes/add-cyl-trait-source-provenance/design.md
+++ b/openspec/changes/add-cyl-trait-source-provenance/design.md
@@ -1,0 +1,111 @@
+## Context
+
+`cyl_trait_sources` is a thin provenance dimension (`id BIGINT`, `name TEXT`) referenced
+by `cyl_scan_traits.source_id` (already present) and — once change B lands —
+`cyl_image_traits.source_id`. Sub-project #2 turns it into the **identity of one per-scan
+pipeline run**: it must carry the run's full `Provenance` envelope and a unique key so the
+write-back RPC can upsert idempotently.
+
+Source of truth for the envelope shape is the contract:
+`C:\repos\sleap-roots-contracts\schema\result_envelope.schema.json` (`$defs.Provenance`,
+whose docstring states it *"serializes to cyl_trait_sources.metadata jsonb (sub-project
+#2)"*). `Provenance.idempotency_key` is deterministic, computed producer-side from
+`(scan_key, images_checksum, sorted model tuples, param_hash, predict_code_sha,
+traits_code_sha)`; Bloom stores and compares it as an **opaque string** and never
+recomputes it. Critically, the contract types it `string` with **`default: ""`** — an
+unset key arrives as an empty string, never as SQL `NULL`.
+
+## Goals / Non-Goals
+
+- Goals: give `cyl_trait_sources` a `metadata jsonb` provenance column and a unique,
+  non-empty `idempotency_key`; ship it as a forward additive migration with a manual
+  rollback script; prove the columns + constraints with tests.
+- Non-Goals: the write-back RPC, trait/blob writes, RLS changes, jsonb shape validation,
+  contract codegen. No changes to existing rows or other tables.
+
+## Decisions
+
+- **Both new columns are nullable.** Existing `name`-only source rows (and any future
+  non-pipeline source) have no envelope and no key. Postgres allows *multiple* NULLs under
+  a UNIQUE constraint, so legacy rows coexist with pipeline rows without a backfill.
+- **Plain `UNIQUE` constraint, not a partial index.** A nullable `UNIQUE` column already
+  permits multiple NULLs, and the CHECK below handles the `""` case, so a partial index
+  (`WHERE idempotency_key IS NOT NULL`) adds no integrity over `UNIQUE` + `CHECK` while
+  forcing change D's RPC to restate the predicate in `ON CONFLICT`. The plain constraint
+  is targetable by `ON CONFLICT (idempotency_key)` directly. The UNIQUE constraint also
+  provides the lookup index the RPC's upsert needs — no separate index.
+- **CHECK rejects the empty-string sentinel at the DB layer.** `CHECK (idempotency_key IS
+  NULL OR length(idempotency_key) > 0)`. This is **not** coupling the migration to producer
+  behavior — it enforces the table's own invariant that `""` is not a valid idempotency
+  key. Rationale (defense in depth for a provenance anchor): the contract's `default: ""`
+  means a producer that fails to compute a key emits `""`, not `NULL`. Without the CHECK,
+  the first `""` row inserts, then every subsequent keyless run collides on UNIQUE — and
+  change D's planned "unique-violation → idempotent no-op" would return the *existing*
+  `source_id`, silently binding a distinct run's traits to the wrong provenance. A CHECK
+  turns that silent semantic corruption into an immediate, loud violation, costs nothing,
+  and stays additive/rollback-safe (all existing values are NULL, which the CHECK permits).
+  Boundary: the CHECK guards the empty string `''` only. A whitespace-only key (`'   '`)
+  passes `length > 0` and is **permitted** — a legitimately-computed key is a sha256-derived
+  hash and can never be whitespace, so blank-but-nonempty keys are the producer's
+  responsibility (caught producer-side by the contract and by change F's CI match), not a
+  DB invariant. The CHECK deliberately rejects, never rewrites/normalizes, an opaque anchor.
+- **`metadata` is stored as opaque jsonb, not validated at the DB layer.** Envelope
+  validity is guaranteed producer-side by the Pydantic contract and (change F) by a CI
+  migration/types-match check. A DB-side jsonb schema check is out of scope and would
+  duplicate the contract.
+- **`idempotency_key` is denormalized.** The same value lives both in its own column (so a
+  UNIQUE constraint can anchor it) and nested in `metadata->>'idempotency_key'`. The
+  write-back RPC (change D) MUST keep them consistent; they must not diverge. Documented
+  here so an implementer doesn't treat the column and the envelope field as independent.
+- **No GIN/expression index on `metadata` yet (YAGNI).** No query path filters on metadata
+  in #2. This change forecloses nothing: an expression index or `GENERATED` column on
+  `metadata->>'contract_version'` (to find rows under a stale contract) or
+  `metadata->>'scan_key'` (to audit source→scan resolution) can be added non-destructively
+  later if an audit need appears.
+
+## Risks / Trade-offs
+
+- **Nullable `idempotency_key` → an RPC bug could write a NULL-key row** that passes all
+  constraints yet is permanently untraceable to its run (distinct from the `""` collision:
+  this is the NULL-escape). A cannot fix it (nullable is required for legacy coexistence).
+  Invariant recorded for changes D/E: every row written through the sanctioned RPC carries
+  a non-empty key, ideally validated by the RPC and by a periodic "sources missing a key"
+  audit query.
+- **Forgeable-provenance window until change E.** `cyl_trait_sources` still has a legacy
+  `CREATE POLICY ... FOR INSERT TO authenticated WITH CHECK (true)` (from its 2024 create
+  migration), OR-combined with the 2026 role policies. Any authenticated user can therefore
+  INSERT a forged `metadata`/`idempotency_key` row — and pre-claim a run's key, making the
+  RPC's no-op bind real traits to attacker/buggy-client provenance. **Change E must DROP
+  that legacy policy** (not merely add role policies). Recorded so it cannot fall through.
+- A unique violation surfaces to the RPC as a Postgres error (SQLSTATE 23505) → change D
+  must use the catch-23505-and-return-existing pattern (cf. gravi #252, the RPC-side
+  catch-23505 fix), not SELECT-then-INSERT, to make re-delivery a clean no-op. The
+  NULL-escape risk below is the same failure mode as gravi #250 (UNIQUE treats NULLs as
+  distinct, so NULL keys do not collide). (#251 was a *client-side* bloom-js upsert fix, a
+  different pattern — not the model for D's RPC.)
+
+## Migration Plan
+
+This repo is **forward-only**: migrations are applied with `supabase db push`
+(`make migrate-local`, `Makefile`; CI `pr-checks.yml` `compose-health-check`). There is no
+down-runner; "reversibility" is a **separate, manual** script under `supabase/rollbacks/`
+(wrapped in `BEGIN; … COMMIT;`, `DROP … IF EXISTS`), never applied by CI.
+
+- Forward migration (`make new-migration name=add_cyl_trait_source_provenance`):
+  - `ALTER TABLE cyl_trait_sources ADD COLUMN metadata jsonb;`
+  - `ALTER TABLE cyl_trait_sources ADD COLUMN idempotency_key text;`
+  - `ALTER TABLE cyl_trait_sources ADD CONSTRAINT cyl_trait_sources_idempotency_key_key UNIQUE (idempotency_key);`
+  - `ALTER TABLE cyl_trait_sources ADD CONSTRAINT cyl_trait_sources_idempotency_key_nonempty CHECK (idempotency_key IS NULL OR length(idempotency_key) > 0);`
+  - Additive only — no drops/rewrites, safe to `db push` once onto the persistent DB; the
+    timestamp prefix must exceed the current max (`scripts/lint_migrations.sh`).
+- Companion rollback (`supabase/rollbacks/<version>_add_cyl_trait_source_provenance_rollback.sql`),
+  manual: `BEGIN;` drop both constraints `IF EXISTS`, drop both columns `IF EXISTS`; `COMMIT;`.
+- Apply + reset locally only (`make migrate-local` / `supabase db reset`), never prod.
+- Regenerate TS types (`make gen-types`, which syncs 4 `database.types.ts` files) and
+  manually update the orphaned 5th (`web/types/database.types.ts`); commit all.
+
+## Open Questions
+
+- None blocking. (The `scan_key → cyl_scans.id` resolution is settled for later changes:
+  resolve via `Provenance.inputs.image_ids → cyl_images.scan_id`, caller-side; it does not
+  affect this column-only change.)

--- a/openspec/changes/add-cyl-trait-source-provenance/proposal.md
+++ b/openspec/changes/add-cyl-trait-source-provenance/proposal.md
@@ -12,7 +12,9 @@ anchor, so trait values cannot be traced to the run that produced them and the s
 ingested twice would mint duplicate sources.
 
 This is **change A** (the foundation) of sub-project #2. It only widens the source table;
-the service-role write-back RPC that upserts on this key is a later change.
+the sanctioned, idempotent write-back RPC that upserts on this key is a later change (D). Its
+role model (`SECURITY DEFINER` vs. caller-as-`bloom_writer`) is an open decision for D — see
+design.md.
 
 **Supersedes** the `cyl_trait_sources` schema proposed in issue #13 / `docs/issues/
 issue-4-results-sync.md` (which added `pipeline_run_id UUID REFERENCES cyl_pipeline_runs`

--- a/openspec/changes/add-cyl-trait-source-provenance/proposal.md
+++ b/openspec/changes/add-cyl-trait-source-provenance/proposal.md
@@ -1,0 +1,93 @@
+## Why
+
+The sleap-roots pipeline produces per-scan results that must be written back into
+Bloom **traceably** and **idempotently** (program sub-project #2; tracked under EPIC #9,
+GitHub issue #13 "Results Sync", building on #12 "Metadata & Provenance"). The settled
+contract (`sleap-roots-contracts`, `ResultEnvelope`) carries a `Provenance` envelope that
+needs a home, and each pipeline run must map to **exactly one** `cyl_trait_sources` row so
+that re-delivery of the same result is a no-op.
+
+Today `cyl_trait_sources` is `(id, name)` only — it has no provenance and no idempotency
+anchor, so trait values cannot be traced to the run that produced them and the same run
+ingested twice would mint duplicate sources.
+
+This is **change A** (the foundation) of sub-project #2. It only widens the source table;
+the service-role write-back RPC that upserts on this key is a later change.
+
+**Supersedes** the `cyl_trait_sources` schema proposed in issue #13 / `docs/issues/
+issue-4-results-sync.md` (which added `pipeline_run_id UUID REFERENCES cyl_pipeline_runs`
++ a mutable `version` string and keyed source identity on `pipeline_run_id`). That design
+predates the contract, depends on tables that do not exist (`cyl_pipeline_runs`,
+`cyl_predictions`, `cyl_models`), and uses a mutable key. This change replaces it with the
+contract's **deterministic, opaque `idempotency_key`** and stores the full run provenance
+as `jsonb`, with no FK to an unbuilt table. Supersession is scoped to **#13's
+`cyl_trait_sources` schema only** — #13's predictions table, Box backup, sync-status, and
+trait-query API scope are untouched here. The contract's key-distinct-rows model also
+replaces #13's `v1/v2` `version`-string UX: a re-run with new inputs/models/code yields a
+different `idempotency_key` → a new source row (full history); same run re-delivered → same
+key → no-op.
+
+This is pipeline-side provenance (the #9/#12/#13 lineage). It does **not** address issue
+#28 ("Add analysis provenance tracking"), which is the separate `sleap-roots-analyze`-side
+provenance concern.
+
+## What Changes
+
+- ALTER `cyl_trait_sources`: add `metadata jsonb` (nullable) to hold the contract
+  `Provenance` envelope. Stored as **opaque jsonb** — Bloom does not validate its shape at
+  the DB layer (the contract validates it producer-side; change F adds a CI match check).
+- ALTER `cyl_trait_sources`: add `idempotency_key text` (nullable) with:
+  - a **UNIQUE** constraint — the anchor the write-back RPC upserts on. Nullable so
+    existing/legacy `name`-only source rows coexist (Postgres permits multiple NULLs under
+    UNIQUE);
+  - a **CHECK** `idempotency_key IS NULL OR length(idempotency_key) > 0` — the contract
+    defaults this field to `""` (empty string, *not* `NULL`); without this guard, the
+    first `""` row would insert and every later keyless run would collide on the same
+    `""`, and the write-back RPC's "unique-violation → no-op" path (change D) would return
+    the **wrong `source_id`**, silently conflating distinct runs. The CHECK enforces the
+    table's own invariant that `""` is not a valid key.
+- The same `idempotency_key` value also appears nested inside the `metadata` envelope
+  (`Provenance.idempotency_key`). It is **denormalized** into its own column so a UNIQUE
+  constraint can anchor it; the write-back RPC (change D) is responsible for keeping the
+  two consistent — they MUST NOT diverge. Enforcing that equality is **change D's** hard
+  requirement (a generated column or cross-column CHECK here would break A's nullable /
+  legacy-coexistence and opaque-jsonb design), not A's.
+- Ship as a single **forward, additive** `supabase db push` migration (this repo is
+  forward-only; see design.md), plus a companion manual rollback script under
+  `supabase/rollbacks/`.
+- Regenerate and commit the tracked Supabase TS types: `make gen-types` syncs **4**
+  `database.types.ts` files (`packages/bloom-fs`, `packages/bloom-js`,
+  `packages/bloom-nextjs-auth`, `web/lib`) that currently hardcode the old `(id, name)`
+  shape. A 5th tracked copy, `web/types/database.types.ts`, is **not** written by
+  `gen-types` and is an orphaned/stale legacy file (nothing imports
+  `@/types/database.types`; the live import is `@/lib/database.types`) — update it by hand
+  so the tracked types don't silently diverge.
+
+Non-goals (separate changes): the write-back RPC (D), trait/blob row writes (B/C), the RLS
+lockdown (E), and contract codegen / CI match (F). Empty-key rejection is enforced here at
+the column level; **absent-key (NULL) detection** for RPC-written rows is the RPC's job.
+
+## Impact
+
+- Affected specs: `cyl-trait-writeback` (new capability)
+- Affected code:
+  - `supabase/migrations/` (one new forward migration) + `supabase/rollbacks/` (companion)
+  - `tests/integration/` (new migration/constraint assertions, pytest)
+  - 4 tracked `database.types.ts` files via `make gen-types` + `web/types/database.types.ts`
+    by hand (gen-types does not write it)
+- Affected issues: foundation under EPIC #9; supersedes #13's `cyl_trait_sources` schema
+  only; depends conceptually on #12's provenance model; does not address #28 (analyze-side)
+- Data: additive nullable columns + a UNIQUE constraint (multiple NULLs allowed) + a CHECK
+  — safe on existing rows (all legacy sources keep `NULL` key/metadata; no backfill)
+- **Interim exposure (sequencing risk):** `cyl_trait_sources` still carries a legacy
+  permissive `authenticated` INSERT RLS policy (from its 2024 create migration), OR-combined
+  with the 2026 `bloom_admin`/`bloom_user` role policies. Until **change E explicitly DROPs
+  that legacy policy**, any authenticated user can write a row with a forged `metadata`
+  envelope and a chosen `idempotency_key`. So the idempotency/provenance invariant is not
+  fully DB-enforced until changes D + E land. This change records the window; it does not
+  change RLS.
+- **Cross-change ordering:** change **E** (DROP the legacy `authenticated` INSERT policy)
+  MUST land **no later than change D** in any shared/deployed environment. The forgeable
+  window only becomes exploitable once D's "unique-violation → no-op" RPC exists (a forged
+  pre-claimed key is inert until something resolves traits against it), so E must not lag D
+  into production.

--- a/openspec/changes/add-cyl-trait-source-provenance/specs/cyl-trait-writeback/spec.md
+++ b/openspec/changes/add-cyl-trait-source-provenance/specs/cyl-trait-writeback/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Trait source provenance column
+
+`cyl_trait_sources` SHALL provide a nullable `metadata` column of type `jsonb` capable of
+storing a JSON object (the contract `Provenance` envelope). Bloom SHALL treat the value as
+opaque jsonb and MUST NOT validate its internal shape at the database layer. The column
+MUST be nullable so that legacy or non-pipeline source rows (which have no envelope) remain
+valid. (Writing an envelope for a specific pipeline run is the write-back RPC's behavior,
+specified separately.)
+
+#### Scenario: Metadata column persists and round-trips a JSON object
+
+- **WHEN** a JSON object is stored in `cyl_trait_sources.metadata`
+- **THEN** it is persisted and read back unchanged as `jsonb` (`jsonb_typeof` is `object`)
+
+#### Scenario: Metadata accepts non-object jsonb (no shape validation)
+
+- **WHEN** a non-object jsonb value (e.g. an array or scalar) is stored in
+  `cyl_trait_sources.metadata`
+- **THEN** the database accepts it, confirming no database-layer shape validation
+
+#### Scenario: Legacy source rows remain valid
+
+- **WHEN** a `cyl_trait_sources` row exists with only `id` and `name` set
+- **THEN** its `metadata` column is `NULL` and the row is valid
+
+### Requirement: Trait source idempotency anchor
+
+`cyl_trait_sources` SHALL provide a nullable `idempotency_key` column of type `text` with a
+`UNIQUE` constraint, so that each pipeline run maps to at most one source row and
+re-delivery of the same run cannot create a duplicate source. The column MUST reject the
+empty string via a `CHECK` constraint (`idempotency_key IS NULL OR length(idempotency_key)
+> 0`), because the contract defaults this field to `""` and a shared empty-string key would
+collapse all keyless runs onto one source row. The column MUST be nullable so that legacy
+or non-pipeline source rows without a key coexist.
+
+#### Scenario: Duplicate non-null key is rejected
+
+- **WHEN** a second source row is inserted with the same non-null `idempotency_key` as an
+  existing row
+- **THEN** the database rejects the insert with a unique-constraint violation
+
+#### Scenario: Empty-string key is rejected
+
+- **WHEN** a source row is inserted with `idempotency_key = ''`
+- **THEN** the database rejects the insert with a check-constraint violation
+
+#### Scenario: Multiple keyless sources are permitted
+
+- **WHEN** more than one source row is inserted with a `NULL` `idempotency_key`
+- **THEN** all such inserts succeed and the UNIQUE constraint is not violated
+
+### Requirement: Additive, non-destructive provenance migration
+
+The migration that adds the provenance and idempotency columns SHALL be **additive only**:
+it MUST NOT drop or rewrite existing columns or data, so a single forward `supabase db push`
+applies it safely to the persistent database and adding columns MUST NOT break existing
+inserts. A companion manual rollback script SHALL be provided under `supabase/rollbacks/`
+that, when applied, removes the added columns and their constraints, returning
+`cyl_trait_sources` to its prior `(id, name)` shape.
+
+#### Scenario: Existing inserts keep working after the migration
+
+- **WHEN** the migration has been applied and a row is inserted supplying only `name`
+- **THEN** the insert succeeds and `metadata` and `idempotency_key` default to `NULL`
+
+#### Scenario: Rollback script restores the prior schema
+
+- **WHEN** the companion rollback script is applied to a database where the migration had
+  been applied
+- **THEN** `cyl_trait_sources` no longer has the `metadata` or `idempotency_key` columns
+  nor their UNIQUE/CHECK constraints

--- a/openspec/changes/add-cyl-trait-source-provenance/tasks.md
+++ b/openspec/changes/add-cyl-trait-source-provenance/tasks.md
@@ -1,0 +1,73 @@
+## 1. Failing tests first (TDD)
+
+All tests live in `tests/integration/test_cyl_trait_source_provenance.py` (pytest), using
+the existing `pg_conn` psycopg fixture from `tests/integration/conftest.py`. They run in
+CI's `compose-health-check` job after migrations are applied
+(`uv run --extra test pytest tests/integration/ -v`). Do NOT use `supabase/tests/` (its
+pgTAP file is not wired into CI, and `implement-database-testing` plans to recreate that
+dir). Each test below maps to a spec scenario and is red until section 2 lands.
+
+**Commit grouping (commit safety):** CI applies migrations *before* collecting tests, so
+the section-1 tests and the section-2 migration MUST land in the **same commit** — never
+commit the tests alone (that commit would be red in CI). The red-first TDD loop is local
+only (task 3.2).
+
+**psycopg3 note:** `pg_conn` runs with `autocommit=False`, so a constraint violation aborts
+the open transaction; after asserting an expected error you MUST `pg_conn.rollback()` (or
+use `SAVEPOINT`/`ROLLBACK TO SAVEPOINT`) before the next statement, or it raises
+`InFailedSqlTransaction`. Assert errors via the exception classes
+`psycopg.errors.UniqueViolation` / `psycopg.errors.CheckViolation` (or `exc.sqlstate ==
+"23505"` / `"23514"` — psycopg3 exposes `.sqlstate`, not psycopg2's `.pgcode`).
+
+- [x] 1.1 Column existence: assert via `information_schema.columns` that
+      `cyl_trait_sources` has `metadata` (`data_type = 'jsonb'`) and `idempotency_key`
+      (`data_type = 'text'`).
+- [x] 1.2 jsonb round-trip: insert a row with `metadata = '{"a":1}'::jsonb`, read it back,
+      assert `jsonb_typeof(metadata) = 'object'` and the value round-trips unchanged (guards
+      against the column being `text` instead of `jsonb`).
+- [x] 1.2b Opaque jsonb: insert a non-object jsonb (`'[1,2]'::jsonb` and/or `'42'::jsonb`)
+      into `metadata` and assert it is accepted (proves "no DB-layer shape validation").
+- [x] 1.3 UNIQUE: inserting two rows with the same non-null `idempotency_key` raises
+      `UniqueViolation` (23505) — use a `SAVEPOINT` so the first (good) insert survives the
+      second's failure within one transaction; two rows with `NULL` `idempotency_key` both
+      succeed.
+- [x] 1.4 Empty-string CHECK: inserting `idempotency_key = ''` raises `CheckViolation`
+      (23514), then `rollback()`. (This is the contract's `default: ""` — the highest-risk
+      value.)
+- [x] 1.5 Additive safety + legacy rows valid: an old-style
+      `INSERT INTO cyl_trait_sources (name) VALUES (...)` still succeeds post-migration, and
+      reading that row back asserts `metadata IS NULL AND idempotency_key IS NULL` (covers
+      both the "existing inserts keep working" and "legacy source rows remain valid"
+      scenarios).
+- [x] 1.6 Constraint identity (optional but recommended): assert the named constraints
+      `cyl_trait_sources_idempotency_key_key` (UNIQUE) and
+      `cyl_trait_sources_idempotency_key_nonempty` (CHECK) exist via `pg_constraint`, so
+      change D can rely on the names for `ON CONFLICT`.
+- [x] 1.7 Rollback (self-contained, since CI only rolls forward): in one transaction on
+      `pg_conn`, apply the rollback script body, assert the two columns + both constraints
+      are gone, then `ROLLBACK` so the suite leaves the DB untouched.
+
+## 2. Forward migration + rollback script
+
+- [x] 2.1 Scaffold the migration: `make new-migration name=add_cyl_trait_source_provenance`
+      (timestamp prefix must exceed the current max so `scripts/lint_migrations.sh` passes).
+- [x] 2.2 Write the forward migration (additive only):
+      add `metadata jsonb`; add `idempotency_key text`;
+      `ADD CONSTRAINT cyl_trait_sources_idempotency_key_key UNIQUE (idempotency_key)`;
+      `ADD CONSTRAINT cyl_trait_sources_idempotency_key_nonempty CHECK (idempotency_key IS NULL OR length(idempotency_key) > 0)`.
+- [x] 2.3 Write the companion rollback at
+      `supabase/rollbacks/<same-version>_add_cyl_trait_source_provenance_rollback.sql`,
+      modeled on existing rollbacks (`BEGIN; … COMMIT;`, `DROP CONSTRAINT IF EXISTS` ×2 then
+      `DROP COLUMN IF EXISTS` ×2). This is a manual artifact (not applied by CI).
+
+## 3. Verify
+
+- [x] 3.1 Apply locally (`make migrate-local` / `supabase db reset`); confirm a clean apply
+      and that a second `db push` is a no-op (idempotent).
+- [x] 3.2 Run section 1's tests and confirm green.
+- [x] 3.3 Regenerate and commit Supabase TS types: `make gen-types` (syncs **4**
+      `database.types.ts` files: `packages/bloom-fs`, `packages/bloom-js`,
+      `packages/bloom-nextjs-auth`, `web/lib`), then **manually** update the orphaned 5th,
+      `web/types/database.types.ts` (gen-types does not write it). Confirm each shows
+      `cyl_trait_sources` with `metadata` + `idempotency_key`.
+- [x] 3.4 Run repo lint/format and `openspec validate add-cyl-trait-source-provenance --strict`.

--- a/packages/bloom-fs/src/types/database.types.ts
+++ b/packages/bloom-fs/src/types/database.types.ts
@@ -866,14 +866,20 @@ export type Database = {
       cyl_trait_sources: {
         Row: {
           id: number
+          idempotency_key: string | null
+          metadata: Json | null
           name: string
         }
         Insert: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name: string
         }
         Update: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name?: string
         }
         Relationships: []

--- a/packages/bloom-js/src/types/database.types.ts
+++ b/packages/bloom-js/src/types/database.types.ts
@@ -866,14 +866,20 @@ export type Database = {
       cyl_trait_sources: {
         Row: {
           id: number
+          idempotency_key: string | null
+          metadata: Json | null
           name: string
         }
         Insert: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name: string
         }
         Update: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name?: string
         }
         Relationships: []

--- a/packages/bloom-nextjs-auth/src/lib/database.types.ts
+++ b/packages/bloom-nextjs-auth/src/lib/database.types.ts
@@ -866,14 +866,20 @@ export type Database = {
       cyl_trait_sources: {
         Row: {
           id: number
+          idempotency_key: string | null
+          metadata: Json | null
           name: string
         }
         Insert: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name: string
         }
         Update: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name?: string
         }
         Relationships: []

--- a/supabase/migrations/20260609000000_add_cyl_trait_source_provenance.sql
+++ b/supabase/migrations/20260609000000_add_cyl_trait_source_provenance.sql
@@ -1,0 +1,23 @@
+-- Add run provenance + idempotency anchor to cyl_trait_sources
+-- (sleap-roots write-back, sub-project #2, change A foundation).
+--
+-- metadata:        the contract `Provenance` envelope, stored as opaque jsonb. Bloom does
+--                  NOT validate its shape at the DB layer (the contract validates it
+--                  producer-side). Nullable so legacy name-only source rows stay valid.
+-- idempotency_key: deterministic per-run key the write-back RPC upserts on. Nullable so
+--                  legacy/non-pipeline sources coexist (Postgres permits multiple NULLs
+--                  under UNIQUE). The CHECK rejects the contract's "" default, so keyless
+--                  runs cannot all collide onto a single source row.
+--
+-- Additive only (forward-only `supabase db push`); see the companion manual rollback at
+-- supabase/rollbacks/20260609000000_add_cyl_trait_source_provenance_rollback.sql.
+
+ALTER TABLE cyl_trait_sources ADD COLUMN metadata jsonb;
+ALTER TABLE cyl_trait_sources ADD COLUMN idempotency_key text;
+
+ALTER TABLE cyl_trait_sources
+  ADD CONSTRAINT cyl_trait_sources_idempotency_key_key UNIQUE (idempotency_key);
+
+ALTER TABLE cyl_trait_sources
+  ADD CONSTRAINT cyl_trait_sources_idempotency_key_nonempty
+  CHECK (idempotency_key IS NULL OR length(idempotency_key) > 0);

--- a/supabase/migrations/20260609000000_add_cyl_trait_source_provenance.sql
+++ b/supabase/migrations/20260609000000_add_cyl_trait_source_provenance.sql
@@ -9,15 +9,19 @@
 --                  under UNIQUE). The CHECK rejects the contract's "" default, so keyless
 --                  runs cannot all collide onto a single source row.
 --
--- Additive only (forward-only `supabase db push`); see the companion manual rollback at
+-- Additive (forward-only `supabase db push`); see the companion manual rollback at
 -- supabase/rollbacks/20260609000000_add_cyl_trait_source_provenance_rollback.sql.
+-- Written re-runnably so a partial-failure re-apply is a clean no-op: IF NOT EXISTS on the
+-- columns, and drop-then-add on the constraints (Postgres has no ADD CONSTRAINT IF NOT EXISTS).
 
-ALTER TABLE cyl_trait_sources ADD COLUMN metadata jsonb;
-ALTER TABLE cyl_trait_sources ADD COLUMN idempotency_key text;
+ALTER TABLE cyl_trait_sources ADD COLUMN IF NOT EXISTS metadata jsonb;
+ALTER TABLE cyl_trait_sources ADD COLUMN IF NOT EXISTS idempotency_key text;
 
+ALTER TABLE cyl_trait_sources DROP CONSTRAINT IF EXISTS cyl_trait_sources_idempotency_key_key;
 ALTER TABLE cyl_trait_sources
   ADD CONSTRAINT cyl_trait_sources_idempotency_key_key UNIQUE (idempotency_key);
 
+ALTER TABLE cyl_trait_sources DROP CONSTRAINT IF EXISTS cyl_trait_sources_idempotency_key_nonempty;
 ALTER TABLE cyl_trait_sources
   ADD CONSTRAINT cyl_trait_sources_idempotency_key_nonempty
   CHECK (idempotency_key IS NULL OR length(idempotency_key) > 0);

--- a/supabase/rollbacks/20260609000000_add_cyl_trait_source_provenance_rollback.sql
+++ b/supabase/rollbacks/20260609000000_add_cyl_trait_source_provenance_rollback.sql
@@ -1,0 +1,14 @@
+-- Rollback for 20260609000000_add_cyl_trait_source_provenance.sql
+-- Manual break-glass only: this repo applies migrations forward via `supabase db push`
+-- (no automated down-runner). Drops the constraints and columns, returning
+-- cyl_trait_sources to its prior (id, name) shape. Data in metadata / idempotency_key
+-- is lost.
+
+BEGIN;
+
+ALTER TABLE cyl_trait_sources DROP CONSTRAINT IF EXISTS cyl_trait_sources_idempotency_key_nonempty;
+ALTER TABLE cyl_trait_sources DROP CONSTRAINT IF EXISTS cyl_trait_sources_idempotency_key_key;
+ALTER TABLE cyl_trait_sources DROP COLUMN IF EXISTS idempotency_key;
+ALTER TABLE cyl_trait_sources DROP COLUMN IF EXISTS metadata;
+
+COMMIT;

--- a/tests/integration/test_cyl_trait_source_provenance.py
+++ b/tests/integration/test_cyl_trait_source_provenance.py
@@ -65,10 +65,12 @@ def test_metadata_round_trips_a_json_object(pg_conn):
 
 
 def test_metadata_accepts_non_object_jsonb(pg_conn):
-    # Opaque jsonb: the column performs no DB-layer shape validation.
+    # Opaque jsonb: the column performs no DB-layer shape validation, so arrays,
+    # scalars, and the jsonb `null` literal are all accepted (distinct from SQL NULL).
     with pg_conn.cursor() as cur:
         cur.execute("INSERT INTO cyl_trait_sources (name, metadata) VALUES ('arr', '[1,2]'::jsonb)")
         cur.execute("INSERT INTO cyl_trait_sources (name, metadata) VALUES ('scalar', '42'::jsonb)")
+        cur.execute("INSERT INTO cyl_trait_sources (name, metadata) VALUES ('jnull', 'null'::jsonb)")
     pg_conn.rollback()
 
 
@@ -95,6 +97,19 @@ def test_empty_string_idempotency_key_rejected(pg_conn):
     with pg_conn.cursor() as cur:
         with pytest.raises(psycopg.errors.CheckViolation):
             cur.execute("INSERT INTO cyl_trait_sources (name, idempotency_key) VALUES ('e', '')")
+    pg_conn.rollback()
+
+
+def test_whitespace_only_idempotency_key_is_accepted(pg_conn):
+    # The CHECK guards the empty string `''` ONLY (length > 0), NOT whitespace —
+    # it rejects, it does not trim/normalize an opaque anchor. A legitimately
+    # computed key is a sha256 digest and can never be whitespace, so blank-but-
+    # nonempty keys are the producer's responsibility (caught producer-side by the
+    # contract + change F's CI match), not a DB invariant. This locks in that intent.
+    with pg_conn.cursor() as cur:
+        cur.execute("INSERT INTO cyl_trait_sources (name, idempotency_key) VALUES ('ws', '   ')")
+        cur.execute("SELECT idempotency_key FROM cyl_trait_sources WHERE name = 'ws'")
+        assert cur.fetchone()[0] == "   "
     pg_conn.rollback()
 
 

--- a/tests/integration/test_cyl_trait_source_provenance.py
+++ b/tests/integration/test_cyl_trait_source_provenance.py
@@ -1,0 +1,160 @@
+"""
+Integration tests for change `add-cyl-trait-source-provenance`.
+
+`cyl_trait_sources` gains a nullable `metadata jsonb` column and a nullable
+`idempotency_key text` column with a UNIQUE constraint and a CHECK rejecting the
+empty string. These tests assert the column types, the jsonb round-trip / opaque
+storage, the UNIQUE + CHECK behavior, that legacy `name`-only rows stay valid, and
+that the companion rollback script restores the prior shape.
+
+LOCAL ONLY: the `pg_conn` fixture connects to 127.0.0.1 on POSTGRES_HOST_PORT — it
+cannot reach a remote/production database. Every test mutates inside the fixture's
+uncommitted transaction and rolls back, so the local database is left untouched.
+
+Runs in CI's `compose-health-check` job after migrations are applied
+(`uv run --extra test pytest tests/integration/ -v`).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module if psycopg isn't available (e.g. local dev without the
+# `test` extra); the DB-configured path still exercises it in CI.
+psycopg = pytest.importorskip("psycopg")
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+def _column_type(cur, column: str) -> str | None:
+    cur.execute(
+        """
+        SELECT data_type
+          FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name   = 'cyl_trait_sources'
+           AND column_name  = %s
+        """,
+        (column,),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def test_metadata_and_idempotency_key_columns_exist(pg_conn):
+    with pg_conn.cursor() as cur:
+        assert _column_type(cur, "metadata") == "jsonb"
+        assert _column_type(cur, "idempotency_key") == "text"
+    pg_conn.rollback()
+
+
+def test_metadata_round_trips_a_json_object(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO cyl_trait_sources (name, metadata)
+            VALUES ('rt', '{"a": 1}'::jsonb)
+            RETURNING jsonb_typeof(metadata), metadata
+            """
+        )
+        typeof, value = cur.fetchone()
+        assert typeof == "object"
+        assert value == {"a": 1}
+    pg_conn.rollback()
+
+
+def test_metadata_accepts_non_object_jsonb(pg_conn):
+    # Opaque jsonb: the column performs no DB-layer shape validation.
+    with pg_conn.cursor() as cur:
+        cur.execute("INSERT INTO cyl_trait_sources (name, metadata) VALUES ('arr', '[1,2]'::jsonb)")
+        cur.execute("INSERT INTO cyl_trait_sources (name, metadata) VALUES ('scalar', '42'::jsonb)")
+    pg_conn.rollback()
+
+
+def test_duplicate_non_null_idempotency_key_rejected(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute("INSERT INTO cyl_trait_sources (name, idempotency_key) VALUES ('a', 'dup-key')")
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            cur.execute("INSERT INTO cyl_trait_sources (name, idempotency_key) VALUES ('b', 'dup-key')")
+    pg_conn.rollback()  # clear the aborted transaction
+
+
+def test_multiple_null_idempotency_keys_allowed(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute("INSERT INTO cyl_trait_sources (name, idempotency_key) VALUES ('n1', NULL)")
+        cur.execute("INSERT INTO cyl_trait_sources (name, idempotency_key) VALUES ('n2', NULL)")
+        cur.execute("SELECT count(*) FROM cyl_trait_sources WHERE idempotency_key IS NULL")
+        assert cur.fetchone()[0] >= 2
+    pg_conn.rollback()
+
+
+def test_empty_string_idempotency_key_rejected(pg_conn):
+    # The contract defaults idempotency_key to "" — the CHECK must reject it so
+    # keyless runs cannot all collide onto a single source row.
+    with pg_conn.cursor() as cur:
+        with pytest.raises(psycopg.errors.CheckViolation):
+            cur.execute("INSERT INTO cyl_trait_sources (name, idempotency_key) VALUES ('e', '')")
+    pg_conn.rollback()
+
+
+def test_legacy_name_only_insert_stays_valid(pg_conn):
+    # Existing inserts keep working; legacy rows have NULL metadata + key.
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO cyl_trait_sources (name) VALUES ('legacy') "
+            "RETURNING metadata, idempotency_key"
+        )
+        metadata, idempotency_key = cur.fetchone()
+        assert metadata is None
+        assert idempotency_key is None
+    pg_conn.rollback()
+
+
+def test_named_constraints_exist(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT conname FROM pg_constraint "
+            "WHERE conrelid = 'public.cyl_trait_sources'::regclass"
+        )
+        names = {row[0] for row in cur.fetchall()}
+    assert "cyl_trait_sources_idempotency_key_key" in names
+    assert "cyl_trait_sources_idempotency_key_nonempty" in names
+    pg_conn.rollback()
+
+
+def _find_rollback_sql() -> Path | None:
+    matches = sorted(
+        (REPO_ROOT / "supabase" / "rollbacks").glob(
+            "*_add_cyl_trait_source_provenance_rollback.sql"
+        )
+    )
+    return matches[-1] if matches else None
+
+
+def test_rollback_script_restores_prior_shape(pg_conn):
+    """Self-contained: CI only rolls forward, so apply the rollback script's body
+    inside an uncommitted transaction, assert the columns + constraints are gone,
+    then ROLLBACK so the schema (and other tests) are unaffected."""
+    rollback_path = _find_rollback_sql()
+    if rollback_path is None:
+        pytest.skip("rollback script not written yet")
+
+    # Strip the BEGIN;/COMMIT; wrapper so we stay inside pg_conn's own transaction.
+    body = "\n".join(
+        line
+        for line in rollback_path.read_text().splitlines()
+        if not re.match(r"^\s*(BEGIN|COMMIT)\s*;\s*$", line, re.IGNORECASE)
+    )
+    with pg_conn.cursor() as cur:
+        cur.execute(body)
+        assert _column_type(cur, "metadata") is None
+        assert _column_type(cur, "idempotency_key") is None
+        cur.execute(
+            "SELECT conname FROM pg_constraint "
+            "WHERE conrelid = 'public.cyl_trait_sources'::regclass"
+        )
+        names = {row[0] for row in cur.fetchall()}
+        assert "cyl_trait_sources_idempotency_key_key" not in names
+        assert "cyl_trait_sources_idempotency_key_nonempty" not in names
+    pg_conn.rollback()  # restore the schema — leave the DB untouched

--- a/web/lib/database.types.ts
+++ b/web/lib/database.types.ts
@@ -866,14 +866,20 @@ export type Database = {
       cyl_trait_sources: {
         Row: {
           id: number
+          idempotency_key: string | null
+          metadata: Json | null
           name: string
         }
         Insert: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name: string
         }
         Update: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name?: string
         }
         Relationships: []

--- a/web/types/database.types.ts
+++ b/web/types/database.types.ts
@@ -664,14 +664,20 @@ export interface Database {
       cyl_trait_sources: {
         Row: {
           id: number
+          idempotency_key: string | null
+          metadata: Json | null
           name: string
         }
         Insert: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name: string
         }
         Update: {
           id?: number
+          idempotency_key?: string | null
+          metadata?: Json | null
           name?: string
         }
         Relationships: []


### PR DESCRIPTION
## Tier A2 · change A — `cyl_trait_sources` provenance + idempotency

Part of the **sleap-roots ↔ Bloom integration** ([roadmap](https://github.com/talmolab/sleap-roots-pipeline/blob/main/docs/bloom-integration/roadmap.md)) — **tier A2** (Bloom schema + write-back + CLI), **change A** (the foundation). One OpenSpec change per PR; built tier-by-tier per the `roadmap-driven-pipeline` workflow.

**Tracking:** EPIC #9 → **#12** (Metadata & Provenance). Sibling A2 changes: **#294** consume-pin (*precedes A* — A's types-match-contract CI depends on it), **#295** (B), **#296** (C), **#297** (E), **#298** (read-path); D / CLI / backfill tracked under **#13**.

## Why

The sleap-roots pipeline produces per-scan results that must be written back into Bloom **traceably** and **idempotently**. The settled contract (`sleap-roots-contracts` `ResultEnvelope`, pinned `v0.1.0a0`) carries a `Provenance` envelope that needs a home, and each run must map to **exactly one** `cyl_trait_sources` row so re-delivery is a no-op. Today the table is `(id, name)` only — no provenance, no idempotency anchor.

**Supersedes** the `cyl_trait_sources` schema sketched in #13 / `issue-4-results-sync.md` (`pipeline_run_id UUID REFERENCES cyl_pipeline_runs` + a mutable `version`) — that design predates the contract and FKs a never-built table. Replaced by the contract's deterministic, opaque `idempotency_key` + a `Provenance` `jsonb` column. Scoped to the source-table schema only; #13's predictions/Box/sync-status/API scope is untouched.

## What changes

`ALTER cyl_trait_sources`:
- `metadata jsonb` (nullable) — the `Provenance` envelope, stored **opaque** (no DB-layer shape validation; validated producer-side by the Pydantic contract + #294's migration-matches-schema CI).
- `idempotency_key text` (nullable) with **`UNIQUE`** + **`CHECK (idempotency_key IS NULL OR length(idempotency_key) > 0)`** — the contract defaults the key to `""`; an empty string would satisfy UNIQUE once then collide on every later keyless run, and D's "unique-violation → no-op" RPC would return the **wrong `source_id`**, silently merging unrelated envelopes. The CHECK turns that into a loud violation. Nullable so legacy `name`-only rows coexist (multiple NULLs allowed under UNIQUE).

The `idempotency_key == metadata->>'idempotency_key'` equality CHECK is **deliberately NOT added here** (it would break A's nullable + opaque-jsonb design) — change **D** enforces it RPC-side, which is safe because **E** makes the RPC the sole writer.

Forward-only migration + companion **manual** rollback (`supabase/rollbacks/`). Supabase TS types regenerated, **scoped to the two new columns** across all 5 tracked `database.types.ts` copies.

## Testing (TDD, local Supabase)

`tests/integration/test_cyl_trait_source_provenance.py` (`pg_conn`): **RED** (8 fail — columns absent) → **GREEN** (10 pass). Covers column types, jsonb round-trip, opaque non-object **and `null`-literal** jsonb, UNIQUE (dup rejected / multiple NULL ok), empty-string CHECK (`23514`), **whitespace-only key accepted** (the CHECK guards `''` only — never trims an opaque anchor), legacy `name`-only insert (metadata/key NULL), named constraints, and rollback-restores-prior-shape. `test_migrations.py` parity + migration lint + `openspec validate --strict` pass. (2nd commit adds the whitespace + jsonb-`null` tests from the `/review-pr` pass.)

## Sequencing & safety (from the roadmap)

- A2 order: **consume-pin (#294) → A (this) → {B #295, C #296} → D + E co-land → read-path (#298) → CLI → backfill**.
- **D and E co-land in the same migration/deploy** — never D-without-E (the legacy `authenticated` INSERT policy stays open = forgery hole) and never E-without-D (no write path). This PR documents that legacy-policy window; **A itself changes no RLS** and adds no new exposure (it adds *columns*, not *grants*, to a table the same principals can already write).

## Carried forward (review follow-ups)

- **Change D:** enforce key == `metadata->>'idempotency_key'` (RPC); a "sources missing a key" audit query (NULL-escape); a jsonb size/shape guard at the RPC boundary.
- **Cleanup:** `web/types/database.types.ts` is an orphaned, unimported copy `gen-types` doesn't write — delete in a follow-up (out of scope for this ALTER-one-table PR).

## OpenSpec

`openspec/changes/add-cyl-trait-source-provenance/` (proposal · design · spec · tasks). Twice reviewed via `/openspec-review`; a `/review-pr` subagent-team review is posted on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)