### PR TITLE
feat(hostname): direct cutover to bloom.salk.edu

### DIFF
--- a/.env.prod.defaults
+++ b/.env.prod.defaults
@@ -27,17 +27,12 @@ DOMAIN_MAIN=bloom.salk.edu
 DOMAIN_STUDIO=studio.bloom.salk.edu
 DOMAIN_MINIO=minio.bloom.salk.edu
 
-# Caddy
-# Phase 1 dual-serve: Caddy issues ONE multi-SAN cert covering both the new
-# bloom.salk.edu family AND the legacy bloom-dev.salk.edu family. 
-# Both URL
-# families resolve to this server and Caddy serves them identically so
-# automated clients (cyl-scanners, graviscan) keep working without
-# reconfiguration. Phase 2 (follow-up) switches the legacy family to a 308
-# redirect; Phase 3 drops it entirely.
+# Caddy issues a single multi-SAN cert for bloom.salk.edu + *.bloom.salk.edu.
+# The legacy bloom-dev.salk.edu hostname is not served after cutover —
+# scanner / graviscan clients reconfigure to bloom.salk.edu beforehand.
 CADDY_HTTP_LISTEN_PORT=80
 CADDY_HTTPS_LISTEN_PORT=443
-CADDY_SITE_ADDRESSES=https://bloom.salk.edu, https://*.bloom.salk.edu, https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu
+CADDY_SITE_ADDRESSES=https://bloom.salk.edu, https://*.bloom.salk.edu
 
 # CLOUDFLARE_API_TOKEN needs to be added to github secrets
 
@@ -67,16 +62,9 @@ STUDIO_DEFAULT_PROJECT=default
 # DASHBOARD_USERNAME and MINIO_ROOT_USER live in GitHub Secrets — they pair
 # with admin passwords, so treat as credentials rather than config.
 
-# URLs — all point at the new bloom.salk.edu hostname (the legacy
-# bloom-dev.salk.edu still serves at the Caddy layer for backwards
-# compatibility per Phase 1 dual-serve).
 SITE_URL=https://bloom.salk.edu
 API_EXTERNAL_URL=https://bloom.salk.edu/api
-# ADDITIONAL_REDIRECT_URLS lists BOTH old and new during the transition
-# so Supabase OAuth doesn't reject callbacks from in-flight sign-ins
-# that started on the legacy hostname. Drop the old URL in a follow-up
-# PR ~30 days after cutover.
-ADDITIONAL_REDIRECT_URLS=https://bloom.salk.edu,https://bloom-dev.salk.edu
+ADDITIONAL_REDIRECT_URLS=https://bloom.salk.edu
 NEXT_PUBLIC_SUPABASE_URL=https://bloom.salk.edu/api
 NEXT_PUBLIC_APP_URL=https://bloom.salk.edu
 SUPABASE_URL=http://kong:8000

--- a/.env.prod.defaults
+++ b/.env.prod.defaults
@@ -23,14 +23,21 @@
 # =============================================================================
 
 # Domains
-DOMAIN_MAIN=bloom-dev.salk.edu
-DOMAIN_STUDIO=studio.bloom-dev.salk.edu
-DOMAIN_MINIO=minio.bloom-dev.salk.edu
+DOMAIN_MAIN=bloom.salk.edu
+DOMAIN_STUDIO=studio.bloom.salk.edu
+DOMAIN_MINIO=minio.bloom.salk.edu
 
 # Caddy
+# Phase 1 dual-serve: Caddy issues ONE multi-SAN cert covering both the new
+# bloom.salk.edu family AND the legacy bloom-dev.salk.edu family. 
+# Both URL
+# families resolve to this server and Caddy serves them identically so
+# automated clients (cyl-scanners, graviscan) keep working without
+# reconfiguration. Phase 2 (follow-up) switches the legacy family to a 308
+# redirect; Phase 3 drops it entirely.
 CADDY_HTTP_LISTEN_PORT=80
 CADDY_HTTPS_LISTEN_PORT=443
-CADDY_SITE_ADDRESSES=https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu
+CADDY_SITE_ADDRESSES=https://bloom.salk.edu, https://*.bloom.salk.edu, https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu
 
 # CLOUDFLARE_API_TOKEN needs to be added to github secrets
 
@@ -60,19 +67,25 @@ STUDIO_DEFAULT_PROJECT=default
 # DASHBOARD_USERNAME and MINIO_ROOT_USER live in GitHub Secrets — they pair
 # with admin passwords, so treat as credentials rather than config.
 
-# URLs
-SITE_URL=https://bloom-dev.salk.edu
-API_EXTERNAL_URL=https://bloom-dev.salk.edu/api
-ADDITIONAL_REDIRECT_URLS=https://bloom-dev.salk.edu
-NEXT_PUBLIC_SUPABASE_URL=https://bloom-dev.salk.edu/api
-NEXT_PUBLIC_APP_URL=https://bloom-dev.salk.edu
+# URLs — all point at the new bloom.salk.edu hostname (the legacy
+# bloom-dev.salk.edu still serves at the Caddy layer for backwards
+# compatibility per Phase 1 dual-serve).
+SITE_URL=https://bloom.salk.edu
+API_EXTERNAL_URL=https://bloom.salk.edu/api
+# ADDITIONAL_REDIRECT_URLS lists BOTH old and new during the transition
+# so Supabase OAuth doesn't reject callbacks from in-flight sign-ins
+# that started on the legacy hostname. Drop the old URL in a follow-up
+# PR ~30 days after cutover.
+ADDITIONAL_REDIRECT_URLS=https://bloom.salk.edu,https://bloom-dev.salk.edu
+NEXT_PUBLIC_SUPABASE_URL=https://bloom.salk.edu/api
+NEXT_PUBLIC_APP_URL=https://bloom.salk.edu
 SUPABASE_URL=http://kong:8000
-SUPABASE_PUBLIC_URL=https://bloom-dev.salk.edu/api
+SUPABASE_PUBLIC_URL=https://bloom.salk.edu/api
 SUPABASE_COOKIE_NAME=sb-bloom-auth-token
-STUDIO_SUPABASE_PUBLIC_URL=https://studio.bloom-dev.salk.edu
-MINIO_BROWSER_REDIRECT_URL=https://minio.bloom-dev.salk.edu
-CORS_ORIGINS=https://bloom-dev.salk.edu
-BLOOM_PLOTS_URL=https://bloom-dev.salk.edu/plots
+STUDIO_SUPABASE_PUBLIC_URL=https://studio.bloom.salk.edu
+MINIO_BROWSER_REDIRECT_URL=https://minio.bloom.salk.edu
+CORS_ORIGINS=https://bloom.salk.edu
+BLOOM_PLOTS_URL=https://bloom.salk.edu/plots
 
 # Internal service URLs
 BLOOM_MCP_URL=http://bloommcp:8811/mcp
@@ -92,7 +105,7 @@ JWT_EXPIRY=3600
 # SMTP relay via Salk's neoemex1 MTA (TLS 1.2 on port 25, IP-whitelisted; no auth)
 SMTP_HOST=neoemex1.salk.edu
 SMTP_PORT=25
-SMTP_ADMIN_EMAIL=noreply@bloom-dev.salk.edu
+SMTP_ADMIN_EMAIL=noreply@bloom.salk.edu
 SMTP_SENDER_NAME=Bloom
 SMTP_MAX_FREQUENCY=60s
 
@@ -107,4 +120,4 @@ LOCAL_LLM_MODEL=Qwen/Qwen3.5-9B
 # Browser-facing langchain agent endpoint. Caddy routes /langchain/* on
 # this host to langchain-agent:5002; the URL is baked into the bloom-web
 # JS bundle at build time (NEXT_PUBLIC_*) so the browser can hit it.
-NEXT_PUBLIC_MCP_URL=https://bloom-dev.salk.edu
+NEXT_PUBLIC_MCP_URL=https://bloom.salk.edu

--- a/.env.staging.defaults
+++ b/.env.staging.defaults
@@ -15,15 +15,20 @@
 # =============================================================================
 
 # Domains
-DOMAIN_MAIN=staging.bloom-dev.salk.edu
-DOMAIN_STUDIO=staging-studio.bloom-dev.salk.edu
-DOMAIN_MINIO=staging-minio.bloom-dev.salk.edu
+DOMAIN_MAIN=staging.bloom.salk.edu
+DOMAIN_STUDIO=staging-studio.bloom.salk.edu
+DOMAIN_MINIO=staging-minio.bloom.salk.edu
 
 # Caddy (non-standard ports so prod and staging coexist on the same host)
+# Phase 1 dual-serve: staging's Caddy issues ONE multi-SAN cert covering both
+# the new *.bloom.salk.edu wildcard AND the legacy *.bloom-dev.salk.edu
+# wildcard. Both URL families resolve to this server and Caddy serves them
+# identically. Phase 2 (follow-up) switches the legacy family to a 308
+# redirect; Phase 3 drops it entirely.
 CADDY_HTTP_LISTEN_PORT=8080
 CADDY_HTTPS_LISTEN_PORT=8443
 
-CADDY_SITE_ADDRESSES=https://*.bloom-dev.salk.edu
+CADDY_SITE_ADDRESSES=https://*.bloom.salk.edu, https://*.bloom-dev.salk.edu
 
 
 
@@ -53,19 +58,25 @@ STUDIO_DEFAULT_PROJECT=default
 # DASHBOARD_USERNAME and MINIO_ROOT_USER live in GitHub Secrets — they pair
 # with admin passwords, so treat as credentials rather than config.
 
-# URLs (non-standard 8443 port must appear in every user-facing URL)
-SITE_URL=https://staging.bloom-dev.salk.edu:8443
-API_EXTERNAL_URL=https://staging.bloom-dev.salk.edu:8443/api
-ADDITIONAL_REDIRECT_URLS=https://staging.bloom-dev.salk.edu:8443
-NEXT_PUBLIC_SUPABASE_URL=https://staging.bloom-dev.salk.edu:8443/api
-NEXT_PUBLIC_APP_URL=https://staging.bloom-dev.salk.edu:8443
+# URLs — non-standard 8443 port must appear in every user-facing URL.
+# All point at the new staging.bloom.salk.edu hostname; the legacy
+# staging.bloom-dev.salk.edu still serves at the Caddy layer for
+# backwards compatibility per Phase 1 dual-serve.
+SITE_URL=https://staging.bloom.salk.edu:8443
+API_EXTERNAL_URL=https://staging.bloom.salk.edu:8443/api
+# ADDITIONAL_REDIRECT_URLS lists BOTH old and new during the transition
+# so Supabase OAuth doesn't reject callbacks from in-flight sign-ins
+# that started on the legacy hostname.
+ADDITIONAL_REDIRECT_URLS=https://staging.bloom.salk.edu:8443,https://staging.bloom-dev.salk.edu:8443
+NEXT_PUBLIC_SUPABASE_URL=https://staging.bloom.salk.edu:8443/api
+NEXT_PUBLIC_APP_URL=https://staging.bloom.salk.edu:8443
 SUPABASE_URL=http://kong:8000
-SUPABASE_PUBLIC_URL=https://staging.bloom-dev.salk.edu:8443/api
+SUPABASE_PUBLIC_URL=https://staging.bloom.salk.edu:8443/api
 SUPABASE_COOKIE_NAME=sb-bloom-auth-token
-STUDIO_SUPABASE_PUBLIC_URL=https://staging-studio.bloom-dev.salk.edu:8443
-MINIO_BROWSER_REDIRECT_URL=https://staging-minio.bloom-dev.salk.edu:8443
-CORS_ORIGINS=https://staging.bloom-dev.salk.edu:8443
-BLOOM_PLOTS_URL=https://staging.bloom-dev.salk.edu:8443/plots
+STUDIO_SUPABASE_PUBLIC_URL=https://staging-studio.bloom.salk.edu:8443
+MINIO_BROWSER_REDIRECT_URL=https://staging-minio.bloom.salk.edu:8443
+CORS_ORIGINS=https://staging.bloom.salk.edu:8443
+BLOOM_PLOTS_URL=https://staging.bloom.salk.edu:8443/plots
 
 # Internal service URLs
 BLOOM_MCP_URL=http://bloommcp:8811/mcp
@@ -85,7 +96,7 @@ JWT_EXPIRY=3600
 # SMTP relay via Salk's neoemex1 MTA (TLS 1.2 on port 25, IP-whitelisted; no auth)
 SMTP_HOST=neoemex1.salk.edu
 SMTP_PORT=25
-SMTP_ADMIN_EMAIL=noreply@bloom-dev.salk.edu
+SMTP_ADMIN_EMAIL=noreply@bloom.salk.edu
 SMTP_SENDER_NAME=Bloom
 SMTP_MAX_FREQUENCY=60s
 
@@ -100,4 +111,4 @@ LOCAL_LLM_MODEL=Qwen/Qwen3.5-9B
 # Browser-facing langchain agent endpoint. Caddy routes /langchain/* on
 # this host to langchain-agent:5002; the URL is baked into the bloom-web
 # JS bundle at build time (NEXT_PUBLIC_*) so the browser can hit it.
-NEXT_PUBLIC_MCP_URL=https://staging.bloom-dev.salk.edu:8443
+NEXT_PUBLIC_MCP_URL=https://staging.bloom.salk.edu:8443

--- a/.env.staging.defaults
+++ b/.env.staging.defaults
@@ -20,15 +20,10 @@ DOMAIN_STUDIO=staging-studio.bloom.salk.edu
 DOMAIN_MINIO=staging-minio.bloom.salk.edu
 
 # Caddy (non-standard ports so prod and staging coexist on the same host)
-# Phase 1 dual-serve: staging's Caddy issues ONE multi-SAN cert covering both
-# the new *.bloom.salk.edu wildcard AND the legacy *.bloom-dev.salk.edu
-# wildcard. Both URL families resolve to this server and Caddy serves them
-# identically. Phase 2 (follow-up) switches the legacy family to a 308
-# redirect; Phase 3 drops it entirely.
 CADDY_HTTP_LISTEN_PORT=8080
 CADDY_HTTPS_LISTEN_PORT=8443
 
-CADDY_SITE_ADDRESSES=https://*.bloom.salk.edu, https://*.bloom-dev.salk.edu
+CADDY_SITE_ADDRESSES=https://*.bloom.salk.edu
 
 
 
@@ -59,15 +54,10 @@ STUDIO_DEFAULT_PROJECT=default
 # with admin passwords, so treat as credentials rather than config.
 
 # URLs — non-standard 8443 port must appear in every user-facing URL.
-# All point at the new staging.bloom.salk.edu hostname; the legacy
-# staging.bloom-dev.salk.edu still serves at the Caddy layer for
-# backwards compatibility per Phase 1 dual-serve.
+# All point at the new staging.bloom.salk.edu hostname.
 SITE_URL=https://staging.bloom.salk.edu:8443
 API_EXTERNAL_URL=https://staging.bloom.salk.edu:8443/api
-# ADDITIONAL_REDIRECT_URLS lists BOTH old and new during the transition
-# so Supabase OAuth doesn't reject callbacks from in-flight sign-ins
-# that started on the legacy hostname.
-ADDITIONAL_REDIRECT_URLS=https://staging.bloom.salk.edu:8443,https://staging.bloom-dev.salk.edu:8443
+ADDITIONAL_REDIRECT_URLS=https://staging.bloom.salk.edu:8443
 NEXT_PUBLIC_SUPABASE_URL=https://staging.bloom.salk.edu:8443/api
 NEXT_PUBLIC_APP_URL=https://staging.bloom.salk.edu:8443
 SUPABASE_URL=http://kong:8000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -303,7 +303,7 @@ jobs:
             : \"\${PORT:?missing CADDY_HTTPS_LISTEN_PORT in .env.prod}\"
 
             issuer=
-            for _ in \$(seq 1 36); do
+            for _ in \$(seq 1 24); do
               issuer=\$(echo | openssl s_client -connect 127.0.0.1:\$PORT -servername \"\$DOMAIN_MAIN\" 2>/dev/null | openssl x509 -noout -issuer 2>/dev/null || true)
               if echo \"\$issuer\" | grep -qi encrypt; then
                 echo \"Real Let's Encrypt cert active: \$issuer\"
@@ -793,7 +793,7 @@ jobs:
             : \"\${PORT:?missing CADDY_HTTPS_LISTEN_PORT in .env.staging}\"
 
             issuer=
-            for _ in \$(seq 1 36); do
+            for _ in \$(seq 1 24); do
               issuer=\$(echo | openssl s_client -connect 127.0.0.1:\$PORT -servername \"\$DOMAIN_MAIN\" 2>/dev/null | openssl x509 -noout -issuer 2>/dev/null || true)
               if echo \"\$issuer\" | grep -qi encrypt; then
                 echo \"Real Let's Encrypt cert active: \$issuer\"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -284,10 +284,14 @@ jobs:
           "
 
       # Layer 2 — Verify Caddy obtained a real Let's Encrypt cert. First
-      # deploy: ACME takes 30-90s, poll up to 120s. Subsequent redeploys:
-      # cached cert served instantly, first check passes. Failure here =
-      # Cloudflare flow is broken (token, CNAME, or plugin) and Caddy will
-      # keep retrying — stop the container to protect the LE budget.
+      # deploy: ACME takes 30-90s per SAN, polled up to 180s total. Phase 1
+      # of the bloom.salk.edu migration uses a 4-SAN cert (new apex +
+      # wildcard, plus legacy apex + wildcard); each SAN requires its own
+      # sequential DNS-01 challenge through the dns_challenge_override_domain,
+      # so the timeout was raised from 120s to 180s to accommodate. Subsequent
+      # redeploys: cached cert served instantly, first check passes. Failure
+      # here = Cloudflare flow is broken (token, CNAME, or plugin) and Caddy
+      # will keep retrying — stop the container to protect the LE budget.
       - name: Verify Caddy obtained a Let's Encrypt cert
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
@@ -299,7 +303,7 @@ jobs:
             : \"\${PORT:?missing CADDY_HTTPS_LISTEN_PORT in .env.prod}\"
 
             issuer=
-            for _ in \$(seq 1 24); do
+            for _ in \$(seq 1 36); do
               issuer=\$(echo | openssl s_client -connect 127.0.0.1:\$PORT -servername \"\$DOMAIN_MAIN\" 2>/dev/null | openssl x509 -noout -issuer 2>/dev/null || true)
               if echo \"\$issuer\" | grep -qi encrypt; then
                 echo \"Real Let's Encrypt cert active: \$issuer\"
@@ -307,7 +311,7 @@ jobs:
               fi
               sleep 5
             done
-            echo \"::error::Caddy did not obtain a real Let's Encrypt cert within 120s. Stopping caddy to protect LE rate limits.\"
+            echo \"::error::Caddy did not obtain a real Let's Encrypt cert within 180s. Stopping caddy to protect LE rate limits.\"
             echo \"Last observed issuer: \$issuer\"
             docker compose -f docker-compose.prod.yml --env-file .env.prod stop caddy || true
             exit 1
@@ -789,7 +793,7 @@ jobs:
             : \"\${PORT:?missing CADDY_HTTPS_LISTEN_PORT in .env.staging}\"
 
             issuer=
-            for _ in \$(seq 1 24); do
+            for _ in \$(seq 1 36); do
               issuer=\$(echo | openssl s_client -connect 127.0.0.1:\$PORT -servername \"\$DOMAIN_MAIN\" 2>/dev/null | openssl x509 -noout -issuer 2>/dev/null || true)
               if echo \"\$issuer\" | grep -qi encrypt; then
                 echo \"Real Let's Encrypt cert active: \$issuer\"
@@ -797,7 +801,7 @@ jobs:
               fi
               sleep 5
             done
-            echo \"::error::Caddy did not obtain a real Let's Encrypt cert within 120s. Stopping caddy to protect LE rate limits.\"
+            echo \"::error::Caddy did not obtain a real Let's Encrypt cert within 180s. Stopping caddy to protect LE rate limits.\"
             echo \"Last observed issuer: \$issuer\"
             docker compose -p bloom_v2_staging -f docker-compose.prod.yml --env-file .env.staging stop caddy || true
             exit 1

--- a/_WIKI/CADDY/README.md
+++ b/_WIKI/CADDY/README.md
@@ -33,13 +33,13 @@ We use DNS-01. Here's why HTTP-01 doesn't work for us.
 
 ### Why HTTP-01 doesn't work
 
-HTTP-01 makes Let's Encrypt fetch `http://bloom-dev.salk.edu/.well-known/acme-challenge/<token>`. That requires Let's Encrypt's servers to reach our server on port 80 from the public internet.
+HTTP-01 makes Let's Encrypt fetch `http://bloom.salk.edu/.well-known/acme-challenge/<token>`. That requires Let's Encrypt's servers to reach our server on port 80 from the public internet.
 
-`bloom-dev.salk.edu` sits behind Salk's firewall. Port 80 is blocked from outside. Let's Encrypt can't reach the file → challenge fails → no cert. Dead on arrival.
+`bloom.salk.edu` sits behind Salk's firewall. Port 80 is blocked from outside. Let's Encrypt can't reach the file → challenge fails → no cert. Dead on arrival.
 
 ### Why DNS-01 works (with one catch)
 
-DNS-01 instead asks: "put a TXT record at `_acme-challenge.bloom-dev.salk.edu`." Let's Encrypt then looks up the TXT through normal DNS — no need to reach our server directly. Firewalls don't matter.
+DNS-01 instead asks: "put a TXT record at `_acme-challenge.bloom.salk.edu`." Let's Encrypt then looks up the TXT through normal DNS — no need to reach our server directly. Firewalls don't matter.
 
 The catch: someone has to actually create that TXT record. That means write access to the `salk.edu` DNS zone — which Salk IT does not hand out to application containers.
 
@@ -48,10 +48,11 @@ The catch: someone has to actually create that TXT record. That means write acce
 Since we can't write to Salk's DNS, we go around it. We own a separate Cloudflare zone, `bloom-acme.talmolab.org`. Salk IT publishes one permanent CNAME:
 
 ```text
+_acme-challenge.bloom.salk.edu      CNAME  _acme-challenge.bloom-acme.talmolab.org
 _acme-challenge.bloom-dev.salk.edu  CNAME  _acme-challenge.bloom-acme.talmolab.org
 ```
 
-This says "any lookup for `_acme-challenge.bloom-dev.salk.edu` should go look at `_acme-challenge.bloom-acme.talmolab.org` instead."
+This says "any lookup for `_acme-challenge.bloom.salk.edu` (or the legacy `_acme-challenge.bloom-dev.salk.edu`) should go look at `_acme-challenge.bloom-acme.talmolab.org` instead." Both CNAMEs delegate to the same Cloudflare zone we control. The legacy `bloom-dev` CNAME stays in place during Phase 1 dual-serve so the legacy hostname's TLS cert keeps renewing — see "Hostname history" below.
 
 ### Why a custom Dockerfile
 
@@ -69,8 +70,8 @@ The Caddyfile site block opens with `{$CADDY_SITE_ADDRESSES}`, which expands per
 
 | Env     | `CADDY_SITE_ADDRESSES`                                     | What it issues                                         |
 | ------- | ------------------------------------------------------------ | ------------------------------------------------------ |
-| prod    | `https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu` | One cert with two SANs (apex + wildcard)               |
-| staging | `https://*.bloom-dev.salk.edu`                             | One wildcard cert (covers all three staging hostnames) |
+| prod    | `https://bloom.salk.edu, https://*.bloom.salk.edu, https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu` | One cert with 4 SANs (new apex+wildcard + legacy apex+wildcard during Phase 1 dual-serve) |
+| staging | `https://*.bloom.salk.edu, https://*.bloom-dev.salk.edu` | One cert with 2 SANs (both wildcards covering all staging subdomains in both families) |
 | CI      | `http://localhost`                                         | No cert —`http://` scheme disables ACME entirely    |
 
 ## Cert persistence across redeploys
@@ -89,7 +90,7 @@ It survives `docker compose down`, `docker compose up`, and full container recre
 
 Caddy stores the issued cert, the private key, the ACME account, and the renewal state inside `/data/caddy/certificates/...`.
 
-On every redeploy Caddy boots, reads `/data`, finds the existing `*.bloom-dev.salk.edu` cert, checks the expiry, and:
+On every redeploy Caddy boots, reads `/data`, finds the existing wildcard cert, checks the expiry, and:
 
 - **Cert valid + outside renewal window** → uses the cached cert. Zero Let's Encrypt traffic. The 30–90 s ACME window only happens **once**, on the very first deploy.
 - **Cert within 30 days of expiry** → triggers renewal in the background. Serving continues with the old cert until the new one lands.
@@ -127,7 +128,7 @@ These three must be in place before either environment can issue a cert:
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PROD_CLOUDFLARE_API_TOKEN`    | GitHub Actions repo secret. Scope:`Zone:DNS:Edit` on the Cloudflare zone containing `bloom-acme.talmolab.org`.                                  |
 | `STAGING_CLOUDFLARE_API_TOKEN` | GitHub Actions repo secret. Same scope; same value as the prod token is fine — both environments use the same Cloudflare delegation.               |
-| Salk DNS CNAME                   | `_acme-challenge.bloom-dev.salk.edu  CNAME  _acme-challenge.bloom-acme.talmolab.org` — published by Salk IT, one record covers prod and staging. |
+| Salk DNS CNAMEs                  | Two parallel records — `_acme-challenge.bloom.salk.edu CNAME _acme-challenge.bloom-acme.talmolab.org` (new) and `_acme-challenge.bloom-dev.salk.edu CNAME _acme-challenge.bloom-acme.talmolab.org` (legacy, retained for Phase 1 dual-serve). Each covers both prod and staging Caddy containers because wildcard ACME challenges all land at the parent name. |
 
 The token is consumed at runtime by the `caddy-dns/cloudflare` plugin via the `CLOUDFLARE_API_TOKEN` env var, injected from the per-environment GitHub secret in the deploy workflow's heredoc.
 
@@ -135,9 +136,21 @@ The token is consumed at runtime by the `caddy-dns/cloudflare` plugin via the `C
 
 | Env     | Main (`DOMAIN_MAIN`)         | Studio (`DOMAIN_STUDIO`)            | MinIO (`DOMAIN_MINIO`)             |
 | ------- | ------------------------------ | ------------------------------------- | ------------------------------------ |
-| prod    | `bloom-dev.salk.edu`         | `studio.bloom-dev.salk.edu`         | `minio.bloom-dev.salk.edu`         |
-| staging | `staging.bloom-dev.salk.edu` | `staging-studio.bloom-dev.salk.edu` | `staging-minio.bloom-dev.salk.edu` |
+| prod    | `bloom.salk.edu`         | `studio.bloom.salk.edu`         | `minio.bloom.salk.edu`         |
+| staging | `staging.bloom.salk.edu` | `staging-studio.bloom.salk.edu` | `staging-minio.bloom.salk.edu` |
 
-All staging hostnames sit under `bloom-dev.salk.edu` so the wildcard `*.bloom-dev.salk.edu` covers them. The staging `DOMAIN_MAIN` was previously `staging-bloom-dev.salk.edu` (sibling of `bloom-dev.salk.edu`, not under it) — PR #254 renamed it to `staging.bloom-dev.salk.edu` specifically to bring it under the wildcard.
+All staging hostnames sit under `bloom.salk.edu` so the wildcard `*.bloom.salk.edu` covers them. The legacy `staging.bloom-dev.salk.edu` family still resolves and serves the same content during Phase 1 dual-serve — see "Hostname history" below.
 
-> **DNS note:** browser access to `staging.bloom-dev.salk.edu` requires the name to resolve. Salk's wildcard A record for `*.bloom-dev.salk.edu` covers it from inside the Salk network (or on Salk VPN). From outside, you'll need a temporary `/etc/hosts` entry pointing the hostname at bloom-dev's IP, or an explicit Salk DNS record.
+> **DNS note:** browser access to `staging.bloom.salk.edu` requires the name to resolve. Salk's wildcard A record for `*.bloom.salk.edu` covers it from inside the Salk network (or on Salk VPN). From outside, you'll need a temporary `/etc/hosts` entry pointing the hostname at bloom-dev's IP, or an explicit Salk DNS record.
+
+## Hostname history
+
+The bloom stack originally lived behind `bloom-dev.salk.edu` and its `staging.bloom-dev.salk.edu` sibling — that was the "in-progress" public hostname while the V2 stack matured. The permanent prod hostname is `bloom.salk.edu` (no `-dev`), and the migration shipped via three phases:
+
+| Phase | What | When |
+|---|---|---|
+| Phase 1 | Dual-serve: Caddy serves both `bloom.salk.edu` and `bloom-dev.salk.edu` URL families identically. Both DNS A records resolve to the same bloom-dev server. Automated clients (cyl-scanners, graviscan) keep working at the legacy URL without reconfiguration. | Cutover deploy |
+| Phase 2 | Caddy switches the legacy hostnames from "serve identically" to a 308 Permanent Redirect to the new hostnames. Scanner clients must have been reconfigured (or use HTTP libraries that follow 308 on POST). | ~30 days post-cutover, separate PR |
+| Phase 3 | Legacy hostnames dropped from `CADDY_SITE_ADDRESSES` entirely. Caddy stops issuing certs for them. DNS records on the Salk side can stay (inert) or be removed via a future IT ticket. | ~90 days post-cutover, separate PR |
+
+The previous `staging-bloom-dev.salk.edu` (sibling of `bloom-dev.salk.edu`, not under it) was renamed by PR #254 to `staging.bloom-dev.salk.edu` specifically to bring it under the wildcard. The migration to `bloom.salk.edu` preserved that hyphenated subdomain shape (`staging-studio.bloom.salk.edu`, etc.).

--- a/_WIKI/CADDY/README.md
+++ b/_WIKI/CADDY/README.md
@@ -48,11 +48,10 @@ The catch: someone has to actually create that TXT record. That means write acce
 Since we can't write to Salk's DNS, we go around it. We own a separate Cloudflare zone, `bloom-acme.talmolab.org`. Salk IT publishes one permanent CNAME:
 
 ```text
-_acme-challenge.bloom.salk.edu      CNAME  _acme-challenge.bloom-acme.talmolab.org
-_acme-challenge.bloom-dev.salk.edu  CNAME  _acme-challenge.bloom-acme.talmolab.org
+_acme-challenge.bloom.salk.edu  CNAME  _acme-challenge.bloom-acme.talmolab.org
 ```
 
-This says "any lookup for `_acme-challenge.bloom.salk.edu` (or the legacy `_acme-challenge.bloom-dev.salk.edu`) should go look at `_acme-challenge.bloom-acme.talmolab.org` instead." Both CNAMEs delegate to the same Cloudflare zone we control. The legacy `bloom-dev` CNAME stays in place during Phase 1 dual-serve so the legacy hostname's TLS cert keeps renewing — see "Hostname history" below.
+This says "any lookup for `_acme-challenge.bloom.salk.edu` should go look at `_acme-challenge.bloom-acme.talmolab.org` instead." The CNAME delegates to the Cloudflare zone we control. Wildcard ACME challenges also land at the parent name, so this single record covers both the apex and the wildcard.
 
 ### Why a custom Dockerfile
 
@@ -70,8 +69,8 @@ The Caddyfile site block opens with `{$CADDY_SITE_ADDRESSES}`, which expands per
 
 | Env     | `CADDY_SITE_ADDRESSES`                                     | What it issues                                         |
 | ------- | ------------------------------------------------------------ | ------------------------------------------------------ |
-| prod    | `https://bloom.salk.edu, https://*.bloom.salk.edu, https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu` | One cert with 4 SANs (new apex+wildcard + legacy apex+wildcard during Phase 1 dual-serve) |
-| staging | `https://*.bloom.salk.edu, https://*.bloom-dev.salk.edu` | One cert with 2 SANs (both wildcards covering all staging subdomains in both families) |
+| prod    | `https://bloom.salk.edu, https://*.bloom.salk.edu`         | One cert with 2 SANs (apex + wildcard)                  |
+| staging | `https://*.bloom.salk.edu`                                 | One cert with 1 SAN (wildcard covering all staging subdomains) |
 | CI      | `http://localhost`                                         | No cert —`http://` scheme disables ACME entirely    |
 
 ## Cert persistence across redeploys
@@ -128,7 +127,7 @@ These three must be in place before either environment can issue a cert:
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PROD_CLOUDFLARE_API_TOKEN`    | GitHub Actions repo secret. Scope:`Zone:DNS:Edit` on the Cloudflare zone containing `bloom-acme.talmolab.org`.                                  |
 | `STAGING_CLOUDFLARE_API_TOKEN` | GitHub Actions repo secret. Same scope; same value as the prod token is fine — both environments use the same Cloudflare delegation.               |
-| Salk DNS CNAMEs                  | Two parallel records — `_acme-challenge.bloom.salk.edu CNAME _acme-challenge.bloom-acme.talmolab.org` (new) and `_acme-challenge.bloom-dev.salk.edu CNAME _acme-challenge.bloom-acme.talmolab.org` (legacy, retained for Phase 1 dual-serve). Each covers both prod and staging Caddy containers because wildcard ACME challenges all land at the parent name. |
+| Salk DNS CNAME                   | `_acme-challenge.bloom.salk.edu CNAME _acme-challenge.bloom-acme.talmolab.org`. Covers both prod and staging Caddy containers because wildcard ACME challenges all land at the parent name. |
 
 The token is consumed at runtime by the `caddy-dns/cloudflare` plugin via the `CLOUDFLARE_API_TOKEN` env var, injected from the per-environment GitHub secret in the deploy workflow's heredoc.
 
@@ -139,18 +138,10 @@ The token is consumed at runtime by the `caddy-dns/cloudflare` plugin via the `C
 | prod    | `bloom.salk.edu`         | `studio.bloom.salk.edu`         | `minio.bloom.salk.edu`         |
 | staging | `staging.bloom.salk.edu` | `staging-studio.bloom.salk.edu` | `staging-minio.bloom.salk.edu` |
 
-All staging hostnames sit under `bloom.salk.edu` so the wildcard `*.bloom.salk.edu` covers them. The legacy `staging.bloom-dev.salk.edu` family still resolves and serves the same content during Phase 1 dual-serve — see "Hostname history" below.
+All staging hostnames sit under `bloom.salk.edu` so the wildcard `*.bloom.salk.edu` covers them.
 
-> **DNS note:** browser access to `staging.bloom.salk.edu` requires the name to resolve. Salk's wildcard A record for `*.bloom.salk.edu` covers it from inside the Salk network (or on Salk VPN). From outside, you'll need a temporary `/etc/hosts` entry pointing the hostname at bloom-dev's IP, or an explicit Salk DNS record.
+> **DNS note:** browser access to `staging.bloom.salk.edu` requires the name to resolve. Salk's wildcard A record for `*.bloom.salk.edu` covers it from inside the Salk network (or on Salk VPN). From outside, you'll need a temporary `/etc/hosts` entry pointing the hostname at the bloom server's IP, or an explicit Salk DNS record.
 
 ## Hostname history
 
-The bloom stack originally lived behind `bloom-dev.salk.edu` and its `staging.bloom-dev.salk.edu` sibling — that was the "in-progress" public hostname while the V2 stack matured. The permanent prod hostname is `bloom.salk.edu` (no `-dev`), and the migration shipped via three phases:
-
-| Phase | What | When |
-|---|---|---|
-| Phase 1 | Dual-serve: Caddy serves both `bloom.salk.edu` and `bloom-dev.salk.edu` URL families identically. Both DNS A records resolve to the same bloom-dev server. Automated clients (cyl-scanners, graviscan) keep working at the legacy URL without reconfiguration. | Cutover deploy |
-| Phase 2 | Caddy switches the legacy hostnames from "serve identically" to a 308 Permanent Redirect to the new hostnames. Scanner clients must have been reconfigured (or use HTTP libraries that follow 308 on POST). | ~30 days post-cutover, separate PR |
-| Phase 3 | Legacy hostnames dropped from `CADDY_SITE_ADDRESSES` entirely. Caddy stops issuing certs for them. DNS records on the Salk side can stay (inert) or be removed via a future IT ticket. | ~90 days post-cutover, separate PR |
-
-The previous `staging-bloom-dev.salk.edu` (sibling of `bloom-dev.salk.edu`, not under it) was renamed by PR #254 to `staging.bloom-dev.salk.edu` specifically to bring it under the wildcard. The migration to `bloom.salk.edu` preserved that hyphenated subdomain shape (`staging-studio.bloom.salk.edu`, etc.).
+The bloom stack originally lived behind `bloom-dev.salk.edu` and its `staging.bloom-dev.salk.edu` sibling — that was the "in-progress" public hostname while the V2 stack matured. The permanent prod hostname is `bloom.salk.edu` (no `-dev`); the migration shipped as a single-deploy cutover (scanner clients were reconfigured beforehand) rather than a multi-phase dual-serve. The legacy `bloom-dev.salk.edu` family is no longer served.

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,21 +18,17 @@
 #   pitfall where `host_a, host_b:port` would attach :port only to host_b
 #   and leave host_a defaulting to :443 with automatic HTTPS.
 #
-#     prod:    `https://bloom.salk.edu, https://*.bloom.salk.edu,
-#               https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu`
-#              (Phase 1 dual-serve: both new and legacy hostnames; 4-SAN cert.
-#              Phase 2 drops the legacy pair; Phase 3 removes entirely.)
-#     staging: `https://*.bloom.salk.edu, https://*.bloom-dev.salk.edu`
-#              (2 wildcards covering all staging subdomains, both families)
+#     prod:    `https://bloom.salk.edu, https://*.bloom.salk.edu`
+#              (2-SAN cert: apex + wildcard)
+#     staging: `https://*.bloom.salk.edu`
+#              (1 wildcard covering all staging subdomains)
 #     CI:      `http://localhost`
 #              (forces HTTP-only — no TLS, no ACME, no Let's Encrypt call)
 #
-#   Both prod and staging issue their certs via two Salk-DNS CNAMEs:
-#     _acme-challenge.bloom.salk.edu     -> _acme-challenge.bloom-acme.talmolab.org
-#     _acme-challenge.bloom-dev.salk.edu -> _acme-challenge.bloom-acme.talmolab.org
+#   Prod and staging both issue their certs via the Salk-DNS CNAME:
+#     _acme-challenge.bloom.salk.edu -> _acme-challenge.bloom-acme.talmolab.org
 #   Wildcard challenges land at the parent name per the ACME spec, so a
-#   single CNAME per parent (bloom.salk.edu, bloom-dev.salk.edu) covers
-#   both the apex and the wildcard.
+#   single CNAME at bloom.salk.edu covers both the apex and the wildcard.
 #
 #   Per-hostname routing is done inside the block via `@matcher host X` +
 #   `handle @matcher`, preserving the previous per-host route logic.
@@ -54,33 +50,18 @@
 
 {$CADDY_SITE_ADDRESSES} {
 	# Multi-SAN cert covering all the subjects listed in CADDY_SITE_ADDRESSES,
-	# issued via ACME DNS-01 against Cloudflare's API. Prod's cert carries 4
-	# SANs during Phase 1 dual-serve (bloom.salk.edu + *.bloom.salk.edu +
-	# bloom-dev.salk.edu + *.bloom-dev.salk.edu); staging's carries 2 SANs.
-	# For http://-scheme addresses (CI mode) the tls block is parsed but
-	# inert — Caddy does not request a cert.
-	#
-	# `dns_challenge_override_domain` makes CNAME delegation work. It takes
-	# the LITERAL FQDN where the TXT will be written — not a parent domain
-	# that gets `_acme-challenge.` prepended. (The directive's documentation
-	# is ambiguous on this; certmagic at runtime treats the value as the
-	# exact target name.) So the value MUST include the `_acme-challenge.`
-	# prefix so it matches the Salk CNAME target. Confirmed in Caddy 2.11.3
-	# with caddy-dns/cloudflare v0.2.4 — see the dns_manager debug log
-	# `"creating DNS record","dns_name":"<value>"` to verify after a deploy.
+	# issued via ACME DNS-01 against Cloudflare's API. Prod's cert carries
+	# 2 SANs (bloom.salk.edu + *.bloom.salk.edu); staging's carries 1
+	# (*.bloom.salk.edu).
 	tls {
 		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
 		dns_challenge_override_domain _acme-challenge.bloom-acme.talmolab.org
 	}
 
 	# -------------------
-	# Main Application — DOMAIN_MAIN + legacy hostnames (Phase 1 dual-serve).
-	# Both the new bloom.salk.edu/staging.bloom.salk.edu AND the legacy
-	# bloom-dev.salk.edu/staging.bloom-dev.salk.edu match the same handlers
-	# so automated clients keep working. Phase 2 (follow-up PR) switches
-	# the legacy hostnames to a 308 redirect; Phase 3 drops them entirely.
+	# Main Application — DOMAIN_MAIN
 	# -------------------
-	@main host {$DOMAIN_MAIN} bloom-dev.salk.edu staging.bloom-dev.salk.edu
+	@main host {$DOMAIN_MAIN}
 	handle @main {
 		# Supabase API — strip /api prefix, proxy to Kong
 		handle_path /api/* {
@@ -114,10 +95,7 @@
 	# -------------------
 	# Supabase Studio — DOMAIN_STUDIO
 	# -------------------
-	# Phase 1 dual-serve: matches both the new studio.bloom.salk.edu /
-	# staging-studio.bloom.salk.edu AND the legacy studio.bloom-dev.salk.edu /
-	# staging-studio.bloom-dev.salk.edu.
-	@studio host {$DOMAIN_STUDIO} studio.bloom-dev.salk.edu staging-studio.bloom-dev.salk.edu
+	@studio host {$DOMAIN_STUDIO}
 	handle @studio {
 		# Studio backend routes → Kong
 		handle_path /auth/* {
@@ -151,11 +129,9 @@
 	}
 
 	# -------------------
-	# MinIO Console — DOMAIN_MINIO + legacy hostnames (Phase 1 dual-serve).
-	# Matches both new minio.bloom.salk.edu / staging-minio.bloom.salk.edu
-	# AND legacy minio.bloom-dev.salk.edu / staging-minio.bloom-dev.salk.edu.
+	# MinIO Console — DOMAIN_MINIO
 	# -------------------
-	@minio host {$DOMAIN_MINIO} minio.bloom-dev.salk.edu staging-minio.bloom-dev.salk.edu
+	@minio host {$DOMAIN_MINIO}
 	handle @minio {
 		reverse_proxy supabase-minio:{$MINIO_CONSOLE_PORT} {
 			transport http {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,18 +18,21 @@
 #   pitfall where `host_a, host_b:port` would attach :port only to host_b
 #   and leave host_a defaulting to :443 with automatic HTTPS.
 #
-#     prod:    `https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu`
-#              (apex needed — wildcards do not match the parent)
-#     staging: `https://*.bloom-dev.salk.edu`
-#              (all 3 staging hostnames are wildcard-covered)
+#     prod:    `https://bloom.salk.edu, https://*.bloom.salk.edu,
+#               https://bloom-dev.salk.edu, https://*.bloom-dev.salk.edu`
+#              (Phase 1 dual-serve: both new and legacy hostnames; 4-SAN cert.
+#              Phase 2 drops the legacy pair; Phase 3 removes entirely.)
+#     staging: `https://*.bloom.salk.edu, https://*.bloom-dev.salk.edu`
+#              (2 wildcards covering all staging subdomains, both families)
 #     CI:      `http://localhost`
 #              (forces HTTP-only — no TLS, no ACME, no Let's Encrypt call)
 #
-#   Both prod and staging issue their cert via the same single Salk-DNS CNAME
-#   (_acme-challenge.bloom-dev.salk.edu -> _acme-challenge.bloom-acme.talmolab.org)
-#   because the apex challenge and the wildcard challenge BOTH land at
-#   _acme-challenge.bloom-dev.salk.edu (wildcards challenge at the parent name
-#   per the ACME spec).
+#   Both prod and staging issue their certs via two Salk-DNS CNAMEs:
+#     _acme-challenge.bloom.salk.edu     -> _acme-challenge.bloom-acme.talmolab.org
+#     _acme-challenge.bloom-dev.salk.edu -> _acme-challenge.bloom-acme.talmolab.org
+#   Wildcard challenges land at the parent name per the ACME spec, so a
+#   single CNAME per parent (bloom.salk.edu, bloom-dev.salk.edu) covers
+#   both the apex and the wildcard.
 #
 #   Per-hostname routing is done inside the block via `@matcher host X` +
 #   `handle @matcher`, preserving the previous per-host route logic.
@@ -50,9 +53,12 @@
 # =============================================================================
 
 {$CADDY_SITE_ADDRESSES} {
-	# One wildcard SAN cert covering apex + *.bloom-dev.salk.edu via ACME
-	# DNS-01 against Cloudflare's API. For http://-scheme addresses (CI mode)
-	# the tls block is parsed but inert — Caddy does not request a cert.
+	# Multi-SAN cert covering all the subjects listed in CADDY_SITE_ADDRESSES,
+	# issued via ACME DNS-01 against Cloudflare's API. Prod's cert carries 4
+	# SANs during Phase 1 dual-serve (bloom.salk.edu + *.bloom.salk.edu +
+	# bloom-dev.salk.edu + *.bloom-dev.salk.edu); staging's carries 2 SANs.
+	# For http://-scheme addresses (CI mode) the tls block is parsed but
+	# inert — Caddy does not request a cert.
 	#
 	# `dns_challenge_override_domain` makes CNAME delegation work. It takes
 	# the LITERAL FQDN where the TXT will be written — not a parent domain
@@ -68,9 +74,13 @@
 	}
 
 	# -------------------
-	# Main Application — DOMAIN_MAIN
+	# Main Application — DOMAIN_MAIN + legacy hostnames (Phase 1 dual-serve).
+	# Both the new bloom.salk.edu/staging.bloom.salk.edu AND the legacy
+	# bloom-dev.salk.edu/staging.bloom-dev.salk.edu match the same handlers
+	# so automated clients keep working. Phase 2 (follow-up PR) switches
+	# the legacy hostnames to a 308 redirect; Phase 3 drops them entirely.
 	# -------------------
-	@main host {$DOMAIN_MAIN}
+	@main host {$DOMAIN_MAIN} bloom-dev.salk.edu staging.bloom-dev.salk.edu
 	handle @main {
 		# Supabase API — strip /api prefix, proxy to Kong
 		handle_path /api/* {
@@ -104,7 +114,10 @@
 	# -------------------
 	# Supabase Studio — DOMAIN_STUDIO
 	# -------------------
-	@studio host {$DOMAIN_STUDIO}
+	# Phase 1 dual-serve: matches both the new studio.bloom.salk.edu /
+	# staging-studio.bloom.salk.edu AND the legacy studio.bloom-dev.salk.edu /
+	# staging-studio.bloom-dev.salk.edu.
+	@studio host {$DOMAIN_STUDIO} studio.bloom-dev.salk.edu staging-studio.bloom-dev.salk.edu
 	handle @studio {
 		# Studio backend routes → Kong
 		handle_path /auth/* {
@@ -138,9 +151,11 @@
 	}
 
 	# -------------------
-	# MinIO Console — DOMAIN_MINIO
+	# MinIO Console — DOMAIN_MINIO + legacy hostnames (Phase 1 dual-serve).
+	# Matches both new minio.bloom.salk.edu / staging-minio.bloom.salk.edu
+	# AND legacy minio.bloom-dev.salk.edu / staging-minio.bloom-dev.salk.edu.
 	# -------------------
-	@minio host {$DOMAIN_MINIO}
+	@minio host {$DOMAIN_MINIO} minio.bloom-dev.salk.edu staging-minio.bloom-dev.salk.edu
 	handle @minio {
 		reverse_proxy supabase-minio:{$MINIO_CONSOLE_PORT} {
 			transport http {

--- a/scripts/generate-env-config.sh
+++ b/scripts/generate-env-config.sh
@@ -13,26 +13,31 @@ ENV="${1:-prod}"
 PREFIX=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
 
 if [ "$ENV" = "prod" ]; then
-  # Production uses the server's hostname-matching domain (bloom-dev.salk.edu)
-  # since bloom-dev IS the production host. The parent domain already resolves
-  # in Salk DNS; Salk IT only needs to add the studio./minio. subdomains.
-  DOMAIN_MAIN="bloom-dev.salk.edu"
-  DOMAIN_STUDIO="studio.bloom-dev.salk.edu"
-  DOMAIN_MINIO="minio.bloom-dev.salk.edu"
+  # Production uses the permanent bloom.salk.edu hostname. 
+  # During Phase 1
+  # dual-serve the legacy bloom-dev.salk.edu family is ALSO served by Caddy
+  # (see CADDY_SITE_ADDRESSES in .env.prod.defaults and the host matchers
+  # in caddy/Caddyfile). DOMAIN_* below names only the new (canonical)
+  # hostnames since these are what the frontend bakes into its bundle and
+  # what new bookmarks should use.
+  DOMAIN_MAIN="bloom.salk.edu"
+  DOMAIN_STUDIO="studio.bloom.salk.edu"
+  DOMAIN_MINIO="minio.bloom.salk.edu"
   CADDY_HTTP_LISTEN_PORT="80"
   CADDY_HTTPS_LISTEN_PORT="443"
   # Data paths live on /data (40 TB) — root filesystem is only 98 GB.
   MINIO_DATA_PATH="/data/bloom/minio-data"
   DEPLOY_PATH="/data/bloom/production"
 elif [ "$ENV" = "staging" ]; then
-  # Staging hostname uses a dot (`staging.bloom-dev.salk.edu`) so it sits as
-  # a direct child of bloom-dev.salk.edu and is covered by the wildcard SAN
-  # cert. The studio./minio. subdomains keep the `staging-` prefix because
-  # they predate the rename. Non-standard ports so prod + staging coexist on
-  # the same server.
-  DOMAIN_MAIN="staging.bloom-dev.salk.edu"
-  DOMAIN_STUDIO="staging-studio.bloom-dev.salk.edu"
-  DOMAIN_MINIO="staging-minio.bloom-dev.salk.edu"
+  # Staging hostname uses a dot (`staging.bloom.salk.edu`) so it sits as
+  # a direct child of bloom.salk.edu and is covered by the wildcard SAN
+  # cert. The studio./minio. subdomains keep the `staging-` hyphenated
+  # prefix from the bloom-dev era. Non-standard ports so prod + staging
+  # coexist on the same server. Phase 1 dual-serve also covers the
+  # legacy *.bloom-dev.salk.edu family (see .env.staging.defaults).
+  DOMAIN_MAIN="staging.bloom.salk.edu"
+  DOMAIN_STUDIO="staging-studio.bloom.salk.edu"
+  DOMAIN_MINIO="staging-minio.bloom.salk.edu"
   CADDY_HTTP_LISTEN_PORT="8080"
   CADDY_HTTPS_LISTEN_PORT="8443"
   MINIO_DATA_PATH="/data/bloom/minio-staging"

--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -28,7 +28,7 @@ USAGE
 -----
 Set these env vars (or put them in a .env file next to this script):
 
-    SUPABASE_URL=https://staging.bloom-dev.salk.edu:8443/api
+    SUPABASE_URL=https://staging.bloom.salk.edu:8443/api
     SERVICE_ROLE_KEY=<staging service_role JWT>
     POSTGRES_DSN=postgres://supabase_admin:<pass>@host:port/postgres
 


### PR DESCRIPTION
# Cutover prod + staging to `bloom.salk.edu`

## Summary

This PR migrates the public hostname for the bloom stack from `bloom-dev.salk.edu` (the "in-progress" name used during V2 buildout) to the permanent prod name `bloom.salk.edu`.

Both staging and prod cut over together in a **single deploy** — no dual-serve phase. Scanner clients (cyl-scanners, graviscan) are reconfigured to the new URL beforehand; after the deploy the legacy `bloom-dev.salk.edu` family is no longer served.

This branch carries 2 commits — the first set up dual-serve, the second simplifies it to direct cutover after the team decided to skip the multi-phase plan.

---

### What's NOT in this PR

- **Cert monitor `EXPECTED_IDENTIFIERS_PER_ENV` update** — depends on PR #288 (cert renewal monitor) merging first. Will land as a follow-up commit on this same branch once that PR ships.
- **Salk IT removal of legacy DNS records** — separate cleanup ticket. Once the deploy is verified, the `bloom-dev.salk.edu`, `*.bloom-dev.salk.edu`, and `_acme-challenge.bloom-dev.salk.edu` records can be removed (they become inert once Caddy stops responding for them).

### What works after this PR's deploy

✅ **Browser users**: see `bloom.salk.edu` as the canonical URL (env-driven `NEXT_PUBLIC_*` vars). Existing bookmarks at `bloom-dev.salk.edu` no longer resolve to a served page (the URL is dead).

✅ **Cyl-scanners, graviscan, automated uploaders**: must be reconfigured to `https://bloom.salk.edu/api/...` *before* this deploy. After deploy, the legacy `bloom-dev.salk.edu` endpoint returns a connection refused / cert error.

✅ **OAuth + Supabase auth**: callbacks go to `bloom.salk.edu` only. In-flight sign-ins started on the legacy URL would fail — acceptable for a planned cutover.

✅ **TLS**: a single multi-SAN cert per Caddy container. Prod's cert has 2 SANs (`bloom.salk.edu` + `*.bloom.salk.edu`); staging's has 1 (`*.bloom.salk.edu`). Both renew via the existing ACME flow.

---

## Test plan

### Post-merge — staging first

Watch the staging deploy run:

- [ ] **Layer 1**: Cloudflare token preflight passes
- [ ] **Layer 2 (~100s)**: staging's Caddy obtains a 1-SAN cert (`*.bloom.salk.edu`). Cert-verify step's `Last observed issuer` populates with a Let's Encrypt issuer name (`YE1`, `YE2`, etc).
- [ ] **Layer 3**: smoke test passes on the new hostname endpoints:
  - `https://staging.bloom.salk.edu:8443/`
  - `https://staging-studio.bloom.salk.edu:8443/`
  - `https://staging-minio.bloom.salk.edu:8443/`
  - `https://staging.bloom.salk.edu:8443/api/rest/v1/`

Browser verify staging:

- [ ] Log in at `https://staging.bloom.salk.edu:8443/` — Supabase auth works
- [ ] Studio at `staging-studio.bloom.salk.edu:8443` loads
- [ ] MinIO console at `staging-minio.bloom.salk.edu:8443` loads
- [ ] `https://staging.bloom-dev.salk.edu:8443/` returns a connection error (sanity-check that legacy is no longer served)

### Post-merge — prod cutover (promote staging → main)

- [ ] Open staging→main PR
- [ ] Approve the Production env-protection gate
- [ ] Watch the prod deploy:
  - [ ] **Layer 1**: Cloudflare token preflight passes
  - [ ] **Layer 2 (~120s)**: prod's Caddy obtains a 2-SAN cert (`bloom.salk.edu` + `*.bloom.salk.edu`)
  - [ ] **Layer 3**: smoke test passes on the new hostname endpoints:
    - `https://bloom.salk.edu/`
    - `https://studio.bloom.salk.edu/`
    - `https://minio.bloom.salk.edu/`
    - `https://bloom.salk.edu/api/rest/v1/`

Browser verify prod:

- [ ] Log in at `https://bloom.salk.edu/` — Supabase auth works
- [ ] Studio at `studio.bloom.salk.edu` loads
- [ ] MinIO console at `minio.bloom.salk.edu` loads
- [ ] One cyl-scanner upload completes via the new URL
- [ ] `https://bloom-dev.salk.edu/` returns a connection error

---

## Rollback path

If anything breaks at cutover, the existing deploy workflow's rollback step reverts both the git tree and the env file on Layer 2 failure. Re-applying the previous `.env.{prod,staging}.defaults` restores `CADDY_SITE_ADDRESSES` to the bloom-dev family.

If scanner clients turn out not to have been reconfigured, the rollback restores `bloom-dev.salk.edu` service and we can re-plan.

---

## Related

- Tracked in #291 (umbrella issue) — DNS pre-flight, scanner reconfig checklist, deploy verification
- Builds on #254 (Caddy ACME DNS-01 via CNAME delegation), #283 (`dns_challenge_override_domain` directive), #284 (`_acme-challenge.` prefix fix)
- Coordinates with #288 (cert renewal monitor) — after #288 merges, this branch gets a follow-up commit updating `EXPECTED_IDENTIFIERS_PER_ENV` to the new 2-SAN / 1-SAN identifiers
