### PR TITLE
fix(prod): resolve #105 — Kong routes, realtime hostname, PROD_SETUP.md

### DIFF
--- a/PROD_SETUP.md
+++ b/PROD_SETUP.md
@@ -1,205 +1,115 @@
-# 🏭 Bloom Production Setup Guide
+# Bloom Production Setup
 
-This guide covers deploying Bloom in production mode with optimized builds and proper security configurations.
+This guide covers the **one-time host setup** needed before the first deploy.
+After that, every deploy runs automatically through
+[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) when a PR is
+merged to `main`. There is no supported manual `docker compose up` path on
+production — the workflow is the only sanctioned entrypoint.
 
----
-
-## 📋 Prerequisites
-
-Before starting, ensure you have:
-
-- Docker and Docker Compose installed
-- Python 3.8 or higher
-- Root or sudo access
-- Domain names configured (optional)
-
+For how the stack actually works (Caddy, TLS, DNS, container topology), see
+the wiki pages linked at the bottom of this doc.
 
 ---
 
-## 💾 STEP 1: MinIO Storage Setup
+## What needs to be on the host before the first deploy
 
-### Create Storage Directory
+1. **Docker + Docker Compose v2.** The deploy workflow refuses to run if
+   `docker compose version` reports a major version below 2.
 
-```bash
-# Create directory
-sudo mkdir -p /var/lib/bloom/minio
+2. **A self-hosted GitHub Actions runner**, registered to this repo,
+   running as the `bloom-deploy` system user. The deploy workflow checks
+   out into the runner's workspace at
+   `/home/bloom-deploy/actions-runner/_work/bloom/bloom` and runs
+   `docker compose` from there.
 
-# Set ownership
-sudo chown -R $USER:$USER /var/lib/bloom/minio
+3. **MinIO storage directory:**
+   ```bash
+   sudo mkdir -p /var/lib/bloom/minio
+   sudo chown -R bloom-deploy:bloom-deploy /var/lib/bloom/minio
+   sudo chmod 755 /var/lib/bloom/minio
+   ```
 
-# Set permissions
-chmod 755 /var/lib/bloom/minio
-```
+4. **Salk DNS — one CNAME record**, published by Salk IT:
+   ```
+   _acme-challenge.bloom-dev.salk.edu  CNAME  _acme-challenge.bloom-acme.talmolab.org
+   ```
+   Without this, Caddy cannot complete the DNS-01 ACME challenge and no
+   TLS cert is issued. See the Caddy wiki page for the full delegation
+   story.
 
----
+5. **GitHub Secrets** in the repo settings under the `Production`
+   environment. The deploy workflow refuses to run without all of these:
 
-## ⚙️ STEP 2: Environment Configuration
+   | Secret | Purpose |
+   |---|---|
+   | `PROD_POSTGRES_PASSWORD` | Postgres superuser password |
+   | `PROD_JWT_SECRET` | Signs all Supabase JWTs |
+   | `PROD_ANON_KEY` | Anonymous client key |
+   | `PROD_SERVICE_ROLE_KEY` | Server-side service role key |
+   | `PROD_DB_ENC_KEY` | Database column encryption key |
+   | `PROD_MINIO_PASSWORD` | MinIO root password |
+   | `PROD_VAULT_ENC_KEY` | Supabase vault encryption key |
+   | `PROD_SUPAVISOR_ENC_KEY` | Supavisor pooler encryption key |
+   | `PROD_SECRET_KEY_BASE` | Realtime / phoenix secret base |
+   | `PROD_DASHBOARD_PASSWORD` | Supabase Studio dashboard password |
+   | `PROD_BLOOMMCP_API_KEY` | bloommcp tool-auth key |
+   | `PROD_OPENAI_API_KEY` | OpenAI for langchain-agent |
+   | `PROD_LANGCHAIN_API_KEY` | LangSmith tracing key |
+   | `PROD_BLOOM_AGENT_KEY` | Service role for the agent's Supabase access |
+   | `PROD_CLOUDFLARE_API_TOKEN` | Caddy DNS-01 ACME token (zone: `bloom-acme.talmolab.org`) |
 
-### Step 1: Get Environment Template
-
-Get the production environment template from:
-**[Notion: Environment Configuration](https://www.notion.so/Plan-2734a67a766780e89373c1e1ec687a4d)**
-
-Copy the `.env.prod` template content and create the file:
-
-```bash
-# Create .env.prod file
-nano .env.prod
-# Or use your preferred editor
-```
-
-### Step 2: Generate Secure Keys
-
-Generate new JWT keys and secrets:
-
-```bash
-# Generate random strings for keys
-openssl rand -base64 32  # For JWT_SECRET
-openssl rand -base64 32  # For VAULT_ENC_KEY
-openssl rand -hex 32     # For SUPAVISOR_ENC_KEY
-```
-
-### Step 3: Configure Critical Variables
-
-Edit `.env.prod` and update these values:
-
-**Domain Configuration:**
-```bash
-DOMAIN_MAIN=yourdomain.com
-DOMAIN_STUDIO=studio.yourdomain.com
-DOMAIN_MINIO=minio.yourdomain.com
-DOMAIN_FLASK=api.yourdomain.com
-```
-
-**Database Security:**
-```bash
-POSTGRES_PASSWORD=CHANGE_TO_SECURE_PASSWORD
-DASHBOARD_USERNAME=admin
-DASHBOARD_PASSWORD=CHANGE_TO_SECURE_PASSWORD
-```
-
-**MinIO Security:**
-```bash
-MINIO_ROOT_USER=admin
-MINIO_ROOT_PASSWORD=CHANGE_TO_SECURE_PASSWORD
-MINIO_DATA_PATH=/var/lib/bloom/minio
-```
-
-**JWT Keys** (use generated values):
-```bash
-JWT_SECRET=your-generated-secret
-ANON_KEY=your-generated-anon-key
-SERVICE_ROLE_KEY=your-generated-service-role-key
-VAULT_ENC_KEY=your-generated-vault-key
-SUPAVISOR_ENC_KEY=your-generated-supavisor-key
-```
-
-### Step 4: Set Permissions
-
-```bash
-chmod 600 .env.prod
-```
+   Non-sensitive values (domains, ports, URLs, flags) live in
+   [`.env.prod.defaults`](.env.prod.defaults), which is committed and read
+   by the workflow at deploy time.
 
 ---
 
-## 🚀 STEP 3: Starting Production Stack
+## Deploying
 
-### Start Services
+Merge a PR to `main`. The `deploy` workflow will:
 
-```bash
-make prod-up
-```
+1. SSH to the prod host via the self-hosted runner
+2. Concatenate `.env.prod.defaults` + the GitHub Secrets into `.env.prod`
+3. Validate the assembled file has every required key
+4. Run `docker compose -f docker-compose.prod.yml --env-file .env.prod up -d`
+5. Wait for Caddy to obtain / renew its TLS cert
+6. Run `supabase db push` for any new migrations
+7. Print `docker compose ps` to the workflow log
 
-This will:
-- Build optimized Next.js production bundle
-- Start all services in detached mode
-- Initialize MinIO buckets
-
-### Verify Services Running
-
-```bash
-docker ps
-```
-
-You should see: `db-prod`, `supabase-minio`, `supabase-storage`, `supabase-kong`, `supabase-auth`, `bloom-web-prod`, `langchain-agent`, `bloommcp`
-
-### Check Logs
-
-```bash
-make prod-logs
-```
+If any step fails, the workflow surfaces logs and stops — the stack is
+left in whatever state the failed step produced. Investigate from the
+workflow logs first, then SSH to the host if needed.
 
 ---
 
-## 🗄️ STEP 4: Database Migrations
+## Verifying the stack
 
-### Verify Database Ready
+After a deploy, on the prod host:
 
 ```bash
-docker compose -f docker-compose.prod.yml exec db-prod pg_isready -U supabase_admin
+sudo docker ps --format 'table {{.Names}}\t{{.Status}}'
 ```
 
+You should see fifteen containers, all `(healthy)` except `bloom_v2_prod-rest-1`
+which is intentionally bare (see issue #161 for the reason). Container
+names use the `bloom_v2_prod-<service>-1` prefix.
 
-### Apply Migrations
-
-Migrations are applied automatically by the deploy workflow when you merge to `main` — see `.github/workflows/deploy.yml`. Do not run `supabase db push` manually against production; the deploy workflow is the only sanctioned path.
-
-Once the deploy workflow has run, you should see tables like: `species`, `phenotypers`, `cyl_experiments`, `cyl_scans`, `cyl_images`, etc.
+For deeper troubleshooting, the wiki has runbook-style pages.
 
 ---
 
-## 📊 STEP 5: Loading Initial Data
+## Architecture and runbooks (wiki)
 
-### Load Test Data
+The wiki is the authoritative source for how each piece of the stack is
+designed, why, and how to operate it. Don't duplicate that content here.
 
-```bash
-# Load CSV data into database
-make load-test-data
-
-# Upload test images to MinIO
-make upload-images
-```
-
-### Load Production Data (Alternative)
-
-Replace test data with your actual production data:
-
-1. Place CSV files in `test_data/` directory
-2. Run: `make load-test-data`
-3. Upload production images to MinIO buckets
+- **Caddy + TLS + DNS-01 ACME** — `_WIKI/CADDY/README.md`
+- **Deploy workflow internals** — `.github/workflows/deploy.yml`
+- **Env layout (defaults + secrets)** — `.env.prod.defaults` header comment
 
 ---
 
-## 🌐 STEP 6: Service URLs and Ports
+## Loading initial / test data (development only)
 
-### Internal Services (Docker Network)
-
-| Service | Internal URL | Port | Description |
-|---------|-------------|------|-------------|
-| PostgreSQL | db-prod:5432 | 5432 | Database |
-| Kong Gateway | kong:8000 | 8000 | API Gateway |
-| MinIO API | supabase-minio:9000 | 9000 | S3 API |
-| Storage API | storage:5000 | 5000 | Supabase Storage |
-| Auth API | auth:9999 | 9999 | Authentication |
-| REST API | rest:3000 | 3000 | PostgREST |
-| LangChain Agent | langchain-agent:5002 | 5002 | AI agent chat API |
-| Bloom MCP | bloommcp:8811 | 8811 | FastMCP Bloom analysis tools |
-
-### External Access (via Caddy)
-
-Production services are accessed through Caddy reverse proxy (auto HTTPS via Let's Encrypt):
-
-| Service | URL | Description |
-|---------|-----|-------------|
-| Main App | http://yourdomain.com | Frontend application |
-| API | http://yourdomain.com/api | Supabase services |
-| Studio | http://studio.yourdomain.com | Database management |
-| MinIO | http://minio.yourdomain.com | Storage management |
-| API | http://api.yourdomain.com | AI agent and MCP services |
-
-
-
-
-
-
-
+The `make load-test-data` and `make upload-images` targets are intended
+for local development environments. Do not run them against production.

--- a/volumes/api/kong.yml
+++ b/volumes/api/kong.yml
@@ -190,27 +190,42 @@ services:
     plugins:
       - name: cors
 
-  ## Edge Functions routes
-  - name: functions-v1
-    _comment: 'Edge Functions: /functions/v1/* -> http://functions:9000/*'
-    url: http://functions:9000/
-    routes:
-      - name: functions-v1-all
-        strip_path: true
-        paths:
-          - /functions/v1/
-    plugins:
-      - name: cors
+  # ─── DORMANT ROUTES (commented out) ───────────────────────────────────
+  # The `functions` (Supabase Edge Functions) and `analytics` (Logflare)
+  # services are NOT in docker-compose.prod.yml — they were never wired
+  # in for this stack. Without an actual container behind the hostname,
+  # Kong returns 502 Bad Gateway for any client that hits these paths
+  # (most clients never do, but a security scanner / Supabase-docs probe
+  # can trigger them).
+  #
+  # The route definitions are retained here as a commented-out reference
+  # so they're trivially restorable if/when we decide to add either
+  # service: uncomment the block, add the matching `functions` /
+  # `analytics` service to docker-compose.prod.yml, redeploy.
+  #
+  # ----------------------------------------------------------------------
 
-  ## Analytics routes
-  - name: analytics-v1
-    _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
-    url: http://analytics:4000/
-    routes:
-      - name: analytics-v1-all
-        strip_path: true
-        paths:
-          - /analytics/v1/
+  ## Edge Functions routes (DORMANT — see note above)
+  # - name: functions-v1
+  #   _comment: 'Edge Functions: /functions/v1/* -> http://functions:9000/*'
+  #   url: http://functions:9000/
+  #   routes:
+  #     - name: functions-v1-all
+  #       strip_path: true
+  #       paths:
+  #         - /functions/v1/
+  #   plugins:
+  #     - name: cors
+
+  ## Analytics routes (DORMANT — see note above)
+  # - name: analytics-v1
+  #   _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
+  #   url: http://analytics:4000/
+  #   routes:
+  #     - name: analytics-v1-all
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1/
 
   ## Secure Database routes
   - name: meta

--- a/volumes/api/kong.yml
+++ b/volumes/api/kong.yml
@@ -140,7 +140,7 @@ services:
   ## Secure Realtime routes
   - name: realtime-v1-ws
     _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-    url: http://realtime-dev.supabase-realtime:4000/socket
+    url: http://realtime:4000/socket
     protocol: ws
     routes:
       - name: realtime-v1-ws
@@ -159,8 +159,8 @@ services:
             - admin
             - anon
   - name: realtime-v1-rest
-    _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-    url: http://realtime-dev.supabase-realtime:4000/api
+    _comment: 'Realtime: /realtime/v1/api -> http://realtime:4000/api'
+    url: http://realtime:4000/api
     protocol: http
     routes:
       - name: realtime-v1-rest


### PR DESCRIPTION

## What this changes

Three cleanups that together resolve #105.

### 1. Kong realtime hostname (was broken)

`realtime-v1-ws` and `realtime-v1-rest` in `volumes/api/kong.yml` were
pointing at `http://realtime-dev.supabase-realtime:4000/...` — a hostname
that doesn't resolve on the `supanet` Docker network. The actual service
in `docker-compose.prod.yml` is named `realtime`.

Fix: routes now point at `http://realtime:4000/...`.

### 2. Kong dormant routes commented out

- `functions-v1` → `http://functions:9000/` (Supabase Edge Functions — never deployed)
- `analytics-v1` → `http://analytics:4000/` (Logflare — never deployed)

Neither service exists in `docker-compose.prod.yml`. Routes are commented
out with a note explaining how to restore them if/when we ever add either
service.

### 3. PROD_SETUP.md rewrite (205 → 115 lines)

Replaced stale content from the old hand-deployed Flask/nginx era with
what someone setting up a fresh prod host actually needs today (runner
registration, MinIO directory, Salk DNS CNAME, `PROD_*` secrets, deploy
walkthrough). See the file itself for the full guide.

## After this merges

- Closes #105
- Live updates start working on the recent-phenotypes home page
- New people setting up a prod host have an accurate guide