### PR TITLE
ci(bloommcp): smoke-test the built wheel imports in a clean env

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -142,6 +142,34 @@ jobs:
           SUPABASE_URL: ""
           BLOOM_AGENT_KEY: ""
 
+      # Build the wheel and import it from a clean, project-free env so a
+      # packaging regression (bad module-name/module-root, dropped __init__.py,
+      # empty-namespace wheel) fails the PR — the src/-on-sys.path import tests
+      # AND the editable Docker install both resolve `bloom_mcp` off the source
+      # tree, so neither can catch this. The `__file__` assert proves the import
+      # resolved the installed wheel, not src/. `--no-project` gives the src-free
+      # namespace (the actual goal); `--isolated` is omitted on purpose — it
+      # bypasses the uv cache and would cold-download the whole heavy dep tree
+      # (sleap-roots-analyze/statsmodels/umap/scipy/fastmcp) from PyPI every run.
+      # `rm -rf dist` + the single-wheel test guard the glob. SUPABASE_URL/
+      # BLOOM_AGENT_KEY empty keeps the lazy-validation contract load-bearing.
+      # `--with <wheel>` is allowed by the uv-conventions guard (Invariant 3
+      # only forbids --with alongside pytest; this line runs `python -c`).
+      # (`uv build` has no --frozen flag — it builds in PEP 517 isolation and
+      # does not sync the project env, so there is no lockfile to freeze.)
+      - name: Build bloom_mcp wheel and import in a clean env
+        run: |
+          cd bloommcp
+          rm -rf dist
+          uv build --wheel
+          wheel=$(echo dist/bloommcp-*.whl)
+          test -f "$wheel" || { echo "expected exactly one wheel, got: $wheel"; exit 1; }
+          uv run --no-project --with "$wheel" \
+            python -c "import bloom_mcp, bloom_mcp.tools, bloom_mcp.storage, bloom_mcp.server; assert 'site-packages' in bloom_mcp.__file__, bloom_mcp.__file__"
+        env:
+          SUPABASE_URL: ""
+          BLOOM_AGENT_KEY: ""
+
       # Enforce lockfile-pyproject sync on the server side. Pre-commit catches
       # this locally but can be bypassed (--no-verify, web-UI merge, Dependabot
       # auto-merge). `uv export --frozen` (used by the audit steps below) exits

--- a/openspec/changes/add-bloommcp-wheel-import-ci/proposal.md
+++ b/openspec/changes/add-bloommcp-wheel-import-ci/proposal.md
@@ -33,7 +33,8 @@ This change closes that gap by building the wheel in CI and importing it from a 
 
 ## Impact
 
-- **Affected specs**: `bloommcp-packaging` (ADDED only — composes with PR #313's in-flight capability).
+- **Affected specs**: `bloommcp-packaging` (ADDED only — composes with PR #313's capability).
+- **Archive order**: the `bloommcp-packaging` capability exists only as the (un-archived) `add-bloommcp-package-baseline` delta — it is not yet in `openspec/specs/`. Both changes are ADDED-only, so `validate --strict` and merge order are unaffected, but archiving MUST do `add-bloommcp-package-baseline` first (creating the canonical spec), then this change (appending the CI-gate requirement).
 - **Affected code**:
   - `.github/workflows/pr-checks.yml` — one step added to the `python-audit` job.
   - `tests/unit/test_bloommcp_wheel_import_gate.py` — new file.

--- a/openspec/changes/add-bloommcp-wheel-import-ci/proposal.md
+++ b/openspec/changes/add-bloommcp-wheel-import-ci/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The `bloommcp-packaging` capability (added by `add-bloommcp-package-baseline`, PR #313) declares:
+
+> **Scenario: Built wheel imports under the new namespace**
+> WHEN the package is built with `uv build` and the resulting wheel is installed into a clean environment
+> THEN `bloom_mcp`, `bloom_mcp.tools`, and `bloom_mcp.storage` import without error
+
+**No automated check exercises the built wheel.** Every import test in `bloommcp/tests/test_package_baseline.py` loads `bloom_mcp` off `src/` on `sys.path`, so it still passes even if the `[tool.uv.build-backend]` packaging (`module-name` / `module-root` at `bloommcp/pyproject.toml`) or the `__init__.py` / `__main__.py` layout were misconfigured and the wheel shipped nothing importable. `uv build` was run once by hand (baseline task 4.5) but is not gated in CI, so a packaging regression — a renamed module root, a dropped `__init__.py`, a wheel that ships an empty namespace — would merge green.
+
+This change closes that gap by building the wheel in CI and importing it from a clean, project-free environment that cannot see the source tree, so a packaging regression actually fails the PR. Tracked out of the review of #313 (refs #313, #305).
+
+## What Changes
+
+- **ADD** a build + clean-import step to the existing `python-audit` job in `.github/workflows/pr-checks.yml` (the job that already runs the bloommcp Supabase-free suite, the `Run bloom_mcp package tests` step). The step:
+  - builds the wheel in `bloommcp/`, then imports it from a project-free env and asserts the import resolved the **wheel**, not the `src/` checkout:
+    ```bash
+    cd bloommcp
+    rm -rf dist
+    uv build --wheel
+    wheel=$(echo dist/bloommcp-*.whl)
+    test -f "$wheel" || { echo "expected exactly one wheel, got: $wheel"; exit 1; }
+    uv run --no-project --with "$wheel" \
+      python -c "import bloom_mcp, bloom_mcp.tools, bloom_mcp.storage, bloom_mcp.server; assert 'site-packages' in bloom_mcp.__file__, bloom_mcp.__file__"
+    ```
+  - `--no-project` + `--with <wheel>` resolves the wheel into an ephemeral env with **no** editable/`src` path, so the import exercises the shipped artifact, not the checkout. The `__file__` assertion makes that load-bearing: if `--no-project` ever stopped being honored and `src/` leaked back onto the path, the gate fails instead of passing green.
+  - `--isolated` is deliberately **omitted**: `--no-project` already delivers the src-free namespace (the actual goal), whereas `--isolated` bypasses the uv cache and cold-downloads the entire heavy runtime closure (`sleap-roots-analyze`, `statsmodels`, `umap-learn`→`numba`/`llvmlite`, `scipy`, `fastmcp`, `supabase`…) from PyPI on every run — minutes of networked, PyPI-flaky cost for zero smoke-test benefit.
+  - `rm -rf dist` + the single-wheel `test -f` guard defend against a stale/multi-match glob (and keep the CI step in parity with the local repro). `--wheel` builds wheel-only, so no sdist pollutes the glob. (`uv build` has no `--frozen` flag — unlike `uv run`/`uv export`, it builds in PEP 517 isolation and never syncs the project env, so there is no lockfile to freeze.)
+  - runs with `SUPABASE_URL: ""` and `BLOOM_AGENT_KEY: ""` (matching the sibling test step), proving the lazy-validation contract — `import bloom_mcp.*` must succeed with no usable Supabase env. (Empty string, not literal unset, is the accurate description and matches the sibling step; for the import-only contract the two are equivalent because all env validation is deferred to `validate_env()` and never runs at import.)
+- **ADD** a regression-guard unit test (`tests/unit/test_bloommcp_wheel_import_gate.py`) that parses `pr-checks.yml` and asserts the `python-audit` job contains a step which (a) runs `uv build` in `bloommcp`, (b) imports **all four** of `bloom_mcp`, `bloom_mcp.tools`, `bloom_mcp.storage`, `bloom_mcp.server` from a `--no-project` env, and (c) pins `SUPABASE_URL` / `BLOOM_AGENT_KEY` empty — so the gate cannot be silently deleted or quietly narrowed. It reuses the `_iter_steps` / `_logical_lines` helpers from `tests/unit/test_ci_workflow_uv_conventions.py` (backslash-continuation joining matters — the import line is multi-line) and matches on step *presence*, never a fixed index. This is the TDD vehicle: it fails (red) before the workflow step exists and passes (green) after. Runs inside the existing `Run Python unit tests` step (`uv run --extra test pytest tests/unit/`) — no new job.
+- **EXTEND** the `bloommcp-packaging` spec with one ADDED requirement — "CI Gates the Built-Wheel Import" — so the wheel-import scenario gains a CI-enforcement clause. ADDED-only, so the delta composes cleanly with PR #313 regardless of merge order.
+- **VERIFY** `bloommcp/dist/` is not committed (`.gitignore:20` already lists `dist/`); the task confirms it and the guard does not require committing artifacts.
+
+## Impact
+
+- **Affected specs**: `bloommcp-packaging` (ADDED only — composes with PR #313's in-flight capability).
+- **Affected code**:
+  - `.github/workflows/pr-checks.yml` — one step added to the `python-audit` job.
+  - `tests/unit/test_bloommcp_wheel_import_gate.py` — new file.
+- **Affected CI**: no new job. The build+import runs in `python-audit` (already has `setup-uv`); the guard test runs in the existing unit-test step. Adds one `uv build` (seconds) to that job.
+- **uv-convention guard interaction**: the existing `tests/unit/test_ci_workflow_uv_conventions.py` forbids `--with` only on lines that contain BOTH `uv run` AND `pytest` (Invariant 3). The clean-import line uses `uv run ... --with <wheel> python -c` — no `pytest` — so it is permitted. Invariant 1 (no `pip install uv`) and Invariant 2 (no `setup-python` alongside uv) are also satisfied.
+- **Dependency on #313**: the `src/bloom_mcp` layout and `[tool.uv.build-backend]` config this gate exercises exist only on PR #313's branch. This change is stacked on `eberrigan/bloommcp-tier0-baseline` and **cannot merge before #313** (the `uv build` config and the anchor step don't exist on `staging`).
+- **`pr-checks.yml` conflict on rebase-onto-staging (expected)**: #313 edits the same `python-audit` hunk this change appends to. While stacked there is no conflict, but after #313 merges to `staging` (esp. via squash/rebase → new SHAs), retargeting + rebasing this branch onto `staging` will conflict in `pr-checks.yml`. Resolution is mechanical: keep **both** the merged `Run bloom_mcp package tests` step and the new wheel-import step. Do not rely on GitHub auto-retarget; assume a manual rebase (see tasks.md §4). The spec delta itself is ADDED-only and composes cleanly regardless of merge order — only the YAML hunk overlaps.
+
+## Non-goals
+
+- Not building or scanning a Docker image — the `docker-build` job already builds/Trivy-scans the bloommcp image; this is a pure wheel-import gate.
+- Not editing `bloommcp/pyproject.toml` packaging config — that is #313's deliverable; this change only exercises it.
+- Not editing `openspec/project.md` or `CLAUDE.md` (the latter is managed by `openspec update`).

--- a/openspec/changes/add-bloommcp-wheel-import-ci/specs/bloommcp-packaging/spec.md
+++ b/openspec/changes/add-bloommcp-wheel-import-ci/specs/bloommcp-packaging/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: CI Gates the Built-Wheel Import
+
+CI SHALL build the `bloommcp` wheel (wheel-only, resolving to exactly one artifact)
+with `uv build` and import it from a clean, project-free environment that does not see
+the `bloommcp/src/` tree, so a packaging regression that ships an unimportable wheel
+fails the PR. The import SHALL cover `bloom_mcp`, `bloom_mcp.tools`, `bloom_mcp.storage`,
+and `bloom_mcp.server`, SHALL assert the imported package resolves from the installed
+wheel and not the source checkout, and SHALL run with `SUPABASE_URL` and `BLOOM_AGENT_KEY`
+set empty (no usable Supabase env) so the lazy-validation contract is load-bearing.
+CI SHALL retain a regression-guard test asserting the gate's presence so it cannot be
+silently deleted. Built artifacts (`bloommcp/dist/`) SHALL NOT be committed.
+
+#### Scenario: Clean-env wheel import is gated by CI
+
+- **WHEN** the `python-audit` job runs `uv build --wheel` in `bloommcp/` and
+  imports the resulting wheel via `uv run --no-project --with <wheel>
+  python -c "import bloom_mcp, bloom_mcp.tools, bloom_mcp.storage, bloom_mcp.server;
+  assert 'site-packages' in bloom_mcp.__file__"`
+- **THEN** the import resolves the shipped wheel (the `__file__` assertion proves it is
+  not the `src/` checkout) and a packaging regression — a misconfigured `module-name` /
+  `module-root`, a dropped `__init__.py`, or a wheel that ships an empty namespace —
+  fails the job
+
+#### Scenario: Wheel import gate runs with no Supabase env
+
+- **WHEN** the clean-env import runs with `SUPABASE_URL` and `BLOOM_AGENT_KEY` set empty
+- **THEN** `import bloom_mcp`, `bloom_mcp.tools`, `bloom_mcp.storage`, and
+  `bloom_mcp.server` succeed and raise no `RuntimeError`, proving no import-time Supabase
+  dependency
+
+#### Scenario: Gate presence is regression-guarded
+
+- **WHEN** the `tests/unit/` suite parses `.github/workflows/pr-checks.yml`
+- **THEN** it asserts the `python-audit` job contains a step that runs `uv build` in
+  `bloommcp`, imports `bloom_mcp` from a `--no-project` environment, and pins
+  `SUPABASE_URL` / `BLOOM_AGENT_KEY` empty — failing the PR if the gate is removed

--- a/openspec/changes/add-bloommcp-wheel-import-ci/specs/bloommcp-packaging/spec.md
+++ b/openspec/changes/add-bloommcp-wheel-import-ci/specs/bloommcp-packaging/spec.md
@@ -2,26 +2,26 @@
 
 ### Requirement: CI Gates the Built-Wheel Import
 
-CI SHALL build the `bloommcp` wheel (wheel-only, resolving to exactly one artifact)
-with `uv build` and import it from a clean, project-free environment that does not see
-the `bloommcp/src/` tree, so a packaging regression that ships an unimportable wheel
+CI SHALL build the `bloommcp` wheel and import it from a clean environment that cannot
+see the `bloommcp/src/` tree, so a packaging regression that ships an unimportable wheel
 fails the PR. The import SHALL cover `bloom_mcp`, `bloom_mcp.tools`, `bloom_mcp.storage`,
-and `bloom_mcp.server`, SHALL assert the imported package resolves from the installed
-wheel and not the source checkout, and SHALL run with `SUPABASE_URL` and `BLOOM_AGENT_KEY`
-set empty (no usable Supabase env) so the lazy-validation contract is load-bearing.
-CI SHALL retain a regression-guard test asserting the gate's presence so it cannot be
-silently deleted. Built artifacts (`bloommcp/dist/`) SHALL NOT be committed.
+and `bloom_mcp.server`, SHALL verify the imported package resolves from the installed
+wheel and not the source checkout, and SHALL run with no usable Supabase environment
+(`SUPABASE_URL` / `BLOOM_AGENT_KEY` empty) so the lazy-validation contract is
+load-bearing. CI SHALL retain a regression-guard test asserting the gate's presence and
+its load-bearing assertions so it cannot be silently deleted or hollowed out. Built
+artifacts (`bloommcp/dist/`) SHALL NOT be committed. (The exact `uv` invocation and the
+rationale for omitting `--isolated` live in the proposal and tasks, not this contract.)
 
 #### Scenario: Clean-env wheel import is gated by CI
 
-- **WHEN** the `python-audit` job runs `uv build --wheel` in `bloommcp/` and
-  imports the resulting wheel via `uv run --no-project --with <wheel>
-  python -c "import bloom_mcp, bloom_mcp.tools, bloom_mcp.storage, bloom_mcp.server;
-  assert 'site-packages' in bloom_mcp.__file__"`
-- **THEN** the import resolves the shipped wheel (the `__file__` assertion proves it is
-  not the `src/` checkout) and a packaging regression — a misconfigured `module-name` /
-  `module-root`, a dropped `__init__.py`, or a wheel that ships an empty namespace —
-  fails the job
+- **WHEN** the `python-audit` job builds the wheel and imports `bloom_mcp` and its
+  `tools`, `storage`, and `server` submodules in an environment that does not place
+  `bloommcp/src/` on the import path
+- **THEN** the import resolves the shipped wheel (verified by checking the imported
+  package's file location, not the `src/` checkout) and a packaging regression — a
+  misconfigured `module-name` / `module-root`, a dropped `__init__.py`, or a wheel that
+  ships an empty namespace — fails the job
 
 #### Scenario: Wheel import gate runs with no Supabase env
 
@@ -33,6 +33,8 @@ silently deleted. Built artifacts (`bloommcp/dist/`) SHALL NOT be committed.
 #### Scenario: Gate presence is regression-guarded
 
 - **WHEN** the `tests/unit/` suite parses `.github/workflows/pr-checks.yml`
-- **THEN** it asserts the `python-audit` job contains a step that runs `uv build` in
-  `bloommcp`, imports `bloom_mcp` from a `--no-project` environment, and pins
-  `SUPABASE_URL` / `BLOOM_AGENT_KEY` empty — failing the PR if the gate is removed
+- **THEN** it asserts the `python-audit` job contains a step that builds the wheel in
+  `bloommcp`, imports all four modules from a project-free environment, installs the
+  built wheel, verifies the import resolved from the wheel (not `src/`), and pins
+  `SUPABASE_URL` / `BLOOM_AGENT_KEY` empty — failing the PR if the gate is removed or any
+  of its load-bearing assertions is dropped

--- a/openspec/changes/add-bloommcp-wheel-import-ci/tasks.md
+++ b/openspec/changes/add-bloommcp-wheel-import-ci/tasks.md
@@ -1,0 +1,64 @@
+## 1. Test-first: regression-guard for the gate (TDD red)
+
+- [x] 1.1 Create `tests/unit/test_bloommcp_wheel_import_gate.py`. **Reuse** the `_iter_steps` and `_logical_lines` helpers from `tests/unit/test_ci_workflow_uv_conventions.py` (import them, or factor both files onto a shared `tests/unit/_workflow_helpers.py`) — logical-line joining matters because the import command is split across physical lines with backslash continuations. PyYAML is already in the root `test` extra (added by `harden-ci-uv-conventions`). Locate the `python-audit` job and assert it contains **a** step (match on presence, never a fixed index) whose joined `run:` body:
+  - runs `uv build` with the working dir in `bloommcp` (`cd bloommcp` then a `uv build` line), AND
+  - imports from a project-free env — a logical line contains `--no-project` AND names **all four** modules `import bloom_mcp`, `bloom_mcp.tools`, `bloom_mcp.storage`, `bloom_mcp.server` (so the gate can't be silently narrowed), AND
+  - the step's `env:` sets `SUPABASE_URL` and `BLOOM_AGENT_KEY` to empty strings.
+  Do NOT assert on `--isolated` (the step deliberately omits it). Emit a locating failure message (`f"pr-checks.yml: python-audit: <missing assertion>"`). The test MUST FAIL before task 2 (no such step exists yet).
+- [x] 1.2 Run `cd ~/bloom && uv run --extra test pytest tests/unit/test_bloommcp_wheel_import_gate.py -v` and confirm red.
+
+## 2. Add the build + clean-import step (TDD green)
+
+- [x] 2.1 In `.github/workflows/pr-checks.yml`, add a step to the `python-audit` job, after the `Run bloom_mcp package tests` step:
+  ```yaml
+  # Build the wheel and import it from a clean, project-free env so a
+  # packaging regression (bad module-name/module-root, dropped __init__.py,
+  # empty-namespace wheel) fails the PR — the src/-on-sys.path import tests
+  # and the editable Docker install can't catch that. The __file__ assert
+  # proves the import resolved the wheel, not src/. --no-project gives the
+  # src-free namespace; --isolated is omitted on purpose (it would cold-
+  # download the whole heavy dep tree from PyPI every run). rm -rf dist +
+  # the single-wheel test guard the glob. SUPABASE_URL/BLOOM_AGENT_KEY empty
+  # keeps the lazy-validation contract load-bearing. `--with <wheel>` is
+  # permitted by the uv-conventions guard (Invariant 3 only forbids --with
+  # alongside pytest; this line runs `python -c`, not pytest). (uv build has
+  # no --frozen flag — it builds in PEP 517 isolation, nothing to freeze.)
+  - name: Build bloom_mcp wheel and import in a clean env
+    run: |
+      cd bloommcp
+      rm -rf dist
+      uv build --wheel
+      wheel=$(echo dist/bloommcp-*.whl)
+      test -f "$wheel" || { echo "expected exactly one wheel, got: $wheel"; exit 1; }
+      uv run --no-project --with "$wheel" \
+        python -c "import bloom_mcp, bloom_mcp.tools, bloom_mcp.storage, bloom_mcp.server; assert 'site-packages' in bloom_mcp.__file__, bloom_mcp.__file__"
+    env:
+      SUPABASE_URL: ""
+      BLOOM_AGENT_KEY: ""
+  ```
+- [x] 2.2 Run the guard test again — confirm green: `uv run --extra test pytest tests/unit/test_bloommcp_wheel_import_gate.py -v`.
+- [x] 2.3 Confirm the existing uv-conventions guard still passes (the new `--with` line co-occurs with `python`, not `pytest`): `uv run --extra test pytest tests/unit/test_ci_workflow_uv_conventions.py -v`.
+
+## 3. Verify the step locally end-to-end
+
+- [x] 3.1 Reproduce the CI step locally to prove a real wheel imports clean:
+  ```bash
+  cd bloommcp && rm -rf dist && uv build --wheel
+  SUPABASE_URL="" BLOOM_AGENT_KEY="" \
+    uv run --no-project --with ./dist/bloommcp-*.whl \
+    python -c "import bloom_mcp, bloom_mcp.tools, bloom_mcp.storage, bloom_mcp.server; assert 'site-packages' in bloom_mcp.__file__, bloom_mcp.__file__; print('clean import OK:', bloom_mcp.__file__)"
+  ```
+- [x] 3.2 Sanity-check the negative path: confirm the import would fail if the wheel were misconfigured (e.g. temporarily build with a broken `module-name`, observe non-zero exit, then revert). Document the observation in the PR description; do not commit the broken config.
+- [x] 3.3 Confirm `bloommcp/dist/` is gitignored (`.gitignore:20` lists `dist/`) and `git status` shows no `dist/` artifacts staged.
+
+## 4. Validate + finalize
+
+- [x] 4.1 `openspec validate add-bloommcp-wheel-import-ci --strict` passes.
+- [x] 4.2 Full unit suite green: `uv run --extra test pytest tests/unit/ -v`.
+- [ ] 4.3 Update `tasks.md` checkboxes via `/openspec:apply`; open the PR (base: `eberrigan/bloommcp-tier0-baseline`, stacked on #313) with `/pr-description`. Commit the new test and the `pr-checks.yml` step **together** (one `ci(bloommcp):` commit) so no pushed commit is red — the red→green cycle (tasks 1.2/2.2) is a local TDD checkpoint, not a commit boundary. Squash-merge. Suggested commits: `docs(bloommcp): OpenSpec proposal — CI-gate built-wheel import` (proposal docs) then `ci(bloommcp): build wheel + clean-import gate in python-audit` (test + workflow).
+- [ ] 4.4 **After #313 merges to `staging`**: retarget this PR's base to `staging` in the GitHub UI, then rebase onto the new tip (do not rely on GitHub auto-retarget — #313 may squash/rebase-merge to new SHAs):
+  ```bash
+  git fetch origin staging
+  git rebase --onto origin/staging eberrigan/bloommcp-tier0-baseline add-bloommcp-wheel-import-ci
+  ```
+  Expect a `pr-checks.yml` conflict (the `python-audit` hunk overlaps #313's `Run bloom_mcp package tests` addition) — resolve by keeping **both** steps. Re-run the new guard test + `test_ci_workflow_uv_conventions.py`, confirm CI green against `staging`, then `git push --force-with-lease`.

--- a/openspec/changes/add-bloommcp-wheel-import-ci/tasks.md
+++ b/openspec/changes/add-bloommcp-wheel-import-ci/tasks.md
@@ -55,10 +55,5 @@
 
 - [x] 4.1 `openspec validate add-bloommcp-wheel-import-ci --strict` passes.
 - [x] 4.2 Full unit suite green: `uv run --extra test pytest tests/unit/ -v`.
-- [ ] 4.3 Update `tasks.md` checkboxes via `/openspec:apply`; open the PR (base: `eberrigan/bloommcp-tier0-baseline`, stacked on #313) with `/pr-description`. Commit the new test and the `pr-checks.yml` step **together** (one `ci(bloommcp):` commit) so no pushed commit is red — the red→green cycle (tasks 1.2/2.2) is a local TDD checkpoint, not a commit boundary. Squash-merge. Suggested commits: `docs(bloommcp): OpenSpec proposal — CI-gate built-wheel import` (proposal docs) then `ci(bloommcp): build wheel + clean-import gate in python-audit` (test + workflow).
-- [ ] 4.4 **After #313 merges to `staging`**: retarget this PR's base to `staging` in the GitHub UI, then rebase onto the new tip (do not rely on GitHub auto-retarget — #313 may squash/rebase-merge to new SHAs):
-  ```bash
-  git fetch origin staging
-  git rebase --onto origin/staging eberrigan/bloommcp-tier0-baseline add-bloommcp-wheel-import-ci
-  ```
-  Expect a `pr-checks.yml` conflict (the `python-audit` hunk overlaps #313's `Run bloom_mcp package tests` addition) — resolve by keeping **both** steps. Re-run the new guard test + `test_ci_workflow_uv_conventions.py`, confirm CI green against `staging`, then `git push --force-with-lease`.
+- [x] 4.3 Opened PR #320 with two commits — `docs(bloommcp): OpenSpec proposal …` then `ci(bloommcp): build wheel + clean-import gate in python-audit` (test + workflow together, so no pushed commit is red; the red→green cycle in 1.2/2.2 was a local TDD checkpoint).
+- [x] 4.4 #313 merged to `staging` (via merge-commit) while this was in flight, so PR #320 targets `staging` directly — no longer stacked. Rebased `add-bloommcp-wheel-import-ci` onto `origin/staging`: **clean, no `pr-checks.yml` conflict** (the merge-commit kept the baseline commit as an ancestor, so the `python-audit` hunk replayed without overlap). Re-ran the guard + `test_ci_workflow_uv_conventions.py` + `test_pr_checks_workflow_shape.py` (16 passed) and force-pushed with `--force-with-lease`.

--- a/tests/unit/_workflow_helpers.py
+++ b/tests/unit/_workflow_helpers.py
@@ -1,0 +1,60 @@
+"""Shared helpers for parsing ``.github/workflows/*.yml`` in unit tests.
+
+Extracted from ``test_ci_workflow_uv_conventions.py`` so multiple workflow-shape
+guards (e.g. ``test_bloommcp_wheel_import_gate.py``) can reuse the logical-line
+joiner without a test-module-imports-test-module coupling.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+
+def _strip_line_comment(line: str) -> str:
+    """Return the line with anything from an unquoted ``#`` onward removed.
+
+    Quoting in shell is permissive — we only care about defeating trivial
+    comment-out patterns like ``# pip install uv``. A character-by-character
+    scan that respects single/double quotes is sufficient for the workflow
+    files we audit.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    for ch in line:
+        if quote is None:
+            if ch == "#":
+                break
+            if ch in ("'", '"'):
+                quote = ch
+        elif ch == quote:
+            quote = None
+        out.append(ch)
+    return "".join(out)
+
+
+def _logical_lines(run_block: str) -> Iterator[tuple[int, str]]:
+    """Yield (starting-physical-line-number, joined-logical-line) pairs.
+
+    Physical lines connected by a trailing backslash (``\\``) are joined into one
+    logical line, matching shell continuation semantics. Comments are stripped
+    before the backslash check, so ``cmd \\  # comment`` continues correctly.
+    The starting physical line number is preserved so failure messages still
+    point at the right place.
+    """
+    physical = run_block.splitlines()
+    i = 0
+    while i < len(physical):
+        start = i + 1  # 1-based for human-readable error messages
+        accumulated: list[str] = []
+        while i < len(physical):
+            stripped = _strip_line_comment(physical[i]).rstrip()
+            if stripped.endswith("\\"):
+                accumulated.append(stripped[:-1].rstrip())
+                i += 1
+                continue
+            accumulated.append(stripped)
+            i += 1
+            break
+        joined = " ".join(seg.strip() for seg in accumulated if seg.strip())
+        if joined:
+            yield start, joined

--- a/tests/unit/test_bloommcp_wheel_import_gate.py
+++ b/tests/unit/test_bloommcp_wheel_import_gate.py
@@ -1,0 +1,101 @@
+"""Regression-guard: the bloommcp built-wheel clean-import CI gate exists.
+
+Enforces the "CI Gates the Built-Wheel Import" requirement added by
+``openspec/changes/add-bloommcp-wheel-import-ci/specs/bloommcp-packaging/spec.md``.
+
+The real behavioural assertion (does the wheel actually import?) can only run
+in CI — it needs ``uv build`` plus a network resolve of the heavy runtime
+closure (sleap-roots-analyze, statsmodels, umap, scipy, fastmcp, ...). This
+local guard instead asserts the gate is PRESENT and correctly shaped in
+``.github/workflows/pr-checks.yml`` so it cannot be silently deleted or quietly
+narrowed (e.g. dropping a module from the import line, or removing the empty
+Supabase env that makes the lazy-validation contract load-bearing).
+
+Mirrors ``tests/unit/test_ci_workflow_uv_conventions.py`` and reuses its
+logical-line joiner so a gate whose command is split across backslash
+continuations is still detected. Matches on step *presence* (never a fixed
+index), so reordering steps in ``python-audit`` does not break the guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tests.unit.test_ci_workflow_uv_conventions import _logical_lines
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+PR_CHECKS = REPO_ROOT / ".github" / "workflows" / "pr-checks.yml"
+
+JOB = "python-audit"
+# All four must appear on the import line — `bloom_mcp.server` imports the whole
+# tool surface + both validate_env functions, so it is the strongest single
+# assertion that the shipped wheel's namespace is intact.
+REQUIRED_IMPORTS = (
+    "bloom_mcp",
+    "bloom_mcp.tools",
+    "bloom_mcp.storage",
+    "bloom_mcp.server",
+)
+EMPTY_ENV_VARS = ("SUPABASE_URL", "BLOOM_AGENT_KEY")
+
+
+def _python_audit_steps() -> list[dict]:
+    """Return the ``python-audit`` job's steps from pr-checks.yml."""
+    workflow = yaml.safe_load(PR_CHECKS.read_text(encoding="utf-8"))
+    jobs = workflow.get("jobs") or {}
+    assert JOB in jobs, f"pr-checks.yml has no {JOB!r} job"
+    return jobs[JOB].get("steps") or []
+
+
+def _logical_run(step: dict) -> str:
+    """Join a step's ``run`` body into one string with continuations resolved."""
+    return " ".join(line for _, line in _logical_lines(str(step.get("run") or "")))
+
+
+def _find_gate_step() -> dict | None:
+    """Locate the wheel build + clean-import step by shape, not by name/index."""
+    for step in _python_audit_steps():
+        run = _logical_run(step)
+        if "cd bloommcp" in run and "uv build" in run and "--no-project" in run:
+            return step
+    return None
+
+
+def test_wheel_import_gate_step_exists() -> None:
+    """A step builds the bloommcp wheel and imports it from a clean env."""
+    assert _find_gate_step() is not None, (
+        f"pr-checks.yml: {JOB}: no step builds the bloommcp wheel and imports it "
+        "from a clean (--no-project) env. The built-wheel import gate is missing — "
+        "see openspec/changes/add-bloommcp-wheel-import-ci."
+    )
+
+
+def test_wheel_import_gate_covers_all_modules() -> None:
+    """The import line names every required module (guards against narrowing)."""
+    step = _find_gate_step()
+    assert (
+        step is not None
+    ), "gate step missing (see test_wheel_import_gate_step_exists)"
+    run = _logical_run(step)
+    missing = [mod for mod in REQUIRED_IMPORTS if mod not in run]
+    assert not missing, (
+        f"pr-checks.yml: {JOB}: wheel-import gate omits {missing} from its import "
+        f"line; it must import all of {list(REQUIRED_IMPORTS)} so a narrowed "
+        "namespace still fails the gate."
+    )
+
+
+def test_wheel_import_gate_runs_with_empty_supabase_env() -> None:
+    """The gate pins SUPABASE_URL / BLOOM_AGENT_KEY empty (lazy-validation proof)."""
+    step = _find_gate_step()
+    assert (
+        step is not None
+    ), "gate step missing (see test_wheel_import_gate_step_exists)"
+    env = step.get("env") or {}
+    for var in EMPTY_ENV_VARS:
+        assert var in env and env[var] == "", (
+            f'pr-checks.yml: {JOB}: wheel-import gate must set {var}: "" so the '
+            f"lazy-validation contract is load-bearing; got {env.get(var)!r}."
+        )

--- a/tests/unit/test_bloommcp_wheel_import_gate.py
+++ b/tests/unit/test_bloommcp_wheel_import_gate.py
@@ -11,10 +11,14 @@ local guard instead asserts the gate is PRESENT and correctly shaped in
 narrowed (e.g. dropping a module from the import line, or removing the empty
 Supabase env that makes the lazy-validation contract load-bearing).
 
-Mirrors ``tests/unit/test_ci_workflow_uv_conventions.py`` and reuses its
-logical-line joiner so a gate whose command is split across backslash
-continuations is still detected. Matches on step *presence* (never a fixed
-index), so reordering steps in ``python-audit`` does not break the guard.
+Reuses the logical-line joiner from ``tests/unit/_workflow_helpers.py`` so a
+gate whose command is split across backslash continuations is still detected.
+Matches on step *presence* (never a fixed index), so reordering steps in
+``python-audit`` does not break the guard. The guard also asserts the gate's
+own load-bearing pieces — that it installs the built wheel (``--with`` the
+``bloommcp-*.whl``) and verifies provenance (``site-packages`` in
+``__file__``) — so a future edit cannot hollow the gate out while leaving it
+green.
 """
 
 from __future__ import annotations
@@ -23,7 +27,7 @@ from pathlib import Path
 
 import yaml
 
-from tests.unit.test_ci_workflow_uv_conventions import _logical_lines
+from tests.unit._workflow_helpers import _logical_lines
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 PR_CHECKS = REPO_ROOT / ".github" / "workflows" / "pr-checks.yml"
@@ -84,6 +88,35 @@ def test_wheel_import_gate_covers_all_modules() -> None:
         f"pr-checks.yml: {JOB}: wheel-import gate omits {missing} from its import "
         f"line; it must import all of {list(REQUIRED_IMPORTS)} so a narrowed "
         "namespace still fails the gate."
+    )
+
+
+def test_wheel_import_gate_installs_the_built_wheel() -> None:
+    """The gate imports the *built wheel* (``--with`` the bloommcp wheel), not src/."""
+    step = _find_gate_step()
+    assert (
+        step is not None
+    ), "gate step missing (see test_wheel_import_gate_step_exists)"
+    run = _logical_run(step)
+    assert "--with" in run and ("bloommcp-" in run and ".whl" in run), (
+        f"pr-checks.yml: {JOB}: wheel-import gate must install the built wheel via "
+        "`--with <bloommcp-*.whl>` so the import exercises the shipped artifact; "
+        "without it `--no-project` would import nothing (or leak src/)."
+    )
+
+
+def test_wheel_import_gate_asserts_wheel_provenance() -> None:
+    """The gate verifies the import resolved from the wheel, not the src/ checkout."""
+    step = _find_gate_step()
+    assert (
+        step is not None
+    ), "gate step missing (see test_wheel_import_gate_step_exists)"
+    run = _logical_run(step)
+    missing = [token for token in ("site-packages", "__file__") if token not in run]
+    assert not missing, (
+        f"pr-checks.yml: {JOB}: wheel-import gate is missing its provenance check "
+        f"({missing}); it must assert `'site-packages' in bloom_mcp.__file__` so a "
+        "regression that silently re-imports src/ still fails the gate."
     )
 
 

--- a/tests/unit/test_ci_workflow_uv_conventions.py
+++ b/tests/unit/test_ci_workflow_uv_conventions.py
@@ -34,6 +34,13 @@ from typing import Iterator, NamedTuple
 import pytest
 import yaml
 
+from tests.unit._workflow_helpers import _logical_lines, _strip_line_comment
+
+# Re-exported for backwards compatibility — these helpers now live in
+# tests/unit/_workflow_helpers.py so sibling workflow-shape guards can reuse
+# them without importing this test module.
+__all__ = ["_logical_lines", "_strip_line_comment"]
+
 REPO_ROOT = Path(__file__).parent.parent.parent
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
@@ -51,56 +58,6 @@ class Step(NamedTuple):
     name: str  # step `name:` or "<unnamed>"
     run: str  # `run:` body or ""
     uses: str  # `uses:` value or ""
-
-
-def _strip_line_comment(line: str) -> str:
-    """Return the line with anything from an unquoted `#` onward removed.
-
-    Quoting in shell is permissive — we only care about defeating trivial
-    comment-out patterns like `# pip install uv`. A character-by-character
-    scan that respects single/double quotes is sufficient for the workflow
-    files we audit.
-    """
-    out: list[str] = []
-    quote: str | None = None
-    for ch in line:
-        if quote is None:
-            if ch == "#":
-                break
-            if ch in ("'", '"'):
-                quote = ch
-        elif ch == quote:
-            quote = None
-        out.append(ch)
-    return "".join(out)
-
-
-def _logical_lines(run_block: str) -> Iterator[tuple[int, str]]:
-    """Yield (starting-physical-line-number, joined-logical-line) pairs.
-
-    Physical lines connected by a trailing backslash (`\\`) are joined into one
-    logical line, matching shell continuation semantics. Comments are stripped
-    before the backslash check, so `cmd \\  # comment` continues correctly.
-    The starting physical line number is preserved so failure messages still
-    point at the right place.
-    """
-    physical = run_block.splitlines()
-    i = 0
-    while i < len(physical):
-        start = i + 1  # 1-based for human-readable error messages
-        accumulated: list[str] = []
-        while i < len(physical):
-            stripped = _strip_line_comment(physical[i]).rstrip()
-            if stripped.endswith("\\"):
-                accumulated.append(stripped[:-1].rstrip())
-                i += 1
-                continue
-            accumulated.append(stripped)
-            i += 1
-            break
-        joined = " ".join(seg.strip() for seg in accumulated if seg.strip())
-        if joined:
-            yield start, joined
 
 
 def _iter_steps() -> Iterator[Step]:
@@ -289,7 +246,9 @@ def test_pytest_uses_extra_test_not_with() -> None:
             if "--extra test" not in line:
                 problems.append("missing `--extra test`")
             if "--with" in line:
-                problems.append("uses forbidden `--with` (test deps come from the test extra)")
+                problems.append(
+                    "uses forbidden `--with` (test deps come from the test extra)"
+                )
             if problems:
                 violations.append(
                     f"{_step_label(step)}: line {line_no}: {', '.join(problems)}: "


### PR DESCRIPTION
## Why

The `bloommcp-packaging` capability (#313) declares a *"Built wheel imports under the new namespace"* scenario, but **nothing exercised the built wheel**. Every import test in `bloommcp/tests/test_package_baseline.py` loads `bloom_mcp` off `src/` on `sys.path`, and the Docker image installs the package **editable** (src on path too) — so a packaging regression (bad `module-name`/`module-root`, dropped `__init__.py`, empty-namespace wheel) would merge green.

Closes #316. Tracked out of the review of #313 (refs #313, #305).

## What

Adds one step to the `python-audit` job in `.github/workflows/pr-checks.yml` that builds the wheel and imports it from a clean, project-free env:

```bash
cd bloommcp
rm -rf dist
uv build --wheel
wheel=$(echo dist/bloommcp-*.whl)
test -f "$wheel" || { echo "expected exactly one wheel, got: $wheel"; exit 1; }
uv run --no-project --with "$wheel" \
  python -c "import bloom_mcp, bloom_mcp.tools, bloom_mcp.storage, bloom_mcp.server; assert 'site-packages' in bloom_mcp.__file__, bloom_mcp.__file__"
```
with `SUPABASE_URL: ""` / `BLOOM_AGENT_KEY: ""`.

- **`--no-project`** gives the src-free namespace (the actual goal). **`--isolated` is deliberately omitted** — it bypasses the uv cache and would cold-download the whole heavy dep tree (sleap-roots-analyze/statsmodels/umap/scipy/fastmcp) from PyPI every run.
- The **`bloom_mcp.__file__` assert** makes the wheel-vs-src distinction load-bearing: if `--no-project` ever stopped being honored and `src/` leaked back, the gate fails instead of passing green.
- New regression guard `tests/unit/test_bloommcp_wheel_import_gate.py` asserts the gate stays present and can't be silently narrowed (reuses `_logical_lines` from `test_ci_workflow_uv_conventions.py`).
- Spec delta is **ADDED-only** on `bloommcp-packaging`.

## Verification (local)

- **TDD red→green**: guard failed before the step existed, passes after.
- `test_ci_workflow_uv_conventions.py` still passes — the `--with` line is allowed (Invariant 3 only forbids `--with` alongside `pytest`; this line runs `python -c`).
- **Real wheel build + clean import** succeeded — `bloom_mcp.__file__` resolved to the uv-cache `site-packages`, not `src/`.
- **Negative path**: project-mode import resolves `bloommcp/src/bloom_mcp/__init__.py` and the assert fires — proving the provenance check works.
- Full unit suite: **227 passed, 1 skipped**. `dist/` confirmed gitignored. Black + Ruff clean. Re-verified green after rebasing onto `staging`.

> Note: `uv build` has **no** `--frozen` flag (unlike `uv run`/`uv export`) — it builds in PEP 517 isolation and never syncs the project env, so there's no lockfile to freeze.

## Notes

- #313 (the `bloommcp-packaging` baseline this gate exercises) merged to `staging` while this was in flight, so this targets `staging` directly — no longer stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
