### PR TITLE
feat(contracts): pin sleap-roots-contracts v0.1.0a1 + codegen TS + drift CI (A2 consume-pin, #294)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,6 +25,13 @@
 # database is left half-initialised (issue #124). Force LF for everything there.
 volumes/db/** text eol=lf
 
+# Generated contract types (pin-sleap-roots-contract / #294). The `* text=auto`
+# default would round-trip .ts through CRLF on Windows working trees, while
+# json-schema-to-typescript emits LF — breaking the byte-for-byte drift guard
+# (scripts/contract_types.mjs --check) locally vs CI. Force LF so the guard is
+# reproducible cross-platform. (The vendored schema is already covered by *.json.)
+contracts/generated/*.ts text eol=lf
+
 # Jupyter notebooks
 *.ipynb text eol=lf
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,12 +36,12 @@ jobs:
       # TS types from the pinned sleap-roots-contracts schema and fail if the
       # committed contracts/generated/ types or contracts/pin.json drift from it.
       - name: Contract types drift guard
-        run: node scripts/contract_types.mjs --check
+        run: npm run contracts:check
 
       # Negative-path + $id-no-op unit tests for the drift guard (built-in
       # node:test runner — no vitest config).
       - name: Contract types guard unit tests
-        run: node --test scripts/contract_types.test.mjs
+        run: npm run contracts:test
 
       # Checks npm packages for known CVEs (critical only)
       - name: Security audit (npm)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,6 +32,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Contract drift guard (pin-sleap-roots-contract / #294): regenerate the
+      # TS types from the pinned sleap-roots-contracts schema and fail if the
+      # committed contracts/generated/ types or contracts/pin.json drift from it.
+      - name: Contract types drift guard
+        run: node scripts/contract_types.mjs --check
+
+      # Negative-path + $id-no-op unit tests for the drift guard (built-in
+      # node:test runner — no vitest config).
+      - name: Contract types guard unit tests
+        run: node --test scripts/contract_types.test.mjs
+
       # Checks npm packages for known CVEs (critical only)
       - name: Security audit (npm)
         run: npm audit --audit-level=critical

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# Vendored + generated contract artifacts (sleep-roots-contracts pin, change
+# pin-sleap-roots-contract / #294). These are NOT ours to reformat:
+# - contracts/generated/ is emitted by json-schema-to-typescript; its bytes are
+#   guarded byte-for-byte by scripts/contract_types.mjs --check, so repo prettier
+#   must not rewrite it (the two formatters disagree and would fight the guard).
+# - contracts/schema/ is a faithful copy of the published JSON Schema artifact;
+#   reflowing it would make it no longer match upstream.
+# NOTE: this ignore is root-relative — never run prettier from inside contracts/.
+contracts/generated/
+contracts/schema/

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,6 +7,24 @@ The contract itself is owned by
 the consumer and only **pins** a version, codegens TypeScript from it, and checks its DB schema
 against it in CI.
 
+## Terminology & roadmap
+
+References here (and in this change's proposal/design) to **sub-projects** (`#1` the contract
+library, `#2` the Bloom write-back) and to **#2's changes** (`A`, `B`, `C`, `D`, `E`,
+`consume-pin`, `read-path`, `CLI`, `backfill`) come from the integration roadmap. This change is
+**consume-pin** (#294), historically lettered **F**.
+
+- **Roadmap** — the canonical change list, GitHub issues, and status (see its "A2 change
+  breakdown" table):
+  <https://github.com/talmolab/sleap-roots-pipeline/blob/main/docs/bloom-integration/roadmap.md>
+- **Contract design doc** — the rationale and the original `A–H` decomposition (§10 lists the
+  changes; §6 the cross-language drift guard; §7 the deferred models seam):
+  <https://github.com/talmolab/sleap-roots-contracts/blob/main/docs/01-contract-library-design.md>
+
+Where the two differ, the **roadmap is the more current source** (it renamed `F`→`consume-pin`,
+sequenced it first, and added `read-path` #298); the design doc uses the `A–H` letters
+(`F`=consume-pin, `G`=ingest CLI, `H`=backfill).
+
 ## What's here
 
 | Path                                 | What                                                                                                         | Authority                                                 |

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,75 @@
+# Pinned `sleap-roots-contracts` (Bloom consumer)
+
+This directory pins the cross-language **result contract** that the sleap-roots pipeline
+produces and Bloom consumes (sub-project #1 → #2; change `pin-sleap-roots-contract`, #294).
+The contract itself is owned by
+[`talmolab/sleap-roots-contracts`](https://github.com/talmolab/sleap-roots-contracts); Bloom is
+the consumer and only **pins** a version, codegens TypeScript from it, and checks its DB schema
+against it in CI.
+
+## What's here
+
+| Path                                 | What                                                                                                         | Authority                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `schema/result_envelope.schema.json` | Vendored, LF-normalized copy of the pinned JSON Schema                                                       | Faithful copy of the published artifact — **do not edit** |
+| `pin.json`                           | The pin manifest: `package`, `version`, full schema `$id`, `source`, file paths                              | The declared pin                                          |
+| `generated/result-envelope.ts`       | TypeScript types (`ResultEnvelope`/`Provenance`/`TraitValue`/`BlobRef` + sub-defs) generated from the schema | Emitted by codegen — **do not edit by hand**              |
+
+**Currently pinned: `v0.1.0a1`.** These are the _contract_ types (from the JSON Schema), distinct
+from the Supabase `database.types.ts` (generated from the database by `make gen-types`).
+
+> Note on `v0.1.0a1` vs `v0.1.0`: issue #294 named `v0.1.0a0` and preferred a non-prerelease
+> `v0.1.0` cut. That release does not exist yet, so we pin the current `v0.1.0a1` (`result_envelope`
+> is byte-identical to `a0` except its `$id`). When `v0.1.0` is cut, re-pin per below — it will be a
+> zero-TS-diff event (see the `$id` no-op rule).
+
+## Guards (CI)
+
+- **Drift guard** — `npm run contracts:check` (`scripts/contract_types.mjs --check`), in the
+  `build-and-audit` job: regenerates the TS from the pinned schema and fails if the committed
+  `generated/` types are not byte-identical, and fails if `pin.json` disagrees with the schema
+  `$id` (exact `id` + parsed `version`).
+- **Negative-path / `$id`-no-op test** — `node --test scripts/contract_types.test.mjs`, same job.
+- **Migration-matches-schema** — `tests/integration/test_contract_migration_match.py` (in
+  `compose-health-check`): asserts Bloom's applied DB schema agrees with the pinned contract for
+  the mappings built today, and the contract-side facts that justify them.
+
+## The `$id`-restamp-is-a-no-op rule
+
+The schema `$id` carries the package version (`…/schema/v0.1.0a1/result_envelope.schema.json`), so a
+re-pin re-stamps the `$id` even when the payload is unchanged. The codegen **never emits `$id`** into
+the types, so a `$id`-only re-pin regenerates **byte-identical** TS. Treat that as a structural
+no-op — not a contract revision. The intended diff on such a re-pin is exactly two things (kept in
+lockstep by the pin-consistency check): the schema `$id` and `pin.json` `version`/`id`. A _real_
+field change produces a TS diff and fails the drift guard — that is the signal to review.
+
+## Re-pin procedure
+
+1. Replace `schema/result_envelope.schema.json` with the new published schema (keep it LF; it is
+   excluded from repo prettier — see below).
+2. Update `pin.json` `version` and `id` to the new version.
+3. Run `npm run contracts:gen` to regenerate `generated/result-envelope.ts`; commit it.
+4. Run `npm run contracts:check` — it passes when `pin.json`, the schema `$id`, and the regenerated
+   types all agree. For a `$id`-only bump the types diff is empty; any other diff is a real contract
+   change to review.
+
+## Gotchas
+
+- **Never run prettier from inside `contracts/`.** The repo `.prettierignore` excludes
+  `contracts/generated/` and `contracts/schema/`, but that ignore is **root-relative** — running
+  prettier from a subdirectory bypasses it and would reformat the generated/vendored files,
+  breaking the byte-for-byte drift guard.
+- `generated/*.ts` is pinned to LF via `.gitattributes` so the guard is reproducible on Windows and
+  Linux.
+
+## Consumer hand-offs (recorded for later changes, not enforced here)
+
+The generated types have **no consumer yet** (changes B/C/D/G pending). When the write-back path is
+built, the consumer (D/G) MUST, at the write boundary:
+
+- validate `provenance.contract_version` against the pinned `version` (or an explicit compatibility
+  set) — the per-row provenance-of-origin anchor;
+- validate each `TraitValue.value` is finite-or-null (the contract normalizes NaN/inf → null).
+
+The reproducibility anchors `inputs.images_checksum` / `image_ids` and `params.param_hash` ride
+inside the opaque `metadata` jsonb and are not promoted to columns by change A.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -29,7 +29,8 @@ from the Supabase `database.types.ts` (generated from the database by `make gen-
   `build-and-audit` job: regenerates the TS from the pinned schema and fails if the committed
   `generated/` types are not byte-identical, and fails if `pin.json` disagrees with the schema
   `$id` (exact `id` + parsed `version`).
-- **Negative-path / `$id`-no-op test** — `node --test scripts/contract_types.test.mjs`, same job.
+- **Negative-path / `$id`-no-op test** — `npm run contracts:test`
+  (`node --test scripts/contract_types.test.mjs`), same job.
 - **Migration-matches-schema** — `tests/integration/test_contract_migration_match.py` (in
   `compose-health-check`): asserts Bloom's applied DB schema agrees with the pinned contract for
   the mappings built today, and the contract-side facts that justify them.
@@ -49,6 +50,8 @@ field change produces a TS diff and fails the drift guard — that is the signal
    excluded from repo prettier — see below).
 2. Update `pin.json` `version` and `id` to the new version.
 3. Run `npm run contracts:gen` to regenerate `generated/result-envelope.ts`; commit it.
+   (`--write` runs the pin-consistency check first and **refuses to write** if `pin.json` and the
+   schema `$id` disagree — so do step 2 before step 3.)
 4. Run `npm run contracts:check` — it passes when `pin.json`, the schema `$id`, and the regenerated
    types all agree. For a `$id`-only bump the types diff is empty; any other diff is a real contract
    change to review.
@@ -73,3 +76,10 @@ built, the consumer (D/G) MUST, at the write boundary:
 
 The reproducibility anchors `inputs.images_checksum` / `image_ids` and `params.param_hash` ride
 inside the opaque `metadata` jsonb and are not promoted to columns by change A.
+
+**Codegen caveat for change C (blob table):** `json-schema-to-typescript` renders `BlobRef` from
+its top-level `anyOf` only (`{ s3_location } | { box_link }`), so the generated `BlobRef` type
+**does not surface** the required `kind`/`scan_key` fields or the `kind` enum
+(`predictions_slp|labels|h5|qc_image`) — they survive only via the `[k: string]: unknown` index
+signature. This is faithful-but-lossy (under-specified, not mis-specified). Change C MUST validate a
+blob against the JSON Schema directly, not trust the generated `BlobRef` for `kind`/`scan_key`.

--- a/contracts/generated/result-envelope.ts
+++ b/contracts/generated/result-envelope.ts
@@ -1,0 +1,123 @@
+/* eslint-disable */
+/**
+ * AUTO-GENERATED — DO NOT EDIT.
+ *
+ * TypeScript types for the sleap-roots-contracts ResultEnvelope, generated from
+ * contracts/schema/result_envelope.schema.json (the pinned JSON Schema) by
+ * json-schema-to-typescript. Regenerate with `npm run contracts:gen`; the
+ * byte-for-byte drift guard `npm run contracts:check` fails CI if this file and
+ * the pinned schema disagree.
+ */
+
+/**
+ * Pointer to an intermediate artifact (rows in the #2 intermediates table).
+ */
+export type BlobRef =
+  | {
+      s3_location: string;
+      [k: string]: unknown;
+    }
+  | {
+      box_link: string;
+      [k: string]: unknown;
+    };
+export type Blobs = BlobRef[];
+export type ArgoNodeId = string | null;
+export type ArgoWorkflowUid = string | null;
+export type ContractVersion = string;
+export type IdempotencyKey = string;
+export type ImageIds = string[];
+export type ImagesChecksum = string;
+export type ParamHash = string;
+export type PipelineRunId = string | null;
+export type PredictCodeSha = string;
+export type PredictContainerDigest = string;
+export type RegistryId = string;
+export type RootType = string | null;
+export type SleapNnVersion = string;
+export type Version = string;
+export type WeightsChecksum = string | null;
+export type PredictModels = ModelRef[];
+export type ProducedAt = string | null;
+export type ScanKey = string;
+export type TraitsCodeSha = string;
+export type TraitsContainerDigest = string;
+export type TraitsSleapRootsVersion = string;
+export type WorkerRequestId = string | null;
+export type Grain = "scan" | "image";
+export type Name = string;
+export type ScanKey1 = string;
+export type Value = number | null;
+export type Traits = TraitValue[];
+
+/**
+ * One per-scan result: 1 envelope : 1 source row : 1 scan.
+ */
+export interface ResultEnvelope {
+  blobs?: Blobs;
+  provenance: Provenance;
+  traits: Traits;
+  [k: string]: unknown;
+}
+/**
+ * Run provenance; serializes to cyl_trait_sources.metadata jsonb (sub-project #2).
+ */
+export interface Provenance {
+  argo_node_id?: ArgoNodeId;
+  argo_workflow_uid?: ArgoWorkflowUid;
+  contract_version: ContractVersion;
+  idempotency_key?: IdempotencyKey;
+  inputs: InputRef;
+  params: ResolvedParams;
+  pipeline_run_id?: PipelineRunId;
+  predict_code_sha: PredictCodeSha;
+  predict_container_digest: PredictContainerDigest;
+  predict_models: PredictModels;
+  produced_at?: ProducedAt;
+  scan_key: ScanKey;
+  traits_code_sha: TraitsCodeSha;
+  traits_container_digest: TraitsContainerDigest;
+  traits_sleap_roots_version: TraitsSleapRootsVersion;
+  worker_request_id?: WorkerRequestId;
+  [k: string]: unknown;
+}
+/**
+ * Pins the input data a run consumed, for reproducibility.
+ */
+export interface InputRef {
+  image_ids: ImageIds;
+  images_checksum: ImagesChecksum;
+  [k: string]: unknown;
+}
+/**
+ * Fully-resolved run params plus their canonical hash.
+ */
+export interface ResolvedParams {
+  param_hash?: ParamHash;
+  values: Values;
+  [k: string]: unknown;
+}
+export interface Values {
+  [k: string]: unknown;
+}
+/**
+ * Identity of one model used in a run (FK-able to a future Bloom models table).
+ */
+export interface ModelRef {
+  registry_id: RegistryId;
+  root_type?: RootType;
+  sleap_nn_version: SleapNnVersion;
+  version: Version;
+  weights_checksum?: WeightsChecksum;
+  [k: string]: unknown;
+}
+/**
+ * One long-format trait row. NaN/inf normalize to None (-> SQL NULL).
+ */
+export interface TraitValue {
+  grain?: Grain;
+  name: Name;
+  scan_key: ScanKey1;
+  value?: Value;
+  [k: string]: unknown;
+}

--- a/contracts/pin.json
+++ b/contracts/pin.json
@@ -1,0 +1,8 @@
+{
+  "package": "sleap-roots-contracts",
+  "version": "v0.1.0a1",
+  "id": "https://github.com/talmolab/sleap-roots-contracts/schema/v0.1.0a1/result_envelope.schema.json",
+  "source": "https://github.com/talmolab/sleap-roots-contracts/blob/v0.1.0a1/schema/result_envelope.schema.json",
+  "schema": "schema/result_envelope.schema.json",
+  "generated": "generated/result-envelope.ts"
+}

--- a/contracts/schema/result_envelope.schema.json
+++ b/contracts/schema/result_envelope.schema.json
@@ -1,0 +1,384 @@
+{
+  "$defs": {
+    "BlobRef": {
+      "anyOf": [
+        {
+          "properties": {
+            "s3_location": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "s3_location"
+          ]
+        },
+        {
+          "properties": {
+            "box_link": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "box_link"
+          ]
+        }
+      ],
+      "description": "Pointer to an intermediate artifact (rows in the #2 intermediates table).",
+      "properties": {
+        "box_link": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Box Link"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Checksum"
+        },
+        "file_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Size"
+        },
+        "kind": {
+          "enum": [
+            "predictions_slp",
+            "labels",
+            "h5",
+            "qc_image"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "s3_location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "S3 Location"
+        },
+        "scan_key": {
+          "title": "Scan Key",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "scan_key"
+      ],
+      "title": "BlobRef",
+      "type": "object"
+    },
+    "InputRef": {
+      "description": "Pins the input data a run consumed, for reproducibility.",
+      "properties": {
+        "image_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Image Ids",
+          "type": "array"
+        },
+        "images_checksum": {
+          "title": "Images Checksum",
+          "type": "string"
+        }
+      },
+      "required": [
+        "image_ids",
+        "images_checksum"
+      ],
+      "title": "InputRef",
+      "type": "object"
+    },
+    "ModelRef": {
+      "description": "Identity of one model used in a run (FK-able to a future Bloom models table).",
+      "properties": {
+        "registry_id": {
+          "title": "Registry Id",
+          "type": "string"
+        },
+        "root_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Root Type"
+        },
+        "sleap_nn_version": {
+          "title": "Sleap Nn Version",
+          "type": "string"
+        },
+        "version": {
+          "title": "Version",
+          "type": "string"
+        },
+        "weights_checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Weights Checksum"
+        }
+      },
+      "required": [
+        "registry_id",
+        "version",
+        "sleap_nn_version"
+      ],
+      "title": "ModelRef",
+      "type": "object"
+    },
+    "Provenance": {
+      "description": "Run provenance; serializes to cyl_trait_sources.metadata jsonb (sub-project #2).",
+      "properties": {
+        "argo_node_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Argo Node Id"
+        },
+        "argo_workflow_uid": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Argo Workflow Uid"
+        },
+        "contract_version": {
+          "title": "Contract Version",
+          "type": "string"
+        },
+        "idempotency_key": {
+          "default": "",
+          "title": "Idempotency Key",
+          "type": "string"
+        },
+        "inputs": {
+          "$ref": "#/$defs/InputRef"
+        },
+        "params": {
+          "$ref": "#/$defs/ResolvedParams"
+        },
+        "pipeline_run_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pipeline Run Id"
+        },
+        "predict_code_sha": {
+          "title": "Predict Code Sha",
+          "type": "string"
+        },
+        "predict_container_digest": {
+          "title": "Predict Container Digest",
+          "type": "string"
+        },
+        "predict_models": {
+          "items": {
+            "$ref": "#/$defs/ModelRef"
+          },
+          "title": "Predict Models",
+          "type": "array"
+        },
+        "produced_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Produced At"
+        },
+        "scan_key": {
+          "title": "Scan Key",
+          "type": "string"
+        },
+        "traits_code_sha": {
+          "title": "Traits Code Sha",
+          "type": "string"
+        },
+        "traits_container_digest": {
+          "title": "Traits Container Digest",
+          "type": "string"
+        },
+        "traits_sleap_roots_version": {
+          "title": "Traits Sleap Roots Version",
+          "type": "string"
+        },
+        "worker_request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Worker Request Id"
+        }
+      },
+      "required": [
+        "contract_version",
+        "scan_key",
+        "inputs",
+        "predict_models",
+        "predict_container_digest",
+        "predict_code_sha",
+        "traits_sleap_roots_version",
+        "traits_container_digest",
+        "traits_code_sha",
+        "params"
+      ],
+      "title": "Provenance",
+      "type": "object"
+    },
+    "ResolvedParams": {
+      "description": "Fully-resolved run params plus their canonical hash.",
+      "properties": {
+        "param_hash": {
+          "default": "",
+          "title": "Param Hash",
+          "type": "string"
+        },
+        "values": {
+          "additionalProperties": true,
+          "title": "Values",
+          "type": "object"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "ResolvedParams",
+      "type": "object"
+    },
+    "TraitValue": {
+      "description": "One long-format trait row. NaN/inf normalize to None (-> SQL NULL).",
+      "properties": {
+        "grain": {
+          "default": "scan",
+          "enum": [
+            "scan",
+            "image"
+          ],
+          "title": "Grain",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "scan_key": {
+          "title": "Scan Key",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        }
+      },
+      "required": [
+        "name",
+        "scan_key"
+      ],
+      "title": "TraitValue",
+      "type": "object"
+    }
+  },
+  "$id": "https://github.com/talmolab/sleap-roots-contracts/schema/v0.1.0a1/result_envelope.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "One per-scan result: 1 envelope : 1 source row : 1 scan.",
+  "properties": {
+    "blobs": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/BlobRef"
+      },
+      "title": "Blobs",
+      "type": "array"
+    },
+    "provenance": {
+      "$ref": "#/$defs/Provenance"
+    },
+    "traits": {
+      "items": {
+        "$ref": "#/$defs/TraitValue"
+      },
+      "title": "Traits",
+      "type": "array"
+    }
+  },
+  "required": [
+    "provenance",
+    "traits"
+  ],
+  "title": "ResultEnvelope",
+  "type": "object"
+}

--- a/openspec/changes/pin-sleap-roots-contract/design.md
+++ b/openspec/changes/pin-sleap-roots-contract/design.md
@@ -1,0 +1,141 @@
+## Context
+
+The contract is owned by sub-project #1 (`sleap-roots-contracts`): Pydantic models →
+`schema/result_envelope.schema.json`, version-stamped in each schema's `$id`, published to PyPI
+and as a GitHub release artifact. Bloom (#2) is the **consumer**: it pins a schema version,
+codegens TS, and checks its DB migration against the schema in CI (contract design
+`docs/01-contract-library-design.md` §6 "Cross-language flow & drift guard").
+
+Change A (#290, on `staging` at `9b17d31`) already added `cyl_trait_sources.metadata jsonb`
+(opaque `Provenance` home) + `idempotency_key text` (UNIQUE + non-empty CHECK), hand-reading the
+contract. Its archived design explicitly defers the "CI migration/types-match check" to a later
+change — the roadmap renamed it **consume-pin** and sequenced it *first* in A2. This change is
+that check.
+
+Two facts shape the design:
+
+1. **Schema `$id` carries the package version.** `result_envelope` is byte-identical between
+   `v0.1.0a0` and `v0.1.0a1` *except* its `$id` (`…/v0.1.0a0/…` → `…/v0.1.0a1/…`). The roadmap's
+   hard constraint: on any re-pin, **regenerate and accept the `$id`-only diff as a structural
+   no-op** — do not treat it as a contract revision.
+2. **Bloom's CI has two relevant homes.** `build-and-audit` (Node; runs `npm ci`; no DB) and
+   `compose-health-check` (brings up the prod compose stack, applies migrations, runs
+   `pytest tests/integration/` against the live DB via the `pg_conn` fixture). The TS drift guard
+   belongs in the former; the DB migration-match belongs in the latter.
+
+## Goals / Non-Goals
+
+- **Goals:** pin `result_envelope.schema.json` at an explicit version; codegen committed TS
+  types with a CI guard that fails on any drift between committed types and `json-schema → TS` of
+  the pinned schema; add a migration-matches-schema CI assertion scoped to what change A built;
+  make the `$id`-restamp-no-op rule mechanically enforceable.
+- **Non-Goals:** no DB migration (A shipped the columns); no consumer wiring of the generated
+  types (deferred to B/C/D/G); no jsonb shape validation at the DB layer (the contract owns
+  that, producer-side); no change to the contract repo.
+
+## Decisions
+
+### D1 — Pin `v0.1.0a1` (current), vendored as a committed copy + manifest
+
+Pin the current release so the next *real* re-pin event (to `v0.1.0`) is the only future churn.
+`result_envelope` is unchanged from a0, so this is purely about recording the pin.
+
+Vendor a **committed copy** (`contracts/schema/result_envelope.schema.json`) rather than
+fetching at CI time: deterministic, offline, reviewable as a diff, and the committed `$id` *is*
+the pin record. A separate `contracts/pin.json` records the version explicitly so humans and the
+guard have a single declared source of truth. **Pin-consistency check:** `pin.json.version` MUST
+equal the version segment parsed from the schema `$id`; they cannot silently disagree. Rejected
+fetch-at-CI: adds a network dependency and a "fetched from where" question (the artifact lives on
+a git tag / release asset, not a CDN), and makes local TDD reproduction harder.
+
+### D2 — Codegen with `json-schema-to-typescript`, pinned exact `15.0.4`, into `contracts/generated/`
+
+`json-schema-to-typescript` (`json2ts`) is the de-facto JSON-Schema→TS tool and handles draft
+2020-12 `$defs`, `anyOf` nullable unions, and enums. **Determinism is the load-bearing property
+of a drift guard**, so:
+
+- Pin json2ts to **exact `15.0.4`** in `package.json` (not a caret). The rest of the dependency
+  tree (including the prettier json2ts uses to format) is pinned by `package-lock.json`, so
+  `npm ci` reproduces byte-identical output in CI (node 20) and locally (node 22).
+- A single module `scripts/contract_types.mjs` drives both generation and checking via the
+  json2ts API (not the CLI), so generate-and-commit and CI-check run the *identical* invocation
+  (same `bannerComment`, same options) — the only way the byte-compare is sound.
+
+Generated types live in a **consumer-neutral** `contracts/generated/result-envelope.ts` with a
+`DO NOT EDIT` banner. No code imports them yet (B/C/D/G pending); co-locating them in a package
+(e.g. `bloom-js`) now would couple the artifact to that package's build/lint before any consumer
+exists. The eventual consumer can import from `contracts/generated/` or the file can move with a
+deliberate refactor when D/G need it.
+
+**`$id`-no-op enforceability (the key mechanism):** json2ts never emits `$id` into the generated
+types. So a future re-pin that only re-stamps `$id` regenerates **byte-identical** TS → the drift
+guard passes with a *zero* TS diff, mechanically proving the structural no-op. The intended,
+reviewable diff on a re-pin is exactly two things kept in lockstep by the pin-consistency check:
+the schema `$id` and `pin.json.version`.
+
+### D3 — Migration-match: pytest DB-introspection, A-subset, declaratively extensible
+
+A pytest integration test (`tests/integration/test_contract_migration_match.py`) introspects the
+**actually-applied** DB (via `pg_conn`) and compares against the vendored contract schema. This
+asserts the real schema, not parsed SQL text, and reuses the established change-A test pattern; it
+auto-runs in `compose-health-check` (the job globs `tests/integration/`), so no workflow edit is
+needed for it.
+
+A **declarative mapping** (a list of `{contract_field, db_table, db_column, db_type, status}`
+entries) drives the assertions:
+
+- **Active (built by change A):**
+  - `Provenance` envelope → `cyl_trait_sources.metadata` is `jsonb` (the contract's `Provenance`
+    docstring states it *"serializes to cyl_trait_sources.metadata jsonb"*).
+  - `Provenance.idempotency_key` (contract type `string`, `default: ""`) →
+    `cyl_trait_sources.idempotency_key` is `text` **and** the non-empty CHECK exists (the DB
+    posture matching the contract's `""` default — an empty key is not valid).
+- **Deferred (skipped with a reason, not asserted):** B (`source_id` FK on the trait tables),
+  C (intermediates/blob table), D (`idempotency_key == metadata->>'idempotency_key'` equality,
+  RPC-enforced). Marked `status="deferred"` so the file is a living extension point: each future
+  change flips its row to active. This keeps the check meaningful today and **not brittle**
+  against tables/columns that do not exist yet.
+
+The test also records (as a documented, non-asserted note) that the remaining `Provenance` fields
+are deliberately carried *inside* the opaque `metadata` jsonb, not promoted to columns — change
+A's intentional boundary.
+
+### D4 — CI wiring
+
+- TS drift guard: a new step in `build-and-audit` → `node scripts/contract_types.mjs --check`
+  (runs after `npm ci`, before/after the existing build steps). Pure Node, fast, no DB.
+- Migration-match: no workflow change — placing the test under `tests/integration/` is sufficient
+  (`compose-health-check` runs the whole directory).
+
+## Risks / Trade-offs
+
+- **json2ts CVE surface.** Adding a devDependency widens `npm audit --audit-level=critical`
+  (already in `build-and-audit`). json2ts is widely used; if a critical advisory appears it is
+  handled like any other dep. → Accept; exact-pin keeps the surface explicit and reviewable.
+- **json2ts output stability across versions.** A json2ts upgrade could change formatting and
+  trip the guard. → That is *correct* behavior (the guard owns the committed bytes): an upgrade is
+  a deliberate `--write` + commit, gated by the exact pin. The risk is only an *unexpected* bump,
+  which the exact pin + lockfile prevent.
+- **Unusual `BlobRef` shape.** `BlobRef` has a top-level `anyOf` (s3 *or* box required) layered
+  over a `properties` block; json2ts emits a union/intersection. Whatever it emits is committed and
+  guarded — correctness of the *type* matters less than determinism for the guard, and the
+  producer-side contract owns semantic validity.
+- **Migration-match needs the compose stack.** It only runs in the heavier
+  `compose-health-check` job. → Acceptable: it reuses existing infra and asserts the real applied
+  schema, which is the meaningful target; the cheap TS guard runs in the fast Node job.
+
+## Migration Plan
+
+No database migration. Pure additive repo content (vendored schema, manifest, generated types,
+guard script, CI step, test) + one devDependency. Rollback = revert the change; nothing is
+applied to any database. Re-pin procedure (documented in `contracts/README.md`): replace the
+vendored schema, bump `pin.json.version`, run `npm run contracts:gen`, commit; the `$id`-only diff
+regenerates identical types and the guards pass.
+
+## Open Questions
+
+- None blocking. The cleaner long-term home for the migration-match requirement is the
+  `cyl-trait-writeback` capability (where B/C/D already edit), but that capability is not a live
+  spec on `staging` until change A's archive (#300) lands. Keeping all three requirements in the
+  new `contract-pinning` capability now avoids coupling this change to #300; relocating req 3 is a
+  deliberate later refactor.

--- a/openspec/changes/pin-sleap-roots-contract/design.md
+++ b/openspec/changes/pin-sleap-roots-contract/design.md
@@ -75,9 +75,16 @@ independent ways it can break — all must be closed, not asserted away:
 1. **Tool/version drift.** Pin json2ts to **exact `15.0.4`** (not a caret); the whole tree
    (including the prettier json2ts uses) is frozen by `package-lock.json`, so `npm ci` reproduces
    identical output in CI (node 20) and locally (node 22). json2ts `engines.node` is `>=16`, so
-   node 20 is fine. A single module `scripts/contract_types.mjs` drives both `--write` and
-   `--check` via the json2ts **API** (identical `bannerComment` + options), so generate and check
-   run the same invocation — the only way the byte-compare is sound.
+   node 20 is fine. A single module `scripts/contract_types.mjs` **exports pure functions** —
+   `generateTypes(schema) → string`, `checkPinConsistency(pin, schema) → {ok, error}`,
+   `checkDrift({schema, pin, committedTs}) → {ok, diff}`, and a `checkContractSanity(schema)` that
+   asserts the pinned schema still requires the `Provenance.contract_version` anchor — that take
+   inputs as **arguments** (no file reads, no `process.exit` inside them). A thin CLI shim
+   (`if (import.meta.url === pathToFileURL(process.argv[1]).href)`) is the **only** place that
+   reads files and calls `process.exit`. Both `--write` and `--check` go through the same pure
+   `generateTypes` (identical `bannerComment` + options), so generate and check run the same
+   invocation — the only way the byte-compare is sound — and the test suite drives the pure
+   functions directly with in-memory inputs (it never spawns the exiting CLI).
 2. **Formatter conflict.** json2ts formats its output with its **own** bundled prettier style
    (`semi:true, singleQuote:false, printWidth:120, trailingComma:'none', bracketSpacing:false`),
    which disagrees with the repo's `.prettierrc.json`
@@ -100,9 +107,13 @@ independent ways it can break — all must be closed, not asserted away:
 Generated types live in a **consumer-neutral** `contracts/generated/result-envelope.ts` with a
 `DO NOT EDIT` banner. No code imports them yet (B/C/D/G pending); co-locating them in a package
 (e.g. `bloom-js`) now would couple the artifact to that package's build/lint before any consumer
-exists. A task runs `tsc --noEmit` on the generated file so the committed types are guaranteed
-valid, usable TS (the `BlobRef` `anyOf`-over-`properties` shape is reviewed for non-degeneracy at
-generation time, not rubber-stamped).
+exists. At generation time (not as a standing CI step — the bytes are frozen by the drift guard,
+so type-validity only needs re-checking when they change), a task runs
+`npx tsc --noEmit --strict --target ES2020 --moduleResolution bundler --skipLibCheck
+contracts/generated/result-envelope.ts` (exact flags, no throwaway tsconfig file) so the committed
+types are valid, usable TS; the generated `$defs` (`ResultEnvelope`, `Provenance`, `TraitValue`,
+`BlobRef`, plus sub-defs `InputRef`, `ModelRef`, `ResolvedParams`) are eyeballed for non-degeneracy
+— the `BlobRef` `anyOf`-over-`properties` shape is the risk case, reviewed not rubber-stamped.
 
 **`$id`-no-op enforceability (the key mechanism) — and its converse.** json2ts never emits `$id`
 into the generated types. So a re-pin that only re-stamps `$id` regenerates **byte-identical** TS →
@@ -112,8 +123,11 @@ pin-consistency check: the schema `$id`/`pin.json.id` and `pin.json.version`. A 
 (`scripts/contract_types.test.mjs`) proves **both directions** so the property can't silently
 regress: (a) mutate only the `$id` version → regenerated TS is identical; (b) mutate a *real*
 field (flip `idempotency_key`'s type / add a property) → regenerated TS **differs** and the guard
-would fail. It also covers the negative paths the spec promises: pin-mismatch → non-zero; a
-hand-edited committed TS → non-zero. This Vitest test runs in `build-and-audit` (no DB).
+would fail. It also covers the negative paths the spec promises: pin-mismatch → not-ok; an
+unparseable `$id` → not-ok; a hand-edited committed TS → not-ok. The test is a **`node --test`**
+file (`scripts/contract_types.test.mjs`) importing the pure functions — no new test framework,
+no config (vitest is already used under `web/`, but the built-in runner avoids the root-config
+question entirely). It runs in `build-and-audit` (no DB).
 
 ### D3 — Migration-match: pytest DB-introspection, A-subset, declaratively extensible
 
@@ -146,10 +160,21 @@ status, reason}` entries) drives the assertions:
     caught). Asserted as a substring match on the literal `cyl_trait_sources.metadata`.
   - `Provenance.idempotency_key` (contract type `string`, `default: ""`) →
     `cyl_trait_sources.idempotency_key` is `text` **with both** the non-empty CHECK
-    (`cyl_trait_sources_idempotency_key_nonempty`) **and** the UNIQUE constraint
-    (`cyl_trait_sources_idempotency_key_key`). The CHECK guards the `""`-collision; the UNIQUE is
-    the contract-level `1 ResultEnvelope : 1 source row` anchor — dropping it (keeping the CHECK)
+    (`cyl_trait_sources_idempotency_key_nonempty`, asserted via `pg_constraint.contype = 'c'`)
+    **and** the UNIQUE constraint (`cyl_trait_sources_idempotency_key_key`, asserted via
+    `contype = 'u'`). Asserting `contype`, not just the constraint *name*, is deliberate: the
+    `_key`/`_nonempty` suffixes are convention, not enforcement — a name match alone wouldn't
+    prove the UNIQUE is actually a UNIQUE. The CHECK guards the `""`-collision; the UNIQUE is the
+    contract-level `1 ResultEnvelope : 1 source row` anchor — dropping it (keeping the CHECK)
     silently breaks idempotency, so both are active assertions.
+  - **Contract sanity:** `contract_version` is in `$defs.Provenance.required` and typed `string`.
+    `contract_version` is the per-row traceability anchor (which contract an envelope was produced
+    under); the whole row-anchor story rests on the contract *guaranteeing* every envelope carries
+    it. If sub-project #1 ever made it optional, D/G's future validation would have nothing to
+    validate — so this structural tripwire is asserted now (no consumer needed). This assertion
+    lives in the Node guard's `checkContractSanity` (fast lane) and is mirrored as a recorded note
+    here; the *runtime* `provenance.contract_version` == `pin.json.version` validation is the
+    deferred D/G hand-off below.
 - **Deferred (skipped with a reason, not asserted):** B (`source_id` FK on the trait tables),
   C (intermediates/blob table), D (`idempotency_key == metadata->>'idempotency_key'` equality,
   RPC-enforced), `Provenance.contract_version` row-anchor validation (consumer-side, D/G), and
@@ -157,17 +182,20 @@ status, reason}` entries) drives the assertions:
   extension point: each future change flips its row to active. This keeps the check meaningful
   today and **not brittle** against tables/columns/values that do not exist yet.
 
-The test also records (as a documented, non-asserted note) that the remaining `Provenance` fields
-are deliberately carried *inside* the opaque `metadata` jsonb, not promoted to columns — change
-A's intentional boundary — and that `contract_version`/`TraitValue.value` finiteness are
-consumer-side hand-offs to D/G (see proposal Cross-change hand-offs).
+The deferred mapping rows are terse one-liners (`{..., status:"deferred", reason:"#295 source_id
+FK"}`). The narrative hand-offs (remaining `Provenance` fields — including the reproducibility
+anchors `inputs.images_checksum`/`image_ids` and `params.param_hash` — live *inside* the opaque
+`metadata` jsonb, not promoted to columns; `contract_version`/`TraitValue.value` finiteness are
+D/G consumer-side validations) live in `contracts/README.md` and the proposal's Cross-change
+hand-offs, **not** duplicated as prose in the test file — the test carries mechanical deferred
+rows only.
 
 ### D4 — CI wiring
 
 - TS drift guard: a new step in `build-and-audit` → `node scripts/contract_types.mjs --check`
   (after `npm ci`). Pure Node, fast, no DB.
-- Vitest negative-path/`$id`-no-op test: a new step in `build-and-audit` running the single
-  `scripts/contract_types.test.mjs` (e.g. `npx vitest run scripts/contract_types.test.mjs`), no DB.
+- Negative-path/`$id`-no-op test: a new step in `build-and-audit` →
+  `node --test scripts/contract_types.test.mjs` (built-in runner, no config), no DB.
 - Migration-match: no workflow change — placing the test under `tests/integration/` is sufficient
   (`compose-health-check` runs the whole directory).
 
@@ -179,10 +207,15 @@ consumer-side hand-offs to D/G (see proposal Cross-change hand-offs).
 - **json2ts output stability across versions.** A json2ts upgrade could change formatting and
   trip the guard — which is *correct*: an upgrade is a deliberate `--write` + commit, gated by the
   exact pin. The risk is only an *unexpected* bump, which the exact pin + lockfile prevent.
-- **Docstring tripwire brittleness.** Asserting `Provenance.description` contains
-  `cyl_trait_sources.metadata` can fail on a benign reword. → That is the intended behavior: a
-  contract docstring change about the home *should* force a human to re-confirm the mapping; the
-  fix is a one-line update to the expected substring after confirming the home is unchanged.
+- **Docstring tripwire brittleness — mitigated by vendoring.** Asserting `Provenance.description`
+  contains `cyl_trait_sources.metadata` looks like a textbook brittle free-text assertion, but the
+  schema is a **vendored, committed copy**: the assertion runs against the frozen file, so it
+  *cannot* spontaneously fail on an upstream reword. It fires only when *we* re-vendor a changed
+  schema — which is exactly the moment a human should re-confirm the home is still
+  `cyl_trait_sources.metadata` (and update the one-line expected substring as part of that re-pin).
+  So a hard failure is correct, and the "false alarm" mode (red build with no re-pin) cannot occur.
+  This is the only contract-side net for a description-level re-home (json2ts drops descriptions,
+  so the TS guard is blind to it).
 - **Migration-match needs the compose stack.** It only runs in `compose-health-check`. → Acceptable:
   it reuses existing infra and asserts the real applied schema; the cheap TS guard + Vitest run in
   the fast Node job.

--- a/openspec/changes/pin-sleap-roots-contract/design.md
+++ b/openspec/changes/pin-sleap-roots-contract/design.md
@@ -21,7 +21,7 @@ Two facts shape the design:
 2. **Bloom's CI has two relevant homes.** `build-and-audit` (Node; runs `npm ci`; no DB) and
    `compose-health-check` (brings up the prod compose stack, applies migrations, runs
    `pytest tests/integration/` against the live DB via the `pg_conn` fixture). The TS drift guard
-   + its Vitest test belong in the former; the DB migration-match belongs in the latter.
+   + its `node --test` test belong in the former; the DB migration-match belongs in the latter.
 
 ## Goals / Non-Goals
 
@@ -76,15 +76,17 @@ independent ways it can break — all must be closed, not asserted away:
    (including the prettier json2ts uses) is frozen by `package-lock.json`, so `npm ci` reproduces
    identical output in CI (node 20) and locally (node 22). json2ts `engines.node` is `>=16`, so
    node 20 is fine. A single module `scripts/contract_types.mjs` **exports pure functions** —
-   `generateTypes(schema) → string`, `checkPinConsistency(pin, schema) → {ok, error}`,
-   `checkDrift({schema, pin, committedTs}) → {ok, diff}`, and a `checkContractSanity(schema)` that
-   asserts the pinned schema still requires the `Provenance.contract_version` anchor — that take
-   inputs as **arguments** (no file reads, no `process.exit` inside them). A thin CLI shim
+   `async generateTypes(schema) → Promise<string>` (json2ts `compile()` is **async** — it returns
+   a Promise — so this and its callers are async/awaited), `checkPinConsistency(pin, schema) →
+   {ok, error}`, and `async checkDrift({schema, pin, committedTs}) → Promise<{ok, diff}>` — that
+   take inputs as **arguments** (no file reads, no `process.exit` inside them). A thin CLI shim
    (`if (import.meta.url === pathToFileURL(process.argv[1]).href)`) is the **only** place that
-   reads files and calls `process.exit`. Both `--write` and `--check` go through the same pure
-   `generateTypes` (identical `bannerComment` + options), so generate and check run the same
-   invocation — the only way the byte-compare is sound — and the test suite drives the pure
-   functions directly with in-memory inputs (it never spawns the exiting CLI).
+   reads files, `await`s the checks, and calls `process.exit`. Both `--write` and `--check` go
+   through the same pure `generateTypes` (`compile(schema, 'ResultEnvelope', {bannerComment,
+   format})`, identical options), so generate and check run the same invocation — the only way the
+   byte-compare is sound — and the test suite `await`s the pure functions directly with in-memory
+   inputs (it never spawns the exiting CLI). (The contract-side sanity assertion lives in the
+   pytest migration-match, not here — see D3.)
 2. **Formatter conflict.** json2ts formats its output with its **own** bundled prettier style
    (`semi:true, singleQuote:false, printWidth:120, trailingComma:'none', bracketSpacing:false`),
    which disagrees with the repo's `.prettierrc.json`
@@ -119,14 +121,15 @@ types are valid, usable TS; the generated `$defs` (`ResultEnvelope`, `Provenance
 into the generated types. So a re-pin that only re-stamps `$id` regenerates **byte-identical** TS →
 the drift guard passes with a *zero* TS diff, mechanically proving the structural no-op. The
 intended, reviewable diff on a re-pin is exactly two things kept in lockstep by the
-pin-consistency check: the schema `$id`/`pin.json.id` and `pin.json.version`. A Vitest test
-(`scripts/contract_types.test.mjs`) proves **both directions** so the property can't silently
-regress: (a) mutate only the `$id` version → regenerated TS is identical; (b) mutate a *real*
-field (flip `idempotency_key`'s type / add a property) → regenerated TS **differs** and the guard
-would fail. It also covers the negative paths the spec promises: pin-mismatch → not-ok; an
-unparseable `$id` → not-ok; a hand-edited committed TS → not-ok. The test is a **`node --test`**
-file (`scripts/contract_types.test.mjs`) importing the pure functions — no new test framework,
-no config (vitest is already used under `web/`, but the built-in runner avoids the root-config
+pin-consistency check: the schema `$id`/`pin.json.id` and `pin.json.version`. A **`node --test`**
+file (`scripts/contract_types.test.mjs`) importing the pure functions proves **both directions** so
+the property can't silently regress: (a) mutate only the `$id` version → regenerated TS is
+identical; (b) mutate a *real* field (flip `idempotency_key`'s type / add a property) → regenerated
+TS **differs** and the guard would fail. It also covers the negative paths the spec promises:
+pin-mismatch → not-ok; an unparseable `$id` → not-ok; a hand-edited committed TS → `checkDrift`
+not-ok (the *only* exercise of `checkDrift`'s failure branch — the runtime `--check` only ever hits
+its pass branch, since the real committed file always matches). No new test framework, no config
+(vitest is already used under `web/`, but the built-in `node --test` runner avoids the root-config
 question entirely). It runs in `build-and-audit` (no DB).
 
 ### D3 — Migration-match: pytest DB-introspection, A-subset, declaratively extensible
@@ -140,13 +143,16 @@ needed for it.
 
 It is honestly a **regression-lock over already-landed change A**, not a fresh RED→GREEN cycle:
 A's columns already exist, so the assertions are green as soon as the contract schema is vendored.
-The genuine "does the oracle discriminate?" proof is a deliberate task that mutates an expected
-value (or drops a constraint inside the `pg_conn` rollback transaction), confirms the failure
-fires **on the assertion line** (not a file-load error), then reverts.
+The genuine "does the oracle discriminate?" proof is a deliberate task that mutates one expected
+literal (e.g. assert `metadata` is `"json"` instead of `"jsonb"`) — no DB mutation, fully
+repeatable — confirms the failure fires **on that assertion** (not a file-load error), then reverts.
 
-**Collection safety:** the contract schema is loaded **lazily** (inside the test/fixture) or
-guarded with `pytest.skip(allow_module_level=True)` when the file is absent, so a commit where the
-test exists but the schema does not can never crash collection for the whole `tests/integration/`
+**Collection safety:** the module-level `MAPPINGS` list holds **literals only** (no schema-derived
+values), so import never touches the schema file — that is what protects *collection*. A
+`_load_schema()` helper reads the vendored schema **lazily inside each test body** and calls a plain
+`pytest.skip("contract schema not vendored")` when it is absent (the `allow_module_level` flag is
+only valid at module scope and is not used here). So a commit where the test exists but the schema
+does not skips at *execution*, and can never crash collection for the whole `tests/integration/`
 directory.
 
 A **declarative mapping** (a list of `{contract_field, db_table, db_column, db_type, constraint,
@@ -167,14 +173,20 @@ status, reason}` entries) drives the assertions:
     prove the UNIQUE is actually a UNIQUE. The CHECK guards the `""`-collision; the UNIQUE is the
     contract-level `1 ResultEnvelope : 1 source row` anchor — dropping it (keeping the CHECK)
     silently breaks idempotency, so both are active assertions.
-  - **Contract sanity:** `contract_version` is in `$defs.Provenance.required` and typed `string`.
-    `contract_version` is the per-row traceability anchor (which contract an envelope was produced
-    under); the whole row-anchor story rests on the contract *guaranteeing* every envelope carries
-    it. If sub-project #1 ever made it optional, D/G's future validation would have nothing to
-    validate — so this structural tripwire is asserted now (no consumer needed). This assertion
-    lives in the Node guard's `checkContractSanity` (fast lane) and is mirrored as a recorded note
-    here; the *runtime* `provenance.contract_version` == `pin.json.version` validation is the
-    deferred D/G hand-off below.
+  - **Contract sanity (contract-side facts that justify change A's DB choices), asserted here in
+    one home — not duplicated in the Node guard:**
+    - `contract_version` is in `$defs.Provenance.required` and typed `string`. It is the per-row
+      traceability anchor (which contract an envelope was produced under); the row-anchor story
+      rests on the contract *guaranteeing* every envelope carries it. If sub-project #1 ever made
+      it optional, D/G's future validation would have nothing to validate — so this structural
+      tripwire is asserted now (no consumer needed).
+    - `$defs.Provenance.properties.idempotency_key.default` is `""`. This is the *documented basis*
+      for change A's non-empty CHECK (an unset key arrives as `""`, never NULL); if the contract
+      changed the default away from `""`, that CHECK's rationale would silently rot. One-line
+      literal assert, lives with the constraint it justifies.
+    These are contract-side schema facts (no DB), so they live in this migration-match test (one
+    home) rather than also in the Node guard. The *runtime* `provenance.contract_version` ==
+    `pin.json.version` validation is the deferred D/G hand-off below.
 - **Deferred (skipped with a reason, not asserted):** B (`source_id` FK on the trait tables),
   C (intermediates/blob table), D (`idempotency_key == metadata->>'idempotency_key'` equality,
   RPC-enforced), `Provenance.contract_version` row-anchor validation (consumer-side, D/G), and
@@ -217,14 +229,14 @@ rows only.
   This is the only contract-side net for a description-level re-home (json2ts drops descriptions,
   so the TS guard is blind to it).
 - **Migration-match needs the compose stack.** It only runs in `compose-health-check`. → Acceptable:
-  it reuses existing infra and asserts the real applied schema; the cheap TS guard + Vitest run in
-  the fast Node job.
+  it reuses existing infra and asserts the real applied schema; the cheap TS guard + `node --test`
+  run in the fast Node job.
 
 ## Migration Plan
 
 No database migration. Pure additive repo content (vendored schema, manifest, generated types,
-guard script + Vitest, `.prettierignore`, one `.gitattributes` line, CI steps, pytest test) + one
-devDependency. Rollback = revert the change; nothing is applied to any database. Re-pin procedure
+guard script + `node --test` file, `.prettierignore`, one `.gitattributes` line, CI steps, pytest
+test) + one devDependency. Rollback = revert the change; nothing is applied to any database. Re-pin procedure
 (documented in `contracts/README.md`): replace the vendored schema, bump `pin.json.version`/`id`,
 run `npm run contracts:gen`, commit; a `$id`-only diff regenerates identical types and all guards
 pass; any real change produces a TS diff (caught by the guard) and a human reviews it.

--- a/openspec/changes/pin-sleap-roots-contract/design.md
+++ b/openspec/changes/pin-sleap-roots-contract/design.md
@@ -21,116 +21,180 @@ Two facts shape the design:
 2. **Bloom's CI has two relevant homes.** `build-and-audit` (Node; runs `npm ci`; no DB) and
    `compose-health-check` (brings up the prod compose stack, applies migrations, runs
    `pytest tests/integration/` against the live DB via the `pg_conn` fixture). The TS drift guard
-   belongs in the former; the DB migration-match belongs in the latter.
+   + its Vitest test belong in the former; the DB migration-match belongs in the latter.
 
 ## Goals / Non-Goals
 
 - **Goals:** pin `result_envelope.schema.json` at an explicit version; codegen committed TS
   types with a CI guard that fails on any drift between committed types and `json-schema → TS` of
   the pinned schema; add a migration-matches-schema CI assertion scoped to what change A built;
-  make the `$id`-restamp-no-op rule mechanically enforceable.
+  make the `$id`-restamp-no-op rule mechanically enforceable *and* prove a real change fails.
 - **Non-Goals:** no DB migration (A shipped the columns); no consumer wiring of the generated
   types (deferred to B/C/D/G); no jsonb shape validation at the DB layer (the contract owns
-  that, producer-side); no change to the contract repo.
+  that, producer-side); no change to the contract repo; `analysis_input.schema.json` (downstream
+  analysis input) is out of scope — only `result_envelope` is consumed by write-back.
 
 ## Decisions
 
 ### D1 — Pin `v0.1.0a1` (current), vendored as a committed copy + manifest
 
 Pin the current release so the next *real* re-pin event (to `v0.1.0`) is the only future churn.
-`result_envelope` is unchanged from a0, so this is purely about recording the pin.
+`result_envelope` is unchanged from a0, so this is purely about recording the pin. #294 names a0
+and prefers a non-prerelease `v0.1.0`; that cut does not exist yet, so a1 is the current pin and
+the `$id`-no-op machinery makes the eventual `v0.1.0` re-pin a zero-TS-diff event — the issue's
+preference is met *when the release exists*, without blocking now.
 
 Vendor a **committed copy** (`contracts/schema/result_envelope.schema.json`) rather than
 fetching at CI time: deterministic, offline, reviewable as a diff, and the committed `$id` *is*
-the pin record. A separate `contracts/pin.json` records the version explicitly so humans and the
-guard have a single declared source of truth. **Pin-consistency check:** `pin.json.version` MUST
-equal the version segment parsed from the schema `$id`; they cannot silently disagree. Rejected
-fetch-at-CI: adds a network dependency and a "fetched from where" question (the artifact lives on
-a git tag / release asset, not a CDN), and makes local TDD reproduction harder.
+the pin record. It is a **faithful, LF-normalized copy** (not a literal byte copy — `.gitattributes`
+forces `*.json eol=lf`, and `.prettierignore` keeps repo prettier from reflowing it). A separate
+`contracts/pin.json` records the pin explicitly:
 
-### D2 — Codegen with `json-schema-to-typescript`, pinned exact `15.0.4`, into `contracts/generated/`
+```json
+{ "package": "sleap-roots-contracts", "version": "v0.1.0a1",
+  "id": "https://github.com/talmolab/sleap-roots-contracts/schema/v0.1.0a1/result_envelope.schema.json",
+  "source": "<github tag/release url>",
+  "schema": "schema/result_envelope.schema.json", "generated": "generated/result-envelope.ts" }
+```
 
-`json-schema-to-typescript` (`json2ts`) is the de-facto JSON-Schema→TS tool and handles draft
-2020-12 `$defs`, `anyOf` nullable unions, and enums. **Determinism is the load-bearing property
-of a drift guard**, so:
+**Pin-consistency check** (in `contract_types.mjs`):
 
-- Pin json2ts to **exact `15.0.4`** in `package.json` (not a caret). The rest of the dependency
-  tree (including the prettier json2ts uses to format) is pinned by `package-lock.json`, so
-  `npm ci` reproduces byte-identical output in CI (node 20) and locally (node 22).
-- A single module `scripts/contract_types.mjs` drives both generation and checking via the
-  json2ts API (not the CLI), so generate-and-commit and CI-check run the *identical* invocation
-  (same `bannerComment`, same options) — the only way the byte-compare is sound.
+- `pin.json.id` MUST exactly equal the schema's `$id` (exact-string match — cannot mis-parse).
+- `pin.json.version` MUST equal the version segment parsed from `$id` with an **anchored regex**
+  (`/\/schema\/(v[^/]+)\/result_envelope\.schema\.json$/`), not a positional `split`.
+- A missing/unparseable `$id`, or any disagreement, exits non-zero. Rejected fetch-at-CI: adds a
+  network dependency and a "fetched from where" question (the artifact lives on a git tag /
+  release asset, not a CDN), and makes local TDD reproduction harder.
+
+### D2 — Codegen with `json-schema-to-typescript` (exact `15.0.4`), determinism owned end-to-end
+
+`json-schema-to-typescript` (`json2ts`) handles draft 2020-12 `$defs`, `anyOf` nullable unions,
+and enums. **Determinism is the load-bearing property of a drift guard**, and there are three
+independent ways it can break — all must be closed, not asserted away:
+
+1. **Tool/version drift.** Pin json2ts to **exact `15.0.4`** (not a caret); the whole tree
+   (including the prettier json2ts uses) is frozen by `package-lock.json`, so `npm ci` reproduces
+   identical output in CI (node 20) and locally (node 22). json2ts `engines.node` is `>=16`, so
+   node 20 is fine. A single module `scripts/contract_types.mjs` drives both `--write` and
+   `--check` via the json2ts **API** (identical `bannerComment` + options), so generate and check
+   run the same invocation — the only way the byte-compare is sound.
+2. **Formatter conflict.** json2ts formats its output with its **own** bundled prettier style
+   (`semi:true, singleQuote:false, printWidth:120, trailingComma:'none', bracketSpacing:false`),
+   which disagrees with the repo's `.prettierrc.json`
+   (`semi:false, singleQuote:true, printWidth:100, trailingComma:'es5'`) on five axes. The repo's
+   `format`/`format:check` scripts glob `**/*.{js,jsx,ts,tsx,json,md}` and there is **no
+   `.prettierignore`**. So `npm run format` would rewrite `contracts/generated/result-envelope.ts`
+   to repo style → the next `contracts:check` regenerates json2ts-style bytes → **guard fails on a
+   file nobody touched** (and `format:check`, run by the local pre-merge/lint skills, flags it).
+   Fix: a new `.prettierignore` excludes `contracts/generated/` and `contracts/schema/`. json2ts
+   owns the generated file's format; the vendored schema is a faithful copy of the published
+   artifact, not ours to reformat. (`format:check` is not a CI job today, so this is a *local*
+   pre-merge footgun — but tasks §6 runs those skills, so it must be fixed.)
+3. **EOL drift (Windows vs Linux).** `.gitattributes` has `* text=auto` and **no `*.ts` rule**, so
+   `.ts` round-trips through CRLF in a Windows working tree while json2ts emits `\n`. A naive
+   byte-compare then **passes in CI (LF) and fails on the author's Windows machine (CRLF)** — the
+   worst kind of flake. Fix (belt and suspenders): add `contracts/generated/*.ts text eol=lf` to
+   `.gitattributes` (working tree is LF even on Windows), **and** have `--write` always write `\n`
+   and `--check` EOL-normalize (`\r\n`→`\n`) before comparing.
 
 Generated types live in a **consumer-neutral** `contracts/generated/result-envelope.ts` with a
 `DO NOT EDIT` banner. No code imports them yet (B/C/D/G pending); co-locating them in a package
 (e.g. `bloom-js`) now would couple the artifact to that package's build/lint before any consumer
-exists. The eventual consumer can import from `contracts/generated/` or the file can move with a
-deliberate refactor when D/G need it.
+exists. A task runs `tsc --noEmit` on the generated file so the committed types are guaranteed
+valid, usable TS (the `BlobRef` `anyOf`-over-`properties` shape is reviewed for non-degeneracy at
+generation time, not rubber-stamped).
 
-**`$id`-no-op enforceability (the key mechanism):** json2ts never emits `$id` into the generated
-types. So a future re-pin that only re-stamps `$id` regenerates **byte-identical** TS → the drift
-guard passes with a *zero* TS diff, mechanically proving the structural no-op. The intended,
-reviewable diff on a re-pin is exactly two things kept in lockstep by the pin-consistency check:
-the schema `$id` and `pin.json.version`.
+**`$id`-no-op enforceability (the key mechanism) — and its converse.** json2ts never emits `$id`
+into the generated types. So a re-pin that only re-stamps `$id` regenerates **byte-identical** TS →
+the drift guard passes with a *zero* TS diff, mechanically proving the structural no-op. The
+intended, reviewable diff on a re-pin is exactly two things kept in lockstep by the
+pin-consistency check: the schema `$id`/`pin.json.id` and `pin.json.version`. A Vitest test
+(`scripts/contract_types.test.mjs`) proves **both directions** so the property can't silently
+regress: (a) mutate only the `$id` version → regenerated TS is identical; (b) mutate a *real*
+field (flip `idempotency_key`'s type / add a property) → regenerated TS **differs** and the guard
+would fail. It also covers the negative paths the spec promises: pin-mismatch → non-zero; a
+hand-edited committed TS → non-zero. This Vitest test runs in `build-and-audit` (no DB).
 
 ### D3 — Migration-match: pytest DB-introspection, A-subset, declaratively extensible
 
-A pytest integration test (`tests/integration/test_contract_migration_match.py`) introspects the
-**actually-applied** DB (via `pg_conn`) and compares against the vendored contract schema. This
-asserts the real schema, not parsed SQL text, and reuses the established change-A test pattern; it
+A pytest **regression-lock / characterization** test
+(`tests/integration/test_contract_migration_match.py`) introspects the **actually-applied** DB
+(via `pg_conn`) and compares against the vendored contract schema. It asserts the real schema, not
+parsed SQL text, reuses the change-A test pattern (`_column_type`, `pg_constraint` queries), and
 auto-runs in `compose-health-check` (the job globs `tests/integration/`), so no workflow edit is
 needed for it.
 
-A **declarative mapping** (a list of `{contract_field, db_table, db_column, db_type, status}`
-entries) drives the assertions:
+It is honestly a **regression-lock over already-landed change A**, not a fresh RED→GREEN cycle:
+A's columns already exist, so the assertions are green as soon as the contract schema is vendored.
+The genuine "does the oracle discriminate?" proof is a deliberate task that mutates an expected
+value (or drops a constraint inside the `pg_conn` rollback transaction), confirms the failure
+fires **on the assertion line** (not a file-load error), then reverts.
+
+**Collection safety:** the contract schema is loaded **lazily** (inside the test/fixture) or
+guarded with `pytest.skip(allow_module_level=True)` when the file is absent, so a commit where the
+test exists but the schema does not can never crash collection for the whole `tests/integration/`
+directory.
+
+A **declarative mapping** (a list of `{contract_field, db_table, db_column, db_type, constraint,
+status, reason}` entries) drives the assertions:
 
 - **Active (built by change A):**
-  - `Provenance` envelope → `cyl_trait_sources.metadata` is `jsonb` (the contract's `Provenance`
-    docstring states it *"serializes to cyl_trait_sources.metadata jsonb"*).
+  - `Provenance` envelope → `cyl_trait_sources.metadata` is `jsonb` — **and** the loaded schema's
+    `$defs.Provenance.description` still names `cyl_trait_sources.metadata` as the home (a tripwire:
+    if the contract re-homes Provenance via its docstring, json2ts can't see it and the byte-equal
+    TS guard would wave it through, so this is the *only* place a description-level re-home is
+    caught). Asserted as a substring match on the literal `cyl_trait_sources.metadata`.
   - `Provenance.idempotency_key` (contract type `string`, `default: ""`) →
-    `cyl_trait_sources.idempotency_key` is `text` **and** the non-empty CHECK exists (the DB
-    posture matching the contract's `""` default — an empty key is not valid).
+    `cyl_trait_sources.idempotency_key` is `text` **with both** the non-empty CHECK
+    (`cyl_trait_sources_idempotency_key_nonempty`) **and** the UNIQUE constraint
+    (`cyl_trait_sources_idempotency_key_key`). The CHECK guards the `""`-collision; the UNIQUE is
+    the contract-level `1 ResultEnvelope : 1 source row` anchor — dropping it (keeping the CHECK)
+    silently breaks idempotency, so both are active assertions.
 - **Deferred (skipped with a reason, not asserted):** B (`source_id` FK on the trait tables),
   C (intermediates/blob table), D (`idempotency_key == metadata->>'idempotency_key'` equality,
-  RPC-enforced). Marked `status="deferred"` so the file is a living extension point: each future
-  change flips its row to active. This keeps the check meaningful today and **not brittle**
-  against tables/columns that do not exist yet.
+  RPC-enforced), `Provenance.contract_version` row-anchor validation (consumer-side, D/G), and
+  `scan_key`→`cyl_scans.id` resolution. Marked `status="deferred"` so the file is a living
+  extension point: each future change flips its row to active. This keeps the check meaningful
+  today and **not brittle** against tables/columns/values that do not exist yet.
 
 The test also records (as a documented, non-asserted note) that the remaining `Provenance` fields
 are deliberately carried *inside* the opaque `metadata` jsonb, not promoted to columns — change
-A's intentional boundary.
+A's intentional boundary — and that `contract_version`/`TraitValue.value` finiteness are
+consumer-side hand-offs to D/G (see proposal Cross-change hand-offs).
 
 ### D4 — CI wiring
 
 - TS drift guard: a new step in `build-and-audit` → `node scripts/contract_types.mjs --check`
-  (runs after `npm ci`, before/after the existing build steps). Pure Node, fast, no DB.
+  (after `npm ci`). Pure Node, fast, no DB.
+- Vitest negative-path/`$id`-no-op test: a new step in `build-and-audit` running the single
+  `scripts/contract_types.test.mjs` (e.g. `npx vitest run scripts/contract_types.test.mjs`), no DB.
 - Migration-match: no workflow change — placing the test under `tests/integration/` is sufficient
   (`compose-health-check` runs the whole directory).
 
 ## Risks / Trade-offs
 
 - **json2ts CVE surface.** Adding a devDependency widens `npm audit --audit-level=critical`
-  (already in `build-and-audit`). json2ts is widely used; if a critical advisory appears it is
-  handled like any other dep. → Accept; exact-pin keeps the surface explicit and reviewable.
+  (already in `build-and-audit`). json2ts's tree is small/mainstream; no current criticals. →
+  Accept; exact-pin keeps it explicit.
 - **json2ts output stability across versions.** A json2ts upgrade could change formatting and
-  trip the guard. → That is *correct* behavior (the guard owns the committed bytes): an upgrade is
-  a deliberate `--write` + commit, gated by the exact pin. The risk is only an *unexpected* bump,
-  which the exact pin + lockfile prevent.
-- **Unusual `BlobRef` shape.** `BlobRef` has a top-level `anyOf` (s3 *or* box required) layered
-  over a `properties` block; json2ts emits a union/intersection. Whatever it emits is committed and
-  guarded — correctness of the *type* matters less than determinism for the guard, and the
-  producer-side contract owns semantic validity.
-- **Migration-match needs the compose stack.** It only runs in the heavier
-  `compose-health-check` job. → Acceptable: it reuses existing infra and asserts the real applied
-  schema, which is the meaningful target; the cheap TS guard runs in the fast Node job.
+  trip the guard — which is *correct*: an upgrade is a deliberate `--write` + commit, gated by the
+  exact pin. The risk is only an *unexpected* bump, which the exact pin + lockfile prevent.
+- **Docstring tripwire brittleness.** Asserting `Provenance.description` contains
+  `cyl_trait_sources.metadata` can fail on a benign reword. → That is the intended behavior: a
+  contract docstring change about the home *should* force a human to re-confirm the mapping; the
+  fix is a one-line update to the expected substring after confirming the home is unchanged.
+- **Migration-match needs the compose stack.** It only runs in `compose-health-check`. → Acceptable:
+  it reuses existing infra and asserts the real applied schema; the cheap TS guard + Vitest run in
+  the fast Node job.
 
 ## Migration Plan
 
 No database migration. Pure additive repo content (vendored schema, manifest, generated types,
-guard script, CI step, test) + one devDependency. Rollback = revert the change; nothing is
-applied to any database. Re-pin procedure (documented in `contracts/README.md`): replace the
-vendored schema, bump `pin.json.version`, run `npm run contracts:gen`, commit; the `$id`-only diff
-regenerates identical types and the guards pass.
+guard script + Vitest, `.prettierignore`, one `.gitattributes` line, CI steps, pytest test) + one
+devDependency. Rollback = revert the change; nothing is applied to any database. Re-pin procedure
+(documented in `contracts/README.md`): replace the vendored schema, bump `pin.json.version`/`id`,
+run `npm run contracts:gen`, commit; a `$id`-only diff regenerates identical types and all guards
+pass; any real change produces a TS diff (caught by the guard) and a human reviews it.
 
 ## Open Questions
 

--- a/openspec/changes/pin-sleap-roots-contract/proposal.md
+++ b/openspec/changes/pin-sleap-roots-contract/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+The sleap-roots ↔ Bloom integration's most failure-prone seam is the **cross-language
+contract boundary**: the `sleap-roots-contracts` `ResultEnvelope`/`Provenance` shape is
+authored in Python (Pydantic → JSON Schema), and Bloom (TypeScript + Postgres) consumes it.
+Today Bloom consumes it only *implicitly* — change A (#290) added `cyl_trait_sources.metadata`
+(the opaque `Provenance` envelope home) and `idempotency_key` by hand-reading the contract,
+with **no machine check** that Bloom's generated types or DB schema still agree with a specific
+contract version. The contract can change, or Bloom can drift, and nothing fails.
+
+This is the **A2 "consume (pin)" change (#294)**. The roadmap sequences it *first* in A2 and
+notes change A's "types-match-contract CI" was always meant to depend on it (A shipped first
+pragmatically; this closes that gap). It pins the contract at an explicit version, codegens the
+TypeScript types from its JSON Schema, and adds a **migration-matches-schema CI check** so
+Bloom's generated types and DB schema cannot silently drift from the pinned contract.
+
+Per the roadmap's **contract version pinning** hard constraint, the schema `$id` is
+version-stamped, so any future re-pin re-stamps `result_envelope`'s `$id` with **no payload
+change**. The design makes that an enforceable structural no-op (codegen ignores `$id`, so a
+`$id`-only re-pin regenerates byte-identical types).
+
+## What Changes
+
+- **Vendor the pinned contract** (`v0.1.0a1`, current) as a committed copy under `contracts/`:
+  - `contracts/schema/result_envelope.schema.json` — byte copy of the published a1 schema
+    (`$id …/v0.1.0a1/…`).
+  - `contracts/pin.json` — a manifest recording the pinned `package` + `version` + `source` +
+    `schema`/`generated` paths. The **pin is the committed `$id`**; the manifest records it
+    explicitly.
+  - `contracts/README.md` — documents the pin, the `$id`-restamp-is-a-no-op rule, and the
+    re-pin procedure.
+- **Codegen TypeScript types** from the pinned schema with `json-schema-to-typescript`
+  (added as a root devDependency, **pinned to exact `15.0.4`** for deterministic output),
+  generated into `contracts/generated/result-envelope.ts` (`ResultEnvelope`, `Provenance`,
+  `TraitValue`, `BlobRef`, and their sub-defs). This is the *contract* types — distinct from the
+  Supabase `database.types.ts` (generated from the DB by `make gen-types`).
+- **TS drift guard (the oracle):** a Node ESM script `scripts/contract_types.mjs` with `--write`
+  (regenerate) and `--check` (regenerate in-memory, byte-compare to the committed file, exit 1 +
+  diff on mismatch) modes, plus a **pin-consistency check** that `pin.json.version` equals the
+  version segment parsed from the schema `$id`. Wired into the existing `build-and-audit` CI job
+  (Node, no DB).
+- **Migration-matches-schema CI check:** a pytest integration test
+  (`tests/integration/test_contract_migration_match.py`) that introspects the live applied DB
+  (via the existing `pg_conn` fixture, in `compose-health-check`) and asserts the contract↔DB
+  mappings **built today**: the `Provenance` envelope home is `cyl_trait_sources.metadata` jsonb,
+  and `Provenance.idempotency_key` (contract type `string`, `default: ""`) maps to
+  `cyl_trait_sources.idempotency_key` text with the non-empty CHECK. A declarative mapping marks
+  the B/C/D mappings (`source_id` FK, blob table, RPC equality) **deferred/skipped**, so the
+  check is meaningful now and extends as those changes land — never asserting against tables that
+  do not exist yet.
+
+Non-goals (separate changes): no DB migration here (change A already shipped the columns); no
+consumer is wired to the generated types yet (changes B/C/D/G pending) — the artifact + guards
+exist now, consumption lands with the consumer; no change to the contract itself (owned by
+sub-project #1, `sleap-roots-contracts`).
+
+## Impact
+
+- Affected specs: `contract-pinning` (new capability)
+- Affected code:
+  - `contracts/` (new: vendored schema, pin manifest, generated types, README)
+  - `scripts/contract_types.mjs` (new drift guard) + root `package.json`/`package-lock.json`
+    (json2ts devDep + `contracts:gen`/`contracts:check` scripts)
+  - `.github/workflows/pr-checks.yml` (new drift-guard step in `build-and-audit`)
+  - `tests/integration/test_contract_migration_match.py` (new; auto-runs in
+    `compose-health-check`)
+- Affected issues: A2 consume-pin **#294**; unblocks/back-fills change A's intended
+  types-match-contract CI; precedes change B (#295)
+- Data: none — no migration, no schema change, no row changes
+- Cross-change: the migration-match check is written as the extension point for B (#295,
+  `source_id` FK), C (#296, blob table), and D (#297/#13, write-back RPC); each fills in its
+  deferred mapping row when it lands. Relocating the migration-match requirement into the
+  `cyl-trait-writeback` capability is a deliberate future refactor (deferred until change A's
+  archive lands that live spec on `staging`).

--- a/openspec/changes/pin-sleap-roots-contract/proposal.md
+++ b/openspec/changes/pin-sleap-roots-contract/proposal.md
@@ -45,12 +45,15 @@ a *real* field change does fail the guard.
   Supabase `database.types.ts` (generated from the DB by `make gen-types`).
 - **TS drift guard (the oracle):** a Node ESM script `scripts/contract_types.mjs` with `--write`
   (regenerate) and `--check` (regenerate in-memory, EOL-normalize, byte-compare to the committed
-  file, exit 1 + diff on mismatch) modes, plus a **pin-consistency check** that `pin.json.version`
-  and `pin.json.id` agree with the schema's `$id` (exact-string match on the full `$id`; the
-  version segment is parsed with an anchored regex). Wired into the existing `build-and-audit` CI
-  job (Node, no DB). A **Vitest test** (`scripts/contract_types.test.mjs`, also in
-  `build-and-audit`) exercises the guard's negative paths and the `$id`-no-op property (see
-  Testing in design.md / tasks.md).
+  file, exit 1 + diff on mismatch) modes, plus a **pin-consistency / contract-sanity check** that
+  `pin.json.version` and `pin.json.id` agree with the schema's `$id` (exact-string match on the
+  full `$id`; the version segment is parsed with an anchored regex) and that the pinned schema
+  still requires the `Provenance.contract_version` traceability anchor. The script **exports pure
+  functions** (no file I/O or `process.exit` inside them) behind a thin CLI shim, so it is
+  unit-testable. Wired into the existing `build-and-audit` CI job (Node, no DB). A companion
+  `node --test` file (`scripts/contract_types.test.mjs`, also in `build-and-audit`; uses the
+  built-in Node test runner, no new framework) exercises the guard's negative paths and the
+  `$id`-no-op property in both directions (see Testing in design.md / tasks.md).
 - **Determinism guards (new repo config):** a `.prettierignore` excluding `contracts/generated/`
   and `contracts/schema/` (json2ts owns the generated file's format; the vendored schema is a
   faithful copy), and a `.gitattributes` rule `contracts/generated/*.ts text eol=lf` so the guard
@@ -65,9 +68,10 @@ a *real* field change does fail the guard.
     `cyl_trait_sources.metadata` — a tripwire on a contract-side re-home);
   - `Provenance.idempotency_key` (contract type `string`, `default: ""`) maps to
     `cyl_trait_sources.idempotency_key` text with **both** the non-empty CHECK
-    (`cyl_trait_sources_idempotency_key_nonempty`) **and** the UNIQUE constraint
-    (`cyl_trait_sources_idempotency_key_key`) — the UNIQUE is the actual 1-envelope:1-row anchor,
-    not just the empty-string guard.
+    (`cyl_trait_sources_idempotency_key_nonempty`, asserted by `contype = 'c'`) **and** the UNIQUE
+    constraint (`cyl_trait_sources_idempotency_key_key`, asserted by `contype = 'u'` — a name match
+    alone doesn't prove it is a UNIQUE rather than some other constraint) — the UNIQUE is the
+    actual 1-envelope:1-row anchor, not just the empty-string guard.
   A declarative mapping marks the B/C/D mappings (`source_id` FK, blob table, RPC key-equality,
   `scan_key`→`cyl_scans` resolution) **deferred/skipped**, so the check is meaningful now and
   extends as those changes land — never asserting against tables that do not exist yet. The schema
@@ -89,11 +93,11 @@ intentionally out of scope — only `result_envelope` is consumed by Bloom's A2 
   until change A's archive (#300) lands that live spec on `staging`.
 - Affected code:
   - `contracts/` (new: vendored schema, pin manifest, generated types, README)
-  - `scripts/contract_types.mjs` (new drift guard) + `scripts/contract_types.test.mjs` (new
-    Vitest) + root `package.json`/`package-lock.json` (json2ts devDep + `contracts:gen`/
-    `contracts:check` scripts)
+  - `scripts/contract_types.mjs` (new drift guard, pure-function exports + CLI shim) +
+    `scripts/contract_types.test.mjs` (new `node --test`) + root `package.json`/
+    `package-lock.json` (json2ts devDep + `contracts:gen`/`contracts:check` scripts)
   - `.prettierignore` (new) + `.gitattributes` (one new rule)
-  - `.github/workflows/pr-checks.yml` (new drift-guard + vitest steps in `build-and-audit`)
+  - `.github/workflows/pr-checks.yml` (new drift-guard + `node --test` steps in `build-and-audit`)
   - `tests/integration/test_contract_migration_match.py` (new; auto-runs in
     `compose-health-check`)
 - Affected issues: A2 consume-pin **#294** (parent #12, EPIC #9); unblocks/back-fills change A's

--- a/openspec/changes/pin-sleap-roots-contract/proposal.md
+++ b/openspec/changes/pin-sleap-roots-contract/proposal.md
@@ -1,3 +1,5 @@
+# Pin sleap-roots contract (A2 consume-pin, #294)
+
 ## Why
 
 The sleap-roots ↔ Bloom integration's most failure-prone seam is the **cross-language
@@ -17,58 +19,95 @@ Bloom's generated types and DB schema cannot silently drift from the pinned cont
 Per the roadmap's **contract version pinning** hard constraint, the schema `$id` is
 version-stamped, so any future re-pin re-stamps `result_envelope`'s `$id` with **no payload
 change**. The design makes that an enforceable structural no-op (codegen ignores `$id`, so a
-`$id`-only re-pin regenerates byte-identical types).
+`$id`-only re-pin regenerates byte-identical types), and an automated test proves the converse:
+a *real* field change does fail the guard.
 
 ## What Changes
 
-- **Vendor the pinned contract** (`v0.1.0a1`, current) as a committed copy under `contracts/`:
-  - `contracts/schema/result_envelope.schema.json` — byte copy of the published a1 schema
-    (`$id …/v0.1.0a1/…`).
-  - `contracts/pin.json` — a manifest recording the pinned `package` + `version` + `source` +
-    `schema`/`generated` paths. The **pin is the committed `$id`**; the manifest records it
-    explicitly.
+- **Vendor the pinned contract** (`v0.1.0a1`, current) as a committed, LF-normalized copy under
+  `contracts/`:
+  - `contracts/schema/result_envelope.schema.json` — the published a1 schema
+    (`$id …/v0.1.0a1/…`), normalized to LF and excluded from repo prettier (see Determinism
+    below) so it stays a faithful copy of the published artifact.
+  - `contracts/pin.json` — a manifest recording the pinned `package`, `version`, the **full
+    `$id` string**, `source`, and the schema/generated file paths. The **pin is the committed
+    `$id`**; the manifest records it explicitly.
   - `contracts/README.md` — documents the pin, the `$id`-restamp-is-a-no-op rule, and the
     re-pin procedure.
+  - **Version choice vs #294:** #294 names `v0.1.0a0` and states a preference for a
+    non-prerelease `v0.1.0` cut. That release does not exist yet, so we pin the **current
+    `v0.1.0a1`** (`result_envelope` is byte-identical to a0 except its `$id`); the `$id`-no-op
+    machinery makes the eventual `v0.1.0` re-pin a zero-TS-diff event.
 - **Codegen TypeScript types** from the pinned schema with `json-schema-to-typescript`
   (added as a root devDependency, **pinned to exact `15.0.4`** for deterministic output),
   generated into `contracts/generated/result-envelope.ts` (`ResultEnvelope`, `Provenance`,
   `TraitValue`, `BlobRef`, and their sub-defs). This is the *contract* types — distinct from the
   Supabase `database.types.ts` (generated from the DB by `make gen-types`).
 - **TS drift guard (the oracle):** a Node ESM script `scripts/contract_types.mjs` with `--write`
-  (regenerate) and `--check` (regenerate in-memory, byte-compare to the committed file, exit 1 +
-  diff on mismatch) modes, plus a **pin-consistency check** that `pin.json.version` equals the
-  version segment parsed from the schema `$id`. Wired into the existing `build-and-audit` CI job
-  (Node, no DB).
+  (regenerate) and `--check` (regenerate in-memory, EOL-normalize, byte-compare to the committed
+  file, exit 1 + diff on mismatch) modes, plus a **pin-consistency check** that `pin.json.version`
+  and `pin.json.id` agree with the schema's `$id` (exact-string match on the full `$id`; the
+  version segment is parsed with an anchored regex). Wired into the existing `build-and-audit` CI
+  job (Node, no DB). A **Vitest test** (`scripts/contract_types.test.mjs`, also in
+  `build-and-audit`) exercises the guard's negative paths and the `$id`-no-op property (see
+  Testing in design.md / tasks.md).
+- **Determinism guards (new repo config):** a `.prettierignore` excluding `contracts/generated/`
+  and `contracts/schema/` (json2ts owns the generated file's format; the vendored schema is a
+  faithful copy), and a `.gitattributes` rule `contracts/generated/*.ts text eol=lf` so the guard
+  is reproducible on Windows (local) and Linux (CI). Without these, repo prettier would reflow the
+  generated file and CRLF/LF would diverge — both breaking the byte-equal guard.
 - **Migration-matches-schema CI check:** a pytest integration test
   (`tests/integration/test_contract_migration_match.py`) that introspects the live applied DB
   (via the existing `pg_conn` fixture, in `compose-health-check`) and asserts the contract↔DB
-  mappings **built today**: the `Provenance` envelope home is `cyl_trait_sources.metadata` jsonb,
-  and `Provenance.idempotency_key` (contract type `string`, `default: ""`) maps to
-  `cyl_trait_sources.idempotency_key` text with the non-empty CHECK. A declarative mapping marks
-  the B/C/D mappings (`source_id` FK, blob table, RPC equality) **deferred/skipped**, so the
-  check is meaningful now and extends as those changes land — never asserting against tables that
-  do not exist yet.
+  mappings **built today**:
+  - the `Provenance` envelope home is `cyl_trait_sources.metadata` jsonb, **and** the contract
+    still designates that home (the loaded schema's `Provenance.description` names
+    `cyl_trait_sources.metadata` — a tripwire on a contract-side re-home);
+  - `Provenance.idempotency_key` (contract type `string`, `default: ""`) maps to
+    `cyl_trait_sources.idempotency_key` text with **both** the non-empty CHECK
+    (`cyl_trait_sources_idempotency_key_nonempty`) **and** the UNIQUE constraint
+    (`cyl_trait_sources_idempotency_key_key`) — the UNIQUE is the actual 1-envelope:1-row anchor,
+    not just the empty-string guard.
+  A declarative mapping marks the B/C/D mappings (`source_id` FK, blob table, RPC key-equality,
+  `scan_key`→`cyl_scans` resolution) **deferred/skipped**, so the check is meaningful now and
+  extends as those changes land — never asserting against tables that do not exist yet. The schema
+  is **loaded lazily / module-level-skipped** when absent so it can never crash pytest collection.
 
 Non-goals (separate changes): no DB migration here (change A already shipped the columns); no
 consumer is wired to the generated types yet (changes B/C/D/G pending) — the artifact + guards
 exist now, consumption lands with the consumer; no change to the contract itself (owned by
-sub-project #1, `sleap-roots-contracts`).
+sub-project #1, `sleap-roots-contracts`). **`schema/analysis_input.schema.json`** (the
+downstream sleap-roots-analyze *input* contract, not the write-back result envelope) is
+intentionally out of scope — only `result_envelope` is consumed by Bloom's A2 write-back, so
+`schema/*.json` in #294 is narrowed to the one schema Bloom consumes.
 
 ## Impact
 
-- Affected specs: `contract-pinning` (new capability)
+- Affected specs: `contract-pinning` (new capability). NB: the migration-matches-schema
+  requirement is housed here as an interim home; its natural long-term home is
+  `cyl-trait-writeback` (where B/C/D edit), and relocating it is a deliberate refactor deferred
+  until change A's archive (#300) lands that live spec on `staging`.
 - Affected code:
   - `contracts/` (new: vendored schema, pin manifest, generated types, README)
-  - `scripts/contract_types.mjs` (new drift guard) + root `package.json`/`package-lock.json`
-    (json2ts devDep + `contracts:gen`/`contracts:check` scripts)
-  - `.github/workflows/pr-checks.yml` (new drift-guard step in `build-and-audit`)
+  - `scripts/contract_types.mjs` (new drift guard) + `scripts/contract_types.test.mjs` (new
+    Vitest) + root `package.json`/`package-lock.json` (json2ts devDep + `contracts:gen`/
+    `contracts:check` scripts)
+  - `.prettierignore` (new) + `.gitattributes` (one new rule)
+  - `.github/workflows/pr-checks.yml` (new drift-guard + vitest steps in `build-and-audit`)
   - `tests/integration/test_contract_migration_match.py` (new; auto-runs in
     `compose-health-check`)
-- Affected issues: A2 consume-pin **#294**; unblocks/back-fills change A's intended
-  types-match-contract CI; precedes change B (#295)
+- Affected issues: A2 consume-pin **#294** (parent #12, EPIC #9); unblocks/back-fills change A's
+  intended types-match-contract CI; precedes change B (#295)
 - Data: none — no migration, no schema change, no row changes
-- Cross-change: the migration-match check is written as the extension point for B (#295,
-  `source_id` FK), C (#296, blob table), and D (#297/#13, write-back RPC); each fills in its
-  deferred mapping row when it lands. Relocating the migration-match requirement into the
-  `cyl-trait-writeback` capability is a deliberate future refactor (deferred until change A's
-  archive lands that live spec on `staging`).
+- Cross-change hand-offs (recorded so later changes don't drop them):
+  - The migration-match check is the extension point for B (#295, `source_id` FK), C (#296, blob
+    table), and D (write-back RPC; tracked under #13, sub-issue TBD; co-lands with E #297 — note
+    #297 is change **E**, the RLS lockdown, not D). Each fills in its deferred mapping row when it
+    lands.
+  - **`Provenance.contract_version`** is the per-row traceability anchor (which contract an
+    envelope was produced under). This change pins the *consumer* version but cannot assert
+    runtime rows; change **D/G's consumer MUST validate `provenance.contract_version` against
+    `pin.json.version`** (or an explicit compatibility set) at the consume boundary. Recorded as a
+    deferred mapping row + design hand-off so it is not forgotten.
+  - **`TraitValue.value`** must be finite-or-null (the contract normalizes NaN/inf → null); change
+    **G's consumer MUST validate** finiteness at the write boundary. Recorded as a hand-off.

--- a/openspec/changes/pin-sleap-roots-contract/proposal.md
+++ b/openspec/changes/pin-sleap-roots-contract/proposal.md
@@ -45,15 +45,15 @@ a *real* field change does fail the guard.
   Supabase `database.types.ts` (generated from the DB by `make gen-types`).
 - **TS drift guard (the oracle):** a Node ESM script `scripts/contract_types.mjs` with `--write`
   (regenerate) and `--check` (regenerate in-memory, EOL-normalize, byte-compare to the committed
-  file, exit 1 + diff on mismatch) modes, plus a **pin-consistency / contract-sanity check** that
-  `pin.json.version` and `pin.json.id` agree with the schema's `$id` (exact-string match on the
-  full `$id`; the version segment is parsed with an anchored regex) and that the pinned schema
-  still requires the `Provenance.contract_version` traceability anchor. The script **exports pure
-  functions** (no file I/O or `process.exit` inside them) behind a thin CLI shim, so it is
-  unit-testable. Wired into the existing `build-and-audit` CI job (Node, no DB). A companion
-  `node --test` file (`scripts/contract_types.test.mjs`, also in `build-and-audit`; uses the
-  built-in Node test runner, no new framework) exercises the guard's negative paths and the
-  `$id`-no-op property in both directions (see Testing in design.md / tasks.md).
+  file, exit 1 + diff on mismatch) modes, plus a **pin-consistency check** that `pin.json.version`
+  and `pin.json.id` agree with the schema's `$id` (exact-string match on the full `$id`; the
+  version segment is parsed with an anchored regex). The script **exports pure functions** (`async
+  generateTypes`, `checkPinConsistency`, `async checkDrift`; json2ts `compile()` is async — no file
+  I/O or `process.exit` inside them) behind a thin CLI shim, so it is unit-testable. Wired into the
+  existing `build-and-audit` CI job (Node, no DB). A companion `node --test` file
+  (`scripts/contract_types.test.mjs`, also in `build-and-audit`; uses the built-in Node test
+  runner, no new framework) exercises the guard's negative paths and the `$id`-no-op property in
+  both directions (see Testing in design.md / tasks.md).
 - **Determinism guards (new repo config):** a `.prettierignore` excluding `contracts/generated/`
   and `contracts/schema/` (json2ts owns the generated file's format; the vendored schema is a
   faithful copy), and a `.gitattributes` rule `contracts/generated/*.ts text eol=lf` so the guard
@@ -71,7 +71,10 @@ a *real* field change does fail the guard.
     (`cyl_trait_sources_idempotency_key_nonempty`, asserted by `contype = 'c'`) **and** the UNIQUE
     constraint (`cyl_trait_sources_idempotency_key_key`, asserted by `contype = 'u'` — a name match
     alone doesn't prove it is a UNIQUE rather than some other constraint) — the UNIQUE is the
-    actual 1-envelope:1-row anchor, not just the empty-string guard.
+    actual 1-envelope:1-row anchor, not just the empty-string guard;
+  - **contract-side sanity** (schema facts that justify change A's DB choices, asserted in this one
+    home): `Provenance.contract_version` is `required` + `string` (the per-row provenance anchor),
+    and `Provenance.idempotency_key.default` is `""` (the documented basis for the non-empty CHECK).
   A declarative mapping marks the B/C/D mappings (`source_id` FK, blob table, RPC key-equality,
   `scan_key`→`cyl_scans` resolution) **deferred/skipped**, so the check is meaningful now and
   extends as those changes land — never asserting against tables that do not exist yet. The schema

--- a/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
+++ b/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
@@ -37,13 +37,6 @@ no-op (not a contract revision).
   the expected `…/schema/<version>/result_envelope.schema.json` shape
 - **THEN** the check fails with a non-zero exit status rather than silently passing
 
-#### Scenario: Pinned schema retains the contract_version traceability anchor
-
-- **WHEN** the contract-sanity check runs against the pinned schema
-- **THEN** it confirms `contract_version` is a required `string` field of `Provenance`, and fails
-  if a re-pin ever drops it from `required` (the per-row provenance-of-origin anchor must be
-  guaranteed by every envelope)
-
 ### Requirement: Generated TypeScript types match the pinned schema
 
 Bloom SHALL commit TypeScript types generated from the pinned `result_envelope.schema.json`
@@ -97,7 +90,10 @@ that the `Provenance` envelope home is `cyl_trait_sources.metadata` of type `jso
 loaded contract still designates that home (the schema's `Provenance` description names
 `cyl_trait_sources.metadata`); and that `Provenance.idempotency_key` (contract type `string`,
 default `""`) maps to `cyl_trait_sources.idempotency_key` of type `text` guarded by **both** a
-non-empty CHECK constraint and a UNIQUE constraint. The check SHALL be driven by a declarative
+non-empty CHECK constraint and a UNIQUE constraint. The check SHALL also assert the contract-side
+schema facts that justify change A's DB choices: `Provenance.contract_version` is `required` and
+typed `string` (the per-row provenance-of-origin anchor), and `Provenance.idempotency_key.default`
+is `""` (the documented basis for the non-empty CHECK). The check SHALL be driven by a declarative
 mapping in which mappings introduced by later changes (`source_id` foreign keys, the
 intermediates/blob table, RPC-enforced key equality, `contract_version` row-anchor validation, and
 `scan_key` resolution) are marked deferred and explicitly skipped, so the check does not assert
@@ -120,6 +116,13 @@ Note: this requirement may relocate to the `cyl-trait-writeback` capability in a
   string` with `default: ""`), and a constraint of type UNIQUE (`contype = 'u'`, the
   `1 ResultEnvelope : 1 source row` anchor) — verified by constraint *type*, not name alone
 
+#### Scenario: Contract-side anchors that justify the DB schema are present
+
+- **WHEN** the check inspects the loaded contract
+- **THEN** `Provenance.contract_version` is in `required` and typed `string`, and
+  `Provenance.idempotency_key.default` is `""`, and the check fails if a re-pin drops either (the
+  provenance anchor and the empty-string CHECK rationale must stay guaranteed by the contract)
+
 #### Scenario: Deferred mappings are skipped, not asserted
 
 - **WHEN** the check encounters a mapping marked deferred (e.g. a `source_id` foreign key, the
@@ -136,6 +139,7 @@ Note: this requirement may relocate to the `cyl-trait-writeback` capability in a
 
 #### Scenario: Missing contract schema does not crash test collection
 
-- **WHEN** the test module is collected and the vendored contract schema file is absent
-- **THEN** the test is skipped (module-level) rather than raising and failing collection for the
-  whole integration suite
+- **WHEN** the test module is collected and the vendored contract schema file is absent (module-level
+  state references only literals, so collection does not read the schema)
+- **THEN** the affected tests are skipped at execution rather than raising and failing collection for
+  the whole integration suite

--- a/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
+++ b/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
@@ -2,47 +2,60 @@
 
 ### Requirement: Pinned contract schema is vendored at an explicit version
 
-Bloom SHALL vendor the `sleap-roots-contracts` `result_envelope.schema.json` as a committed copy
-under `contracts/schema/`, pinned at an explicit version, accompanied by a `contracts/pin.json`
-manifest that records the pinned package, version, source, and the schema/generated file paths.
-The vendored schema's version-stamped `$id` and the manifest's recorded version MUST agree; a
-pin-consistency check SHALL fail when they diverge. The repository SHALL document, in
-`contracts/README.md`, the pinned version, the re-pin procedure, and the rule that a re-pin which
-only re-stamps the schema `$id` is a structural no-op (not a contract revision).
+Bloom SHALL vendor the `sleap-roots-contracts` `result_envelope.schema.json` as a committed,
+LF-normalized copy under `contracts/schema/`, pinned at an explicit version, accompanied by a
+`contracts/pin.json` manifest that records the pinned package, version, the full schema `$id`
+string, source, and the schema/generated file paths. A pin-consistency check SHALL fail unless
+the manifest's recorded `$id` exactly equals the vendored schema's `$id` AND the manifest's
+recorded version equals the version segment parsed from that `$id` (parsed with an anchored rule
+matching `…/schema/<version>/result_envelope.schema.json`). A missing or unparseable `$id` SHALL
+fail the check. The repository SHALL document, in `contracts/README.md`, the pinned version, the
+re-pin procedure, and the rule that a re-pin which only re-stamps the schema `$id` is a structural
+no-op (not a contract revision).
 
 #### Scenario: Vendored schema and manifest are committed
 
 - **WHEN** the repository is inspected
 - **THEN** `contracts/schema/result_envelope.schema.json` and `contracts/pin.json` exist, and the
-  manifest records the pinned package, version, and file paths
+  manifest records the pinned package, version, full `$id`, and file paths
 
 #### Scenario: Pin-consistency holds when manifest matches the schema $id
 
-- **WHEN** the pin-consistency check runs and `pin.json.version` equals the version segment parsed
-  from the vendored schema's `$id`
+- **WHEN** the pin-consistency check runs and both `pin.json.id` equals the vendored schema's
+  `$id` and `pin.json.version` equals the version segment parsed from that `$id`
 - **THEN** the check passes
 
 #### Scenario: Pin-consistency fails when manifest and schema $id disagree
 
-- **WHEN** the pin-consistency check runs and `pin.json.version` does not equal the version
-  segment parsed from the vendored schema's `$id`
+- **WHEN** the pin-consistency check runs and `pin.json.id`/`pin.json.version` does not match the
+  vendored schema's `$id`
 - **THEN** the check fails with a non-zero exit status identifying the mismatch
+
+#### Scenario: Pin-consistency fails when the schema $id is missing or unparseable
+
+- **WHEN** the pin-consistency check runs against a schema whose `$id` is absent or does not match
+  the expected `…/schema/<version>/result_envelope.schema.json` shape
+- **THEN** the check fails with a non-zero exit status rather than silently passing
 
 ### Requirement: Generated TypeScript types match the pinned schema
 
 Bloom SHALL commit TypeScript types generated from the pinned `result_envelope.schema.json`
 (`ResultEnvelope`, `Provenance`, `TraitValue`, `BlobRef`, and their sub-definitions) under
-`contracts/generated/`, produced by a deterministic, exact-version-pinned codegen tool. A CI drift
-guard SHALL regenerate the types from the pinned schema and fail when the committed types are not
-byte-identical to the regenerated output. Because the codegen does not emit the schema `$id` into
-the types, a re-pin that only re-stamps the `$id` MUST regenerate byte-identical types so the
-guard passes with no type change. These contract types are distinct from the Supabase
+`contracts/generated/`, produced by a deterministic, exact-version-pinned codegen tool. The
+generated file SHALL be excluded from repository prettier formatting and pinned to LF line endings
+so the codegen tool's output is the single authority over its bytes across operating systems. A CI
+drift guard SHALL regenerate the types from the pinned schema, normalize line endings, and fail
+when the committed types are not byte-identical to the regenerated output. Because the codegen does
+not emit the schema `$id` into the types, a re-pin that only re-stamps the `$id` MUST regenerate
+byte-identical types so the guard passes with no type change; conversely, a change to any contract
+field MUST produce a different generated output so the guard fails. The committed types SHALL be
+valid TypeScript (type-checkable). These contract types are distinct from the Supabase
 `database.types.ts` generated from the database.
 
 #### Scenario: Drift guard passes when committed types match the pinned schema
 
-- **WHEN** the drift guard regenerates the types from the vendored schema and compares them to the
-  committed `contracts/generated/` output
+- **WHEN** the drift guard regenerates the types from the vendored schema and compares them
+  (line-ending-normalized) to the committed `contracts/generated/` output
 - **THEN** they are byte-identical and the guard exits zero
 
 #### Scenario: Drift guard fails when committed types diverge from the pinned schema
@@ -58,37 +71,65 @@ guard passes with no type change. These contract types are distinct from the Sup
 - **THEN** the regenerated types are byte-identical to the previous committed types and the drift
   guard passes
 
+#### Scenario: A real contract field change fails the guard
+
+- **WHEN** a contract field changes (a property is added/removed or a type changes) in addition to
+  or instead of the `$id`, and the types are regenerated
+- **THEN** the regenerated types differ from the committed types and the drift guard exits non-zero
+
+#### Scenario: Generated types are valid TypeScript
+
+- **WHEN** the committed `contracts/generated/` types are type-checked
+- **THEN** they compile without type errors
+
 ### Requirement: Database schema matches the pinned contract
 
 A CI check SHALL assert that Bloom's applied database schema agrees with the pinned contract for
 the contract↔database mappings built today, by introspecting the live database. It SHALL assert
-that the `Provenance` envelope home is `cyl_trait_sources.metadata` of type `jsonb`, and that
-`Provenance.idempotency_key` (contract type `string`, default `""`) maps to
-`cyl_trait_sources.idempotency_key` of type `text` guarded by a non-empty CHECK constraint. The
-check SHALL be driven by a declarative mapping in which mappings introduced by later changes
-(`source_id` foreign keys, the intermediates/blob table, and RPC-enforced key equality) are marked
-deferred and explicitly skipped, so the check does not assert against database objects that do not
-yet exist and can be extended as those changes land.
+that the `Provenance` envelope home is `cyl_trait_sources.metadata` of type `jsonb`; that the
+loaded contract still designates that home (the schema's `Provenance` description names
+`cyl_trait_sources.metadata`); and that `Provenance.idempotency_key` (contract type `string`,
+default `""`) maps to `cyl_trait_sources.idempotency_key` of type `text` guarded by **both** a
+non-empty CHECK constraint and a UNIQUE constraint. The check SHALL be driven by a declarative
+mapping in which mappings introduced by later changes (`source_id` foreign keys, the
+intermediates/blob table, RPC-enforced key equality, `contract_version` row-anchor validation, and
+`scan_key` resolution) are marked deferred and explicitly skipped, so the check does not assert
+against database objects that do not yet exist and can be extended as those changes land. Loading
+the contract schema SHALL NOT crash test collection when the schema file is absent.
 
-#### Scenario: Provenance envelope home is present and correctly typed
+Note: this requirement is housed in the `contract-pinning` capability as an interim home; its
+natural long-term home is `cyl-trait-writeback`, and relocation is a deliberate future refactor
+pending change A's archive landing that live spec.
+
+#### Scenario: Provenance envelope home is present, correctly typed, and contract-designated
+
+- **WHEN** the check introspects the applied database and the loaded contract
+- **THEN** `cyl_trait_sources.metadata` exists with type `jsonb`, and the contract's `Provenance`
+  description still designates `cyl_trait_sources.metadata` as the home
+
+#### Scenario: Idempotency anchor matches the contract field, default posture, and uniqueness
 
 - **WHEN** the check introspects the applied database
-- **THEN** `cyl_trait_sources.metadata` exists with type `jsonb`
-
-#### Scenario: Idempotency anchor matches the contract field and its default posture
-
-- **WHEN** the check introspects the applied database
-- **THEN** `cyl_trait_sources.idempotency_key` exists with type `text` and a CHECK constraint that
-  rejects the empty string, matching the contract's `idempotency_key: string` with `default: ""`
+- **THEN** `cyl_trait_sources.idempotency_key` exists with type `text`, a CHECK constraint that
+  rejects the empty string (matching the contract's `idempotency_key: string` with `default: ""`),
+  and a UNIQUE constraint (the `1 ResultEnvelope : 1 source row` anchor)
 
 #### Scenario: Deferred mappings are skipped, not asserted
 
 - **WHEN** the check encounters a mapping marked deferred (e.g. a `source_id` foreign key, the
-  blob table, or RPC-enforced key equality not yet built)
+  blob table, RPC-enforced key equality, `contract_version` validation, or `scan_key` resolution
+  not yet built)
 - **THEN** that mapping is skipped with a recorded reason and does not cause a failure
 
 #### Scenario: A regression in a built mapping fails the check
 
 - **WHEN** an active mapping no longer holds (e.g. `cyl_trait_sources.metadata` is missing or not
-  `jsonb`, or the non-empty CHECK on `idempotency_key` is absent)
+  `jsonb`, the contract no longer designates that home, or the non-empty CHECK or the UNIQUE
+  constraint on `idempotency_key` is absent)
 - **THEN** the check fails, identifying the violated contract↔database mapping
+
+#### Scenario: Missing contract schema does not crash test collection
+
+- **WHEN** the test module is collected and the vendored contract schema file is absent
+- **THEN** the test is skipped (module-level) rather than raising and failing collection for the
+  whole integration suite

--- a/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
+++ b/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Pinned contract schema is vendored at an explicit version
+
+Bloom SHALL vendor the `sleap-roots-contracts` `result_envelope.schema.json` as a committed copy
+under `contracts/schema/`, pinned at an explicit version, accompanied by a `contracts/pin.json`
+manifest that records the pinned package, version, source, and the schema/generated file paths.
+The vendored schema's version-stamped `$id` and the manifest's recorded version MUST agree; a
+pin-consistency check SHALL fail when they diverge. The repository SHALL document, in
+`contracts/README.md`, the pinned version, the re-pin procedure, and the rule that a re-pin which
+only re-stamps the schema `$id` is a structural no-op (not a contract revision).
+
+#### Scenario: Vendored schema and manifest are committed
+
+- **WHEN** the repository is inspected
+- **THEN** `contracts/schema/result_envelope.schema.json` and `contracts/pin.json` exist, and the
+  manifest records the pinned package, version, and file paths
+
+#### Scenario: Pin-consistency holds when manifest matches the schema $id
+
+- **WHEN** the pin-consistency check runs and `pin.json.version` equals the version segment parsed
+  from the vendored schema's `$id`
+- **THEN** the check passes
+
+#### Scenario: Pin-consistency fails when manifest and schema $id disagree
+
+- **WHEN** the pin-consistency check runs and `pin.json.version` does not equal the version
+  segment parsed from the vendored schema's `$id`
+- **THEN** the check fails with a non-zero exit status identifying the mismatch
+
+### Requirement: Generated TypeScript types match the pinned schema
+
+Bloom SHALL commit TypeScript types generated from the pinned `result_envelope.schema.json`
+(`ResultEnvelope`, `Provenance`, `TraitValue`, `BlobRef`, and their sub-definitions) under
+`contracts/generated/`, produced by a deterministic, exact-version-pinned codegen tool. A CI drift
+guard SHALL regenerate the types from the pinned schema and fail when the committed types are not
+byte-identical to the regenerated output. Because the codegen does not emit the schema `$id` into
+the types, a re-pin that only re-stamps the `$id` MUST regenerate byte-identical types so the
+guard passes with no type change. These contract types are distinct from the Supabase
+`database.types.ts` generated from the database.
+
+#### Scenario: Drift guard passes when committed types match the pinned schema
+
+- **WHEN** the drift guard regenerates the types from the vendored schema and compares them to the
+  committed `contracts/generated/` output
+- **THEN** they are byte-identical and the guard exits zero
+
+#### Scenario: Drift guard fails when committed types diverge from the pinned schema
+
+- **WHEN** the committed generated types differ from regenerating from the vendored schema (the
+  schema changed without regenerating, or the types were hand-edited)
+- **THEN** the guard exits non-zero and reports the difference
+
+#### Scenario: A $id-only re-pin regenerates identical types
+
+- **WHEN** the vendored schema is re-pinned to a new version whose only change is the
+  version-stamped `$id` and the types are regenerated
+- **THEN** the regenerated types are byte-identical to the previous committed types and the drift
+  guard passes
+
+### Requirement: Database schema matches the pinned contract
+
+A CI check SHALL assert that Bloom's applied database schema agrees with the pinned contract for
+the contract↔database mappings built today, by introspecting the live database. It SHALL assert
+that the `Provenance` envelope home is `cyl_trait_sources.metadata` of type `jsonb`, and that
+`Provenance.idempotency_key` (contract type `string`, default `""`) maps to
+`cyl_trait_sources.idempotency_key` of type `text` guarded by a non-empty CHECK constraint. The
+check SHALL be driven by a declarative mapping in which mappings introduced by later changes
+(`source_id` foreign keys, the intermediates/blob table, and RPC-enforced key equality) are marked
+deferred and explicitly skipped, so the check does not assert against database objects that do not
+yet exist and can be extended as those changes land.
+
+#### Scenario: Provenance envelope home is present and correctly typed
+
+- **WHEN** the check introspects the applied database
+- **THEN** `cyl_trait_sources.metadata` exists with type `jsonb`
+
+#### Scenario: Idempotency anchor matches the contract field and its default posture
+
+- **WHEN** the check introspects the applied database
+- **THEN** `cyl_trait_sources.idempotency_key` exists with type `text` and a CHECK constraint that
+  rejects the empty string, matching the contract's `idempotency_key: string` with `default: ""`
+
+#### Scenario: Deferred mappings are skipped, not asserted
+
+- **WHEN** the check encounters a mapping marked deferred (e.g. a `source_id` foreign key, the
+  blob table, or RPC-enforced key equality not yet built)
+- **THEN** that mapping is skipped with a recorded reason and does not cause a failure
+
+#### Scenario: A regression in a built mapping fails the check
+
+- **WHEN** an active mapping no longer holds (e.g. `cyl_trait_sources.metadata` is missing or not
+  `jsonb`, or the non-empty CHECK on `idempotency_key` is absent)
+- **THEN** the check fails, identifying the violated contract↔database mapping

--- a/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
+++ b/openspec/changes/pin-sleap-roots-contract/specs/contract-pinning/spec.md
@@ -37,6 +37,13 @@ no-op (not a contract revision).
   the expected `…/schema/<version>/result_envelope.schema.json` shape
 - **THEN** the check fails with a non-zero exit status rather than silently passing
 
+#### Scenario: Pinned schema retains the contract_version traceability anchor
+
+- **WHEN** the contract-sanity check runs against the pinned schema
+- **THEN** it confirms `contract_version` is a required `string` field of `Provenance`, and fails
+  if a re-pin ever drops it from `required` (the per-row provenance-of-origin anchor must be
+  guaranteed by every envelope)
+
 ### Requirement: Generated TypeScript types match the pinned schema
 
 Bloom SHALL commit TypeScript types generated from the pinned `result_envelope.schema.json`
@@ -97,9 +104,7 @@ intermediates/blob table, RPC-enforced key equality, `contract_version` row-anch
 against database objects that do not yet exist and can be extended as those changes land. Loading
 the contract schema SHALL NOT crash test collection when the schema file is absent.
 
-Note: this requirement is housed in the `contract-pinning` capability as an interim home; its
-natural long-term home is `cyl-trait-writeback`, and relocation is a deliberate future refactor
-pending change A's archive landing that live spec.
+Note: this requirement may relocate to the `cyl-trait-writeback` capability in a future refactor.
 
 #### Scenario: Provenance envelope home is present, correctly typed, and contract-designated
 
@@ -110,9 +115,10 @@ pending change A's archive landing that live spec.
 #### Scenario: Idempotency anchor matches the contract field, default posture, and uniqueness
 
 - **WHEN** the check introspects the applied database
-- **THEN** `cyl_trait_sources.idempotency_key` exists with type `text`, a CHECK constraint that
-  rejects the empty string (matching the contract's `idempotency_key: string` with `default: ""`),
-  and a UNIQUE constraint (the `1 ResultEnvelope : 1 source row` anchor)
+- **THEN** `cyl_trait_sources.idempotency_key` exists with type `text`, a constraint of type CHECK
+  (`contype = 'c'`) that rejects the empty string (matching the contract's `idempotency_key:
+  string` with `default: ""`), and a constraint of type UNIQUE (`contype = 'u'`, the
+  `1 ResultEnvelope : 1 source row` anchor) — verified by constraint *type*, not name alone
 
 #### Scenario: Deferred mappings are skipped, not asserted
 

--- a/openspec/changes/pin-sleap-roots-contract/tasks.md
+++ b/openspec/changes/pin-sleap-roots-contract/tasks.md
@@ -5,15 +5,15 @@
 
 ## 1. Oracle — TS drift guard + determinism config (write first, RED locally)
 
-- [ ] 1.1 Add `json-schema-to-typescript` pinned **exact `15.0.4`** to root `package.json`
+- [x] 1.1 Add `json-schema-to-typescript` pinned **exact `15.0.4`** to root `package.json`
   `devDependencies`; run `npm install` to update `package-lock.json` (committed).
-- [ ] 1.2 Add npm scripts to root `package.json`: `"contracts:gen": "node scripts/contract_types.mjs --write"`
+- [x] 1.2 Add npm scripts to root `package.json`: `"contracts:gen": "node scripts/contract_types.mjs --write"`
   and `"contracts:check": "node scripts/contract_types.mjs --check"`.
-- [ ] 1.3 Add **determinism config** (prevents the guard from fighting repo tooling):
+- [x] 1.3 Add **determinism config** (prevents the guard from fighting repo tooling):
   - New `.prettierignore` excluding `contracts/generated/` and `contracts/schema/`.
   - Add `contracts/generated/*.ts text eol=lf` to `.gitattributes` (vendored schema already
     covered by the existing `*.json text eol=lf`).
-- [ ] 1.4 Write `scripts/contract_types.mjs` (Node ESM) as **pure functions + a thin CLI shim**.
+- [x] 1.4 Write `scripts/contract_types.mjs` (Node ESM) as **pure functions + a thin CLI shim**.
   json2ts `compile()` is **async** (returns a Promise), so `generateTypes` and `checkDrift` are
   `async`/awaited.
   - Exports (no file I/O, no `process.exit` inside them):
@@ -31,12 +31,12 @@
     `contracts/generated/...`, `await`s the pure functions, prints diffs, and `process.exit`s.
     `--write` writes the generated file; `--check` runs both checks and exits non-zero on any
     failure or missing file.
-- [ ] 1.5 Run `node scripts/contract_types.mjs --check` → **RED** (expected here as a *file-not-found*
+- [x] 1.5 Run `node scripts/contract_types.mjs --check` → **RED** (expected here as a *file-not-found*
   error: no `contracts/` files yet — distinct from the byte-mismatch RED proven in §4); capture it.
 
 ## 2. Migration-match characterization test (regression-lock; write first, RED locally)
 
-- [ ] 2.1 Write `tests/integration/test_contract_migration_match.py`. Structure for collection
+- [x] 2.1 Write `tests/integration/test_contract_migration_match.py`. Structure for collection
   safety: `MAPPINGS` is a module-level list of **literals only** (no schema-derived values) —
   `{contract_field, db_table, db_column, db_type, constraint, contype, status, reason}`. Collection
   safety has two parts: (a) `MAPPINGS` holds **literals only** (no schema-derived values) so import
@@ -46,7 +46,7 @@
   `allow_module_level` (it is only valid at module scope and is not needed here). This skips at
   *execution*; collection is already safe via (a). Reuse `_column_type`/`pg_constraint` patterns +
   the `pg_conn` fixture from `test_cyl_trait_source_provenance.py` (rollback per test).
-- [ ] 2.2 Active assertions (A-subset), each tied back to the lazily-loaded contract:
+- [x] 2.2 Active assertions (A-subset), each tied back to the lazily-loaded contract:
   - `cyl_trait_sources.metadata` is `jsonb` **and** `schema["$defs"]["Provenance"]["description"]`
     contains the literal `cyl_trait_sources.metadata` (contract-side home tripwire).
   - `cyl_trait_sources.idempotency_key` is `text`; contract `Provenance.idempotency_key` is
@@ -58,28 +58,28 @@
     `"contract_version" in schema["$defs"]["Provenance"]["required"]` and it is typed `string`; and
     `schema["$defs"]["Provenance"]["properties"]["idempotency_key"].get("default") == ""` (the basis
     for the non-empty CHECK). These read the lazily-loaded schema only (no DB).
-- [ ] 2.3 Deferred rows (`source_id` FK / blob table / RPC key-equality / `contract_version`
+- [x] 2.3 Deferred rows (`source_id` FK / blob table / RPC key-equality / `contract_version`
   runtime validation / `scan_key` resolution) marked `status="deferred"` and **skipped with a
   one-line reason** (`pytest.skip`), never asserted. Keep these mechanical — the narrative
   hand-offs (opaque-metadata fields incl. `inputs.images_checksum`/`param_hash`; `contract_version`
   + `TraitValue.value` finiteness as D/G validations) live in `contracts/README.md` + the proposal,
   **not** as prose in the test.
-- [ ] 2.4 Run `uv run --extra test pytest tests/integration/test_contract_migration_match.py`
+- [x] 2.4 Run `uv run --extra test pytest tests/integration/test_contract_migration_match.py`
   against local Supabase → **RED** (in-body `pytest.skip` fires — schema not vendored yet; the
   suite does not crash); capture it.
 
 ## 3. Vendor the pinned schema + manifest (GREEN: pin-consistency + test loads)
 
-- [ ] 3.1 Copy `C:\repos\sleap-roots-contracts\schema\result_envelope.schema.json` →
+- [x] 3.1 Copy `C:\repos\sleap-roots-contracts\schema\result_envelope.schema.json` →
   `contracts/schema/result_envelope.schema.json` (LF-normalized; `$id …/v0.1.0a1/…`).
-- [ ] 3.2 Write `contracts/pin.json`: `{ package, version: "v0.1.0a1", id: "<full $id>", source:
+- [x] 3.2 Write `contracts/pin.json`: `{ package, version: "v0.1.0a1", id: "<full $id>", source:
   "<github tag/release url>", schema: "schema/result_envelope.schema.json", generated:
   "generated/result-envelope.ts" }`.
-- [ ] 3.3 Write `contracts/README.md`: the pinned version (+ the #294 a0/v0.1.0 reconciliation),
+- [x] 3.3 Write `contracts/README.md`: the pinned version (+ the #294 a0/v0.1.0 reconciliation),
   the re-pin procedure (`--write` + commit), the `$id`-restamp-is-a-structural-no-op rule, the
   recorded D/G hand-offs (`contract_version` + `TraitValue.value` finiteness validation), and the
   caveat **"never run prettier from inside `contracts/`"** (the `.prettierignore` is root-relative).
-- [ ] 3.4 Re-run the migration-match test → **GREEN** (loads the contract; A's columns already
+- [x] 3.4 Re-run the migration-match test → **GREEN** (loads the contract; A's columns already
   applied locally). Then prove the oracle discriminates with the **canonical deterministic step**:
   temporarily change one expected literal (e.g. assert `metadata` is `"json"` instead of `"jsonb"`),
   run, confirm the failure fires **on that assertion** (note the exact assert message/line), then
@@ -87,19 +87,19 @@
 
 ## 4. Generate + commit the contract TS types (GREEN: drift guard)
 
-- [ ] 4.1 Run `npm run contracts:gen` → writes `contracts/generated/result-envelope.ts`
+- [x] 4.1 Run `npm run contracts:gen` → writes `contracts/generated/result-envelope.ts`
   (all six `$defs`: `ResultEnvelope`/`Provenance`/`TraitValue`/`BlobRef` + `InputRef`/`ModelRef`/
   `ResolvedParams`, `DO NOT EDIT` banner). **Review** all six are sane, non-degenerate shapes
   before committing (the `anyOf`-over-`properties` `BlobRef` is the risk case).
-- [ ] 4.2 Type-check the generated file (exact flags, no throwaway tsconfig):
+- [x] 4.2 Type-check the generated file (exact flags, no throwaway tsconfig):
   `npx tsc --noEmit --strict --target ES2020 --moduleResolution bundler --skipLibCheck
   contracts/generated/result-envelope.ts` → no errors (generation-time gate; the drift guard
   freezes the bytes thereafter).
-- [ ] 4.3 Run `npm run contracts:check` → **GREEN** (byte-identical after EOL-normalize;
+- [x] 4.3 Run `npm run contracts:check` → **GREEN** (byte-identical after EOL-normalize;
   pin-consistency passes). This live run also covers the *positive* paths (each check returns
   `{ok:true}`) against the real vendored schema — the `node --test` file (§4.4) carries only the
   negative/no-op cases, so the spec's "passes/holds" scenarios are covered here, not duplicated.
-- [ ] 4.4 Write `scripts/contract_types.test.mjs` (**`node --test`**, `async` tests importing the
+- [x] 4.4 Write `scripts/contract_types.test.mjs` (**`node --test`**, `async` tests importing the
   pure functions from `contract_types.mjs` — never spawning the exiting CLI; `await` the async ones)
   covering the spec's negative/no-op scenarios, all via the **same `generateTypes`** the guard uses:
   - pin-mismatch (in-memory schema/pin with disagreeing `version`/`id`) → `checkPinConsistency`
@@ -115,25 +115,25 @@
 
 ## 5. CI wiring
 
-- [ ] 5.1 Add two steps to the `build-and-audit` job in `.github/workflows/pr-checks.yml` (after
+- [x] 5.1 Add two steps to the `build-and-audit` job in `.github/workflows/pr-checks.yml` (after
   `npm ci`), clearly named: `node scripts/contract_types.mjs --check` (drift guard +
   pin-consistency) and `node --test scripts/contract_types.test.mjs`
   (negative-path/no-op test). No new vitest config — built-in Node runner.
-- [ ] 5.2 Confirm the migration-match test needs **no** workflow change (it auto-runs in
+- [x] 5.2 Confirm the migration-match test needs **no** workflow change (it auto-runs in
   `compose-health-check`, which globs `tests/integration/`).
 
 ## 6. Verify + pre-merge
 
-- [ ] 6.1 `openspec validate pin-sleap-roots-contract --strict` passes.
-- [ ] 6.2 Format/lint the new files **excluding the prettier-ignored `contracts/generated/` and
+- [x] 6.1 `openspec validate pin-sleap-roots-contract --strict` passes.
+- [x] 6.2 Format/lint the new files **excluding the prettier-ignored `contracts/generated/` and
   `contracts/schema/`** (ruff/black for the pytest test; prettier for `scripts/*.mjs`,
   `pin.json`, READMEs); run `npm run format:check` and confirm the generated/schema files are not
   flagged (i.e. `.prettierignore` is effective) and that `npm run format` does **not** rewrite the
   generated file. Also confirm the pre-commit prettier hook leaves the generated file unchanged.
-- [ ] 6.3 Run the migration-match test + the existing change-A provenance test locally against
+- [x] 6.3 Run the migration-match test + the existing change-A provenance test locally against
   local Supabase to confirm both pass; run `npm run contracts:check` and
   `node --test scripts/contract_types.test.mjs` on the author's (Windows, `core.autocrlf=true`)
   machine to confirm no CRLF/LF flake — this is the worst-case config for the byte guard.
-- [ ] 6.4 Run the relevant pre-merge subset (run-ci-locally / pre-merge skill) and confirm the new
+- [x] 6.4 Run the relevant pre-merge subset (run-ci-locally / pre-merge skill) and confirm the new
   drift-guard + node-test steps pass.
-- [ ] 6.5 Update `tasks.md` checkboxes to reflect reality.
+- [x] 6.5 Update `tasks.md` checkboxes to reflect reality.

--- a/openspec/changes/pin-sleap-roots-contract/tasks.md
+++ b/openspec/changes/pin-sleap-roots-contract/tasks.md
@@ -1,6 +1,7 @@
 > **Commit/PR safety:** the RED captures in §1–§2 are **local-only**. Do not push a PR until the
 > §3/§4 artifacts exist in the same push, so the first pushed (and CI-run) commit is already GREEN.
-> CI runs on the PR head, not per-commit.
+> CI runs on the PR head, not per-commit. (This safety depends on §2.1's collection guard: a
+> pushed pre-vendor state must skip, not crash the integration suite.)
 
 ## 1. Oracle — TS drift guard + determinism config (write first, RED locally)
 
@@ -12,36 +13,47 @@
   - New `.prettierignore` excluding `contracts/generated/` and `contracts/schema/`.
   - Add `contracts/generated/*.ts text eol=lf` to `.gitattributes` (vendored schema already
     covered by the existing `*.json text eol=lf`).
-- [ ] 1.4 Write `scripts/contract_types.mjs` (Node ESM): reads `contracts/pin.json` +
-  `contracts/schema/result_envelope.schema.json`; **pin-consistency** — assert `pin.json.id` ==
-  schema `$id` (exact) AND `pin.json.version` == version parsed from `$id` via anchored regex
-  `/\/schema\/(v[^/]+)\/result_envelope\.schema\.json$/`; fail on missing/unparseable `$id`.
-  Generates TS via the json2ts **API** (fixed `bannerComment` + options); `--write` writes
-  `contracts/generated/result-envelope.ts` (always `\n`); `--check` regenerates in-memory,
-  EOL-normalizes both sides (`\r\n`→`\n`), byte-compares, exits non-zero + prints a diff on
-  mismatch or on missing files.
+- [ ] 1.4 Write `scripts/contract_types.mjs` (Node ESM) as **pure functions + a thin CLI shim**:
+  - Exports (no file I/O, no `process.exit` inside them): `generateTypes(schema) → string`
+    (json2ts **API**, fixed `bannerComment` + options; always `\n` line endings);
+    `checkPinConsistency(pin, schema) → {ok, error}` — `pin.id` exactly equals schema `$id`, and
+    `pin.version` equals the version parsed from `$id` via anchored regex
+    `/\/schema\/(v[^/]+)\/result_envelope\.schema\.json$/`; fail on missing/unparseable `$id`;
+    `checkContractSanity(schema) → {ok, error}` — `contract_version` is in
+    `$defs.Provenance.required` and typed `string`; `checkDrift({schema, pin, committedTs}) →
+    {ok, diff}` — regenerate, EOL-normalize both sides (`\r\n`→`\n`), byte-compare.
+  - CLI shim guarded by `if (import.meta.url === pathToFileURL(process.argv[1]).href)` is the
+    **only** place that reads `contracts/pin.json` + `contracts/schema/...` + the committed
+    `contracts/generated/...`, calls the pure functions, prints diffs, and `process.exit`s.
+    `--write` writes the generated file; `--check` runs all three pure checks and exits non-zero
+    on any failure or missing file.
 - [ ] 1.5 Run `node scripts/contract_types.mjs --check` → **RED** (expected here as a *file-not-found*
   error: no `contracts/` files yet — distinct from the byte-mismatch RED proven in §4); capture it.
 
 ## 2. Migration-match characterization test (regression-lock; write first, RED locally)
 
-- [ ] 2.1 Write `tests/integration/test_contract_migration_match.py`: a module-level declarative
-  `MAPPINGS` list of `{contract_field, db_table, db_column, db_type, constraint, status, reason}`;
-  **load the contract schema lazily** (inside the test/fixture) or guard with
-  `pytest.skip(allow_module_level=True)` when `contracts/schema/result_envelope.schema.json` is
-  absent — must never crash collection. Reuse the `_column_type`/`pg_constraint` helpers from
-  `test_cyl_trait_source_provenance.py`; use the `pg_conn` fixture (rollback per test).
-- [ ] 2.2 Active assertions (A-subset), each tied back to the loaded contract:
+- [ ] 2.1 Write `tests/integration/test_contract_migration_match.py`. Structure for collection
+  safety: `MAPPINGS` is a module-level list of **literals only** (no schema-derived values) —
+  `{contract_field, db_table, db_column, db_type, constraint, contype, status, reason}`. A
+  `_load_schema()` helper reads `contracts/schema/result_envelope.schema.json` **lazily inside the
+  test body** and does `pytest.skip("contract schema not vendored", allow_module_level=False)` (or
+  a module-level `allow_module_level=True` skip if the file is absent) so collection never crashes.
+  Reuse `_column_type`/`pg_constraint` patterns + the `pg_conn` fixture from
+  `test_cyl_trait_source_provenance.py` (rollback per test).
+- [ ] 2.2 Active assertions (A-subset), each tied back to the lazily-loaded contract:
   - `cyl_trait_sources.metadata` is `jsonb` **and** `schema["$defs"]["Provenance"]["description"]`
     contains the literal `cyl_trait_sources.metadata` (contract-side home tripwire).
-  - `cyl_trait_sources.idempotency_key` is `text`, contract `Provenance.idempotency_key` is
-    `string`, **and both** constraints exist: `cyl_trait_sources_idempotency_key_nonempty` (CHECK)
-    **and** `cyl_trait_sources_idempotency_key_key` (UNIQUE).
+  - `cyl_trait_sources.idempotency_key` is `text`; contract `Provenance.idempotency_key` is
+    `string`; **both** constraints exist *and have the right `contype`* (query `conname, contype`
+    from `pg_constraint`): `cyl_trait_sources_idempotency_key_nonempty` with `contype='c'` (CHECK)
+    and `cyl_trait_sources_idempotency_key_key` with `contype='u'` (UNIQUE). Name alone is
+    insufficient — assert the type.
 - [ ] 2.3 Deferred rows (`source_id` FK / blob table / RPC key-equality / `contract_version`
-  validation / `scan_key` resolution) marked `status="deferred"` and **skipped with reason**
-  (`pytest.skip`), never asserted. Add a documented (non-asserted) note that remaining `Provenance`
-  fields live inside opaque `metadata`, and that `contract_version`/`TraitValue.value` finiteness
-  are D/G consumer-side hand-offs.
+  runtime validation / `scan_key` resolution) marked `status="deferred"` and **skipped with a
+  one-line reason** (`pytest.skip`), never asserted. Keep these mechanical — the narrative
+  hand-offs (opaque-metadata fields incl. `inputs.images_checksum`/`param_hash`; `contract_version`
+  + `TraitValue.value` finiteness as D/G validations) live in `contracts/README.md` + the proposal,
+  **not** as prose in the test.
 - [ ] 2.4 Run `uv run --extra test pytest tests/integration/test_contract_migration_match.py`
   against local Supabase → **RED** (module-level skip / load fails before vendoring); capture it.
 
@@ -53,36 +65,46 @@
   "<github tag/release url>", schema: "schema/result_envelope.schema.json", generated:
   "generated/result-envelope.ts" }`.
 - [ ] 3.3 Write `contracts/README.md`: the pinned version (+ the #294 a0/v0.1.0 reconciliation),
-  the re-pin procedure (`--write` + commit), and the `$id`-restamp-is-a-structural-no-op rule.
+  the re-pin procedure (`--write` + commit), the `$id`-restamp-is-a-structural-no-op rule, the
+  recorded D/G hand-offs (`contract_version` + `TraitValue.value` finiteness validation), and the
+  caveat **"never run prettier from inside `contracts/`"** (the `.prettierignore` is root-relative).
 - [ ] 3.4 Re-run the migration-match test → **GREEN** (loads the contract; A's columns already
-  applied locally). Then prove the oracle discriminates: temporarily mutate one expected value
-  (e.g. assert `metadata` is `"json"`) or drop a constraint inside the `pg_conn` transaction,
-  confirm the failure fires **on the assertion line**, then revert.
+  applied locally). Then prove the oracle discriminates with the **canonical deterministic step**:
+  temporarily change one expected literal (e.g. assert `metadata` is `"json"` instead of `"jsonb"`),
+  run, confirm the failure fires **on that assertion** (note the exact assert message/line), then
+  revert. (This needs no DB mutation and is repeatable — preferred over dropping a constraint.)
 
 ## 4. Generate + commit the contract TS types (GREEN: drift guard)
 
 - [ ] 4.1 Run `npm run contracts:gen` → writes `contracts/generated/result-envelope.ts`
-  (`ResultEnvelope`/`Provenance`/`TraitValue`/`BlobRef` + sub-defs, `DO NOT EDIT` banner).
-  **Review** the `BlobRef`/`ResultEnvelope` output is a sane, non-degenerate shape before
-  committing (the `anyOf`-over-`properties` `BlobRef` is the risk case).
-- [ ] 4.2 Run `npx tsc --noEmit` on the generated file (a throwaway tsconfig or `--strict` flags)
-  to confirm it is valid, usable TypeScript.
+  (all six `$defs`: `ResultEnvelope`/`Provenance`/`TraitValue`/`BlobRef` + `InputRef`/`ModelRef`/
+  `ResolvedParams`, `DO NOT EDIT` banner). **Review** all six are sane, non-degenerate shapes
+  before committing (the `anyOf`-over-`properties` `BlobRef` is the risk case).
+- [ ] 4.2 Type-check the generated file (exact flags, no throwaway tsconfig):
+  `npx tsc --noEmit --strict --target ES2020 --moduleResolution bundler --skipLibCheck
+  contracts/generated/result-envelope.ts` → no errors (generation-time gate; the drift guard
+  freezes the bytes thereafter).
 - [ ] 4.3 Run `npm run contracts:check` → **GREEN** (byte-identical after EOL-normalize;
-  pin-consistency passes).
-- [ ] 4.4 Write `scripts/contract_types.test.mjs` (Vitest) covering the spec's negative/no-op
-  scenarios, all using the **same json2ts invocation** the guard uses:
-  - pin-mismatch (in-memory schema/pin with disagreeing version/`$id`) → check returns non-zero.
-  - hand-edited committed TS (temp copy) → `--check` returns non-zero with a diff.
-  - `$id`-only mutation → regenerated TS **identical** (structural no-op).
-  - real field mutation (flip `idempotency_key` type / add a property) → regenerated TS **differs**
-    (proves a real change fails).
-  - Run `npx vitest run scripts/contract_types.test.mjs` → GREEN.
+  pin-consistency + contract-sanity pass).
+- [ ] 4.4 Write `scripts/contract_types.test.mjs` (**`node --test`**, importing the pure functions
+  from `contract_types.mjs` — never spawning the exiting CLI) covering the spec's negative/no-op
+  scenarios, all via the **same `generateTypes`** the guard uses:
+  - pin-mismatch (in-memory schema/pin with disagreeing `version`/`id`) → `checkPinConsistency`
+    returns `{ok:false}`.
+  - unparseable/missing `$id` → `checkPinConsistency` returns `{ok:false}`.
+  - missing `contract_version` in `Provenance.required` → `checkContractSanity` returns `{ok:false}`.
+  - hand-edited committed TS (in-memory string) → `checkDrift` returns `{ok:false}` with a diff.
+  - `$id`-only mutation → `generateTypes` output **identical** (structural no-op).
+  - real field mutation (flip `idempotency_key` type / add a property) → `generateTypes` output
+    **differs** (proves a real change fails).
+  - Run `node --test scripts/contract_types.test.mjs` → GREEN.
 
 ## 5. CI wiring
 
 - [ ] 5.1 Add two steps to the `build-and-audit` job in `.github/workflows/pr-checks.yml` (after
-  `npm ci`): `node scripts/contract_types.mjs --check` (drift guard) and
-  `npx vitest run scripts/contract_types.test.mjs` (negative-path/no-op test). Name them clearly.
+  `npm ci`), clearly named: `node scripts/contract_types.mjs --check` (drift guard +
+  pin-consistency + contract-sanity) and `node --test scripts/contract_types.test.mjs`
+  (negative-path/no-op test). No new vitest config — built-in Node runner.
 - [ ] 5.2 Confirm the migration-match test needs **no** workflow change (it auto-runs in
   `compose-health-check`, which globs `tests/integration/`).
 
@@ -92,10 +114,12 @@
 - [ ] 6.2 Format/lint the new files **excluding the prettier-ignored `contracts/generated/` and
   `contracts/schema/`** (ruff/black for the pytest test; prettier for `scripts/*.mjs`,
   `pin.json`, READMEs); run `npm run format:check` and confirm the generated/schema files are not
-  flagged (i.e. `.prettierignore` is effective).
+  flagged (i.e. `.prettierignore` is effective) and that `npm run format` does **not** rewrite the
+  generated file. Also confirm the pre-commit prettier hook leaves the generated file unchanged.
 - [ ] 6.3 Run the migration-match test + the existing change-A provenance test locally against
-  local Supabase to confirm both pass; run `npm run contracts:check` and the Vitest test on the
-  author's (Windows) machine to confirm no CRLF/LF flake.
+  local Supabase to confirm both pass; run `npm run contracts:check` and
+  `node --test scripts/contract_types.test.mjs` on the author's (Windows, `core.autocrlf=true`)
+  machine to confirm no CRLF/LF flake — this is the worst-case config for the byte guard.
 - [ ] 6.4 Run the relevant pre-merge subset (run-ci-locally / pre-merge skill) and confirm the new
-  drift-guard + vitest steps pass and `npm run format` does **not** rewrite the generated file.
+  drift-guard + node-test steps pass.
 - [ ] 6.5 Update `tasks.md` checkboxes to reflect reality.

--- a/openspec/changes/pin-sleap-roots-contract/tasks.md
+++ b/openspec/changes/pin-sleap-roots-contract/tasks.md
@@ -13,20 +13,24 @@
   - New `.prettierignore` excluding `contracts/generated/` and `contracts/schema/`.
   - Add `contracts/generated/*.ts text eol=lf` to `.gitattributes` (vendored schema already
     covered by the existing `*.json text eol=lf`).
-- [ ] 1.4 Write `scripts/contract_types.mjs` (Node ESM) as **pure functions + a thin CLI shim**:
-  - Exports (no file I/O, no `process.exit` inside them): `generateTypes(schema) → string`
-    (json2ts **API**, fixed `bannerComment` + options; always `\n` line endings);
-    `checkPinConsistency(pin, schema) → {ok, error}` — `pin.id` exactly equals schema `$id`, and
-    `pin.version` equals the version parsed from `$id` via anchored regex
-    `/\/schema\/(v[^/]+)\/result_envelope\.schema\.json$/`; fail on missing/unparseable `$id`;
-    `checkContractSanity(schema) → {ok, error}` — `contract_version` is in
-    `$defs.Provenance.required` and typed `string`; `checkDrift({schema, pin, committedTs}) →
-    {ok, diff}` — regenerate, EOL-normalize both sides (`\r\n`→`\n`), byte-compare.
+- [ ] 1.4 Write `scripts/contract_types.mjs` (Node ESM) as **pure functions + a thin CLI shim**.
+  json2ts `compile()` is **async** (returns a Promise), so `generateTypes` and `checkDrift` are
+  `async`/awaited.
+  - Exports (no file I/O, no `process.exit` inside them):
+    - `async generateTypes(schema) → Promise<string>` — `compile(schema, 'ResultEnvelope',
+      {bannerComment, format})`, fixed options; always `\n` line endings.
+    - `checkPinConsistency(pin, schema) → {ok, error}` — `pin.id` exactly equals schema `$id`, and
+      `pin.version` equals the version parsed from `$id` via anchored regex
+      `/\/schema\/(v[^/]+)\/result_envelope\.schema\.json$/`; fail on missing/unparseable `$id`.
+    - `async checkDrift({schema, pin, committedTs}) → Promise<{ok, diff}>` — regenerate,
+      EOL-normalize both sides (`\r\n`→`\n`), byte-compare.
+    (Contract-side sanity — `contract_version` required, `idempotency_key.default == ""` — is **not**
+    here; it lives in the pytest migration-match, §2.2, to keep one home.)
   - CLI shim guarded by `if (import.meta.url === pathToFileURL(process.argv[1]).href)` is the
     **only** place that reads `contracts/pin.json` + `contracts/schema/...` + the committed
-    `contracts/generated/...`, calls the pure functions, prints diffs, and `process.exit`s.
-    `--write` writes the generated file; `--check` runs all three pure checks and exits non-zero
-    on any failure or missing file.
+    `contracts/generated/...`, `await`s the pure functions, prints diffs, and `process.exit`s.
+    `--write` writes the generated file; `--check` runs both checks and exits non-zero on any
+    failure or missing file.
 - [ ] 1.5 Run `node scripts/contract_types.mjs --check` → **RED** (expected here as a *file-not-found*
   error: no `contracts/` files yet — distinct from the byte-mismatch RED proven in §4); capture it.
 
@@ -34,12 +38,14 @@
 
 - [ ] 2.1 Write `tests/integration/test_contract_migration_match.py`. Structure for collection
   safety: `MAPPINGS` is a module-level list of **literals only** (no schema-derived values) —
-  `{contract_field, db_table, db_column, db_type, constraint, contype, status, reason}`. A
-  `_load_schema()` helper reads `contracts/schema/result_envelope.schema.json` **lazily inside the
-  test body** and does `pytest.skip("contract schema not vendored", allow_module_level=False)` (or
-  a module-level `allow_module_level=True` skip if the file is absent) so collection never crashes.
-  Reuse `_column_type`/`pg_constraint` patterns + the `pg_conn` fixture from
-  `test_cyl_trait_source_provenance.py` (rollback per test).
+  `{contract_field, db_table, db_column, db_type, constraint, contype, status, reason}`. Collection
+  safety has two parts: (a) `MAPPINGS` holds **literals only** (no schema-derived values) so import
+  never reads the schema — this is what protects *collection*; (b) a `_load_schema()` helper reads
+  `contracts/schema/result_envelope.schema.json` **lazily inside each test body** and, when the file
+  is absent, calls a plain in-body `pytest.skip("contract schema not vendored")` — do **not** pass
+  `allow_module_level` (it is only valid at module scope and is not needed here). This skips at
+  *execution*; collection is already safe via (a). Reuse `_column_type`/`pg_constraint` patterns +
+  the `pg_conn` fixture from `test_cyl_trait_source_provenance.py` (rollback per test).
 - [ ] 2.2 Active assertions (A-subset), each tied back to the lazily-loaded contract:
   - `cyl_trait_sources.metadata` is `jsonb` **and** `schema["$defs"]["Provenance"]["description"]`
     contains the literal `cyl_trait_sources.metadata` (contract-side home tripwire).
@@ -48,6 +54,10 @@
     from `pg_constraint`): `cyl_trait_sources_idempotency_key_nonempty` with `contype='c'` (CHECK)
     and `cyl_trait_sources_idempotency_key_key` with `contype='u'` (UNIQUE). Name alone is
     insufficient — assert the type.
+  - **Contract-side sanity** (schema facts justifying A's DB choices, one home): assert
+    `"contract_version" in schema["$defs"]["Provenance"]["required"]` and it is typed `string`; and
+    `schema["$defs"]["Provenance"]["properties"]["idempotency_key"].get("default") == ""` (the basis
+    for the non-empty CHECK). These read the lazily-loaded schema only (no DB).
 - [ ] 2.3 Deferred rows (`source_id` FK / blob table / RPC key-equality / `contract_version`
   runtime validation / `scan_key` resolution) marked `status="deferred"` and **skipped with a
   one-line reason** (`pytest.skip`), never asserted. Keep these mechanical — the narrative
@@ -55,7 +65,8 @@
   + `TraitValue.value` finiteness as D/G validations) live in `contracts/README.md` + the proposal,
   **not** as prose in the test.
 - [ ] 2.4 Run `uv run --extra test pytest tests/integration/test_contract_migration_match.py`
-  against local Supabase → **RED** (module-level skip / load fails before vendoring); capture it.
+  against local Supabase → **RED** (in-body `pytest.skip` fires — schema not vendored yet; the
+  suite does not crash); capture it.
 
 ## 3. Vendor the pinned schema + manifest (GREEN: pin-consistency + test loads)
 
@@ -85,25 +96,28 @@
   contracts/generated/result-envelope.ts` → no errors (generation-time gate; the drift guard
   freezes the bytes thereafter).
 - [ ] 4.3 Run `npm run contracts:check` → **GREEN** (byte-identical after EOL-normalize;
-  pin-consistency + contract-sanity pass).
-- [ ] 4.4 Write `scripts/contract_types.test.mjs` (**`node --test`**, importing the pure functions
-  from `contract_types.mjs` — never spawning the exiting CLI) covering the spec's negative/no-op
-  scenarios, all via the **same `generateTypes`** the guard uses:
+  pin-consistency passes). This live run also covers the *positive* paths (each check returns
+  `{ok:true}`) against the real vendored schema — the `node --test` file (§4.4) carries only the
+  negative/no-op cases, so the spec's "passes/holds" scenarios are covered here, not duplicated.
+- [ ] 4.4 Write `scripts/contract_types.test.mjs` (**`node --test`**, `async` tests importing the
+  pure functions from `contract_types.mjs` — never spawning the exiting CLI; `await` the async ones)
+  covering the spec's negative/no-op scenarios, all via the **same `generateTypes`** the guard uses:
   - pin-mismatch (in-memory schema/pin with disagreeing `version`/`id`) → `checkPinConsistency`
     returns `{ok:false}`.
   - unparseable/missing `$id` → `checkPinConsistency` returns `{ok:false}`.
-  - missing `contract_version` in `Provenance.required` → `checkContractSanity` returns `{ok:false}`.
-  - hand-edited committed TS (in-memory string) → `checkDrift` returns `{ok:false}` with a diff.
-  - `$id`-only mutation → `generateTypes` output **identical** (structural no-op).
-  - real field mutation (flip `idempotency_key` type / add a property) → `generateTypes` output
-    **differs** (proves a real change fails).
+  - hand-edited committed TS (in-memory string) → `await checkDrift(...)` returns `{ok:false}` with
+    a diff. (This is the **only** exercise of `checkDrift`'s failure branch — the runtime `--check`
+    only ever hits its pass branch.)
+  - `$id`-only mutation → `await generateTypes` output **identical** (structural no-op).
+  - real field mutation (flip `idempotency_key` type / add a property) → `await generateTypes`
+    output **differs** (proves a real change fails).
   - Run `node --test scripts/contract_types.test.mjs` → GREEN.
 
 ## 5. CI wiring
 
 - [ ] 5.1 Add two steps to the `build-and-audit` job in `.github/workflows/pr-checks.yml` (after
   `npm ci`), clearly named: `node scripts/contract_types.mjs --check` (drift guard +
-  pin-consistency + contract-sanity) and `node --test scripts/contract_types.test.mjs`
+  pin-consistency) and `node --test scripts/contract_types.test.mjs`
   (negative-path/no-op test). No new vitest config — built-in Node runner.
 - [ ] 5.2 Confirm the migration-match test needs **no** workflow change (it auto-runs in
   `compose-health-check`, which globs `tests/integration/`).

--- a/openspec/changes/pin-sleap-roots-contract/tasks.md
+++ b/openspec/changes/pin-sleap-roots-contract/tasks.md
@@ -1,0 +1,70 @@
+## 1. Oracle — TS drift guard (write first, watch it fail / RED)
+
+- [ ] 1.1 Add `json-schema-to-typescript` pinned **exact `15.0.4`** to root `package.json`
+  `devDependencies`; run `npm install` to update `package-lock.json` (committed).
+- [ ] 1.2 Add npm scripts to root `package.json`: `"contracts:gen": "node scripts/contract_types.mjs --write"`
+  and `"contracts:check": "node scripts/contract_types.mjs --check"`.
+- [ ] 1.3 Write `scripts/contract_types.mjs` (Node ESM): reads `contracts/pin.json` +
+  `contracts/schema/result_envelope.schema.json`; **pin-consistency** (assert `pin.json.version`
+  == version segment parsed from schema `$id`); generates TS via the json2ts **API** (fixed
+  `bannerComment` + options); `--write` writes `contracts/generated/result-envelope.ts`,
+  `--check` byte-compares and exits non-zero + prints a diff on mismatch or on missing files.
+- [ ] 1.4 Run `node scripts/contract_types.mjs --check` → **RED** (no `contracts/` files yet);
+  capture the failure.
+
+## 2. Migration-match test (write first, watch it fail / RED)
+
+- [ ] 2.1 Write `tests/integration/test_contract_migration_match.py`: a module-level declarative
+  `MAPPINGS` list of `{contract_field, db_table, db_column, db_type, status, reason}`; loads
+  `contracts/schema/result_envelope.schema.json`; uses the `pg_conn` fixture (mirror the
+  `_column_type`/`pg_constraint` helpers from `test_cyl_trait_source_provenance.py`).
+- [ ] 2.2 Active assertions (A-subset): `cyl_trait_sources.metadata` is `jsonb`;
+  `cyl_trait_sources.idempotency_key` is `text` with the non-empty CHECK
+  (`cyl_trait_sources_idempotency_key_nonempty`). Tie types back to the loaded contract
+  (`Provenance.idempotency_key` is `string`).
+- [ ] 2.3 Deferred rows (`source_id` FK / blob table / RPC key-equality) marked
+  `status="deferred"` and **skipped with reason** (`pytest.skip`), never asserted.
+- [ ] 2.4 Run `uv run --extra test pytest tests/integration/test_contract_migration_match.py`
+  against local Supabase → **RED** (vendored contract schema not present yet → load fails);
+  capture the failure.
+
+## 3. Vendor the pinned schema + manifest (GREEN: pin-consistency + test can load)
+
+- [ ] 3.1 Copy `C:\repos\sleap-roots-contracts\schema\result_envelope.schema.json` →
+  `contracts/schema/result_envelope.schema.json` (byte copy; `$id …/v0.1.0a1/…`).
+- [ ] 3.2 Write `contracts/pin.json`: `{ package: "sleap-roots-contracts", version: "v0.1.0a1",
+  source: "<github tag/release url>", schema: "schema/result_envelope.schema.json", generated:
+  "generated/result-envelope.ts" }`.
+- [ ] 3.3 Write `contracts/README.md`: the pinned version, the re-pin procedure
+  (`--write` + commit), and the `$id`-restamp-is-a-structural-no-op rule.
+- [ ] 3.4 Re-run the migration-match test → **GREEN** (loads the contract; A's columns already
+  applied locally).
+
+## 4. Generate + commit the contract TS types (GREEN: drift guard)
+
+- [ ] 4.1 Run `npm run contracts:gen` → writes `contracts/generated/result-envelope.ts`
+  (`ResultEnvelope`/`Provenance`/`TraitValue`/`BlobRef` + sub-defs, `DO NOT EDIT` banner).
+- [ ] 4.2 Run `npm run contracts:check` → **GREEN** (byte-identical; pin-consistency passes).
+- [ ] 4.3 Verify the `$id`-no-op property: temporarily edit the vendored schema's `$id` to a
+  different version, re-run `contracts:gen` to a temp path (or re-run `--check`), confirm the
+  generated TS is **unchanged**; revert the edit. (Demonstrates the structural no-op; no commit.)
+
+## 5. CI wiring
+
+- [ ] 5.1 Add a step to the `build-and-audit` job in `.github/workflows/pr-checks.yml`:
+  `node scripts/contract_types.mjs --check` (after `npm ci`). Name it clearly (contract types
+  drift guard).
+- [ ] 5.2 Confirm the migration-match test needs **no** workflow change (it auto-runs in
+  `compose-health-check`, which globs `tests/integration/`).
+
+## 6. Verify + pre-merge
+
+- [ ] 6.1 `openspec validate pin-sleap-roots-contract --strict` passes.
+- [ ] 6.2 Format/lint the new files (`scripts/contract_types.mjs`, `contracts/*`, the pytest
+  test) per repo conventions (prettier for JS/JSON/MD; ruff/black for Python); `npm run
+  format:check`.
+- [ ] 6.3 Run the migration-match test + the existing change-A provenance test locally against
+  local Supabase to confirm both pass; run `npm run contracts:check`.
+- [ ] 6.4 Run the relevant pre-merge subset (run-ci-locally / pre-merge skill) and confirm the new
+  drift-guard step passes.
+- [ ] 6.5 Update `tasks.md` checkboxes to reflect reality.

--- a/openspec/changes/pin-sleap-roots-contract/tasks.md
+++ b/openspec/changes/pin-sleap-roots-contract/tasks.md
@@ -1,70 +1,101 @@
-## 1. Oracle — TS drift guard (write first, watch it fail / RED)
+> **Commit/PR safety:** the RED captures in §1–§2 are **local-only**. Do not push a PR until the
+> §3/§4 artifacts exist in the same push, so the first pushed (and CI-run) commit is already GREEN.
+> CI runs on the PR head, not per-commit.
+
+## 1. Oracle — TS drift guard + determinism config (write first, RED locally)
 
 - [ ] 1.1 Add `json-schema-to-typescript` pinned **exact `15.0.4`** to root `package.json`
   `devDependencies`; run `npm install` to update `package-lock.json` (committed).
 - [ ] 1.2 Add npm scripts to root `package.json`: `"contracts:gen": "node scripts/contract_types.mjs --write"`
   and `"contracts:check": "node scripts/contract_types.mjs --check"`.
-- [ ] 1.3 Write `scripts/contract_types.mjs` (Node ESM): reads `contracts/pin.json` +
-  `contracts/schema/result_envelope.schema.json`; **pin-consistency** (assert `pin.json.version`
-  == version segment parsed from schema `$id`); generates TS via the json2ts **API** (fixed
-  `bannerComment` + options); `--write` writes `contracts/generated/result-envelope.ts`,
-  `--check` byte-compares and exits non-zero + prints a diff on mismatch or on missing files.
-- [ ] 1.4 Run `node scripts/contract_types.mjs --check` → **RED** (no `contracts/` files yet);
-  capture the failure.
+- [ ] 1.3 Add **determinism config** (prevents the guard from fighting repo tooling):
+  - New `.prettierignore` excluding `contracts/generated/` and `contracts/schema/`.
+  - Add `contracts/generated/*.ts text eol=lf` to `.gitattributes` (vendored schema already
+    covered by the existing `*.json text eol=lf`).
+- [ ] 1.4 Write `scripts/contract_types.mjs` (Node ESM): reads `contracts/pin.json` +
+  `contracts/schema/result_envelope.schema.json`; **pin-consistency** — assert `pin.json.id` ==
+  schema `$id` (exact) AND `pin.json.version` == version parsed from `$id` via anchored regex
+  `/\/schema\/(v[^/]+)\/result_envelope\.schema\.json$/`; fail on missing/unparseable `$id`.
+  Generates TS via the json2ts **API** (fixed `bannerComment` + options); `--write` writes
+  `contracts/generated/result-envelope.ts` (always `\n`); `--check` regenerates in-memory,
+  EOL-normalizes both sides (`\r\n`→`\n`), byte-compares, exits non-zero + prints a diff on
+  mismatch or on missing files.
+- [ ] 1.5 Run `node scripts/contract_types.mjs --check` → **RED** (expected here as a *file-not-found*
+  error: no `contracts/` files yet — distinct from the byte-mismatch RED proven in §4); capture it.
 
-## 2. Migration-match test (write first, watch it fail / RED)
+## 2. Migration-match characterization test (regression-lock; write first, RED locally)
 
 - [ ] 2.1 Write `tests/integration/test_contract_migration_match.py`: a module-level declarative
-  `MAPPINGS` list of `{contract_field, db_table, db_column, db_type, status, reason}`; loads
-  `contracts/schema/result_envelope.schema.json`; uses the `pg_conn` fixture (mirror the
-  `_column_type`/`pg_constraint` helpers from `test_cyl_trait_source_provenance.py`).
-- [ ] 2.2 Active assertions (A-subset): `cyl_trait_sources.metadata` is `jsonb`;
-  `cyl_trait_sources.idempotency_key` is `text` with the non-empty CHECK
-  (`cyl_trait_sources_idempotency_key_nonempty`). Tie types back to the loaded contract
-  (`Provenance.idempotency_key` is `string`).
-- [ ] 2.3 Deferred rows (`source_id` FK / blob table / RPC key-equality) marked
-  `status="deferred"` and **skipped with reason** (`pytest.skip`), never asserted.
+  `MAPPINGS` list of `{contract_field, db_table, db_column, db_type, constraint, status, reason}`;
+  **load the contract schema lazily** (inside the test/fixture) or guard with
+  `pytest.skip(allow_module_level=True)` when `contracts/schema/result_envelope.schema.json` is
+  absent — must never crash collection. Reuse the `_column_type`/`pg_constraint` helpers from
+  `test_cyl_trait_source_provenance.py`; use the `pg_conn` fixture (rollback per test).
+- [ ] 2.2 Active assertions (A-subset), each tied back to the loaded contract:
+  - `cyl_trait_sources.metadata` is `jsonb` **and** `schema["$defs"]["Provenance"]["description"]`
+    contains the literal `cyl_trait_sources.metadata` (contract-side home tripwire).
+  - `cyl_trait_sources.idempotency_key` is `text`, contract `Provenance.idempotency_key` is
+    `string`, **and both** constraints exist: `cyl_trait_sources_idempotency_key_nonempty` (CHECK)
+    **and** `cyl_trait_sources_idempotency_key_key` (UNIQUE).
+- [ ] 2.3 Deferred rows (`source_id` FK / blob table / RPC key-equality / `contract_version`
+  validation / `scan_key` resolution) marked `status="deferred"` and **skipped with reason**
+  (`pytest.skip`), never asserted. Add a documented (non-asserted) note that remaining `Provenance`
+  fields live inside opaque `metadata`, and that `contract_version`/`TraitValue.value` finiteness
+  are D/G consumer-side hand-offs.
 - [ ] 2.4 Run `uv run --extra test pytest tests/integration/test_contract_migration_match.py`
-  against local Supabase → **RED** (vendored contract schema not present yet → load fails);
-  capture the failure.
+  against local Supabase → **RED** (module-level skip / load fails before vendoring); capture it.
 
-## 3. Vendor the pinned schema + manifest (GREEN: pin-consistency + test can load)
+## 3. Vendor the pinned schema + manifest (GREEN: pin-consistency + test loads)
 
 - [ ] 3.1 Copy `C:\repos\sleap-roots-contracts\schema\result_envelope.schema.json` →
-  `contracts/schema/result_envelope.schema.json` (byte copy; `$id …/v0.1.0a1/…`).
-- [ ] 3.2 Write `contracts/pin.json`: `{ package: "sleap-roots-contracts", version: "v0.1.0a1",
-  source: "<github tag/release url>", schema: "schema/result_envelope.schema.json", generated:
+  `contracts/schema/result_envelope.schema.json` (LF-normalized; `$id …/v0.1.0a1/…`).
+- [ ] 3.2 Write `contracts/pin.json`: `{ package, version: "v0.1.0a1", id: "<full $id>", source:
+  "<github tag/release url>", schema: "schema/result_envelope.schema.json", generated:
   "generated/result-envelope.ts" }`.
-- [ ] 3.3 Write `contracts/README.md`: the pinned version, the re-pin procedure
-  (`--write` + commit), and the `$id`-restamp-is-a-structural-no-op rule.
+- [ ] 3.3 Write `contracts/README.md`: the pinned version (+ the #294 a0/v0.1.0 reconciliation),
+  the re-pin procedure (`--write` + commit), and the `$id`-restamp-is-a-structural-no-op rule.
 - [ ] 3.4 Re-run the migration-match test → **GREEN** (loads the contract; A's columns already
-  applied locally).
+  applied locally). Then prove the oracle discriminates: temporarily mutate one expected value
+  (e.g. assert `metadata` is `"json"`) or drop a constraint inside the `pg_conn` transaction,
+  confirm the failure fires **on the assertion line**, then revert.
 
 ## 4. Generate + commit the contract TS types (GREEN: drift guard)
 
 - [ ] 4.1 Run `npm run contracts:gen` → writes `contracts/generated/result-envelope.ts`
   (`ResultEnvelope`/`Provenance`/`TraitValue`/`BlobRef` + sub-defs, `DO NOT EDIT` banner).
-- [ ] 4.2 Run `npm run contracts:check` → **GREEN** (byte-identical; pin-consistency passes).
-- [ ] 4.3 Verify the `$id`-no-op property: temporarily edit the vendored schema's `$id` to a
-  different version, re-run `contracts:gen` to a temp path (or re-run `--check`), confirm the
-  generated TS is **unchanged**; revert the edit. (Demonstrates the structural no-op; no commit.)
+  **Review** the `BlobRef`/`ResultEnvelope` output is a sane, non-degenerate shape before
+  committing (the `anyOf`-over-`properties` `BlobRef` is the risk case).
+- [ ] 4.2 Run `npx tsc --noEmit` on the generated file (a throwaway tsconfig or `--strict` flags)
+  to confirm it is valid, usable TypeScript.
+- [ ] 4.3 Run `npm run contracts:check` → **GREEN** (byte-identical after EOL-normalize;
+  pin-consistency passes).
+- [ ] 4.4 Write `scripts/contract_types.test.mjs` (Vitest) covering the spec's negative/no-op
+  scenarios, all using the **same json2ts invocation** the guard uses:
+  - pin-mismatch (in-memory schema/pin with disagreeing version/`$id`) → check returns non-zero.
+  - hand-edited committed TS (temp copy) → `--check` returns non-zero with a diff.
+  - `$id`-only mutation → regenerated TS **identical** (structural no-op).
+  - real field mutation (flip `idempotency_key` type / add a property) → regenerated TS **differs**
+    (proves a real change fails).
+  - Run `npx vitest run scripts/contract_types.test.mjs` → GREEN.
 
 ## 5. CI wiring
 
-- [ ] 5.1 Add a step to the `build-and-audit` job in `.github/workflows/pr-checks.yml`:
-  `node scripts/contract_types.mjs --check` (after `npm ci`). Name it clearly (contract types
-  drift guard).
+- [ ] 5.1 Add two steps to the `build-and-audit` job in `.github/workflows/pr-checks.yml` (after
+  `npm ci`): `node scripts/contract_types.mjs --check` (drift guard) and
+  `npx vitest run scripts/contract_types.test.mjs` (negative-path/no-op test). Name them clearly.
 - [ ] 5.2 Confirm the migration-match test needs **no** workflow change (it auto-runs in
   `compose-health-check`, which globs `tests/integration/`).
 
 ## 6. Verify + pre-merge
 
 - [ ] 6.1 `openspec validate pin-sleap-roots-contract --strict` passes.
-- [ ] 6.2 Format/lint the new files (`scripts/contract_types.mjs`, `contracts/*`, the pytest
-  test) per repo conventions (prettier for JS/JSON/MD; ruff/black for Python); `npm run
-  format:check`.
+- [ ] 6.2 Format/lint the new files **excluding the prettier-ignored `contracts/generated/` and
+  `contracts/schema/`** (ruff/black for the pytest test; prettier for `scripts/*.mjs`,
+  `pin.json`, READMEs); run `npm run format:check` and confirm the generated/schema files are not
+  flagged (i.e. `.prettierignore` is effective).
 - [ ] 6.3 Run the migration-match test + the existing change-A provenance test locally against
-  local Supabase to confirm both pass; run `npm run contracts:check`.
+  local Supabase to confirm both pass; run `npm run contracts:check` and the Vitest test on the
+  author's (Windows) machine to confirm no CRLF/LF flake.
 - [ ] 6.4 Run the relevant pre-merge subset (run-ci-locally / pre-merge skill) and confirm the new
-  drift-guard step passes.
+  drift-guard + vitest steps pass and `npm run format` does **not** rewrite the generated file.
 - [ ] 6.5 Update `tasks.md` checkboxes to reflect reality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^5.0.0",
+        "json-schema-to-typescript": "15.0.4",
         "prettier": "^3.6.2",
         "prettier-plugin-nginx": "^1.0.3",
         "turbo": "^2.5.8",
@@ -48,6 +49,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2927,6 +2946,13 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@leeoniya/ufuzzy": {
       "version": "1.0.19",
@@ -9538,6 +9564,30 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",
     "contracts:gen": "node scripts/contract_types.mjs --write",
-    "contracts:check": "node scripts/contract_types.mjs --check"
+    "contracts:check": "node scripts/contract_types.mjs --check",
+    "contracts:test": "node --test scripts/contract_types.test.mjs"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.0.0",
+    "json-schema-to-typescript": "15.0.4",
     "prettier": "^3.6.2",
     "prettier-plugin-nginx": "^1.0.3",
     "turbo": "^2.5.8",
@@ -46,6 +47,8 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "test": "turbo run test",
-    "test:coverage": "turbo run test:coverage"
+    "test:coverage": "turbo run test:coverage",
+    "contracts:gen": "node scripts/contract_types.mjs --write",
+    "contracts:check": "node scripts/contract_types.mjs --check"
   }
 }

--- a/scripts/contract_types.mjs
+++ b/scripts/contract_types.mjs
@@ -1,0 +1,144 @@
+// Contract types drift guard for the pinned sleap-roots-contracts schema
+// (pin-sleap-roots-contract / #294).
+//
+// Pure functions (no file I/O, no process.exit) + a thin CLI shim. The shim is
+// the ONLY place that reads files and exits, so scripts/contract_types.test.mjs
+// can import and drive the pure functions with in-memory inputs.
+//
+//   node scripts/contract_types.mjs --write   # regenerate contracts/generated/
+//   node scripts/contract_types.mjs --check    # fail (exit 1) on any drift
+//
+// json-schema-to-typescript's compile() is async, so generateTypes/checkDrift
+// are async. The codegen never emits the schema $id, so a re-pin that only
+// re-stamps $id regenerates byte-identical TS (a structural no-op); a real
+// field change produces a different file and fails the guard.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import json2ts from 'json-schema-to-typescript'
+
+const { compile } = json2ts
+
+// Version-free banner: a re-pin that only re-stamps $id must regenerate this
+// file unchanged, so nothing version-specific may appear in the output.
+const BANNER = [
+  '/* eslint-disable */',
+  '/**',
+  ' * AUTO-GENERATED — DO NOT EDIT.',
+  ' *',
+  ' * TypeScript types for the sleap-roots-contracts ResultEnvelope, generated from',
+  ' * contracts/schema/result_envelope.schema.json (the pinned JSON Schema) by',
+  ' * json-schema-to-typescript. Regenerate with `npm run contracts:gen`; the',
+  ' * byte-for-byte drift guard `npm run contracts:check` fails CI if this file and',
+  ' * the pinned schema disagree.',
+  ' */',
+].join('\n')
+
+const JSON2TS_OPTIONS = { bannerComment: BANNER, format: true }
+
+// Anchored on the version-stamped path segment, e.g.
+// https://…/schema/v0.1.0a1/result_envelope.schema.json -> "v0.1.0a1".
+const ID_VERSION_RE = /\/schema\/(v[^/]+)\/result_envelope\.schema\.json$/
+
+const normalizeEol = (s) => s.replace(/\r\n/g, '\n')
+
+/** Generate the contract TS from a parsed JSON Schema object. Async: compile() returns a Promise. */
+export async function generateTypes(schema) {
+  return normalizeEol(await compile(schema, 'ResultEnvelope', JSON2TS_OPTIONS))
+}
+
+/** Assert the pin manifest agrees with the schema's $id (exact id + parsed version). */
+export function checkPinConsistency(pin, schema) {
+  const id = schema && schema.$id
+  if (typeof id !== 'string' || id.length === 0) {
+    return { ok: false, error: 'schema $id is missing' }
+  }
+  if (!pin || pin.id !== id) {
+    return { ok: false, error: `pin.json id (${pin && pin.id}) != schema $id (${id})` }
+  }
+  const m = ID_VERSION_RE.exec(id)
+  if (!m) {
+    return { ok: false, error: `schema $id has no parseable version segment: ${id}` }
+  }
+  if (pin.version !== m[1]) {
+    return { ok: false, error: `pin.json version (${pin.version}) != $id version (${m[1]})` }
+  }
+  return { ok: true }
+}
+
+/** Regenerate from the schema and compare (EOL-normalized) to the committed types. */
+export async function checkDrift({ schema, pin, committedTs }) {
+  const pinResult = checkPinConsistency(pin, schema)
+  if (!pinResult.ok) return { ok: false, diff: pinResult.error }
+  const generated = await generateTypes(schema)
+  const committed = normalizeEol(committedTs)
+  if (generated === committed) return { ok: true }
+  const g = generated.split('\n')
+  const c = committed.split('\n')
+  let i = 0
+  while (i < g.length && i < c.length && g[i] === c[i]) i++
+  const diff =
+    `committed contract types differ from regenerating the pinned schema ` +
+    `(first difference at line ${i + 1}):\n` +
+    `  committed:   ${JSON.stringify(c[i] ?? '<EOF>')}\n` +
+    `  regenerated: ${JSON.stringify(g[i] ?? '<EOF>')}\n` +
+    'Run `npm run contracts:gen` and commit, or revert the unintended change.'
+  return { ok: false, diff }
+}
+
+// ---- CLI shim: the only place with file I/O and process.exit ----
+
+function isMain() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href
+}
+
+if (isMain()) {
+  const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+  const schemaPath = join(root, 'contracts', 'schema', 'result_envelope.schema.json')
+  const pinPath = join(root, 'contracts', 'pin.json')
+  const generatedPath = join(root, 'contracts', 'generated', 'result-envelope.ts')
+  const mode = process.argv[2]
+
+  const readText = (p, label) => {
+    try {
+      return readFileSync(p, 'utf8')
+    } catch (err) {
+      console.error(`error: cannot read ${label} at ${p}: ${err.message}`)
+      process.exit(1)
+    }
+  }
+  const readJson = (p, label) => JSON.parse(readText(p, label))
+
+  if (mode === '--write') {
+    const schema = readJson(schemaPath, 'schema')
+    const pin = readJson(pinPath, 'pin.json')
+    const pinResult = checkPinConsistency(pin, schema)
+    if (!pinResult.ok) {
+      console.error(`pin-consistency failed: ${pinResult.error}`)
+      process.exit(1)
+    }
+    writeFileSync(generatedPath, await generateTypes(schema), 'utf8')
+    console.log(`wrote ${generatedPath}`)
+    process.exit(0)
+  } else if (mode === '--check') {
+    const schema = readJson(schemaPath, 'schema')
+    const pin = readJson(pinPath, 'pin.json')
+    const committedTs = readText(generatedPath, 'generated types')
+    const pinResult = checkPinConsistency(pin, schema)
+    if (!pinResult.ok) {
+      console.error(`pin-consistency failed: ${pinResult.error}`)
+      process.exit(1)
+    }
+    const drift = await checkDrift({ schema, pin, committedTs })
+    if (!drift.ok) {
+      console.error(drift.diff)
+      process.exit(1)
+    }
+    console.log('contract types OK: pinned schema and committed types agree.')
+    process.exit(0)
+  } else {
+    console.error('usage: node scripts/contract_types.mjs --write|--check')
+    process.exit(2)
+  }
+}

--- a/scripts/contract_types.mjs
+++ b/scripts/contract_types.mjs
@@ -35,7 +35,14 @@ const BANNER = [
   ' */',
 ].join('\n')
 
-const JSON2TS_OPTIONS = { bannerComment: BANNER, format: true }
+// `$refOptions.resolve.http: false` hard-fails (rather than fetching) if a future
+// re-pinned schema ever carried a remote http(s) `$ref` — codegen stays offline and
+// deterministic. The current schema uses only intra-document `#/$defs/...` refs.
+const JSON2TS_OPTIONS = {
+  bannerComment: BANNER,
+  format: true,
+  $refOptions: { resolve: { http: false } },
+}
 
 // Anchored on the version-stamped path segment, e.g.
 // https://…/schema/v0.1.0a1/result_envelope.schema.json -> "v0.1.0a1".
@@ -108,7 +115,15 @@ if (isMain()) {
       process.exit(1)
     }
   }
-  const readJson = (p, label) => JSON.parse(readText(p, label))
+  const readJson = (p, label) => {
+    const text = readText(p, label)
+    try {
+      return JSON.parse(text)
+    } catch (err) {
+      console.error(`error: cannot parse ${label} at ${p}: ${err.message}`)
+      process.exit(1)
+    }
+  }
 
   if (mode === '--write') {
     const schema = readJson(schemaPath, 'schema')

--- a/scripts/contract_types.test.mjs
+++ b/scripts/contract_types.test.mjs
@@ -1,0 +1,85 @@
+// Negative-path + $id-no-op tests for the contract drift guard
+// (pin-sleap-roots-contract / #294). Built-in `node --test` runner — no config.
+//
+//   node --test scripts/contract_types.test.mjs
+//
+// Imports the PURE functions from contract_types.mjs (the CLI shim never runs on
+// import) and drives them with in-memory mutations of the real vendored schema.
+// The POSITIVE paths (everything agrees) are covered by the live `npm run
+// contracts:check` against the committed file; this file carries the cases that
+// can't be exercised by the real, always-consistent artifacts.
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { generateTypes, checkPinConsistency, checkDrift } from './contract_types.mjs'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const schema = JSON.parse(
+  readFileSync(join(root, 'contracts/schema/result_envelope.schema.json'), 'utf8')
+)
+const pin = JSON.parse(readFileSync(join(root, 'contracts/pin.json'), 'utf8'))
+const clone = (o) => JSON.parse(JSON.stringify(o))
+
+test('pin-consistency: matching pin and schema is ok', () => {
+  assert.equal(checkPinConsistency(pin, schema).ok, true)
+})
+
+test('pin-consistency: version mismatch is rejected', () => {
+  assert.equal(checkPinConsistency({ ...pin, version: 'v9.9.9' }, schema).ok, false)
+})
+
+test('pin-consistency: id mismatch is rejected', () => {
+  assert.equal(
+    checkPinConsistency({ ...pin, id: 'https://example.com/wrong.json' }, schema).ok,
+    false
+  )
+})
+
+test('pin-consistency: missing $id is rejected', () => {
+  const noId = clone(schema)
+  delete noId.$id
+  assert.equal(checkPinConsistency(pin, noId).ok, false)
+})
+
+test('pin-consistency: unparseable $id (no version segment) is rejected', () => {
+  const weird = clone(schema)
+  weird.$id = 'https://example.com/no-version-here.json'
+  // Matching pin.id exactly, so only the version-parse path can reject it.
+  assert.equal(checkPinConsistency({ ...pin, id: weird.$id }, weird).ok, false)
+})
+
+test('drift: a hand-edited committed file is detected (checkDrift fail branch)', async () => {
+  const good = await generateTypes(schema)
+  const tampered = good.replace('export interface ResultEnvelope', 'export interface Tampered')
+  const res = await checkDrift({ schema, pin, committedTs: tampered })
+  assert.equal(res.ok, false)
+  assert.match(res.diff, /differ/)
+})
+
+test('drift: identical committed types pass', async () => {
+  const good = await generateTypes(schema)
+  assert.equal((await checkDrift({ schema, pin, committedTs: good })).ok, true)
+})
+
+test('$id-only re-pin regenerates byte-identical types (structural no-op)', async () => {
+  const before = await generateTypes(schema)
+  const restamped = clone(schema)
+  restamped.$id = restamped.$id.replace('/v0.1.0a1/', '/v0.1.0/')
+  assert.equal(await generateTypes(restamped), before)
+})
+
+test('a real field change produces different types (guard would fail)', async () => {
+  const before = await generateTypes(schema)
+  const mutated = clone(schema)
+  // Flip idempotency_key from string to integer — a genuine contract change.
+  mutated.$defs.Provenance.properties.idempotency_key = {
+    type: 'integer',
+    default: 0,
+    title: 'Idempotency Key',
+  }
+  assert.notEqual(await generateTypes(mutated), before)
+})

--- a/tests/integration/test_contract_migration_match.py
+++ b/tests/integration/test_contract_migration_match.py
@@ -124,13 +124,21 @@ def _column_type(cur, table: str, column: str) -> str | None:
     return row[0] if row else None
 
 
-def _constraints(cur, table: str) -> dict[str, str]:
-    """Return {conname: contype} (contype cast to text) for a public table."""
+def _constraint_types_on_column(cur, table: str, column: str) -> set[str]:
+    """Return the set of constraint types (pg_constraint.contype) whose key columns
+    include `column`. Keyed on the column, NOT on constraint names — so a legitimate
+    constraint rename can't false-positive this assertion."""
     cur.execute(
-        "SELECT conname, contype::text FROM pg_constraint WHERE conrelid = %s::regclass",
-        (f"public.{table}",),
+        """
+        SELECT c.contype::text
+          FROM pg_constraint c
+          JOIN pg_attribute a
+            ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+         WHERE c.conrelid = %s::regclass AND a.attname = %s
+        """,
+        (f"public.{table}", column),
     )
-    return {name: contype for name, contype in cur.fetchall()}
+    return {row[0] for row in cur.fetchall()}
 
 
 # --------------------------------------------------------------------------- #
@@ -172,6 +180,7 @@ def test_contract_idempotency_key_default_is_empty_string():
 
 def test_active_mapping_columns_have_expected_types(pg_conn):
     """Declarative sweep: every active mapping naming a column+type holds in the DB."""
+    checked = 0
     with pg_conn.cursor() as cur:
         for m in ACTIVE:
             if m["db_column"] and m["db_type"]:
@@ -180,21 +189,22 @@ def test_active_mapping_columns_have_expected_types(pg_conn):
                     f"{m['contract_field']}: expected {m['db_table']}.{m['db_column']} "
                     f"to be {m['db_type']}, got {actual!r}"
                 )
+                checked += 1
     pg_conn.rollback()
+    # Floor: a future edit that empties ACTIVE (or drops every column) must not let
+    # this test pass vacuously. Change A ships exactly two column-typed active rows.
+    assert checked >= 2, f"expected >= 2 active column mappings checked, got {checked}"
 
 
 def test_idempotency_anchor_constraints_by_type(pg_conn):
-    # Assert by contype, NOT name alone — the _key/_nonempty suffixes are
-    # convention, not enforcement. A UNIQUE is the 1-envelope:1-row anchor; the
-    # CHECK rejects the contract's "" default.
+    # Assert by contype on the COLUMN, NOT by constraint name — the _key/_nonempty
+    # suffixes are convention, not enforcement, and a legitimate rename must not
+    # false-positive. A UNIQUE is the 1-envelope:1-row anchor; the CHECK rejects the
+    # contract's "" default.
     with pg_conn.cursor() as cur:
-        cons = _constraints(cur, "cyl_trait_sources")
-        assert cons.get("cyl_trait_sources_idempotency_key_key") == "u", (
-            "UNIQUE anchor missing"
-        )
-        assert cons.get("cyl_trait_sources_idempotency_key_nonempty") == "c", (
-            "non-empty CHECK missing"
-        )
+        types = _constraint_types_on_column(cur, "cyl_trait_sources", "idempotency_key")
+    assert "u" in types, "UNIQUE anchor on idempotency_key missing"
+    assert "c" in types, "non-empty CHECK on idempotency_key missing"
     pg_conn.rollback()
 
 

--- a/tests/integration/test_contract_migration_match.py
+++ b/tests/integration/test_contract_migration_match.py
@@ -1,0 +1,210 @@
+"""
+Migration-matches-schema check for change `pin-sleap-roots-contract` (#294).
+
+Asserts Bloom's applied DB schema agrees with the pinned sleap-roots-contracts
+`result_envelope.schema.json` for the contract<->DB mappings BUILT TODAY (change
+A only: `cyl_trait_sources.metadata` jsonb + `idempotency_key` text with UNIQUE +
+non-empty CHECK). It also asserts the contract-side schema facts that justify
+those DB choices (the `Provenance` envelope-home designation, the required
+`contract_version` anchor, and the `idempotency_key` default of "").
+
+Mappings introduced by later changes (B `source_id` FK, C blob table, D RPC key
+equality, `contract_version` runtime validation, `scan_key` resolution) are
+recorded as DEFERRED rows and skipped — never asserted against objects that do
+not exist yet. As each lands, flip its row to `status="active"`.
+
+Collection safety: `MAPPINGS` holds LITERALS ONLY (no schema-derived values), so
+importing this module never reads the schema — that is what keeps collection safe
+when the schema is not vendored yet. The schema is read lazily inside each test
+via `_load_schema()`, which skips (does not crash) when the file is absent.
+
+LOCAL ONLY: the `pg_conn` fixture connects to 127.0.0.1 on POSTGRES_HOST_PORT and
+mutates nothing — every DB test rolls back. Runs in CI's `compose-health-check`
+after migrations are applied (`uv run --extra test pytest tests/integration/ -v`).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module if psycopg isn't available (matches the change-A test).
+# This does not read the schema, so it is collection-safe.
+psycopg = pytest.importorskip("psycopg")
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SCHEMA_PATH = REPO_ROOT / "contracts" / "schema" / "result_envelope.schema.json"
+
+# Declarative contract<->DB mapping. LITERALS ONLY — no schema-derived values, so
+# importing this module never touches the schema file (collection stays safe).
+MAPPINGS = [
+    # --- Active: built by change A (#290) ---
+    {
+        "contract_field": "Provenance (envelope)",
+        "db_table": "cyl_trait_sources",
+        "db_column": "metadata",
+        "db_type": "jsonb",
+        "status": "active",
+        "reason": "change A: opaque Provenance envelope home",
+    },
+    {
+        "contract_field": "Provenance.idempotency_key",
+        "db_table": "cyl_trait_sources",
+        "db_column": "idempotency_key",
+        "db_type": "text",
+        "status": "active",
+        "reason": "change A: per-run idempotency anchor",
+    },
+    # --- Deferred: skipped, never asserted. Flip to active as each change lands. ---
+    {
+        "contract_field": "source_id FK",
+        "db_table": "cyl_scan_traits / cyl_image_traits",
+        "db_column": "source_id",
+        "db_type": None,
+        "status": "deferred",
+        "reason": "#295 change B: source_id FK on the trait tables",
+    },
+    {
+        "contract_field": "BlobRef",
+        "db_table": "(intermediates/blob table)",
+        "db_column": None,
+        "db_type": None,
+        "status": "deferred",
+        "reason": "#296 change C: intermediates/blob table",
+    },
+    {
+        "contract_field": "idempotency_key == metadata->>'idempotency_key'",
+        "db_table": "cyl_trait_sources",
+        "db_column": None,
+        "db_type": None,
+        "status": "deferred",
+        "reason": "change D: RPC-enforced key equality (RPC-only)",
+    },
+    {
+        "contract_field": "Provenance.contract_version (runtime row value)",
+        "db_table": "cyl_trait_sources",
+        "db_column": None,
+        "db_type": None,
+        "status": "deferred",
+        "reason": "D/G consumer: validate provenance.contract_version == pinned version",
+    },
+    {
+        "contract_field": "Provenance.scan_key -> cyl_scans.id",
+        "db_table": "cyl_scans",
+        "db_column": None,
+        "db_type": None,
+        "status": "deferred",
+        "reason": "caller-side scan_key resolution via inputs.image_ids",
+    },
+]
+
+ACTIVE = [m for m in MAPPINGS if m["status"] == "active"]
+DEFERRED = [m for m in MAPPINGS if m["status"] == "deferred"]
+
+
+def _load_schema() -> dict:
+    """Lazily read the vendored contract schema. Skip (do NOT crash) if absent."""
+    if not SCHEMA_PATH.exists():
+        pytest.skip(
+            "contract schema not vendored (contracts/schema/result_envelope.schema.json)"
+        )
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _column_type(cur, table: str, column: str) -> str | None:
+    cur.execute(
+        """
+        SELECT data_type
+          FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = %s AND column_name = %s
+        """,
+        (table, column),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _constraints(cur, table: str) -> dict[str, str]:
+    """Return {conname: contype} (contype cast to text) for a public table."""
+    cur.execute(
+        "SELECT conname, contype::text FROM pg_constraint WHERE conrelid = %s::regclass",
+        (f"public.{table}",),
+    )
+    return {name: contype for name, contype in cur.fetchall()}
+
+
+# --------------------------------------------------------------------------- #
+# Contract-side sanity — schema facts that justify change A's DB choices.
+# (Schema-only; no DB needed.)
+# --------------------------------------------------------------------------- #
+
+
+def test_contract_designates_metadata_as_provenance_home():
+    # The ONLY contract-side net for a description-level re-home: json2ts drops
+    # descriptions, so the byte-equal TS guard is blind to this. Runs against the
+    # frozen vendored copy, so it only fires on a deliberate re-pin.
+    schema = _load_schema()
+    assert "cyl_trait_sources.metadata" in schema["$defs"]["Provenance"]["description"]
+
+
+def test_contract_requires_contract_version_anchor():
+    # contract_version is the per-row provenance-of-origin anchor; D/G's future
+    # validation has nothing to validate if a re-pin ever makes it optional.
+    schema = _load_schema()
+    provenance = schema["$defs"]["Provenance"]
+    assert "contract_version" in provenance["required"]
+    assert provenance["properties"]["contract_version"]["type"] == "string"
+
+
+def test_contract_idempotency_key_default_is_empty_string():
+    # The documented basis for change A's non-empty CHECK: an unset key arrives
+    # as "" (never NULL). If this default changed, the CHECK rationale would rot.
+    schema = _load_schema()
+    idem = schema["$defs"]["Provenance"]["properties"]["idempotency_key"]
+    assert idem.get("default") == ""
+    assert idem["type"] == "string"
+
+
+# --------------------------------------------------------------------------- #
+# Active contract<->DB mappings — introspect the live applied schema.
+# --------------------------------------------------------------------------- #
+
+
+def test_active_mapping_columns_have_expected_types(pg_conn):
+    """Declarative sweep: every active mapping naming a column+type holds in the DB."""
+    with pg_conn.cursor() as cur:
+        for m in ACTIVE:
+            if m["db_column"] and m["db_type"]:
+                actual = _column_type(cur, m["db_table"], m["db_column"])
+                assert actual == m["db_type"], (
+                    f"{m['contract_field']}: expected {m['db_table']}.{m['db_column']} "
+                    f"to be {m['db_type']}, got {actual!r}"
+                )
+    pg_conn.rollback()
+
+
+def test_idempotency_anchor_constraints_by_type(pg_conn):
+    # Assert by contype, NOT name alone — the _key/_nonempty suffixes are
+    # convention, not enforcement. A UNIQUE is the 1-envelope:1-row anchor; the
+    # CHECK rejects the contract's "" default.
+    with pg_conn.cursor() as cur:
+        cons = _constraints(cur, "cyl_trait_sources")
+        assert cons.get("cyl_trait_sources_idempotency_key_key") == "u", (
+            "UNIQUE anchor missing"
+        )
+        assert cons.get("cyl_trait_sources_idempotency_key_nonempty") == "c", (
+            "non-empty CHECK missing"
+        )
+    pg_conn.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Deferred mappings — skipped with a reason, never asserted.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "mapping", DEFERRED, ids=[m["contract_field"] for m in DEFERRED]
+)
+def test_deferred_mapping_is_skipped(mapping):
+    pytest.skip(f"deferred: {mapping['reason']}")


### PR DESCRIPTION
## Why

A2 **consume-pin** (#294). The sleap-roots ↔ Bloom contract boundary is the most failure-prone seam: the `ResultEnvelope`/`Provenance` shape is authored in Python (Pydantic → JSON Schema) and consumed by Bloom (TS + Postgres). Change A (#290) added `cyl_trait_sources.metadata` + `idempotency_key` by hand-reading the contract, with **no machine check** that Bloom's generated types or DB schema still agree with a pinned version. This adds those guards. The roadmap sequences consume-pin *first* in A2; A shipped first pragmatically, and this closes that gap.

**No DB migration** (change A already shipped the columns). **No consumer wired yet** (B/C/D/G pending) — the artifact + guards exist now; consumption lands with the consumer.

## What changes

- **Pin** `result_envelope.schema.json` @ `v0.1.0a1` as a vendored, LF-normalized copy under `contracts/` + a `pin.json` manifest (full `$id` + version) + `README.md` (pin, re-pin procedure, `$id`-no-op rule).
- **Codegen** the contract TS types (`contracts/generated/result-envelope.ts`) via `json-schema-to-typescript` pinned **exact `15.0.4`** (deterministic). Distinct from the Supabase `database.types.ts`.
- **Drift guard** `scripts/contract_types.mjs` (pure functions + thin CLI shim): `--check` regenerates and byte-compares (EOL-normalized) and verifies `pin.json` ↔ schema `$id`. `npm run contracts:gen` / `contracts:check`. Codegen never emits `$id`, so a `$id`-only re-pin regenerates byte-identical TS (structural no-op); a real field change fails the guard.
- **`scripts/contract_types.test.mjs`** (`node --test`, no new framework): negative paths + `$id`-no-op proven in **both** directions (`$id`-only → identical; real field change → differs).
- **Determinism config**: `.prettierignore` (excludes `contracts/generated/` + `contracts/schema/`; json2ts owns those bytes) and `.gitattributes` (`contracts/generated/*.ts text eol=lf`) so the byte-equal guard is reproducible across repo prettier + Windows/Linux EOL.
- **Migration-matches-schema** `tests/integration/test_contract_migration_match.py`: introspects the applied DB and asserts the change-A mappings (`metadata` jsonb; `idempotency_key` text + UNIQUE/CHECK **by `contype`**) plus contract-side sanity (`contract_version` required+string; `idempotency_key` default `""`). B/C/D mappings are declarative **deferred** rows, skipped — never asserted against objects that don't exist. Collection-safe (literals-only `MAPPINGS` + lazy schema load).
- **CI**: drift guard + `node --test` steps in `build-and-audit`; the pytest auto-runs in `compose-health-check`.

## Process

OpenSpec change `pin-sleap-roots-contract` (capability `contract-pinning`). **Three** adversarial review rounds (5 subagents each) before approval; every BLOCKING/IMPORTANT finding reconciled (determinism, async codegen, collection safety, `contype`/contract-side assertions, pure-function testability). TDD: oracle written first.

## Verification (local)

- `npm run contracts:check` → GREEN; `node --test scripts/contract_types.test.mjs` → 9/9
- `test_contract_migration_match.py` + change-A provenance → 15 passed / 5 deferred against local Supabase (incl. a discrimination proof that the oracle fails on a wrong expected value)
- `tsc --noEmit` on generated types clean; `npm audit --audit-level=critical` clean (json2ts not implicated); `lint_migrations.sh` clean (0 new migrations); `openspec validate --strict` passes

## Notes for reviewer

- No migration, no RLS, no row writes — purely CI/TS/vendoring + one devDependency.
- The migration-match requirement is housed in the new `contract-pinning` capability as an interim home; relocating it into `cyl-trait-writeback` is a deliberate later refactor (deferred until change A's archive #300 lands that live spec on `staging`).
- Needs a non-author approver (staging branch protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)