### PR TITLE
feat(bloommcp): Phase 2 · Tier 1 — contract layer (@as_mcp_tool, Provenance, manifest v3)

### DIFF
--- a/bloommcp/src/bloom_mcp/contract/__init__.py
+++ b/bloommcp/src/bloom_mcp/contract/__init__.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 from .errors import BloomMCPError
 from .provenance import Provenance, resolve_environment, resolve_seed
-from .wrap import as_mcp_tool
+from .wrap import as_mcp_tool, register
 
 __all__ = [
     "as_mcp_tool",
+    "register",
     "BloomMCPError",
     "Provenance",
     "resolve_environment",

--- a/bloommcp/src/bloom_mcp/contract/__init__.py
+++ b/bloommcp/src/bloom_mcp/contract/__init__.py
@@ -1,0 +1,20 @@
+"""bloom-mcp tool contract: the uniform wrapper, provenance, and errors.
+
+`@as_mcp_tool` gives every granular tool the same guarantees (validated Pydantic
+I/O, structured `BloomMCPError`s, a single stamped `Provenance`) so provenance
+and error handling are guaranteed by the contract, not per-tool boilerplate.
+"""
+
+from __future__ import annotations
+
+from .errors import BloomMCPError
+from .provenance import Provenance, resolve_environment, resolve_seed
+from .wrap import as_mcp_tool
+
+__all__ = [
+    "as_mcp_tool",
+    "BloomMCPError",
+    "Provenance",
+    "resolve_environment",
+    "resolve_seed",
+]

--- a/bloommcp/src/bloom_mcp/contract/errors.py
+++ b/bloommcp/src/bloom_mcp/contract/errors.py
@@ -1,11 +1,37 @@
 """Structured, agent-safe errors for the bloom-mcp tool contract.
 
 `@as_mcp_tool` maps every failure to a `BloomMCPError` carrying a stable `code`,
-a human `message`, and a `remedy`. A raw traceback is never returned to the
-agent — the structured form (`to_dict`) is what crosses the wire.
+a human `message`, and a `remedy`. Two promises hold:
+
+- **never a raw traceback** — failures are re-raised `from None`; and
+- **never leak internals** — an *internal* failure (an undeclared exception or
+  an output-contract breach) returns a fixed message plus a short correlation
+  id, while the detail (which may carry paths, hosts, connection strings, SQL,
+  or bucket keys) goes only to the server log. Input-validation errors surface
+  only the field locations + error types, never the offending values.
+
+A *declared* exception (one the tool author opted into via `errors=`) is treated
+as author-controlled and its message is passed through.
 """
 
 from __future__ import annotations
+
+import logging
+import uuid
+
+logger = logging.getLogger(__name__)
+
+
+def _validation_locs(exc: Exception) -> str:
+    """Summarize a Pydantic ValidationError as 'loc: type' pairs — no values."""
+    errors = getattr(exc, "errors", None)
+    if not callable(errors):
+        return "invalid input"
+    parts = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err.get("loc", ()))
+        parts.append(f"{loc or '<root>'}: {err.get('type', 'invalid')}")
+    return "; ".join(parts) or "invalid input"
 
 
 class BloomMCPError(Exception):
@@ -24,31 +50,42 @@ class BloomMCPError(Exception):
 
     @classmethod
     def from_input_validation(cls, exc: Exception) -> "BloomMCPError":
-        """Map an input-model validation failure to a user-fixable error."""
+        """Map an input-model validation failure to a user-fixable error.
+
+        Surfaces only the field locations + error types — never the offending
+        input values, which could carry sensitive data.
+        """
         return cls(
             code="invalid_input",
-            message=f"Input did not match the tool's schema: {exc}",
+            message=f"Input did not match the tool's schema ({_validation_locs(exc)}).",
             remedy="Correct the arguments to match the tool's input schema and retry.",
         )
 
     @classmethod
     def from_output_validation(cls, exc: Exception) -> "BloomMCPError":
-        """Map an output-model validation failure to an internal-breach error."""
+        """Map an output-model validation failure to an internal-breach error.
+
+        The detail is logged server-side under a correlation id; the agent sees
+        only the fixed message + the id.
+        """
+        ref = uuid.uuid4().hex[:12]
+        logger.error("output-contract breach [%s]: %s", ref, exc)
         return cls(
             code="internal_output_contract",
-            message=f"Tool produced output that violates its declared schema: {exc}",
-            remedy="This is an internal contract breach; report it — not a user error.",
+            message=f"Tool produced output that violates its declared schema (ref: {ref}).",
+            remedy="This is an internal contract breach; report the ref id — not a user error.",
         )
 
     @classmethod
     def from_exception(
         cls, exc: Exception, *, declared: tuple[type[Exception], ...] = ()
     ) -> "BloomMCPError":
-        """Map a raised exception to a structured error, never leaking a traceback.
+        """Map a raised exception to a structured error, never leaking internals.
 
-        Declared (expected) exceptions become a ``tool_error``; anything else is
-        an ``internal_error``. The ``message`` carries only ``str(exc)``, never a
-        formatted traceback.
+        A *declared* (expected, author-controlled) exception becomes a
+        ``tool_error`` whose message is passed through. Anything else becomes an
+        ``internal_error`` with a fixed message + correlation id; the detail is
+        logged server-side, never returned to the agent.
         """
         if isinstance(exc, declared):
             return cls(
@@ -56,8 +93,10 @@ class BloomMCPError(Exception):
                 message=str(exc) or exc.__class__.__name__,
                 remedy="Check the inputs/experiment for this tool and retry.",
             )
+        ref = uuid.uuid4().hex[:12]
+        logger.error("internal tool error [%s]", ref, exc_info=exc)
         return cls(
             code="internal_error",
-            message=str(exc) or exc.__class__.__name__,
-            remedy="An unexpected internal error occurred; report it.",
+            message=f"An unexpected internal error occurred (ref: {ref}).",
+            remedy="Report the ref id; the detail is in the server logs.",
         )

--- a/bloommcp/src/bloom_mcp/contract/errors.py
+++ b/bloommcp/src/bloom_mcp/contract/errors.py
@@ -1,0 +1,63 @@
+"""Structured, agent-safe errors for the bloom-mcp tool contract.
+
+`@as_mcp_tool` maps every failure to a `BloomMCPError` carrying a stable `code`,
+a human `message`, and a `remedy`. A raw traceback is never returned to the
+agent — the structured form (`to_dict`) is what crosses the wire.
+"""
+
+from __future__ import annotations
+
+
+class BloomMCPError(Exception):
+    """A structured error surfaced to the agent (code + message + remedy)."""
+
+    def __init__(self, code: str, message: str, remedy: str) -> None:
+        """Store the structured fields and a flat message for ``str()``."""
+        self.code = code
+        self.message = message
+        self.remedy = remedy
+        super().__init__(f"[{code}] {message} — {remedy}")
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the serializable structured form (no traceback)."""
+        return {"code": self.code, "message": self.message, "remedy": self.remedy}
+
+    @classmethod
+    def from_input_validation(cls, exc: Exception) -> "BloomMCPError":
+        """Map an input-model validation failure to a user-fixable error."""
+        return cls(
+            code="invalid_input",
+            message=f"Input did not match the tool's schema: {exc}",
+            remedy="Correct the arguments to match the tool's input schema and retry.",
+        )
+
+    @classmethod
+    def from_output_validation(cls, exc: Exception) -> "BloomMCPError":
+        """Map an output-model validation failure to an internal-breach error."""
+        return cls(
+            code="internal_output_contract",
+            message=f"Tool produced output that violates its declared schema: {exc}",
+            remedy="This is an internal contract breach; report it — not a user error.",
+        )
+
+    @classmethod
+    def from_exception(
+        cls, exc: Exception, *, declared: tuple[type[Exception], ...] = ()
+    ) -> "BloomMCPError":
+        """Map a raised exception to a structured error, never leaking a traceback.
+
+        Declared (expected) exceptions become a ``tool_error``; anything else is
+        an ``internal_error``. The ``message`` carries only ``str(exc)``, never a
+        formatted traceback.
+        """
+        if isinstance(exc, declared):
+            return cls(
+                code="tool_error",
+                message=str(exc) or exc.__class__.__name__,
+                remedy="Check the inputs/experiment for this tool and retry.",
+            )
+        return cls(
+            code="internal_error",
+            message=str(exc) or exc.__class__.__name__,
+            remedy="An unexpected internal error occurred; report it.",
+        )

--- a/bloommcp/src/bloom_mcp/contract/models.py
+++ b/bloommcp/src/bloom_mcp/contract/models.py
@@ -11,14 +11,18 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from bloom_mcp.contract.provenance import SEED_MAX
 
 
 class ToolParams(BaseModel):
     """Base input params for a contract-wrapped tool.
 
     The `seed` is optional; when absent, `@as_mcp_tool` resolves a concrete
-    integer and records it in `Provenance` so the run stays reproducible.
+    integer and records it in `Provenance` so the run stays reproducible. It is
+    `strict` and range-bound to `[0, SEED_MAX)` so a float/bool/out-of-range
+    value is rejected at input validation rather than recorded-but-invalid.
     """
 
-    seed: Optional[int] = None
+    seed: Optional[int] = Field(default=None, ge=0, lt=SEED_MAX, strict=True)

--- a/bloommcp/src/bloom_mcp/contract/models.py
+++ b/bloommcp/src/bloom_mcp/contract/models.py
@@ -1,0 +1,24 @@
+"""Base Pydantic I/O models for contract-wrapped tools.
+
+Tier 1 ships a minimal base: #191 (per-tool Pydantic input models) is unmerged,
+and the real `pca_analysis` / `clustering` models arrive with the granular tools
+(Tiers 3/4). `ToolParams` carries the one field the contract reads directly —
+the optional `seed`, which `@as_mcp_tool` resolves and propagates as
+`random_state=`. Real tool params extend this base.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ToolParams(BaseModel):
+    """Base input params for a contract-wrapped tool.
+
+    The `seed` is optional; when absent, `@as_mcp_tool` resolves a concrete
+    integer and records it in `Provenance` so the run stays reproducible.
+    """
+
+    seed: Optional[int] = None

--- a/bloommcp/src/bloom_mcp/contract/provenance.py
+++ b/bloommcp/src/bloom_mcp/contract/provenance.py
@@ -1,8 +1,9 @@
 """Canonical provenance for the bloom-mcp tool contract.
 
-`Provenance` is stamped exactly once per tool call at **contract time** (around
-delegation, before any artifact is written) and is the single source of truth
-for the manifest `VersionEntry` — there is no parallel provenance record. The
+`Provenance` is stamped at most once per tool call at **contract time** (around
+delegation, before any artifact is written; skipped when input validation fails,
+and discarded on any later failure path) and is the single source of truth for
+the manifest `VersionEntry` — there is no parallel provenance record. The
 per-artifact content hashes (`output_sha256`) and logical storage keys
 (`output_keys`) are **not** contract-time fields: the artifact bytes do not
 exist until the tool writes them to staging, so they are populated at commit by
@@ -32,16 +33,25 @@ from bloom_mcp.storage.schema import CodeVersions, VersionEntry
 # exact-environment identifier when bloom-mcp runs containerized.
 _IMAGE_DIGEST_ENV = "BLOOM_MCP_IMAGE_DIGEST"
 
+# Inclusive-exclusive upper bound for a seed: numpy/sklearn accept [0, 2**32).
+SEED_MAX = 2**32
+
 
 def resolve_seed(seed: Optional[int]) -> int:
     """Resolve the seed actually used: the given value, or a fresh integer.
 
     Recording the *resolved* seed (never null) is what makes a stochastic run
-    reproducible — replaying the recorded integer reproduces the artifact.
+    reproducible — replaying the recorded integer reproduces the artifact. A
+    provided seed must be a plain ``int`` in ``[0, SEED_MAX)`` (``bool`` is
+    rejected, since ``True``/``False`` would silently coerce to ``1``/``0``).
     """
-    if seed is not None:
-        return int(seed)
-    return secrets.randbelow(2**32)
+    if seed is None:
+        return secrets.randbelow(SEED_MAX)
+    if isinstance(seed, bool) or not isinstance(seed, int):
+        raise ValueError(f"seed must be an int in [0, {SEED_MAX}); got {seed!r}")
+    if not 0 <= seed < SEED_MAX:
+        raise ValueError(f"seed must be in [0, {SEED_MAX}); got {seed}")
+    return seed
 
 
 def _uv_lock_hash() -> Optional[str]:
@@ -50,7 +60,10 @@ def _uv_lock_hash() -> Optional[str]:
     for parent in here.parents:
         lock = parent / "uv.lock"
         if lock.is_file():
-            digest = hashlib.sha256(lock.read_bytes()).hexdigest()
+            try:
+                digest = hashlib.sha256(lock.read_bytes()).hexdigest()
+            except OSError:
+                return None
             return f"uvlock:{digest[:16]}"
     return None
 
@@ -61,11 +74,15 @@ def resolve_environment() -> Optional[str]:
     Precedence: container image digest (`BLOOM_MCP_IMAGE_DIGEST`) → `bloom-mcp`
     version → `uv.lock` content hash. Returns None only when none resolves
     (optional for schema back-compat); a persisted run (Tier 2) is expected to
-    carry a value that actually pins a reproducible environment.
+    carry a value that actually pins a reproducible environment. A digest is
+    accepted only when it is a non-empty `sha256:…` string (whitespace stripped);
+    a malformed digest falls through to the next source rather than being stored.
     """
     digest = os.getenv(_IMAGE_DIGEST_ENV)
     if digest:
-        return digest
+        digest = digest.strip()
+        if digest.startswith("sha256:") and len(digest) > len("sha256:"):
+            return digest
 
     versions = get_code_versions()
     if versions.bloommcp:
@@ -88,7 +105,9 @@ class Provenance(BaseModel):
 
     tool: str
     params: dict
-    seed: int
+    # None only for a non-stochastic tool (one whose delegate takes no
+    # random_state); a stochastic call always records the resolved integer.
+    seed: Optional[int] = None
     agent: str = "bloom_agent"
     input_sha256: Optional[str] = None
     code_versions: CodeVersions
@@ -108,11 +127,15 @@ class Provenance(BaseModel):
         *,
         tool: str,
         params: dict,
-        seed: int,
+        seed: Optional[int] = None,
         agent: str = "bloom_agent",
         input_sha256: Optional[str] = None,
     ) -> "Provenance":
-        """Stamp a contract-time record, resolving code_versions + environment once."""
+        """Stamp a contract-time record, resolving code_versions + environment once.
+
+        `seed` is the *resolved* seed when the tool applied one, or None for a
+        non-stochastic tool.
+        """
         return cls(
             tool=tool,
             params=params,

--- a/bloommcp/src/bloom_mcp/contract/provenance.py
+++ b/bloommcp/src/bloom_mcp/contract/provenance.py
@@ -1,0 +1,150 @@
+"""Canonical provenance for the bloom-mcp tool contract.
+
+`Provenance` is stamped exactly once per tool call at **contract time** (around
+delegation, before any artifact is written) and is the single source of truth
+for the manifest `VersionEntry` — there is no parallel provenance record. The
+per-artifact content hashes (`output_sha256`) and logical storage keys
+(`output_keys`) are **not** contract-time fields: the artifact bytes do not
+exist until the tool writes them to staging, so they are populated at commit by
+the `ResultStore` (Tier 2) and merged into the same single version entry.
+
+The exact-environment pointer (`resolve_environment`) records *which environment
+produced the run* — the container image digest, or the `bloom-mcp` version whose
+committed `uv.lock` reproduces the env. `code_versions` is a human-readable
+trace; only the locked environment pins the library math (numpy/scipy/sklearn).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from bloom_mcp.storage.code_versions import get_code_versions
+from bloom_mcp.storage.schema import CodeVersions, VersionEntry
+
+# Set at container build to the image digest (`sha256:…`); the tightest
+# exact-environment identifier when bloom-mcp runs containerized.
+_IMAGE_DIGEST_ENV = "BLOOM_MCP_IMAGE_DIGEST"
+
+
+def resolve_seed(seed: Optional[int]) -> int:
+    """Resolve the seed actually used: the given value, or a fresh integer.
+
+    Recording the *resolved* seed (never null) is what makes a stochastic run
+    reproducible — replaying the recorded integer reproduces the artifact.
+    """
+    if seed is not None:
+        return int(seed)
+    return secrets.randbelow(2**32)
+
+
+def _uv_lock_hash() -> Optional[str]:
+    """Return a short content hash of the nearest committed ``uv.lock``, if any."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        lock = parent / "uv.lock"
+        if lock.is_file():
+            digest = hashlib.sha256(lock.read_bytes()).hexdigest()
+            return f"uvlock:{digest[:16]}"
+    return None
+
+
+def resolve_environment() -> Optional[str]:
+    """Resolve the exact-environment pointer by precedence.
+
+    Precedence: container image digest (`BLOOM_MCP_IMAGE_DIGEST`) → `bloom-mcp`
+    version → `uv.lock` content hash. Returns None only when none resolves
+    (optional for schema back-compat); a persisted run (Tier 2) is expected to
+    carry a value that actually pins a reproducible environment.
+    """
+    digest = os.getenv(_IMAGE_DIGEST_ENV)
+    if digest:
+        return digest
+
+    versions = get_code_versions()
+    if versions.bloommcp:
+        lock = _uv_lock_hash()
+        suffix = f"+{lock}" if lock else ""
+        return f"bloommcp=={versions.bloommcp}{suffix}"
+
+    return _uv_lock_hash()
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 'Z' string (seconds)."""
+    return (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+
+class Provenance(BaseModel):
+    """The canonical contract-time provenance for a single tool call."""
+
+    tool: str
+    params: dict
+    seed: int
+    agent: str = "bloom_agent"
+    input_sha256: Optional[str] = None
+    code_versions: CodeVersions
+    environment: Optional[str] = None
+    created_at: str = Field(default_factory=_utc_now_iso)
+    based_on_version: str = "raw"
+    # Per-artifact fields — empty at contract time, filled at commit (Tier 2).
+    outputs: dict[str, str] = Field(default_factory=dict)
+    output_sha256: dict[str, str] = Field(default_factory=dict)
+    output_keys: dict[str, str] = Field(default_factory=dict)
+    user_label: Optional[str] = None
+    version_dir: str = ""
+
+    @classmethod
+    def stamp(
+        cls,
+        *,
+        tool: str,
+        params: dict,
+        seed: int,
+        agent: str = "bloom_agent",
+        input_sha256: Optional[str] = None,
+    ) -> "Provenance":
+        """Stamp a contract-time record, resolving code_versions + environment once."""
+        return cls(
+            tool=tool,
+            params=params,
+            seed=seed,
+            agent=agent,
+            input_sha256=input_sha256,
+            code_versions=get_code_versions(),
+            environment=resolve_environment(),
+        )
+
+    def to_version_entry(self, *, version_id: str) -> VersionEntry:
+        """Project this provenance into a manifest VersionEntry (schema v3).
+
+        The version id is allocated at commit time by the `ResultStore`, so it is
+        passed in. Per-artifact `output_sha256` / `output_keys` carry whatever is
+        on the record (empty at contract time; filled by the store at commit).
+        `input_sha256` is intentionally not set here — it lives on the manifest's
+        `ExperimentBlock`, not the version entry.
+        """
+        return VersionEntry(
+            id=version_id,
+            created_at=self.created_at,
+            tool=self.tool,
+            params=self.params,
+            based_on_version=self.based_on_version,
+            code_versions=self.code_versions,
+            outputs=self.outputs,
+            user_label=self.user_label,
+            version_dir=self.version_dir,
+            seed=self.seed,
+            agent=self.agent,
+            environment=self.environment,
+            output_sha256=self.output_sha256,
+            output_keys=self.output_keys,
+        )

--- a/bloommcp/src/bloom_mcp/contract/wrap.py
+++ b/bloommcp/src/bloom_mcp/contract/wrap.py
@@ -1,0 +1,116 @@
+"""`@as_mcp_tool` — the uniform contract every granular tool wraps.
+
+This decorator is **our own** glue layered over FastMCP (the MCP framework,
+already a dependency) with **Pydantic** for the I/O models — it wraps, it does
+not replace. On every call it:
+
+1. validates the tool's declared Pydantic **input** model (→ `BloomMCPError`),
+2. resolves the seed (a concrete integer even when none was given) and stamps a
+   single contract-time `Provenance`,
+3. invokes the tool, injecting the resolved `random_state` and the `provenance`
+   into the call **only** for parameters the tool declares (an explicit
+   kwarg-injection contract — not name inference),
+4. maps any raised exception to a structured `BloomMCPError` (never a raw
+   traceback), and
+5. validates the declared Pydantic **output** model (→ `BloomMCPError`).
+
+It does **not** call `np.random.seed()`: global re-seeding would duplicate and
+fight `sleap-roots-analyze`'s per-estimator seeding (and would not reach UMAP's
+numba RNG). Determinism of the function is upstream's (CI-guarded);
+reproducibility of the stored artifact is ours, via the recorded resolved seed.
+
+Registration onto a FastMCP instance happens through a `register(mcp)` seam at
+server-wiring time — the `mcp` instance does not exist at decoration time, and
+Tier 1 does not modify `server.py`. The wrapped callable carries a clean
+single-`params` signature so FastMCP builds a correct input schema without
+seeing the injected `random_state` / `provenance` kwargs.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+from pydantic import BaseModel, ValidationError
+
+from .errors import BloomMCPError
+from .provenance import Provenance, resolve_seed
+
+# Kwargs the decorator injects into a tool that declares them.
+_INJECTED = ("random_state", "provenance")
+
+
+def as_mcp_tool(
+    *,
+    input_model: type[BaseModel],
+    output_model: type[BaseModel],
+    errors: tuple[type[Exception], ...] = (),
+) -> Callable[[Callable], Callable]:
+    """Wrap a tool with the bloom-mcp contract guarantees.
+
+    Args:
+        input_model: Pydantic model validating the tool's inputs (carries `seed`).
+        output_model: Pydantic model validating the tool's result.
+        errors: Declared exception types mapped to a `tool_error` BloomMCPError;
+            anything else maps to an `internal_error` (never a raw traceback).
+
+    Returns:
+        A decorator producing a contract-wrapped callable, registrable onto a
+        FastMCP instance via `mcp.tool()(wrapped)` in a `register(mcp)` seam.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        accepted = set(inspect.signature(func).parameters)
+
+        def wrapper(params: Any = None, /, **kwargs: Any) -> BaseModel:
+            raw = params if params is not None else kwargs
+            if isinstance(raw, input_model):
+                data = raw
+            else:
+                try:
+                    data = input_model.model_validate(raw)
+                except ValidationError as exc:
+                    raise BloomMCPError.from_input_validation(exc) from None
+
+            seed = resolve_seed(getattr(data, "seed", None))
+            provenance = Provenance.stamp(
+                tool=func.__name__, params=data.model_dump(), seed=seed
+            )
+
+            injectable = {"random_state": seed, "provenance": provenance}
+            extra = {k: v for k, v in injectable.items() if k in accepted}
+
+            try:
+                result = func(data, **extra)
+            except BloomMCPError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — mapped, never re-raised raw
+                raise BloomMCPError.from_exception(exc, declared=errors) from None
+
+            if isinstance(result, output_model):
+                return result
+            try:
+                return output_model.model_validate(result)
+            except ValidationError as exc:
+                raise BloomMCPError.from_output_validation(exc) from None
+
+        # Present a clean single-`params` signature to FastMCP (hides the
+        # injected kwargs); preserve identity for registration + discovery.
+        wrapper.__name__ = func.__name__
+        wrapper.__qualname__ = func.__name__
+        wrapper.__doc__ = func.__doc__
+        wrapper.__module__ = func.__module__
+        wrapper.__signature__ = inspect.Signature(
+            [
+                inspect.Parameter(
+                    "params",
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=input_model,
+                )
+            ],
+            return_annotation=output_model,
+        )
+        wrapper.__annotations__ = {"params": input_model, "return": output_model}
+        return wrapper
+
+    return decorator

--- a/bloommcp/src/bloom_mcp/contract/wrap.py
+++ b/bloommcp/src/bloom_mcp/contract/wrap.py
@@ -5,29 +5,36 @@ already a dependency) with **Pydantic** for the I/O models — it wraps, it does
 not replace. On every call it:
 
 1. validates the tool's declared Pydantic **input** model (→ `BloomMCPError`),
-2. resolves the seed (a concrete integer even when none was given) and stamps a
-   single contract-time `Provenance`,
+2. resolves the seed and stamps a single contract-time `Provenance`,
 3. invokes the tool, injecting the resolved `random_state` and the `provenance`
    into the call **only** for parameters the tool declares (an explicit
    kwarg-injection contract — not name inference),
 4. maps any raised exception to a structured `BloomMCPError` (never a raw
-   traceback), and
+   traceback, never leaked internals), and
 5. validates the declared Pydantic **output** model (→ `BloomMCPError`).
+
+**Seed provenance integrity.** The resolved seed is recorded in `Provenance`
+*only when it is actually applied* — i.e. the delegate declares a
+``random_state`` parameter. A non-stochastic tool (no ``random_state``) records
+``seed=None``. If a seed was *explicitly provided* but the delegate cannot
+accept it, that is a tool-wiring bug and raises an ``internal_error`` rather than
+recording a seed that never reached the computation (a reproducibility lie).
 
 It does **not** call `np.random.seed()`: global re-seeding would duplicate and
 fight `sleap-roots-analyze`'s per-estimator seeding (and would not reach UMAP's
 numba RNG). Determinism of the function is upstream's (CI-guarded);
 reproducibility of the stored artifact is ours, via the recorded resolved seed.
 
-Registration onto a FastMCP instance happens through a `register(mcp)` seam at
-server-wiring time — the `mcp` instance does not exist at decoration time, and
-Tier 1 does not modify `server.py`. The wrapped callable carries a clean
-single-`params` signature so FastMCP builds a correct input schema without
-seeing the injected `random_state` / `provenance` kwargs.
+**Registration.** Tools register onto a FastMCP instance through the
+`register(mcp, *tools)` seam at server-wiring time — the `mcp` instance does not
+exist at decoration time, and Tier 1 does not modify `server.py`. The wrapped
+callable carries a clean single-`params` signature so FastMCP builds a correct
+input schema without seeing the injected `random_state` / `provenance` kwargs.
 """
 
 from __future__ import annotations
 
+import functools
 import inspect
 from typing import Any, Callable
 
@@ -36,8 +43,17 @@ from pydantic import BaseModel, ValidationError
 from .errors import BloomMCPError
 from .provenance import Provenance, resolve_seed
 
-# Kwargs the decorator injects into a tool that declares them.
-_INJECTED = ("random_state", "provenance")
+
+def register(mcp: Any, *tools: Callable) -> Any:
+    """Register contract-wrapped tools onto a FastMCP instance.
+
+    The seam the spec mandates: keeps tools decoupled from the live `mcp`
+    instance at decoration time. Equivalent to calling `mcp.tool()(tool)` for
+    each, returned `mcp` for chaining.
+    """
+    for tool in tools:
+        mcp.tool()(tool)
+    return mcp
 
 
 def as_mcp_tool(
@@ -52,17 +68,21 @@ def as_mcp_tool(
         input_model: Pydantic model validating the tool's inputs (carries `seed`).
         output_model: Pydantic model validating the tool's result.
         errors: Declared exception types mapped to a `tool_error` BloomMCPError;
-            anything else maps to an `internal_error` (never a raw traceback).
+            anything else maps to an `internal_error` (never a raw traceback,
+            never leaked internals).
 
     Returns:
         A decorator producing a contract-wrapped callable, registrable onto a
-        FastMCP instance via `mcp.tool()(wrapped)` in a `register(mcp)` seam.
+        FastMCP instance via `register(mcp, wrapped)`.
     """
 
     def decorator(func: Callable) -> Callable:
         accepted = set(inspect.signature(func).parameters)
+        accepts_seed = "random_state" in accepted
+        accepts_provenance = "provenance" in accepted
 
-        def wrapper(params: Any = None, /, **kwargs: Any) -> BaseModel:
+        @functools.wraps(func)
+        def wrapper(params: Any = None, **kwargs: Any) -> BaseModel:
             raw = params if params is not None else kwargs
             if isinstance(raw, input_model):
                 data = raw
@@ -72,13 +92,35 @@ def as_mcp_tool(
                 except ValidationError as exc:
                     raise BloomMCPError.from_input_validation(exc) from None
 
-            seed = resolve_seed(getattr(data, "seed", None))
+            requested = getattr(data, "seed", None)
+            if accepts_seed:
+                try:
+                    seed = resolve_seed(requested)
+                except (ValueError, TypeError) as exc:
+                    raise BloomMCPError.from_input_validation(exc) from None
+            elif requested is not None:
+                # A seed was given but the delegate can't apply it — recording it
+                # would be a reproducibility lie. Surface a tool-wiring bug.
+                raise BloomMCPError(
+                    code="internal_error",
+                    message=(
+                        "A seed was provided but this tool's delegate does not "
+                        "accept a random_state parameter."
+                    ),
+                    remedy="Remove the seed, or wire the delegate to accept random_state.",
+                )
+            else:
+                seed = None
+
             provenance = Provenance.stamp(
                 tool=func.__name__, params=data.model_dump(), seed=seed
             )
 
-            injectable = {"random_state": seed, "provenance": provenance}
-            extra = {k: v for k, v in injectable.items() if k in accepted}
+            extra: dict[str, Any] = {}
+            if accepts_seed:
+                extra["random_state"] = seed
+            if accepts_provenance:
+                extra["provenance"] = provenance
 
             try:
                 result = func(data, **extra)
@@ -95,11 +137,9 @@ def as_mcp_tool(
                 raise BloomMCPError.from_output_validation(exc) from None
 
         # Present a clean single-`params` signature to FastMCP (hides the
-        # injected kwargs); preserve identity for registration + discovery.
-        wrapper.__name__ = func.__name__
-        wrapper.__qualname__ = func.__name__
-        wrapper.__doc__ = func.__doc__
-        wrapper.__module__ = func.__module__
+        # injected kwargs). `functools.wraps` preserves identity + `__wrapped__`
+        # (so `inspect.unwrap` works); the explicit `__signature__` takes
+        # precedence over `__wrapped__` for `inspect.signature`.
         wrapper.__signature__ = inspect.Signature(
             [
                 inspect.Parameter(

--- a/bloommcp/src/bloom_mcp/storage/code_versions.py
+++ b/bloommcp/src/bloom_mcp/storage/code_versions.py
@@ -6,6 +6,8 @@ rather than recorded as `"unknown"` — a vendored/uninstalled package reads as
 noise and obscures the real provenance trace.
 """
 
+from __future__ import annotations
+
 from importlib.metadata import PackageNotFoundError, version
 
 from .schema import CodeVersions

--- a/bloommcp/src/bloom_mcp/storage/code_versions.py
+++ b/bloommcp/src/bloom_mcp/storage/code_versions.py
@@ -1,20 +1,37 @@
-"""Read installed package versions for manifest provenance."""
+"""Read installed package versions for manifest provenance.
+
+Installed-only: a version is recorded for a distribution only when it is
+actually pip-installed. An uninstalled distribution is omitted (left `None`)
+rather than recorded as `"unknown"` — a vendored/uninstalled package reads as
+noise and obscures the real provenance trace.
+"""
 
 from importlib.metadata import PackageNotFoundError, version
 
 from .schema import CodeVersions
 
+# Distribution name (PyPI/pip) -> CodeVersions field name.
+_TRACKED = {
+    "bloommcp": "bloommcp",
+    "supabase": "supabase",
+    "sleap-roots-analyze": "sleap_roots_analyze",
+    "sleap-roots-contracts": "sleap_roots_contracts",
+}
 
-def _version_or_unknown(package_name: str) -> str:
+
+def _installed_version(distribution: str):
+    """Return the installed version of `distribution`, or None if absent."""
     try:
-        return version(package_name)
+        return version(distribution)
     except PackageNotFoundError:
-        return "unknown"
+        return None
 
 
 def get_code_versions() -> CodeVersions:
-    """Return installed versions of packages whose provenance is captured per run."""
-    return CodeVersions(
-        bloommcp=_version_or_unknown("bloommcp"),
-        supabase=_version_or_unknown("supabase"),
-    )
+    """Return installed versions of the tracked distributions (installed-only)."""
+    fields = {}
+    for dist, field in _TRACKED.items():
+        installed = _installed_version(dist)
+        if installed is not None:
+            fields[field] = installed
+    return CodeVersions(**fields)

--- a/bloommcp/src/bloom_mcp/storage/schema.py
+++ b/bloommcp/src/bloom_mcp/storage/schema.py
@@ -1,9 +1,15 @@
-"""Pydantic models for manifest.json (schema version 2).
+"""Pydantic models for manifest.json (schema version 3).
 
 Every (experiment, tool_class) pair has one manifest.json in the
 bloommcp-data bucket listing all its runs. These models define what
 goes in it.
 
+Schema version 3 is an **additive** bump over v2: it adds optional provenance
+fields (`seed`, `agent`, `environment`) and per-artifact content-addressing
+(`output_sha256`, `output_keys`) alongside the retained v2 `outputs` string map,
+and extends `code_versions` with `sleap-roots-analyze` / `sleap-roots-contracts`.
+Every new field is optional, so previously-written v2 manifests still validate
+and read without error (see `tests/contract/test_v2_backcompat.py`).
 
 Strict mode is on: passing an unknown field raises a ValidationError
 instead of being silently accepted into the file.
@@ -13,7 +19,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 
 class _StrictModel(BaseModel):
@@ -24,11 +30,17 @@ class _StrictModel(BaseModel):
 
 class CodeVersions(_StrictModel):
     """Installed package versions captured at write time for provenance.
-    Useful to track which version of the code generated the output in the wrote folder.
+
+    Useful to track which version of the code generated the output in the wrote
+    folder. Every field is **installed-only**: a version is recorded only for an
+    actually pip-installed distribution; an absent distribution is omitted (left
+    `None`) rather than recorded as the literal `"unknown"` (which is noise).
     """
 
-    bloommcp: str
-    supabase: str = "unknown"
+    bloommcp: Optional[str] = None
+    supabase: Optional[str] = None
+    sleap_roots_analyze: Optional[str] = None
+    sleap_roots_contracts: Optional[str] = None
 
 
 class ExperimentBlock(_StrictModel):
@@ -41,7 +53,15 @@ class ExperimentBlock(_StrictModel):
 
 class VersionEntry(_StrictModel):
     """Every time a tool runs and commits a file, a new version of result is noted on the manifest file.
+
     'id' is "v<N>" for the Nth run on this experiment.
+
+    Schema-v3 additive fields: `seed` (resolved random_state) and `agent`/actor
+    for reproducibility provenance; `environment` for the exact-environment
+    pointer; and the per-artifact `output_sha256` / `output_keys` sibling maps
+    (keyed by the same logical output name as `outputs`) for content addressing.
+    The v2 `outputs: dict[str, str]` field is retained unchanged so v2 manifests
+    still load under `extra="forbid"`.
     """
 
     id: str
@@ -53,6 +73,12 @@ class VersionEntry(_StrictModel):
     outputs: dict[str, str]
     user_label: Optional[str] = None
     version_dir: str = ""
+    # --- v3 additive (all optional → v2 manifests still validate) ---
+    seed: Optional[int] = None
+    agent: Optional[str] = None
+    environment: Optional[str] = None
+    output_sha256: dict[str, str] = Field(default_factory=dict)
+    output_keys: dict[str, str] = Field(default_factory=dict)
 
 
 class Manifest(_StrictModel):

--- a/bloommcp/src/bloom_mcp/storage/schema.py
+++ b/bloommcp/src/bloom_mcp/storage/schema.py
@@ -15,6 +15,8 @@ Strict mode is on: passing an unknown field raises a ValidationError
 instead of being silently accepted into the file.
 """
 
+from __future__ import annotations
+
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/bloommcp/tests/contract/conftest.py
+++ b/bloommcp/tests/contract/conftest.py
@@ -1,0 +1,34 @@
+"""Shared stub tool + models for the contract-layer unit suite.
+
+Tier 1 has no real analysis tools (``pca_analysis``/``clustering`` are Tiers
+3/4), so the contract decorator is exercised against a **stub** tool and a
+**stub params model** standing in for the unmerged #191 input models. A
+recorder captures what the decorator injects (resolved ``random_state`` and the
+stamped ``Provenance``) so tests can assert the contract guarantees at the
+wrapper boundary with no live Supabase.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from bloom_mcp.contract.models import ToolParams
+
+
+class StubInput(ToolParams):
+    """Stub tool input — extends the base params (inherits the optional seed)."""
+
+    experiment: str
+
+
+class StubOutput(BaseModel):
+    """Stub tool output."""
+
+    n_components: int
+
+
+@pytest.fixture
+def recorder() -> dict:
+    """Mutable holder for what the stub tool receives from the decorator."""
+    return {}

--- a/bloommcp/tests/contract/test_code_versions_installed_only.py
+++ b/bloommcp/tests/contract/test_code_versions_installed_only.py
@@ -1,0 +1,39 @@
+"""code_versions records installed distributions only — never "unknown".
+
+Maps the spec "Installed-Only Code Versions" scenarios: installed dists are
+recorded with no "unknown"; an uninstalled dist is omitted rather than recorded
+as the literal "unknown".
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+
+import bloom_mcp.storage.code_versions as cv
+
+
+def test_installed_distributions_recorded_no_unknown():
+    """analyze + contracts are recorded; no field is the literal 'unknown'."""
+    versions = cv.get_code_versions()
+    dumped = versions.model_dump(exclude_none=True)
+
+    assert "unknown" not in dumped.values()
+    assert dumped.get("sleap_roots_analyze")
+    assert dumped.get("sleap_roots_contracts")
+    assert dumped.get("bloommcp")
+
+
+def test_uninstalled_distribution_omitted_not_unknown(monkeypatch):
+    """A distribution that is not installed is omitted, not set to 'unknown'."""
+    real_version = cv.version
+
+    def fake_version(name: str) -> str:
+        if name == "supabase":
+            raise PackageNotFoundError(name)
+        return real_version(name)
+
+    monkeypatch.setattr(cv, "version", fake_version)
+
+    dumped = cv.get_code_versions().model_dump(exclude_none=True)
+    assert "supabase" not in dumped
+    assert "unknown" not in dumped.values()

--- a/bloommcp/tests/contract/test_decorator_contract.py
+++ b/bloommcp/tests/contract/test_decorator_contract.py
@@ -1,0 +1,69 @@
+"""@as_mcp_tool: Pydantic I/O validation + the register(mcp) seam.
+
+Maps the spec "Uniform Tool Contract Decorator" scenarios: a decorated stub
+validates I/O and is discoverable once registered; invalid input is rejected
+before the body runs; invalid output is an internal contract breach. All run
+with no live Supabase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from bloom_mcp.contract import BloomMCPError, as_mcp_tool
+
+from .conftest import StubInput, StubOutput
+
+
+def test_valid_input_returns_validated_output_and_is_registrable():
+    """Valid input returns the output object; the tool lists via FastMCP."""
+    from fastmcp import FastMCP
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput) -> StubOutput:
+        return StubOutput(n_components=3)
+
+    out = stub_tool({"experiment": "turface_19"})
+    assert isinstance(out, StubOutput)
+    assert out.n_components == 3
+
+    mcp = FastMCP("test")
+    mcp.tool()(stub_tool)
+
+    async def _names():
+        from fastmcp import Client
+
+        async with Client(mcp) as client:
+            return {t.name for t in await client.list_tools()}
+
+    assert "stub_tool" in asyncio.run(_names())
+
+
+def test_invalid_input_rejected_before_body_runs(recorder):
+    """Input violating the model surfaces as BloomMCPError; body never runs."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput) -> StubOutput:
+        recorder["body_ran"] = True
+        return StubOutput(n_components=3)
+
+    with pytest.raises(BloomMCPError) as exc:
+        stub_tool({"seed": 7})  # missing required `experiment`
+
+    assert exc.value.code == "invalid_input"
+    assert "body_ran" not in recorder
+
+
+def test_invalid_output_is_internal_contract_breach():
+    """Output violating the model surfaces as a coded internal BloomMCPError."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput):
+        return {"n_components": "not-an-int"}
+
+    with pytest.raises(BloomMCPError) as exc:
+        stub_tool({"experiment": "turface_19"})
+
+    assert exc.value.code == "internal_output_contract"

--- a/bloommcp/tests/contract/test_decorator_contract.py
+++ b/bloommcp/tests/contract/test_decorator_contract.py
@@ -12,13 +12,13 @@ import asyncio
 
 import pytest
 
-from bloom_mcp.contract import BloomMCPError, as_mcp_tool
+from bloom_mcp.contract import BloomMCPError, as_mcp_tool, register
 
 from .conftest import StubInput, StubOutput
 
 
 def test_valid_input_returns_validated_output_and_is_registrable():
-    """Valid input returns the output object; the tool lists via FastMCP."""
+    """Valid input returns the output object; the tool lists via the register seam."""
     from fastmcp import FastMCP
 
     @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
@@ -29,8 +29,7 @@ def test_valid_input_returns_validated_output_and_is_registrable():
     assert isinstance(out, StubOutput)
     assert out.n_components == 3
 
-    mcp = FastMCP("test")
-    mcp.tool()(stub_tool)
+    mcp = register(FastMCP("test"), stub_tool)
 
     async def _names():
         from fastmcp import Client
@@ -39,6 +38,20 @@ def test_valid_input_returns_validated_output_and_is_registrable():
             return {t.name for t in await client.list_tools()}
 
     assert "stub_tool" in asyncio.run(_names())
+
+
+def test_params_accepted_positionally_and_by_keyword():
+    """The advertised signature matches: `params` works positionally and by keyword."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput) -> StubOutput:
+        return StubOutput(n_components=len(params.experiment))
+
+    by_dict = stub_tool({"experiment": "abc"})
+    by_keyword = stub_tool(params={"experiment": "abc"})
+    by_model = stub_tool(params=StubInput(experiment="abc"))
+
+    assert by_dict.n_components == by_keyword.n_components == by_model.n_components == 3
 
 
 def test_invalid_input_rejected_before_body_runs(recorder):

--- a/bloommcp/tests/contract/test_environment_pointer.py
+++ b/bloommcp/tests/contract/test_environment_pointer.py
@@ -1,0 +1,28 @@
+"""The environment pointer resolves by precedence and is reproducible.
+
+Maps the spec "Exact-Environment Provenance Pointer" scenarios: the image
+digest takes precedence when present; otherwise a non-empty fallback resolves
+(never "unknown", distinct from the code_versions trace).
+"""
+
+from __future__ import annotations
+
+from bloom_mcp.contract.provenance import resolve_environment
+from bloom_mcp.storage.code_versions import get_code_versions
+
+
+def test_image_digest_takes_precedence(monkeypatch):
+    """BLOOM_MCP_IMAGE_DIGEST, when set, is the environment pointer."""
+    monkeypatch.setenv("BLOOM_MCP_IMAGE_DIGEST", "sha256:abc123")
+    assert resolve_environment() == "sha256:abc123"
+
+
+def test_fallback_is_non_empty_and_distinct(monkeypatch):
+    """With no digest, the fallback resolves non-empty, never 'unknown'."""
+    monkeypatch.delenv("BLOOM_MCP_IMAGE_DIGEST", raising=False)
+
+    env = resolve_environment()
+    assert env
+    assert env != "unknown"
+    # Distinct from the human-readable code_versions trace.
+    assert env != get_code_versions().model_dump(exclude_none=True)

--- a/bloommcp/tests/contract/test_error_envelope.py
+++ b/bloommcp/tests/contract/test_error_envelope.py
@@ -1,0 +1,37 @@
+"""@as_mcp_tool maps a raised exception to a structured BloomMCPError.
+
+Maps the spec "Structured Agent-Safe Errors" scenario: a declared exception
+becomes a BloomMCPError (code + message + remedy), never a raw traceback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bloom_mcp.contract import BloomMCPError, as_mcp_tool
+
+from .conftest import StubInput, StubOutput
+
+
+class _ToolFailure(Exception):
+    """A declared tool-side failure."""
+
+
+def test_declared_exception_becomes_structured_error():
+    """A raised exception surfaces as a complete BloomMCPError."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput, errors=(_ToolFailure,))
+    def stub_tool(params: StubInput) -> StubOutput:
+        raise _ToolFailure("upstream blew up")
+
+    with pytest.raises(BloomMCPError) as exc:
+        stub_tool({"experiment": "turface_19"})
+
+    err = exc.value
+    assert err.code
+    assert err.message
+    assert err.remedy
+    # The structured form is serializable and leaks no traceback.
+    payload = err.to_dict()
+    assert set(payload) >= {"code", "message", "remedy"}
+    assert "Traceback" not in payload["message"]

--- a/bloommcp/tests/contract/test_error_envelope.py
+++ b/bloommcp/tests/contract/test_error_envelope.py
@@ -35,3 +35,36 @@ def test_declared_exception_becomes_structured_error():
     payload = err.to_dict()
     assert set(payload) >= {"code", "message", "remedy"}
     assert "Traceback" not in payload["message"]
+
+
+def test_undeclared_exception_does_not_leak_internal_detail():
+    """An undeclared exception's detail goes to logs, not the agent message."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput) -> StubOutput:
+        raise RuntimeError("postgres://user:pw@db.internal/secret bucket=private")
+
+    with pytest.raises(BloomMCPError) as exc:
+        stub_tool({"experiment": "turface_19"})
+
+    err = exc.value
+    assert err.code == "internal_error"
+    assert "postgres://" not in err.message
+    assert "secret" not in err.message
+    assert "ref:" in err.message  # correlation id for server-side lookup
+
+
+def test_input_validation_does_not_leak_offending_values():
+    """Input-validation errors surface field locations + types, never values."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput) -> StubOutput:
+        return StubOutput(n_components=3)
+
+    with pytest.raises(BloomMCPError) as exc:
+        stub_tool({"experiment": "turface_19", "seed": "leak-me-not"})
+
+    err = exc.value
+    assert err.code == "invalid_input"
+    assert "leak-me-not" not in err.message
+    assert "seed" in err.message  # the field location is named

--- a/bloommcp/tests/contract/test_provenance_roundtrip.py
+++ b/bloommcp/tests/contract/test_provenance_roundtrip.py
@@ -1,0 +1,58 @@
+"""Contract-time Provenance round-trips Pydantic <-> JSON exactly.
+
+Maps the spec "Canonical Contract-Time Provenance Record" scenarios: a
+fully-populated record round-trips with exact equality (no tolerance — this is
+serialization, not recomputation), and per-artifact hashes are empty at contract
+time.
+"""
+
+from __future__ import annotations
+
+import json
+
+from hypothesis import given, strategies as st
+
+from bloom_mcp.contract import Provenance
+from bloom_mcp.storage.schema import CodeVersions
+
+
+def _make(**overrides) -> Provenance:
+    base = dict(
+        tool="pca_analysis",
+        params={"n_components": 3, "svd_solver": "full"},
+        seed=42,
+        agent="bloom_agent",
+        input_sha256="ab" * 32,
+        code_versions=CodeVersions(bloommcp="0.1.0"),
+        environment="sha256:deadbeef",
+        created_at="2026-06-17T00:00:00Z",
+    )
+    base.update(overrides)
+    return Provenance(**base)
+
+
+def test_full_record_roundtrips_exactly():
+    """A fully-populated contract-time Provenance survives JSON unchanged."""
+    prov = _make()
+    again = Provenance.model_validate(json.loads(prov.model_dump_json()))
+    assert again == prov
+
+
+def test_per_artifact_hashes_empty_at_contract_time():
+    """The decorator stamps no per-artifact hashes/keys before delegation."""
+    prov = _make()
+    assert prov.output_sha256 == {}
+    assert prov.output_keys == {}
+    assert prov.outputs == {}
+
+
+@given(
+    seed=st.integers(min_value=0, max_value=2**32 - 1),
+    environment=st.one_of(st.none(), st.text(min_size=1, max_size=40)),
+    params=st.dictionaries(st.text(min_size=1, max_size=8), st.integers(), max_size=4),
+)
+def test_roundtrip_property(seed, environment, params):
+    """Round-trip equality holds across varied seed/environment/params."""
+    prov = _make(seed=seed, environment=environment, params=params)
+    again = Provenance.model_validate(json.loads(prov.model_dump_json()))
+    assert again == prov

--- a/bloommcp/tests/contract/test_provenance_to_version_entry.py
+++ b/bloommcp/tests/contract/test_provenance_to_version_entry.py
@@ -1,0 +1,63 @@
+"""Provenance maps into a v3 manifest VersionEntry — one provenance path.
+
+Maps the spec "Provenance Maps Into The Manifest VersionEntry" scenario: the
+mapping sets the contract-time fields, preserves the v2 fields, and leaves the
+per-artifact collections empty (filled by the ResultStore at commit in Tier 2).
+No live Supabase, no live write.
+"""
+
+from __future__ import annotations
+
+from bloom_mcp.contract import Provenance
+from bloom_mcp.storage.schema import CodeVersions, VersionEntry
+
+
+def _provenance() -> Provenance:
+    return Provenance(
+        tool="pca_analysis",
+        params={"n_components": 3},
+        seed=42,
+        agent="bloom_agent",
+        input_sha256="cd" * 32,
+        code_versions=CodeVersions(
+            bloommcp="0.1.0",
+            sleap_roots_analyze="0.1.0a2",
+            sleap_roots_contracts="0.1.0a1",
+        ),
+        environment="sha256:deadbeef",
+        created_at="2026-06-17T00:00:00Z",
+        based_on_version="raw",
+        outputs={"cleaned": "_cleaned.csv"},
+        user_label="run one",
+        version_dir="v1_2026-06-17_run_one",
+    )
+
+
+def test_mapping_yields_v3_version_entry_with_contract_fields():
+    """to_version_entry sets v3 fields, preserves v2 fields, defers per-artifact."""
+    prov = _provenance()
+    entry = prov.to_version_entry(version_id="v1")
+
+    assert isinstance(entry, VersionEntry)
+
+    # New v3 contract-time fields.
+    assert entry.seed == 42
+    assert entry.agent == "bloom_agent"
+    assert entry.environment == "sha256:deadbeef"
+    assert entry.code_versions.sleap_roots_analyze == "0.1.0a2"
+    assert entry.code_versions.sleap_roots_contracts == "0.1.0a1"
+
+    # Preserved v2 fields, with source values.
+    assert entry.id == "v1"
+    assert entry.created_at == "2026-06-17T00:00:00Z"
+    assert entry.tool == "pca_analysis"
+    assert entry.params == {"n_components": 3}
+    assert entry.based_on_version == "raw"
+    assert entry.code_versions.bloommcp == "0.1.0"
+    assert entry.outputs == {"cleaned": "_cleaned.csv"}
+    assert entry.user_label == "run one"
+    assert entry.version_dir == "v1_2026-06-17_run_one"
+
+    # Per-artifact content addressing is filled at commit (Tier 2), not now.
+    assert entry.output_sha256 == {}
+    assert entry.output_keys == {}

--- a/bloommcp/tests/contract/test_schema_v3.py
+++ b/bloommcp/tests/contract/test_schema_v3.py
@@ -1,0 +1,51 @@
+"""Manifest schema v3: new entries are v3 and v3 entries round-trip.
+
+Maps the spec "Additive Manifest Schema v3" forward-direction scenarios.
+"""
+
+from __future__ import annotations
+
+from bloom_mcp.storage.schema import (
+    CURRENT_SCHEMA_VERSION,
+    CodeVersions,
+    ExperimentBlock,
+    Manifest,
+    VersionEntry,
+)
+
+
+def _v3_entry() -> VersionEntry:
+    return VersionEntry(
+        id="v2",
+        created_at="2026-06-17T00:00:00Z",
+        tool="pca_analysis",
+        params={"n_components": 3},
+        based_on_version="raw",
+        code_versions=CodeVersions(bloommcp="0.1.0", sleap_roots_analyze="0.1.0a2"),
+        outputs={"loadings": "_loadings.csv"},
+        output_sha256={"loadings": "ab" * 32},
+        output_keys={"loadings": "bloommcp_output/pca_turface/v2/_loadings.csv"},
+        seed=42,
+        agent="bloom_agent",
+        environment="sha256:deadbeef",
+        user_label="run two",
+        version_dir="v2_2026-06-17_run_two",
+    )
+
+
+def test_current_schema_version_is_3():
+    """The schema constant and a fresh manifest both report version 3."""
+    assert CURRENT_SCHEMA_VERSION == 3
+    manifest = Manifest(
+        experiment=ExperimentBlock(
+            filename="x.csv", source_path="bloommcp_input/x.csv", input_sha256="0" * 64
+        )
+    )
+    assert manifest.manifest_schema_version == 3
+
+
+def test_v3_version_entry_roundtrips_exactly():
+    """A v3 entry with the new sibling collections round-trips through JSON."""
+    entry = _v3_entry()
+    again = VersionEntry.model_validate(entry.model_dump(mode="json"))
+    assert again == entry

--- a/bloommcp/tests/contract/test_seed_propagation.py
+++ b/bloommcp/tests/contract/test_seed_propagation.py
@@ -1,0 +1,61 @@
+"""@as_mcp_tool resolves, records, and propagates the seed — never global re-seed.
+
+Maps the spec "Seed Recording And Propagation Without Global Re-Seed"
+scenarios: a provided seed is forwarded as ``random_state=`` and recorded while
+the global RNG is untouched; an absent seed is resolved to a concrete integer
+and recorded (never null).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from bloom_mcp.contract import as_mcp_tool
+
+from .conftest import StubInput, StubOutput
+
+
+def _stub_with_recorder(recorder):
+    """A decorated stub that forwards random_state to a fake perform_* and
+    records what the decorator injected."""
+
+    def fake_perform(df=None, *, random_state):
+        recorder["delegate_random_state"] = random_state
+        return random_state
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(
+        params: StubInput, *, random_state=None, provenance=None
+    ) -> StubOutput:
+        fake_perform(random_state=random_state)
+        recorder["provenance"] = provenance
+        return StubOutput(n_components=3)
+
+    return stub_tool
+
+
+def test_provided_seed_recorded_forwarded_rng_untouched(recorder):
+    """A given seed reaches the delegate + Provenance; global RNG is unchanged."""
+    stub_tool = _stub_with_recorder(recorder)
+
+    before = np.random.get_state()
+    stub_tool({"experiment": "turface_19", "seed": 1234})
+    after = np.random.get_state()
+
+    assert recorder["delegate_random_state"] == 1234
+    assert recorder["provenance"].seed == 1234
+    # Byte-identical global RNG state: the decorator never called np.random.seed.
+    assert before[0] == after[0]
+    assert np.array_equal(before[1], after[1])
+    assert before[2:] == after[2:]
+
+
+def test_absent_seed_resolved_to_concrete_int(recorder):
+    """No seed → a concrete integer is resolved, forwarded, and recorded."""
+    stub_tool = _stub_with_recorder(recorder)
+
+    stub_tool({"experiment": "turface_19"})  # no seed
+
+    resolved = recorder["provenance"].seed
+    assert isinstance(resolved, int)
+    assert recorder["delegate_random_state"] == resolved

--- a/bloommcp/tests/contract/test_seed_propagation.py
+++ b/bloommcp/tests/contract/test_seed_propagation.py
@@ -9,10 +9,20 @@ and recorded (never null).
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
-from bloom_mcp.contract import as_mcp_tool
+from bloom_mcp.contract import BloomMCPError, as_mcp_tool
 
 from .conftest import StubInput, StubOutput
+
+
+def _rng_state_equal(before, after) -> bool:
+    """True if two numpy global RNG states are byte-identical."""
+    return (
+        before[0] == after[0]
+        and np.array_equal(before[1], after[1])
+        and before[2:] == after[2:]
+    )
 
 
 def _stub_with_recorder(recorder):
@@ -45,17 +55,52 @@ def test_provided_seed_recorded_forwarded_rng_untouched(recorder):
     assert recorder["delegate_random_state"] == 1234
     assert recorder["provenance"].seed == 1234
     # Byte-identical global RNG state: the decorator never called np.random.seed.
-    assert before[0] == after[0]
-    assert np.array_equal(before[1], after[1])
-    assert before[2:] == after[2:]
+    assert _rng_state_equal(before, after)
 
 
 def test_absent_seed_resolved_to_concrete_int(recorder):
-    """No seed → a concrete integer is resolved, forwarded, and recorded."""
+    """No seed → a concrete integer is resolved, forwarded, recorded; RNG untouched."""
     stub_tool = _stub_with_recorder(recorder)
 
+    before = np.random.get_state()
     stub_tool({"experiment": "turface_19"})  # no seed
+    after = np.random.get_state()
 
     resolved = recorder["provenance"].seed
     assert isinstance(resolved, int)
     assert recorder["delegate_random_state"] == resolved
+    assert _rng_state_equal(before, after)
+
+
+def test_non_stochastic_tool_records_no_seed(recorder):
+    """A tool whose delegate takes no random_state records seed=None."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput, *, provenance=None) -> StubOutput:
+        recorder["provenance"] = provenance
+        return StubOutput(n_components=3)
+
+    stub_tool({"experiment": "turface_19"})  # no seed, no random_state param
+    assert recorder["provenance"].seed is None
+
+
+def test_seed_provided_to_non_stochastic_tool_is_internal_error():
+    """A seed the delegate can't apply is a wiring bug, not a silent lie."""
+
+    @as_mcp_tool(input_model=StubInput, output_model=StubOutput)
+    def stub_tool(params: StubInput, *, provenance=None) -> StubOutput:
+        return StubOutput(n_components=3)
+
+    with pytest.raises(BloomMCPError) as exc:
+        stub_tool({"experiment": "turface_19", "seed": 7})
+    assert exc.value.code == "internal_error"
+
+
+def test_out_of_range_seed_rejected_as_invalid_input(recorder):
+    """An out-of-range seed is rejected at input validation, not recorded."""
+    stub_tool = _stub_with_recorder(recorder)
+
+    with pytest.raises(BloomMCPError) as exc:
+        stub_tool({"experiment": "turface_19", "seed": 2**32})  # == SEED_MAX (excl.)
+    assert exc.value.code == "invalid_input"
+    assert "provenance" not in recorder

--- a/bloommcp/tests/contract/test_v2_backcompat.py
+++ b/bloommcp/tests/contract/test_v2_backcompat.py
@@ -1,0 +1,35 @@
+"""Old v2 manifests still read under v3 code — the additive bump holds.
+
+Maps the spec "Additive Manifest Schema v3" back-compat scenario: a recorded v2
+manifest (string-valued ``outputs``, no v3 fields) validates under v3 code with
+``extra="forbid"`` still on, and its v3 fields default to unset.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bloom_mcp.storage.manifest import validate_schema
+from bloom_mcp.storage.schema import Manifest
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "manifest_v2.json"
+
+
+def test_recorded_v2_manifest_reads_under_v3():
+    """The committed v2 fixture validates and its v3 fields are unset."""
+    raw = json.loads(_FIXTURE.read_text())
+
+    validate_schema(raw)  # version 2 <= known (3): accepted
+    manifest = Manifest.model_validate(raw)
+
+    assert manifest.manifest_schema_version == 2
+    entry = manifest.versions[0]
+    # v2 string-valued outputs load unchanged under extra="forbid".
+    assert entry.outputs == {"cleaned": "_cleaned.csv", "biplot": "_biplot.png"}
+    # v3 fields absent in v2 default to unset.
+    assert entry.seed is None
+    assert entry.agent is None
+    assert entry.environment is None
+    assert entry.output_sha256 == {}
+    assert entry.output_keys == {}

--- a/bloommcp/tests/contract/test_v2_backcompat.py
+++ b/bloommcp/tests/contract/test_v2_backcompat.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from bloom_mcp.storage.manifest import validate_schema
+import pytest
+
+from bloom_mcp.storage.manifest import ManifestSchemaError, validate_schema
 from bloom_mcp.storage.schema import Manifest
 
 _FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "manifest_v2.json"
@@ -33,3 +35,11 @@ def test_recorded_v2_manifest_reads_under_v3():
     assert entry.environment is None
     assert entry.output_sha256 == {}
     assert entry.output_keys == {}
+    # A historical `code_versions.supabase == "unknown"` still reads.
+    assert entry.code_versions.supabase == "unknown"
+
+
+def test_newer_schema_version_is_rejected():
+    """The version guard rejects a manifest newer than this code understands."""
+    with pytest.raises(ManifestSchemaError):
+        validate_schema({"manifest_schema_version": 4})

--- a/bloommcp/tests/fixtures/manifest_v2.json
+++ b/bloommcp/tests/fixtures/manifest_v2.json
@@ -1,0 +1,22 @@
+{
+  "manifest_schema_version": 2,
+  "experiment": {
+    "filename": "turface_19_final_data.csv",
+    "source_path": "bloommcp_input/turface_19_final_data.csv",
+    "input_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "versions": [
+    {
+      "id": "v1",
+      "created_at": "2026-06-01T12:00:00Z",
+      "tool": "dimred_workflow",
+      "params": {"n_components": 3},
+      "based_on_version": "raw",
+      "code_versions": {"bloommcp": "0.1.0", "supabase": "unknown"},
+      "outputs": {"cleaned": "_cleaned.csv", "biplot": "_biplot.png"},
+      "user_label": "first run",
+      "version_dir": "v1_2026-06-01_first_run"
+    }
+  ],
+  "latest": "v1"
+}

--- a/openspec/changes/add-bloommcp-contract-layer/design.md
+++ b/openspec/changes/add-bloommcp-contract-layer/design.md
@@ -1,0 +1,102 @@
+## Context
+
+bloom-mcp delegates all analysis to `sleap-roots-analyze` behind a thin MCP surface. The
+deployed prototype already reads from **and** writes versioned outputs to Supabase Storage
+as `bloom_agent`, and its `manifest.json` (`storage/schema.py`, schema **v2**) is already a
+provenance record. Tier 1 builds the uniform tool contract that every granular tool wraps,
+and **unifies provenance with that manifest** rather than inventing a parallel record.
+Source of truth: `bloommcp/docs/2026-06-15-bloom-mcp-phase2-persistence-design.md` (§4–§6)
+and `2026-06-15-bloom-mcp-phase2-design.md` (§4, §6). Builds on Tier 0 (#313).
+
+## Goals / Non-Goals
+
+- **Goals:** `@as_mcp_tool` (Pydantic I/O validation, exceptions → `BloomMCPError`, seed
+  recording + propagation, single `Provenance` stamp, FastMCP registration); a canonical
+  `Provenance` model; manifest schema **v2 → v3 (additive)**; a unit-tested
+  `Provenance → VersionEntry` mapping. All proven against a **stub tool**.
+- **Non-Goals (deferred):** real tools `pca_analysis`/`clustering` (Tiers 3/4); live
+  persistence write (Tier 2 `ResultStore`); `server.py` tool registration (Tier 3);
+  `_v2`/URL-namespace/api-diff versioning; per-user write identity / real RLS.
+
+## Decisions
+
+- **`@as_mcp_tool` wraps FastMCP; registration is a deferred `register(mcp)` seam.** The
+  decorator owns the contract guarantees and attaches FastMCP-registration metadata, but
+  it does **not** register at decoration time — the deployed code registers via
+  `mcp.tool()(func)` inside a `register(mcp)` function at server-wiring time, because the
+  `mcp = FastMCP(...)` instance does not exist when a tool module is imported (and
+  `server.py` imports the tools — registering at import would be circular). Tier 1 unit
+  tests exercise the seam against an in-process `FastMCP` they construct; the first real
+  `server.py` registration lands in Tier 3. *Alternatives rejected:* register at decoration
+  (needs a live `mcp`, circular, and forbidden by Tier 1's no-`server.py` scope); a bespoke
+  registry (re-implements MCP machinery).
+- **Seed: resolve, record, propagate — never global re-seed.** The decorator resolves the
+  seed (drawing a concrete integer when params carry none), forwards it to the delegated
+  `perform_*` as `random_state=` via an **explicit kwarg-injection contract** (not
+  name-inference), and records the *resolved* integer in `Provenance` (never null for a
+  stochastic run). It does **not** `np.random.seed()` — that duplicates/fights upstream
+  per-estimator seeding and doesn't reach UMAP's numba RNG. *Determinism of the function*
+  is upstream's (CI-guarded); *reproducibility of the stored artifact* is ours (the
+  recorded resolved seed). Caveat for Tiers 3/4: for non-randomized solvers (e.g.
+  `sklearn.PCA` full SVD) the seed is inert, so `params` must also faithfully capture the
+  determinism-governing parameters (`svd_solver`, `n_components`, `n_init`, …) and the
+  resolved feature/column-role selection — `input_sha256` digests only the *source* CSV,
+  not the column-selected matrix actually fed to `perform_*`.
+- **One provenance path; per-artifact fields are commit-time.** `Provenance` is stamped
+  once in `contract/` at **contract time** (around delegation) and persisted into the
+  manifest `VersionEntry` by Tier 2's `ResultStore`. Per-artifact `output_sha256` / logical
+  `key` are **not** knowable at contract time — the artifact bytes do not exist until the
+  tool writes to staging (Tier 2 `commit()`) — so the contract-time `Provenance` leaves
+  them empty and the `ResultStore` fills them into the *same* single entry at commit. Tier 1
+  defines the model + mapping and unit-tests the mapping; no second provenance system.
+- **Schema bump is additive (v2 → v3); `outputs` is retained, not re-typed.** The existing
+  `outputs: dict[str,str]` stays a string map; per-artifact hashes/keys land in NEW optional
+  sibling collections (`output_sha256: dict[str,str]`, `output_keys: dict[str,str]`).
+  Re-typing `outputs` to a richer model would break loading v2 string-valued `outputs` under
+  `extra="forbid"` — *not* additive. All new `VersionEntry`/`CodeVersions` fields are
+  optional, so v2 manifests still validate; `validate_schema` already accepts version `<=`
+  known, so only `CURRENT_SCHEMA_VERSION` advances to 3. *Alternative rejected:* a breaking
+  v3 (drop/rename/re-type v2 fields) — orphans deployed manifests.
+- **`output_sha256` is app-computed, not the object-store ETag.** Hex SHA-256 over the
+  exact pre-upload bytes (at commit, Tier 2). The S3/MinIO ETag is MD5/multipart-dependent
+  and not reliably surfaced through storage-api; bloommcp also never addresses MinIO
+  directly (only logical Supabase keys). Carry-forward caveat for Tiers 3/4: matplotlib
+  embeds non-deterministic metadata (timestamps) in plots — render deterministically (strip
+  `CreationDate`) or hash the underlying data arrays, else plot hashes aren't reproducible.
+- **`code_versions` is installed-only for every entry.** Record a version only for an
+  actually pip-installed distribution — including `bloommcp`/`supabase`; omit rather than
+  emit `importlib.metadata`'s `"unknown"` (which is why Benfica removed `sleap_roots_analyze`
+  while it was vendored). This makes the existing `supabase: "unknown"` default an
+  omit-when-absent optional field (benign, additive). analyze + contracts qualify now that
+  Tier 0 made them real deps.
+- **Two distinct provenance columns: trace vs. reproducer.** `code_versions` is the
+  human-readable *trace* ("produced by bloom-mcp X + analyze Y"); the `environment` pointer
+  (image digest / `bloom-mcp` version → committed `uv.lock`) is the exact *reproducer* that
+  pins `numpy`/`scipy`/`sklearn` — the libs that also move PCA/cluster numbers. Both exist
+  so a future golden drift is diagnosable to an env bump vs. a code change.
+
+## Risks / Trade-offs
+
+- **`extra="forbid"` + new fields.** v2 manifests lack the new keys (fine — additive,
+  optional, and the back-compat test loads a real v2 fixture with string-valued `outputs`).
+  The reverse — a v3 entry read by **old v2 code** — would trip `forbid`; this is a
+  **deploy-ordering constraint** (upgrade readers before any writer emits v3), not just
+  "out of scope," since a rollout may briefly run mixed versions. Tier 1 has no live writer,
+  so the hazard is latent until Tier 2.
+- **#191 (Pydantic input models) is unmerged.** The decorator needs an input model with a
+  `seed` to validate/propagate. Mitigation: Tier 1 ships a minimal **stub params model**
+  (`contract/models.py`); real per-tool models arrive in Tiers 3/4. Tier 1 is not blocked.
+- **`output_sha256` ownership crosses the tier boundary.** Defined here, populated at commit
+  by Tier 2's `ResultStore`. Risk: the Tier 1 mapping could encode an impossible
+  expectation (a contract-time hash). Mitigation: the spec + tests assert per-artifact
+  collections are **empty** at contract time, making the seam explicit.
+- **`environment` pointer: present ≠ reproducible.** Image digest may be absent outside the
+  container; a dev/editable install or a dirty lock resolves to a non-reproducible value.
+  Mitigation: precedence (digest → `bloom-mcp` version → `uv.lock` hash); field optional so
+  unit tests pass, but any **persisted** run (Tier 2) must carry an identifier that resolves
+  to a reproducible env. The spec splits these (optional in unit; required-reproducible when
+  persisted).
+- **Stub-only validation.** Tier 1 never exercises a real `perform_*`. Mitigation: the
+  seed resolution/propagation + the no-global-reseed invariant are asserted at the wrapper
+  boundary here (against a fake delegate); the end-to-end determinism oracle is Tiers 3/4's
+  responsibility (against real calls + the #120 goldens).

--- a/openspec/changes/add-bloommcp-contract-layer/design.md
+++ b/openspec/changes/add-bloommcp-contract-layer/design.md
@@ -20,16 +20,31 @@ and `2026-06-15-bloom-mcp-phase2-design.md` (§4, §6). Builds on Tier 0 (#313).
 
 ## Decisions
 
-- **`@as_mcp_tool` wraps FastMCP; registration is a deferred `register(mcp)` seam.** The
-  decorator owns the contract guarantees and attaches FastMCP-registration metadata, but
-  it does **not** register at decoration time — the deployed code registers via
-  `mcp.tool()(func)` inside a `register(mcp)` function at server-wiring time, because the
-  `mcp = FastMCP(...)` instance does not exist when a tool module is imported (and
-  `server.py` imports the tools — registering at import would be circular). Tier 1 unit
-  tests exercise the seam against an in-process `FastMCP` they construct; the first real
-  `server.py` registration lands in Tier 3. *Alternatives rejected:* register at decoration
-  (needs a live `mcp`, circular, and forbidden by Tier 1's no-`server.py` scope); a bespoke
-  registry (re-implements MCP machinery).
+- **`@as_mcp_tool` wraps FastMCP; registration is a shipped `register(mcp, *tools)` seam.**
+  The decorator owns the contract guarantees but does **not** register at decoration time —
+  the `mcp = FastMCP(...)` instance does not exist when a tool module is imported (and
+  `server.py` imports the tools — registering at import would be circular). Tier 1 ships a
+  trivial `register(mcp, *tools)` helper (each `mcp.tool()(tool)`) so the seam the spec
+  mandates actually exists and tests exercise it against an in-process `FastMCP`; the first
+  real `server.py` wiring lands in Tier 3. The wrapper carries an explicit single-`params`
+  `__signature__` (accepted positionally **and** by keyword — no positional-only mismatch)
+  so FastMCP builds a correct schema without seeing the injected kwargs; `functools.wraps`
+  preserves `__wrapped__` for `inspect.unwrap`. *Alternatives rejected:* register at
+  decoration (needs a live `mcp`, circular, forbidden by Tier 1's no-`server.py` scope); a
+  bespoke registry (re-implements MCP machinery).
+- **Seed-provenance integrity: record only what was applied.** The resolved seed is
+  recorded in `Provenance` **only** when the delegate declares `random_state` (so the
+  recorded value actually reached the computation). A non-stochastic tool records
+  `seed=None`; a seed *provided* to a delegate that can't accept it raises `internal_error`
+  rather than recording an unapplied seed (a reproducibility lie). Seeds are strict ints in
+  `[0, 2**32)`, validated at the input model (out-of-range/float/bool → `invalid_input`).
+  *Alternative rejected:* always stamping the resolved seed — produces a manifest claiming a
+  seed that never reached a `**kwargs`/no-`random_state` delegate.
+- **Errors never leak internals.** Declared (author opted-in) exceptions pass their message
+  through; an undeclared exception or output-contract breach returns a fixed message + a
+  correlation id with the detail logged server-side; input-validation errors surface only
+  field locations + types, never values. Prevents paths/hosts/connection-strings/bucket
+  keys reaching the LLM agent, beyond the existing "no raw traceback" guarantee.
 - **Seed: resolve, record, propagate — never global re-seed.** The decorator resolves the
   seed (drawing a concrete integer when params carry none), forwards it to the delegated
   `perform_*` as `random_state=` via an **explicit kwarg-injection contract** (not

--- a/openspec/changes/add-bloommcp-contract-layer/proposal.md
+++ b/openspec/changes/add-bloommcp-contract-layer/proposal.md
@@ -1,0 +1,120 @@
+## Why
+
+Every granular bloom-mcp tool (Tiers 3–4: `pca_analysis`, `clustering`) needs the **same**
+three guarantees on every call: validated Pydantic I/O, structured errors instead of raw
+tracebacks, and a complete provenance record persisted with the result. Building those
+guarantees per-tool would duplicate boilerplate and let provenance drift between tools.
+Today there is **no** contract layer — `bloommcp/src/bloom_mcp/contract/` does not exist —
+and the deployed manifest (`storage/schema.py`, schema **v2**) lacks the fields that
+stochastic, reproducibility-critical analyses require: it has no `seed`, no `agent`, no
+per-artifact `output_sha256`/logical `key`, records only `bloommcp` + `supabase` in
+`code_versions`, and carries no exact-environment pointer.
+
+This is **bloom-mcp Phase 2 · Tier 1 — the contract layer** (roadmap Tier 1; builds on
+Tier 0's installable package, PR #313). It builds the `@as_mcp_tool` decorator and the
+canonical `Provenance` model, and bumps the manifest **schema v2 → v3 (additive)** so the
+contract's provenance has a single home in the manifest `VersionEntry` — **one provenance
+path, not two**. See issue
+[#306](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/306) and the
+persistence design (`bloommcp/docs/2026-06-15-bloom-mcp-phase2-persistence-design.md` §4).
+
+## What Changes
+
+- **Add the contract package** `bloommcp/src/bloom_mcp/contract/` with three modules:
+  - `errors.py` — `BloomMCPError(code, message, remedy)`: a structured, agent-safe error.
+    The decorator maps declared exceptions to it; the agent **never** sees a raw traceback.
+  - `provenance.py` — the canonical `Provenance` Pydantic model, computed **once** per
+    call, plus a `to_version_entry(...)` mapping into the manifest `VersionEntry` (v3).
+  - `wrap.py` — the `@as_mcp_tool` decorator: **our own** glue layered over FastMCP's
+    `mcp.tool()` (FastMCP stays the MCP framework; Pydantic stays I/O validation — we
+    wrap, we do not replace). On every call it validates Pydantic input/output, maps
+    exceptions → `BloomMCPError`, **resolves and propagates the seed into the delegated
+    `perform_*` call as `random_state=` and records it in `Provenance`** (an explicit
+    kwarg-injection contract, not name-inference), and stamps the contract-time
+    `Provenance`. Registration onto a `FastMCP` instance happens through a `register(mcp)`
+    seam at server-wiring time — **not** at decoration time (the deployed pattern; the
+    `mcp` instance does not exist when a tool module is imported, and Tier 1 does not touch
+    `server.py`). The first real registration lands in Tier 3.
+  - `models.py` — a **stub Tier-1 Pydantic params/input/output model** (carrying
+    `seed: Optional[int]`) for the decorator to validate against. #191 (Pydantic input
+    models) is OPEN/unmerged, so Tier 1 supplies a minimal stub; real per-tool models
+    arrive with the granular tools (Tiers 3/4).
+- **Do NOT seed globally.** The decorator MUST NOT call `np.random.seed()` — that would
+  duplicate/fight `sleap-roots-analyze`'s per-estimator seeding and would not reach UMAP's
+  numba RNG. *Determinism of the function* is upstream's (CI-guarded); *reproducibility of
+  the stored artifact* is ours, via the recorded `seed` field.
+- **Bump the manifest schema v2 → v3 (additive; old v2 manifests still read).** Extend
+  `storage/schema.py` `VersionEntry` + `CodeVersions` and bump `CURRENT_SCHEMA_VERSION`:
+  - `seed` (random_state) — **critical**; Tiers 3/4 are stochastic. Record the
+    **resolved** seed actually used (resolve a concrete integer when none is supplied), so
+    a persisted stochastic run is never `seed: null`.
+  - `agent` / actor — record `bloom_agent` now (real per-user identity deferred).
+  - per-artifact `output_sha256` + logical storage `key`, carried in **new optional
+    sibling collections** on `VersionEntry` (`output_sha256: dict[str,str]`,
+    `output_keys: dict[str,str]`, keyed by the same logical output name) — the existing
+    `outputs: dict[str,str]` field is **retained unchanged** so v2 string-valued `outputs`
+    still loads under `extra="forbid"` (re-typing `outputs` would NOT be additive).
+    `output_sha256` is **app-computed** (hex SHA-256 over the pre-upload bytes — *not* the
+    S3/MinIO ETag) and is populated **at commit by the `ResultStore` (Tier 2)**, not at
+    contract time: the artifact bytes do not exist until the tool writes to staging. Tier 1
+    only defines the fields + the mapping; the contract-time `Provenance` leaves them empty.
+  - `code_versions` extended with **`sleap-roots-analyze` + `sleap-roots-contracts`**
+    (Benfica, PR #310). **Installed-only, for every entry** (incl. `bloommcp`/`supabase`):
+    record a version only for an *actually pip-installed* distribution — omit it rather than
+    emit `importlib.metadata`'s `"unknown"`. This makes the existing `supabase: "unknown"`
+    default an omit-when-absent optional field (benign, additive). analyze/contracts qualify
+    now that Tier 0 made them real deps.
+  - `environment` pointer — an exact-repro key resolved by precedence: container image
+    digest (from `BLOOM_MCP_IMAGE_DIGEST`, `sha256:…`) → the `bloom-mcp` release version
+    whose committed `uv.lock` reproduces the env via `uv sync` → a `uv.lock` content hash.
+    Optional in unit/dev env; a **persisted** run (Tier 2) must carry an identifier that
+    actually resolves to a reproducible env. `seed` pins the RNG; only the locked env pins
+    the library *math* (`numpy`/`scipy`/`sklearn`).
+  - Capture `params` **faithfully** — including the resolved feature/column-role selection
+    and determinism-governing params (`svd_solver`, `n_components`, `n_init`, …): the PCA/
+    cluster numbers depend on the exact matrix fed to `perform_*`, which `input_sha256` (a
+    digest of the *source* CSV) does not pin.
+  - Retain all existing v2 `VersionEntry` fields (`id`, `created_at`, `tool`, `params`,
+    `based_on_version` lineage, `code_versions`, `outputs`, `user_label`, `version_dir`).
+    Note `input_sha256` lives on the manifest's `ExperimentBlock`, **not** the
+    `VersionEntry` — it is preserved there, unchanged.
+- **Define the `Provenance → VersionEntry` mapping and unit-test it** (no live Supabase,
+  no live write). The mapping fills the contract-time fields; per-artifact
+  `output_sha256`/`key` are left for the `ResultStore` (Tier 2), which performs the live
+  manifest write later.
+- **Serialization round-trips assert exact equality** (`==`). The upstream `rtol=1e-6` /
+  exact-integer tolerance is reserved for the golden *recomputation* oracle in Tiers 3/4 —
+  applying a tolerance to a pure JSON round-trip would mask a precision-loss bug.
+- **No hand-maintained per-tool version** (versioning is package-SemVer + stable tool
+  names; `_v2`/URL-namespace/api-diff are deferred per the design).
+
+## Impact
+
+- **New capability:** `bloommcp-tool-contract`.
+- **Affected code:**
+  - New: `bloommcp/src/bloom_mcp/contract/{__init__,wrap,provenance,errors,models}.py`.
+  - Modified: `bloommcp/src/bloom_mcp/storage/schema.py` (v3 `VersionEntry` sibling
+    collections + optional `seed`/`agent`/`environment`, `CodeVersions` omit-on-absent
+    fields, `CURRENT_SCHEMA_VERSION = 3`, docstring), `bloommcp/src/bloom_mcp/storage/
+    code_versions.py` (installed-only resolution for all entries + analyze/contracts).
+    `storage/manifest.py`'s `validate_schema` already accepts any version `<=` known, so
+    old v2 manifests still read after the bump.
+  - New tests: `bloommcp/tests/contract/` (decorator I/O + register seam, error envelope,
+    seed propagation, provenance round-trip, Provenance→VersionEntry mapping, code-versions
+    installed-only, environment pointer, schema-v3 round-trip, v2 back-compat) built against
+    a **stub tool + stub params model**, plus a new `bloommcp/tests/fixtures/manifest_v2.json`
+    fixture.
+- **Out of scope (Tier 1):** no real analysis tools (`pca_analysis`/`clustering` are
+  Tiers 3/4 — tested here against a stub); **no live persistence write** (Tier 2's
+  `ResultStore`); no agent-surface/`server.py` registration change (Tier 3 registers the
+  first real tool). The seed → `random_state=` propagation is *defined and unit-tested at
+  the wrapper boundary* here; its determinism oracle runs against real `perform_*` calls
+  in Tiers 3/4.
+- **Builds on:** Tier 0's installable package (#313, merged to `staging`) and unifies with
+  the deployed `storage/schema.py` manifest. **#191 (Pydantic input models) is unmerged** —
+  Tier 1 does not block on it; it ships a minimal stub params model and the real per-tool
+  models arrive with the granular tools (Tiers 3/4). Consuming `sleap-roots-analyze`'s
+  serializable result dataclasses (`PCAResult`/`ClusterResult`, #149/#151 — now **merged**)
+  rather than reinventing a JSON projection is likewise deferred to Tiers 3/4: Tier 1
+  records provenance over a stub, so there is no real result type to consume yet.
+- **Branch/PR target:** `staging` (staging-first repo); branch off `origin/staging`.

--- a/openspec/changes/add-bloommcp-contract-layer/specs/bloommcp-tool-contract/spec.md
+++ b/openspec/changes/add-bloommcp-contract-layer/specs/bloommcp-tool-contract/spec.md
@@ -1,0 +1,204 @@
+## ADDED Requirements
+
+### Requirement: Uniform Tool Contract Decorator
+
+bloom-mcp SHALL provide an `@as_mcp_tool` decorator in `bloom_mcp.contract.wrap` that
+wraps a tool function with the contract guarantees: it SHALL validate the tool's declared
+Pydantic input and output models, stamp exactly one contract-time `Provenance` record (see
+the Canonical Contract-Time Provenance Record requirement), and map exceptions to a
+structured `BloomMCPError`. The decorator SHALL wrap, not replace, FastMCP; actual
+registration onto a FastMCP instance SHALL occur through a `register(mcp)` seam invoked at
+server-wiring time — the decorator SHALL NOT require a live `FastMCP` instance at
+decoration time (Tier 1 does not modify `server.py`; the first real registration lands in
+Tier 3). The decorator SHALL NOT maintain a per-tool version field (tool identity is the
+tool name; versioning is package-SemVer).
+
+#### Scenario: Decorated stub tool validates I/O and is registrable
+
+- **WHEN** a stub tool with declared Pydantic input/output models is decorated with
+  `@as_mcp_tool`, invoked with valid input, and then registered onto an in-process
+  `FastMCP` instance via the `register(mcp)` seam
+- **THEN** the call returns the validated output object, and the tool is discoverable
+  under its name via an in-process `fastmcp.Client(mcp).list_tools()`
+
+#### Scenario: Invalid input is rejected before the tool body runs
+
+- **WHEN** a decorated stub tool (whose body sets a call-recording flag) is invoked with
+  input that violates its Pydantic input model
+- **THEN** the failure surfaces as a `BloomMCPError` and the call-recording flag shows the
+  tool body never executed
+
+#### Scenario: Invalid output is an internal contract breach, not a raw error
+
+- **WHEN** a decorated stub tool returns a value that violates its declared output model
+- **THEN** the failure surfaces as a `BloomMCPError` whose `code` marks an internal
+  output-contract breach (distinct from a user input error), never a raw `ValidationError`
+  or traceback
+
+### Requirement: Structured Agent-Safe Errors
+
+bloom-mcp SHALL define `BloomMCPError` in `bloom_mcp.contract.errors` carrying a `code`, a
+`message`, and a `remedy`, with a serializable structured form. The `@as_mcp_tool`
+decorator SHALL map declared exceptions raised by a tool to a `BloomMCPError`; a raw
+traceback SHALL NEVER be returned to the agent.
+
+#### Scenario: Declared exception becomes a structured error
+
+- **WHEN** a decorated stub tool raises a declared exception
+- **THEN** the caller receives a `BloomMCPError` with `code`, `message`, and `remedy`
+  populated, and no raw traceback or stack frames are exposed
+
+### Requirement: Seed Recording And Propagation Without Global Re-Seed
+
+The `@as_mcp_tool` decorator SHALL record the **resolved** seed (`random_state`) actually
+used by the call in the `Provenance` record and SHALL propagate it into the delegated
+`perform_*` call as `random_state=`. When the tool's params carry no seed, the decorator
+SHALL resolve a concrete integer seed before delegating and record that integer (the
+recorded seed SHALL never be null for a stochastic delegation). The decorator SHALL NOT
+call `np.random.seed()` or otherwise mutate global RNG state. The kwarg-injection contract
+(the decorator forwards `random_state=<resolved seed>` to the declared delegate) SHALL be
+explicit so downstream tiers depend on a defined behavior, not an inferred one.
+
+#### Scenario: Provided seed is recorded and forwarded, global RNG untouched
+
+- **WHEN** a decorated stub tool delegating to a fake `perform_*` is invoked with a `seed`
+  in its params
+- **THEN** the fake `perform_*` receives that value as `random_state=`, the `Provenance`
+  record's `seed` equals that value, and `np.random.get_state()` is byte-identical before
+  and after the call
+
+#### Scenario: Absent seed is resolved to a concrete integer and recorded
+
+- **WHEN** a decorated stub tool is invoked with no seed in its params
+- **THEN** the decorator resolves a concrete integer seed, forwards it as `random_state=`,
+  and records that same integer in `Provenance.seed` (never null)
+
+### Requirement: Canonical Contract-Time Provenance Record
+
+bloom-mcp SHALL define a canonical `Provenance` model in `bloom_mcp.contract.provenance`,
+stamped exactly once per tool call at **contract time** (around delegation, before any
+artifact is written). It SHALL carry the contract-time fields: `tool`, `params`, the
+resolved `seed`, `agent`/actor, the source-input digest (`input_sha256`, which on the
+manifest lives on the experiment block, not the version entry), the `code_versions` trace,
+the `environment` pointer, and timestamps. Because PCA/clustering numbers depend on the
+exact matrix fed to `perform_*`, `params` SHALL faithfully capture the resolved
+feature/column-role selection and the determinism-governing parameters (e.g. `svd_solver`,
+`n_components`, `n_init`) — not a lossily coerced subset. Per-artifact `output_sha256` and
+logical `key` are NOT contract-time fields; they are populated at commit by the
+`ResultStore` (Tier 2) and merged into the same single version entry. The `Provenance`
+model SHALL round-trip Pydantic ↔ JSON with **exact** equality.
+
+#### Scenario: Contract-time Provenance round-trips through JSON exactly
+
+- **WHEN** a fully-populated contract-time `Provenance` (including the resolved `seed`, the
+  `environment` pointer, and the resolved feature/column selection in `params`) is
+  serialized to JSON and parsed back
+- **THEN** the reconstructed model equals the original exactly (`==`), with no numeric
+  precision loss and no dropped fields
+
+#### Scenario: Per-artifact hashes are absent at contract time
+
+- **WHEN** the decorator stamps a `Provenance` record before delegation
+- **THEN** the per-artifact `output_sha256` / logical `key` collections are empty/unset,
+  reflecting that they are filled at commit by the `ResultStore` in a later tier
+
+### Requirement: Provenance Maps Into The Manifest VersionEntry
+
+bloom-mcp SHALL provide a single mapping from a contract-time `Provenance` to a manifest
+`VersionEntry` (schema v3) so that provenance has one home in the manifest, not a parallel
+record. The mapping SHALL be unit-testable without a live Supabase connection and without
+performing a live manifest write (the live write, and the population of per-artifact
+`output_sha256` / `key`, are the `ResultStore`'s responsibility in a later tier). The
+mapping SHALL preserve the existing v2 `VersionEntry` fields (`id`, `created_at`, `tool`,
+`params`, `based_on_version`, `code_versions`, `outputs`, `user_label`, `version_dir`).
+
+#### Scenario: Mapping yields a v3 VersionEntry with contract-time fields set
+
+- **WHEN** a contract-time `Provenance` record is mapped to a `VersionEntry`
+- **THEN** the entry carries `seed`, `agent`, the extended `code_versions`, and the
+  `environment` pointer; it preserves the existing v2 fields (`id`, `created_at`, `tool`,
+  `params`, `based_on_version`, `code_versions`, `outputs`, `user_label`, `version_dir`);
+  and its per-artifact `output_sha256` / `key` collections are empty (to be filled at
+  commit in Tier 2)
+
+### Requirement: Installed-Only Code Versions
+
+The `code_versions` provenance SHALL record a version only for an actually pip-installed
+distribution, for **every** entry (including `bloommcp` and `supabase`), and SHALL extend
+the set with `sleap-roots-analyze` and `sleap-roots-contracts`. A distribution that is not
+installed SHALL be omitted rather than recorded as the literal `"unknown"`. This makes the
+existing `supabase: str = "unknown"` default an omit-when-absent optional field (a benign,
+additive behavior change).
+
+#### Scenario: Installed distributions are recorded with no "unknown"
+
+- **WHEN** `code_versions` is computed where `sleap-roots-analyze` and
+  `sleap-roots-contracts` are installed
+- **THEN** their versions are recorded and no `code_versions` field holds the literal
+  string `"unknown"`
+
+#### Scenario: Uninstalled distribution is omitted, not "unknown"
+
+- **WHEN** `code_versions` is computed and a tracked distribution is not installed
+  (`importlib.metadata.version` raises `PackageNotFoundError`)
+- **THEN** that key is absent from the result rather than set to `"unknown"`
+
+### Requirement: Exact-Environment Provenance Pointer
+
+The `Provenance` record SHALL carry an `environment` pointer identifying the exact
+environment that produced the artifact, resolved by a documented precedence chain:
+container image digest (from `BLOOM_MCP_IMAGE_DIGEST`, a `sha256:…` value) → the
+`bloom-mcp` release version whose committed `uv.lock` reproduces the env via `uv sync` →
+a `uv.lock` content hash. The pointer is distinct from the human-readable `code_versions`
+trace. The field MAY be absent in unit/dev environments (it is optional for schema
+back-compat), but any **persisted** run (Tier 2) SHALL carry at least one identifier that
+actually resolves to a reproducible environment.
+
+#### Scenario: Image digest takes precedence when present
+
+- **WHEN** a `Provenance` record is stamped with `BLOOM_MCP_IMAGE_DIGEST` set
+- **THEN** the `environment` pointer equals that `sha256:…` digest
+
+#### Scenario: Fallback resolves to a non-empty, reproducible identifier
+
+- **WHEN** a `Provenance` record is stamped with no image digest set (the unit/CI case)
+- **THEN** the `environment` pointer falls back per the precedence chain to a non-empty
+  value (the `bloom-mcp` version and/or `uv.lock` hash), is never the literal `"unknown"`,
+  and is not equal to the `code_versions` trace
+
+### Requirement: Additive Manifest Schema v3
+
+The manifest `VersionEntry` and `CodeVersions` schema SHALL advance from version 2 to
+version 3 **additively** under the existing `extra="forbid"` strictness: the existing
+`outputs: dict[str, str]` field SHALL be retained unchanged, and the per-artifact content
+hashes and logical keys SHALL be carried in NEW optional sibling collections (e.g.
+`output_sha256: dict[str, str]`, `output_keys: dict[str, str]`, keyed by the same logical
+output name). All new `VersionEntry` fields (`seed`, `agent`, `environment`, and the
+per-artifact sibling collections) and new `CodeVersions` fields SHALL be optional so that
+previously-written **v2** manifests — including their string-valued `outputs` — continue
+to validate and read without error. `output_sha256` values SHALL be hex-encoded SHA-256
+over the exact pre-upload artifact bytes (app-computed, never the object-store ETag),
+populated at commit by the `ResultStore` (Tier 2). `CURRENT_SCHEMA_VERSION` SHALL be `3`,
+and the schema-version guard SHALL continue to accept any manifest whose version is less
+than or equal to the known version.
+
+#### Scenario: Old v2 manifest with string outputs still reads under v3 code
+
+- **WHEN** a manifest recorded under schema version 2 — including a `VersionEntry` with a
+  populated string-valued `outputs` (e.g. `{"cleaned": "_cleaned.csv"}`) and no v3 fields —
+  is loaded by the v3 code
+- **THEN** it validates and loads without error, and its absent v3 fields default to unset
+  rather than failing `extra="forbid"` validation
+
+#### Scenario: New manifests are written at schema version 3
+
+- **WHEN** a new manifest is created after this change
+- **THEN** `CURRENT_SCHEMA_VERSION` is `3`, a freshly built `Manifest` reports
+  `manifest_schema_version == 3`, and a `VersionEntry` can carry the new v3 fields
+
+#### Scenario: A v3 VersionEntry round-trips through JSON
+
+- **WHEN** a `VersionEntry` carrying the new v3 fields (retained string `outputs` plus the
+  per-artifact `output_sha256` / `output_keys` siblings, `seed`, `agent`, `environment`)
+  is dumped with `model_dump(mode="json")` and re-validated
+- **THEN** the reconstructed entry equals the original exactly

--- a/openspec/changes/add-bloommcp-contract-layer/specs/bloommcp-tool-contract/spec.md
+++ b/openspec/changes/add-bloommcp-contract-layer/specs/bloommcp-tool-contract/spec.md
@@ -7,19 +7,28 @@ wraps a tool function with the contract guarantees: it SHALL validate the tool's
 Pydantic input and output models, stamp exactly one contract-time `Provenance` record (see
 the Canonical Contract-Time Provenance Record requirement), and map exceptions to a
 structured `BloomMCPError`. The decorator SHALL wrap, not replace, FastMCP; actual
-registration onto a FastMCP instance SHALL occur through a `register(mcp)` seam invoked at
-server-wiring time — the decorator SHALL NOT require a live `FastMCP` instance at
-decoration time (Tier 1 does not modify `server.py`; the first real registration lands in
-Tier 3). The decorator SHALL NOT maintain a per-tool version field (tool identity is the
-tool name; versioning is package-SemVer).
+registration onto a FastMCP instance SHALL occur through a `register(mcp, *tools)` seam
+(provided in `bloom_mcp.contract`) invoked at server-wiring time — the decorator SHALL NOT
+require a live `FastMCP` instance at decoration time (Tier 1 does not modify `server.py`;
+the first real `server.py` wiring lands in Tier 3). The wrapped callable SHALL advertise a
+single `params` parameter (so FastMCP builds a correct input schema) that is accepted both
+positionally and by keyword. The decorator SHALL NOT maintain a per-tool version field
+(tool identity is the tool name; versioning is package-SemVer).
 
 #### Scenario: Decorated stub tool validates I/O and is registrable
 
 - **WHEN** a stub tool with declared Pydantic input/output models is decorated with
   `@as_mcp_tool`, invoked with valid input, and then registered onto an in-process
-  `FastMCP` instance via the `register(mcp)` seam
+  `FastMCP` instance via `register(mcp, stub_tool)`
 - **THEN** the call returns the validated output object, and the tool is discoverable
   under its name via an in-process `fastmcp.Client(mcp).list_tools()`
+
+#### Scenario: The params argument is accepted positionally and by keyword
+
+- **WHEN** a decorated stub tool is invoked as `tool({...})`, `tool(params={...})`, and
+  `tool(params=Model(...))`
+- **THEN** all three validate identically — the real signature matches the advertised
+  single-`params` schema (no positional-only mismatch)
 
 #### Scenario: Invalid input is rejected before the tool body runs
 
@@ -39,8 +48,13 @@ tool name; versioning is package-SemVer).
 
 bloom-mcp SHALL define `BloomMCPError` in `bloom_mcp.contract.errors` carrying a `code`, a
 `message`, and a `remedy`, with a serializable structured form. The `@as_mcp_tool`
-decorator SHALL map declared exceptions raised by a tool to a `BloomMCPError`; a raw
-traceback SHALL NEVER be returned to the agent.
+decorator SHALL map a *declared* (author opted-in via `errors=`) exception to a
+`BloomMCPError` whose message is passed through. A raw traceback SHALL NEVER be returned to
+the agent, and an *internal* failure (an undeclared exception or an output-contract breach)
+SHALL NOT leak internal detail (paths, hosts, connection strings, SQL, bucket keys): it
+SHALL return a fixed message plus a short correlation id, with the detail logged
+server-side. Input-validation errors SHALL surface only the offending field locations and
+error types, never the offending values.
 
 #### Scenario: Declared exception becomes a structured error
 
@@ -48,16 +62,33 @@ traceback SHALL NEVER be returned to the agent.
 - **THEN** the caller receives a `BloomMCPError` with `code`, `message`, and `remedy`
   populated, and no raw traceback or stack frames are exposed
 
+#### Scenario: Internal failure does not leak detail to the agent
+
+- **WHEN** a decorated stub tool raises an undeclared exception whose text carries a
+  connection string / host / bucket key
+- **THEN** the `BloomMCPError` is `internal_error`, its message omits that detail and
+  carries a correlation id (`ref:`), and the detail is logged server-side only
+
+#### Scenario: Input validation surfaces locations, not values
+
+- **WHEN** input validation fails on a field whose value is sensitive
+- **THEN** the `BloomMCPError` (`invalid_input`) names the field location and error type
+  but not the offending value
+
 ### Requirement: Seed Recording And Propagation Without Global Re-Seed
 
-The `@as_mcp_tool` decorator SHALL record the **resolved** seed (`random_state`) actually
-used by the call in the `Provenance` record and SHALL propagate it into the delegated
-`perform_*` call as `random_state=`. When the tool's params carry no seed, the decorator
-SHALL resolve a concrete integer seed before delegating and record that integer (the
-recorded seed SHALL never be null for a stochastic delegation). The decorator SHALL NOT
-call `np.random.seed()` or otherwise mutate global RNG state. The kwarg-injection contract
-(the decorator forwards `random_state=<resolved seed>` to the declared delegate) SHALL be
-explicit so downstream tiers depend on a defined behavior, not an inferred one.
+The `@as_mcp_tool` decorator SHALL propagate the seed into the delegated `perform_*` call
+as `random_state=` via an **explicit** kwarg-injection contract (the resolved seed is
+passed as `random_state=` when, and only when, the delegate declares a `random_state`
+parameter) — never inferred. It SHALL record the **resolved** seed in `Provenance` *only
+when the seed is actually applied*: for a stochastic delegate (one declaring
+`random_state`) the recorded seed SHALL be a concrete integer (resolving one when the
+params carry none), never null. A non-stochastic tool (whose delegate declares no
+`random_state`) SHALL record `seed=None`. If a seed is *explicitly provided* but the
+delegate cannot accept it, the decorator SHALL raise an `internal_error` rather than record
+a seed that never reached the computation. A provided seed SHALL be a plain integer in
+`[0, 2**32)` — a float/bool/out-of-range value SHALL be rejected as `invalid_input`. The
+decorator SHALL NOT call `np.random.seed()` or otherwise mutate global RNG state.
 
 #### Scenario: Provided seed is recorded and forwarded, global RNG untouched
 
@@ -69,16 +100,32 @@ explicit so downstream tiers depend on a defined behavior, not an inferred one.
 
 #### Scenario: Absent seed is resolved to a concrete integer and recorded
 
-- **WHEN** a decorated stub tool is invoked with no seed in its params
+- **WHEN** a decorated stub tool delegating to a stochastic `perform_*` is invoked with no
+  seed in its params
 - **THEN** the decorator resolves a concrete integer seed, forwards it as `random_state=`,
-  and records that same integer in `Provenance.seed` (never null)
+  records that same integer in `Provenance.seed` (never null), and leaves
+  `np.random.get_state()` byte-identical before and after
+
+#### Scenario: Non-stochastic tool records no seed
+
+- **WHEN** a decorated tool whose delegate declares no `random_state` is invoked with no
+  seed
+- **THEN** the `Provenance` record's `seed` is `None` (no fabricated seed)
+
+#### Scenario: Provided seed the delegate cannot apply is an internal error
+
+- **WHEN** a seed is provided to a tool whose delegate declares no `random_state`
+- **THEN** the call raises a `BloomMCPError` with code `internal_error` (rather than
+  recording an unapplied seed)
 
 ### Requirement: Canonical Contract-Time Provenance Record
 
 bloom-mcp SHALL define a canonical `Provenance` model in `bloom_mcp.contract.provenance`,
-stamped exactly once per tool call at **contract time** (around delegation, before any
-artifact is written). It SHALL carry the contract-time fields: `tool`, `params`, the
-resolved `seed`, `agent`/actor, the source-input digest (`input_sha256`, which on the
+stamped at most once per tool call at **contract time** (around delegation, before any
+artifact is written; skipped on input-validation failure, discarded on later failure
+paths). It SHALL carry the contract-time fields: `tool`, `params`, the resolved `seed`
+(or `None` for a non-stochastic tool), `agent`/actor, the source-input digest
+(`input_sha256`, which on the
 manifest lives on the experiment block, not the version entry), the `code_versions` trace,
 the `environment` pointer, and timestamps. Because PCA/clustering numbers depend on the
 exact matrix fed to `perform_*`, `params` SHALL faithfully capture the resolved
@@ -179,8 +226,10 @@ previously-written **v2** manifests — including their string-valued `outputs` 
 to validate and read without error. `output_sha256` values SHALL be hex-encoded SHA-256
 over the exact pre-upload artifact bytes (app-computed, never the object-store ETag),
 populated at commit by the `ResultStore` (Tier 2). `CURRENT_SCHEMA_VERSION` SHALL be `3`,
-and the schema-version guard SHALL continue to accept any manifest whose version is less
-than or equal to the known version.
+and the schema-version guard SHALL accept any manifest whose version is less than or equal
+to the known version and SHALL reject one that is newer. Because new v3 entries would trip
+`extra="forbid"` if read by old v2 code, a deployment SHALL upgrade readers before any
+writer emits v3 — this is a Tier 2 (live-write) deploy gate, recorded here.
 
 #### Scenario: Old v2 manifest with string outputs still reads under v3 code
 
@@ -195,6 +244,12 @@ than or equal to the known version.
 - **WHEN** a new manifest is created after this change
 - **THEN** `CURRENT_SCHEMA_VERSION` is `3`, a freshly built `Manifest` reports
   `manifest_schema_version == 3`, and a `VersionEntry` can carry the new v3 fields
+
+#### Scenario: A newer manifest version is rejected
+
+- **WHEN** the schema-version guard reads a manifest declaring a version newer than the
+  known version (e.g. `4`)
+- **THEN** it raises a schema error rather than silently accepting unknown structure
 
 #### Scenario: A v3 VersionEntry round-trips through JSON
 

--- a/openspec/changes/add-bloommcp-contract-layer/tasks.md
+++ b/openspec/changes/add-bloommcp-contract-layer/tasks.md
@@ -104,6 +104,26 @@
 - [x] 6.3 `uv run black --check` + `uv run ruff check` clean (repo `/lint` convention).
 - [x] 6.4 `openspec validate add-bloommcp-contract-layer --strict` passes.
 
+## 8. Combined-review fixes (pre-merge — /openspec-review + /review-pr)
+
+- [x] 8.1 **B1** seed-provenance integrity: record `Provenance.seed` only when the delegate
+      applies it (declares `random_state`); non-stochastic tools record `None`; a provided
+      seed a delegate can't accept raises `internal_error`. Tests for all three paths.
+- [x] 8.2 **B2** no internal leakage: `errors.py` returns a fixed message + correlation id
+      for `internal_error` / `internal_output_contract` (detail logged server-side); input
+      validation surfaces only field locations + types. Leak tests added.
+- [x] 8.3 **B3** ship `register(mcp, *tools)` seam in `contract/`; reconcile spec + docstrings.
+- [x] 8.4 **I1** drop positional-only `/` so the real signature matches the advertised
+      single-`params` schema; keyword-call test.
+- [x] 8.5 **I2** seed strict + range-bound `[0, 2**32)` on `ToolParams` + `resolve_seed`
+      guard (named `SEED_MAX`); out-of-range/float/bool → `invalid_input`.
+- [x] 8.6 **I3** `resolve_environment` strips + validates the `sha256:` digest; `_uv_lock_hash`
+      guards the read against `OSError`.
+- [x] 8.7 **I4** test gaps: v4-version reject; absent-seed RNG byte-identical; v2 `"unknown"`
+      reads. **I5** version-guard reject scenario + deploy-ordering gate in spec.
+- [x] 8.8 **I6** `functools.wraps` (preserves `__wrapped__`/`inspect.unwrap`); `from __future__
+      import annotations` on `schema.py`/`code_versions.py`; docstrings "at most once".
+
 ## 7. Deferred (recorded, not done here)
 
 - [x] 7.1 Consuming `sleap-roots-analyze`'s serializable result dataclasses

--- a/openspec/changes/add-bloommcp-contract-layer/tasks.md
+++ b/openspec/changes/add-bloommcp-contract-layer/tasks.md
@@ -1,0 +1,112 @@
+## 1. Oracle / acceptance tests first (RED)
+
+> All tests run against a **stub tool** + a **stub Pydantic params model** (see §3.0) with
+> fakes only — no live Supabase, no live manifest write. Round-trip tests assert **exact**
+> equality (`==`); `rtol=1e-6` / exact-int tolerance is reserved for the golden
+> *recomputation* oracle in Tiers 3/4, not these serialization tests.
+
+- [x] 1.1 `tests/contract/test_decorator_contract.py` — decorate a stub tool (declared
+      Pydantic input/output models) with `@as_mcp_tool`: (a) valid input returns the
+      validated output and the tool is discoverable via an in-process
+      `fastmcp.Client(mcp).list_tools()` after `register(mcp)`; (b) invalid **input**
+      surfaces as `BloomMCPError` and the stub body never ran (call-recording flag);
+      (c) invalid **output** surfaces as `BloomMCPError` with an internal-breach `code`,
+      never a raw `ValidationError`.
+- [x] 1.2 `tests/contract/test_error_envelope.py` — a stub tool that raises a declared
+      exception surfaces as `BloomMCPError` (`code` + `message` + `remedy`), never a raw
+      traceback.
+- [x] 1.3 `tests/contract/test_seed_propagation.py` — (a) with a seed: the fake
+      `perform_*` receives it as `random_state=`, `Provenance.seed` equals it, and
+      `np.random.get_state()` is byte-identical before/after (global RNG untouched);
+      (b) with no seed: a concrete integer is resolved, forwarded as `random_state=`, and
+      recorded in `Provenance.seed` (never null).
+- [x] 1.4 `tests/contract/test_provenance_roundtrip.py` — a fully-populated contract-time
+      `Provenance` (resolved seed, `environment`, resolved feature/column selection in
+      `params`) round-trips Pydantic ↔ JSON with **exact** equality; per-artifact
+      `output_sha256` / `key` collections are empty at contract time. Use a `hypothesis`
+      `@given` strategy varying seed/environment presence and artifact count.
+- [x] 1.5 `tests/contract/test_provenance_to_version_entry.py` — `to_version_entry(...)`
+      maps a contract-time `Provenance` to a v3 `VersionEntry` with `seed`, `agent`,
+      extended `code_versions`, `environment` set; preserves the v2 fields with their
+      source values (`id`, `created_at`, `tool`, `params`, `based_on_version`,
+      `code_versions`, `outputs`, `user_label`, `version_dir`); per-artifact
+      `output_sha256` / `output_keys` left empty (filled by `ResultStore` in Tier 2). No
+      `supabase_client` calls (conftest pops Supabase env as a backstop).
+- [x] 1.6 `tests/contract/test_code_versions_installed_only.py` — (a) with analyze +
+      contracts installed: their versions are recorded and no field equals `"unknown"`;
+      (b) with `importlib.metadata.version` monkeypatched to raise `PackageNotFoundError`
+      for a tracked name: that key is omitted entirely (not `"unknown"`).
+- [x] 1.7 `tests/contract/test_environment_pointer.py` — (a) with `BLOOM_MCP_IMAGE_DIGEST`
+      set: the `environment` pointer equals that `sha256:…` digest; (b) with it unset (the
+      unit case): the pointer falls back per precedence to a non-empty value, is never
+      `"unknown"`, and is not equal to the `code_versions` trace.
+- [x] 1.8 `tests/contract/test_schema_v3.py` — (a) `CURRENT_SCHEMA_VERSION == 3` and a
+      fresh `Manifest` reports `manifest_schema_version == 3`; (b) a v3 `VersionEntry`
+      (retained string `outputs` + `output_sha256`/`output_keys` siblings + `seed`/`agent`/
+      `environment`) round-trips `model_dump(mode="json")` ↔ re-validate exactly.
+- [x] 1.9 `tests/contract/test_v2_backcompat.py` + **add fixture**
+      `tests/fixtures/manifest_v2.json` (a hand-recorded schema-v2 manifest whose
+      `VersionEntry` has a populated string-valued `outputs` and only real v2 keys): it
+      validates via `Manifest.model_validate(...)` under v3 code, `manifest_schema_version
+      == 2`, and the v3 fields are unset — proving the additive bump holds under
+      `extra="forbid"`.
+
+## 2. Manifest schema v2 → v3 (additive) (GREEN)
+
+- [x] 2.1 `storage/schema.py`: bump `CURRENT_SCHEMA_VERSION = 3` and update the module
+      docstring (schema version 2 → 3). **Retain `outputs: dict[str, str]` unchanged.** Add
+      optional sibling collections `output_sha256: dict[str, str] = {}` and
+      `output_keys: dict[str, str] = {}` to `VersionEntry`, plus optional `seed`, `agent`,
+      `environment`. Keep `extra="forbid"`. (`outputs` is NOT re-typed — that is what keeps
+      v2 string-valued `outputs` loadable.)
+- [x] 2.2 `storage/schema.py`/`code_versions.py`: make `CodeVersions` fields omit-on-absent
+      optional (no `"unknown"` default) for **all** entries; add optional
+      `sleap_roots_analyze` / `sleap_roots_contracts`. Rewrite `_version_or_unknown` →
+      omit-on-`PackageNotFoundError` resolution.
+- [x] 2.3 Confirm `storage/manifest.py` `validate_schema` still accepts v2 and now v3
+      (`<=` known); `KNOWN_SCHEMA_VERSION` tracks `CURRENT_SCHEMA_VERSION` automatically.
+
+## 3. Provenance model + mapping (GREEN)
+
+- [x] 3.0 `contract/models.py` (or reuse if #191 lands first): a **stub Tier-1 Pydantic
+      params model** carrying `seed: Optional[int]` + the input/output models the decorator
+      validates against. #191 (Pydantic input models) is OPEN/unmerged, so Tier 1 defines a
+      minimal stub; real tool models arrive with the granular tools (Tiers 3/4).
+- [x] 3.1 `contract/provenance.py`: canonical contract-time `Provenance` model (fields per
+      the spec; `params` captures resolved feature/column selection + determinism params) +
+      `to_version_entry(...)` producing a v3 `VersionEntry` (per-artifact fields left for
+      `ResultStore`). Note `input_sha256` belongs on the experiment block, not the entry.
+- [x] 3.2 Wire the `environment` pointer resolver: `BLOOM_MCP_IMAGE_DIGEST` →
+      `bloom-mcp` version → `uv.lock` hash; document the precedence; field optional in unit
+      env. Note `output_sha256` = hex SHA-256 over pre-upload bytes, computed at commit
+      (Tier 2); carry forward to Tiers 3/4 the matplotlib-determinism caveat for plots.
+
+## 4. Error type (GREEN)
+
+- [x] 4.1 `contract/errors.py`: `BloomMCPError(code, message, remedy)` with a serializable
+      structured form; an exception→error mapping helper distinguishing a user input error
+      from an internal output-contract breach.
+
+## 5. The decorator (GREEN)
+
+- [x] 5.1 `contract/wrap.py`: `@as_mcp_tool` — validate Pydantic I/O, map exceptions →
+      `BloomMCPError`, resolve + propagate seed → delegate `random_state=`, stamp the
+      contract-time `Provenance` once, and attach a `register(mcp)` seam (no live `FastMCP`
+      at decoration time; no `server.py` change). **Never** `np.random.seed()`.
+- [x] 5.2 `contract/__init__.py`: export `as_mcp_tool`, `Provenance`, `BloomMCPError`.
+
+## 6. Refactor + green gate
+
+- [x] 6.1 Refactor for clarity/dedup; `from __future__ import annotations` + google
+      docstrings on every new module.
+- [x] 6.2 `cd bloommcp && uv run --extra test pytest` green (full suite, fakes only — no
+      live Supabase); `import bloom_mcp` clean with no env set.
+- [x] 6.3 `uv run black --check` + `uv run ruff check` clean (repo `/lint` convention).
+- [x] 6.4 `openspec validate add-bloommcp-contract-layer --strict` passes.
+
+## 7. Deferred (recorded, not done here)
+
+- [x] 7.1 Consuming `sleap-roots-analyze`'s serializable result dataclasses
+      (`PCAResult`/`ClusterResult`, #149/#151 — now **merged**) instead of reinventing a
+      JSON projection is deferred to Tiers 3/4: Tier 1 records provenance over a **stub**,
+      not a real result type, so there is nothing to consume yet.


### PR DESCRIPTION
## bloom-mcp Phase 2 · Tier 1 — contract layer

Closes #306 · Roadmap Tier 1 (`bloommcp/docs/roadmap.md`) · Builds on Tier 0 (#313, merged to `staging`).

The uniform tool contract every granular tool wraps — so provenance and structured errors are **guaranteed by the contract, not per-tool boilerplate**. Built TDD (oracle/acceptance tests first), validated against a **stub tool** (no real analysis tools, no live persistence write, no `server.py` change — those are Tiers 2–4).

OpenSpec change: `add-bloommcp-contract-layer` (`openspec validate --strict` passes).

### What's in it

- **`contract/wrap.py` — `@as_mcp_tool`.** Our own glue over FastMCP's `mcp.tool()` (we wrap, not replace; Pydantic for I/O). On every call it:
  - validates the tool's Pydantic **input/output** models;
  - maps exceptions → structured **`BloomMCPError`** (`code`/`message`/`remedy`) — never a raw traceback, **never leaked internals** (internal failures return a fixed message + correlation id; detail logged server-side; input errors surface field locations + types, not values);
  - **resolves + propagates** the seed as `random_state=` (explicit kwarg-injection contract) and records it in `Provenance` **only when the delegate applies it** — never `np.random.seed()`;
  - stamps one contract-time **`Provenance`**.
  - Registration is the shipped `register(mcp, *tools)` seam (no `server.py` change; the `mcp` instance doesn't exist at decoration time).
- **`contract/provenance.py`** — canonical `Provenance` + `to_version_entry()` mapping; `resolve_seed()` (strict, range-bound `[0, 2**32)`, records the *resolved* seed); `resolve_environment()` (precedence: `BLOOM_MCP_IMAGE_DIGEST` → `bloom-mcp` version → `uv.lock` hash).
- **`contract/errors.py`**, **`contract/models.py`** (stub `ToolParams` base — #191 is unmerged, so Tier 1 ships a minimal stub; real per-tool models arrive in Tiers 3/4).
- **Manifest schema v2 → v3 (additive).** `storage/schema.py`: `outputs: dict[str,str]` **retained unchanged**; new **optional** sibling collections `output_sha256`/`output_keys` + `seed`/`agent`/`environment`; `CodeVersions` is **installed-only** (omits absent dists instead of `"unknown"`) and adds `sleap-roots-analyze` + `sleap-roots-contracts` (Benfica, #310). Old v2 manifests still read.

**One provenance path:** per-artifact `output_sha256`/`key` are populated **at commit by the `ResultStore` (Tier 2)** — the artifact bytes don't exist at contract time. Tier 1 defines the fields + the mapping and unit-tests the mapping (no live Supabase, no live write).

### Oracle / acceptance (issue #306)

- [x] Every wrapped call stamps a complete `Provenance` (incl. `seed` **and** the environment pointer); it round-trips into a manifest `VersionEntry` (v3).
- [x] `code_versions` records only installed distributions (no `"unknown"`); the environment pointer is present.
- [x] Old (v2) manifests still read without error (additive bump; real v2 fixture with string `outputs` under `extra="forbid"`).
- [x] Declared errors surface as `BloomMCPError` (code + remedy), never raw.
- [x] Schema round-trip (Pydantic ↔ JSON) holds — **exact** equality (tolerance is reserved for the Tier 3/4 recomputation oracle).
- [x] The decorator does **not** `np.random.seed()`; the seed is resolved + recorded in `Provenance` (global RNG byte-identical before/after).

### Combined review addressed (`dd44356`)

Two full review passes (`/openspec-review` + `/review-pr`, 10 subagents) converged on three contract-defining defects — fixed before they propagate to every downstream tool:

- **B1 — seed-provenance integrity:** record `seed` only when the delegate applies it; non-stochastic → `None`; a seed a delegate can't accept → `internal_error` (no recorded-but-unapplied "lie").
- **B2 — no internal leakage:** fixed message + correlation id for internal failures (detail logged server-side); input errors surface locations/types, not values.
- **B3 — register seam:** shipped `register(mcp, *tools)` (was specified/documented but absent).
- Plus: keyword-call signature fix (I1), strict range-bound seed (I2), `resolve_environment` digest/lock hardening (I3), v4-reject + RNG-identity tests (I4/I5), `functools.wraps` (I6).

### Verification

- 24 contract tests; full `bloommcp` suite **40 passed** (fakes only — no live Supabase).
- `black --check` clean · `ruff check` clean · `import bloom_mcp` clean with no env set.
- `openspec validate add-bloommcp-contract-layer --strict` passes.

### Out of scope (deferred, with triggers)

Real tools `pca_analysis`/`clustering` (Tiers 3/4), live persistence write via `ResultStore` (Tier 2), `server.py` tool registration (Tier 3), and consuming `sleap-roots-analyze`'s result dataclasses (talmolab/sleap-roots-analyze#149 / talmolab/sleap-roots-analyze#151, now merged — Tier 1 records provenance over a stub, so there's nothing to consume yet). The scientific carry-forwards (inert-seed/params faithfulness, `matrix_sha256`, lock archival for persisted runs, `output_sha256`-at-commit guard, per-user attribution) become hard, tested gates in Tiers 2–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
