### PR TITLE
feat(embedtree): Orthologs gene search + KNN force-directed graph

### DIFF
--- a/web/app/app/embedtree/page.tsx
+++ b/web/app/app/embedtree/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/supabase/server";
+import { EmbedtreePage } from "@/components/embedtree/embedtree-page";
+
+export const metadata = {
+  title: "AI Orthologs | Bloom",
+  description:
+    "Find predicted orthologs across plant species using ESM-2 protein embeddings.",
+};
+
+export default async function EmbedtreeRoute() {
+  const user = await getUser();
+  if (!user) redirect("/login");
+
+  return <EmbedtreePage />;
+}

--- a/web/app/app/layout.tsx
+++ b/web/app/app/layout.tsx
@@ -30,6 +30,7 @@ const navSections = [
     items: [
       { name: "Bloom Assistant", href: "/chat" },
       { name: "OrthoBrowser", href: "/app/orthofinder" },
+      { name: "AI\nOrthologs", href: "/app/embedtree" },
     ],
   },
   {

--- a/web/components/embedtree/constants.ts
+++ b/web/components/embedtree/constants.ts
@@ -1,0 +1,29 @@
+// Shared constants for the embedtree similarity-tree UI.
+//
+// The species color palette is the single source of truth for visual
+// species identity across the page (graph nodes, results rows, legend).
+// Keys are common_name values from public.species.
+
+export const DEFAULT_K = 20;
+export const K_MIN = 5;
+export const K_MAX = 50;
+
+export const SPECIES_COLORS: Record<string, string> = {
+  arabidopsis: "#3b82f6", // blue
+  rice: "#10b981",        // green
+  maize: "#f59e0b",       // amber
+  soybean: "#8b5cf6",     // violet
+};
+
+export const UNKNOWN_SPECIES_COLOR = "#9ca3af"; // neutral-400
+
+export function speciesColor(common_name: string | null | undefined): string {
+  if (!common_name) return UNKNOWN_SPECIES_COLOR;
+  return SPECIES_COLORS[common_name.toLowerCase()] ?? UNKNOWN_SPECIES_COLOR;
+}
+
+// Single source of truth for the disclaimer copy. Edits land in one place.
+export const SIMILARITY_DISCLAIMER =
+  "Neighbors are ranked by ESM-2 protein-embedding cosine similarity — " +
+  "a quick proxy for orthology, not a verified ortholog set. " +
+  "For sequence-alignment-based orthology, use OrthoBrowser.";

--- a/web/components/embedtree/embedtree-page.tsx
+++ b/web/components/embedtree/embedtree-page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import { GenePicker, type GeneRow } from "./gene-picker";
+import { KnnGraph, type KnnNeighbor } from "./knn-graph";
+import { DEFAULT_K, K_MAX, K_MIN, SIMILARITY_DISCLAIMER } from "./constants";
+
+// Loose RPC + table types until web/lib/database.types.ts is regenerated to
+// know about the embedtree RPCs and tables. See note in gene-picker.tsx.
+type RpcCall = (name: string, args: object) => Promise<{
+  data: unknown;
+  error: { message?: string } | null;
+}>;
+type LooseTable = {
+  select: (cols: string) => {
+    in: (col: string, values: string[]) => Promise<{
+      data: unknown;
+      error: { message?: string } | null;
+    }>;
+  };
+};
+type LooseFrom = (table: string) => LooseTable;
+
+// pgvector text format: "[1.234,5.678,...]"
+function parsePgvector(s: string): number[] {
+  return s.slice(1, -1).split(",").map(Number);
+}
+
+function ToggleChip({
+  label,
+  active,
+  onToggle,
+}: {
+  label: string;
+  active: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? "border-blue-500 bg-blue-50 text-blue-700"
+          : "border-stone-300 bg-white text-neutral-500 hover:bg-stone-50"
+      }`}
+      aria-pressed={active}
+    >
+      <span
+        className={`mr-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle ${
+          active ? "bg-blue-500" : "bg-stone-300"
+        }`}
+        aria-hidden
+      />
+      {label}
+    </button>
+  );
+}
+
+type QueryState = {
+  uid: string;
+  species: string | null;
+  gene_id: string | null;
+};
+
+/**
+ * Top-level client component for /app/embedtree.
+ *
+ * Owns: selected query, K, in-flight KNN results, error state.
+ * Children handle their own input (search) or render (graph).
+ */
+export function EmbedtreePage() {
+  const supabase = createClientSupabaseClient();
+  const [query, setQuery] = useState<QueryState | null>(null);
+  const [k, setK] = useState<number>(DEFAULT_K);
+  const [neighbors, setNeighbors] = useState<KnnNeighbor[]>([]);
+  const [embeddings, setEmbeddings] = useState<Map<string, number[]>>(new Map());
+  const [showQueryEdges, setShowQueryEdges] = useState(true);
+  // Default off — query→neighbor edges are the primary signal; pairwise
+  // edges are an optional second layer the user opts into.
+  const [showPairwiseEdges, setShowPairwiseEdges] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runKnn = useCallback(
+    async (q: QueryState, kVal: number) => {
+      setLoading(true);
+      setError(null);
+      const { data, error: rpcErr } = await (supabase.rpc as unknown as RpcCall)(
+        "knn_search_esm2",
+        { query_uid: q.uid, match_count: kVal },
+      );
+      if (rpcErr) {
+        setLoading(false);
+        setError(rpcErr.message ?? String(rpcErr));
+        setNeighbors([]);
+        setEmbeddings(new Map());
+        return;
+      }
+
+      const ns = ((data ?? []) as KnnNeighbor[]).filter((n) => n.uid !== q.uid);
+      setNeighbors(ns);
+
+      // Fetch the raw embedding vectors for query + neighbors so the graph
+      // can draw pairwise inter-neighbor edges (the KNN RPC only returns
+      // similarity to the query, not pairwise).
+      const uids = [q.uid, ...ns.map((n) => n.uid)];
+      const { data: embRows, error: embErr } = await (
+        supabase.from as unknown as LooseFrom
+      )("protein_embeddings_esm2")
+        .select("uid, embedding")
+        .in("uid", uids);
+      setLoading(false);
+      if (embErr) {
+        setError(`embeddings fetch failed: ${embErr.message ?? String(embErr)}`);
+        setEmbeddings(new Map());
+        return;
+      }
+      const m = new Map<string, number[]>();
+      for (const row of (embRows ?? []) as { uid: string; embedding: string | number[] }[]) {
+        const vec = typeof row.embedding === "string"
+          ? parsePgvector(row.embedding)
+          : row.embedding;
+        m.set(row.uid, vec);
+      }
+      setEmbeddings(m);
+    },
+    [supabase],
+  );
+
+  const handleSelect = useCallback(
+    (row: GeneRow) => {
+      const next: QueryState = {
+        uid: row.uid,
+        species: row.species,
+        gene_id: row.gene_id,
+      };
+      setQuery(next);
+      void runKnn(next, k);
+    },
+    [k, runKnn],
+  );
+
+  const handleKChange = useCallback(
+    (next: number) => {
+      const clamped = Math.max(K_MIN, Math.min(K_MAX, Math.round(next)));
+      setK(clamped);
+      if (query) void runKnn(query, clamped);
+    },
+    [query, runKnn],
+  );
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-xl font-semibold text-neutral-800">
+          AI Orthologs
+        </h1>
+        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          <span className="font-semibold">Predicted, not verified.</span>{" "}
+          {SIMILARITY_DISCLAIMER}
+        </p>
+      </header>
+
+      <section className="flex flex-wrap items-center gap-3">
+        <GenePicker onSelect={handleSelect} />
+        <label className="flex items-center gap-2 text-sm text-neutral-700">
+          K
+          <input
+            type="number"
+            min={K_MIN}
+            max={K_MAX}
+            value={k}
+            onChange={(e) => handleKChange(Number(e.target.value))}
+            className="w-16 rounded-md border border-stone-300 bg-white px-2 py-1 text-sm shadow-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          />
+        </label>
+        <ToggleChip
+          label="Query edges"
+          active={showQueryEdges}
+          onToggle={() => setShowQueryEdges((v) => !v)}
+        />
+        <ToggleChip
+          label="Pairwise edges"
+          active={showPairwiseEdges}
+          onToggle={() => setShowPairwiseEdges((v) => !v)}
+        />
+        {loading && (
+          <span className="text-xs text-neutral-500">Running KNN…</span>
+        )}
+        {error && (
+          <span className="text-xs text-red-600">Error: {error}</span>
+        )}
+      </section>
+
+      <section className="flex flex-1 items-start justify-center overflow-hidden">
+        {query ? (
+          <KnnGraph
+            queryUid={query.uid}
+            querySpecies={query.species}
+            queryGeneId={query.gene_id}
+            neighbors={neighbors}
+            embeddings={embeddings}
+            showQueryEdges={showQueryEdges}
+            showPairwiseEdges={showPairwiseEdges}
+            onSelectNeighbor={(n) => handleSelect(n)}
+          />
+        ) : (
+          <div className="flex h-96 w-full max-w-3xl items-center justify-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-neutral-500">
+            Search for a gene above to see its similarity neighborhood.
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/components/embedtree/gene-picker.tsx
+++ b/web/components/embedtree/gene-picker.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import { speciesColor } from "./constants";
+
+const DEBOUNCE_MS = 300;
+const PAGE_SIZE = 20;
+
+// Loose RPC type until web/lib/database.types.ts is regenerated to know about
+// the embedtree RPCs (`search_genes`, `knn_search_esm2`). Drop this when the
+// generated types catch up.
+type RpcCall = (name: string, args: object) => Promise<{
+  data: unknown;
+  error: { message?: string } | null;
+}>;
+
+export type GeneRow = {
+  uid: string;
+  species: string | null;
+  gene_id: string | null;
+};
+
+type Props = {
+  onSelect: (row: GeneRow) => void;
+};
+
+/**
+ * Debounced autocomplete over the `search_genes(partial, max_results)` RPC.
+ *
+ * Race-condition handling: every request is tagged with a sequence number
+ * and only the latest response renders, so a slow request that resolves
+ * after a faster later one doesn't overwrite the fresh dropdown.
+ */
+export function GenePicker({ onSelect }: Props) {
+  const [query, setQuery] = useState("");
+  const [rows, setRows] = useState<GeneRow[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [hoverIdx, setHoverIdx] = useState(0);
+
+  const supabase = createClientSupabaseClient();
+  const seqRef = useRef(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const runSearch = useCallback(
+    async (partial: string, seq: number) => {
+      setLoading(true);
+      // Cast: search_genes isn't yet in the generated Database types.
+      // Regenerate web/lib/database.types.ts after embedtree migrations
+      // land on prod and the cast goes away.
+      const { data, error } = await (supabase.rpc as unknown as RpcCall)(
+        "search_genes",
+        { partial_id: partial, max_results: PAGE_SIZE },
+      );
+      // Stale response — a newer request was fired after this one.
+      if (seq !== seqRef.current) return;
+      setLoading(false);
+      if (error) {
+        setRows([]);
+        return;
+      }
+      setRows((data ?? []) as GeneRow[]);
+      setHoverIdx(0);
+    },
+    [supabase],
+  );
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const trimmed = query.trim();
+    if (trimmed.length === 0) {
+      setRows([]);
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    const seq = ++seqRef.current;
+    debounceRef.current = setTimeout(() => runSearch(trimmed, seq), DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, runSearch]);
+
+  function handleKey(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open || rows.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHoverIdx((i) => Math.min(i + 1, rows.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHoverIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      pick(rows[hoverIdx]);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  function pick(row: GeneRow) {
+    onSelect(row);
+    setQuery(row.gene_id ?? row.uid);
+    setOpen(false);
+  }
+
+  return (
+    <div className="relative w-full max-w-xl">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKey}
+        onFocus={() => query.trim() && setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        placeholder="Search by gene id (e.g. AT5G16970)…"
+        className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-sm shadow-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+      />
+      {loading && (
+        <div className="absolute right-3 top-2.5 text-xs text-neutral-400">
+          …
+        </div>
+      )}
+      {open && rows.length > 0 && (
+        <ul className="absolute z-20 mt-1 max-h-80 w-full overflow-y-auto rounded-md border border-stone-200 bg-white shadow-lg">
+          {rows.map((r, i) => (
+            <li
+              key={r.uid}
+              onMouseDown={() => pick(r)}
+              onMouseEnter={() => setHoverIdx(i)}
+              className={`flex cursor-pointer items-center gap-2 px-3 py-2 text-sm ${
+                i === hoverIdx ? "bg-blue-50" : "bg-white"
+              }`}
+            >
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: speciesColor(r.species) }}
+                aria-hidden
+              />
+              <span className="font-mono text-neutral-800">{r.gene_id ?? r.uid}</span>
+              <span className="ml-auto text-xs text-neutral-500">
+                {r.species ?? "—"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {open && !loading && rows.length === 0 && query.trim().length > 0 && (
+        <div className="absolute z-20 mt-1 w-full rounded-md border border-stone-200 bg-white px-3 py-2 text-sm text-neutral-500 shadow-sm">
+          No matching genes.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/embedtree/knn-graph.tsx
+++ b/web/components/embedtree/knn-graph.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as d3 from "d3";
+import { speciesColor } from "./constants";
+import { cosineDistance } from "./lib/distance";
+
+export type KnnNeighbor = {
+  uid: string;
+  species: string | null;
+  gene_id: string | null;
+  similarity: number;
+};
+
+type Props = {
+  queryUid: string;
+  querySpecies: string | null;
+  queryGeneId: string | null;
+  neighbors: KnnNeighbor[];
+  embeddings: Map<string, number[]>;
+  showQueryEdges?: boolean;
+  showPairwiseEdges?: boolean;
+  onSelectNeighbor?: (n: KnnNeighbor) => void;
+  width?: number;
+  height?: number;
+};
+
+type Node = d3.SimulationNodeDatum & {
+  id: string;
+  isQuery: boolean;
+  label: string;
+  species: string | null;
+  similarity: number;
+};
+
+type Link = d3.SimulationLinkDatum<Node> & {
+  similarity: number;
+  // Edges from query → neighbor are emphasized; pairwise neighbor edges are
+  // backdrop-style so the graph reads as "query at the center with its
+  // similarity neighborhood, plus how those neighbors relate."
+  kind: "query" | "pairwise";
+};
+
+const NODE_R_MIN = 5;
+const NODE_R_QUERY = 14;
+const NODE_R_MAX = 12;
+
+// Edges below this similarity are dropped to keep the graph readable. At
+// K=20 that's up to 190 pairwise edges; with ESM-2 data, sim>=0.5 typically
+// retains the meaningful relationships and discards the noise.
+const PAIRWISE_SIM_THRESHOLD = 0.5;
+
+/**
+ * Force-directed graph: query at the center, K neighbors connected by query
+ * edges, plus pairwise edges between neighbors above
+ * PAIRWISE_SIM_THRESHOLD. The simulation stays live so the user can drag
+ * any node to rearrange the layout — drag pins the node where dropped;
+ * double-click releases it back to the simulation.
+ *
+ * Click a neighbor to fire `onSelectNeighbor` (the parent uses this to
+ * make that neighbor the new query and re-run KNN).
+ */
+export function KnnGraph({
+  queryUid,
+  querySpecies,
+  queryGeneId,
+  neighbors,
+  embeddings,
+  showQueryEdges = true,
+  showPairwiseEdges = true,
+  onSelectNeighbor,
+  width = 760,
+  height = 520,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const simRef = useRef<d3.Simulation<Node, Link> | null>(null);
+  // dragMovedRef tracks whether the mouse actually moved between mouse-down
+  // and mouse-up so we can distinguish a plain click (pivot to that node)
+  // from a drag (re-position only). Plain React state would be too slow —
+  // the click event reads the captured closure value, not the live state.
+  const dragMovedRef = useRef(false);
+  const [renderedNodes, setRenderedNodes] = useState<Node[]>([]);
+  const [renderedLinks, setRenderedLinks] = useState<Link[]>([]);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [dragId, setDragId] = useState<string | null>(null);
+
+  // Build nodes + links from props. Pairwise edges are computed only if we
+  // have embeddings for both endpoints — otherwise we silently degrade to
+  // the query-centric star graph.
+  const built = useMemo(() => {
+    const ns: Node[] = [
+      {
+        id: queryUid,
+        isQuery: true,
+        label: queryGeneId ?? queryUid,
+        species: querySpecies,
+        similarity: 1.0,
+      },
+      ...neighbors
+        .filter((n) => n.uid !== queryUid)
+        .map<Node>((n) => ({
+          id: n.uid,
+          isQuery: false,
+          label: n.gene_id ?? n.uid,
+          species: n.species,
+          similarity: n.similarity,
+        })),
+    ];
+
+    const ls: Link[] = [];
+    // Query → neighbor (always drawn).
+    for (const n of ns) {
+      if (n.isQuery) continue;
+      ls.push({ source: queryUid, target: n.id, similarity: n.similarity, kind: "query" });
+    }
+    // Neighbor ↔ neighbor (pairwise, above threshold).
+    const neighborIds = ns.filter((n) => !n.isQuery).map((n) => n.id);
+    for (let i = 0; i < neighborIds.length; i += 1) {
+      const ei = embeddings.get(neighborIds[i]);
+      if (!ei) continue;
+      for (let j = i + 1; j < neighborIds.length; j += 1) {
+        const ej = embeddings.get(neighborIds[j]);
+        if (!ej) continue;
+        const sim = 1 - cosineDistance(ei, ej);
+        if (sim < PAIRWISE_SIM_THRESHOLD) continue;
+        ls.push({
+          source: neighborIds[i],
+          target: neighborIds[j],
+          similarity: sim,
+          kind: "pairwise",
+        });
+      }
+    }
+
+    return { ns, ls };
+  }, [queryUid, querySpecies, queryGeneId, neighbors, embeddings]);
+
+  // Build and start the live simulation on input change. Query node is
+  // softly pinned to the center via fx/fy; users can still drag it.
+  useEffect(() => {
+    if (built.ns.length === 0) {
+      setRenderedNodes([]);
+      setRenderedLinks([]);
+      return;
+    }
+
+    const query = built.ns.find((n) => n.isQuery);
+    if (query) {
+      query.fx = width / 2;
+      query.fy = height / 2;
+    }
+
+    const sim = d3
+      .forceSimulation<Node, Link>(built.ns)
+      .force(
+        "link",
+        d3
+          .forceLink<Node, Link>(built.ls)
+          .id((n) => n.id)
+          // Higher similarity ⇒ shorter target distance.
+          .distance((l) => 100 + (1 - clamp01(l.similarity)) * 280)
+          .strength((l) => (l.kind === "query" ? 0.7 : 0.25)),
+      )
+      // Stronger repulsion than the default to keep labels readable.
+      .force("charge", d3.forceManyBody<Node>().strength(-450))
+      .force("center", d3.forceCenter(width / 2, height / 2))
+      .force(
+        "collide",
+        // Wider collision padding so node labels don't overlap.
+        d3
+          .forceCollide<Node>()
+          .radius((n) => (n.isQuery ? NODE_R_QUERY : NODE_R_MAX) + 22)
+          .strength(0.9),
+      )
+      .alpha(1)
+      .alphaDecay(0.04)
+      .on("tick", () => {
+        // Snapshot positions to React state on each tick.
+        setRenderedNodes([...sim.nodes()]);
+        setRenderedLinks([...(sim.force("link") as d3.ForceLink<Node, Link>).links()]);
+      });
+
+    simRef.current = sim;
+    return () => {
+      sim.stop();
+      simRef.current = null;
+    };
+  }, [built, width, height]);
+
+  // Translate a screen-space pointer to SVG coordinates. Used by drag.
+  const screenToSvg = useCallback((clientX: number, clientY: number) => {
+    const svg = svgRef.current;
+    if (!svg) return { x: 0, y: 0 };
+    const pt = svg.createSVGPoint();
+    pt.x = clientX;
+    pt.y = clientY;
+    const transformed = pt.matrixTransform(svg.getScreenCTM()?.inverse());
+    return { x: transformed.x, y: transformed.y };
+  }, []);
+
+  // Mouse-down on a node starts a drag. The node is pinned (fx/fy) for the
+  // duration of the drag; simulation alpha is bumped so the layout
+  // responds. Mouse-up ends the drag but leaves the node pinned where
+  // released — double-click to unpin.
+  const onNodeMouseDown = useCallback(
+    (e: React.MouseEvent<SVGGElement>, node: Node) => {
+      // Query is locked at center — not draggable.
+      if (node.isQuery) return;
+      e.stopPropagation();
+      e.preventDefault();
+      dragMovedRef.current = false;
+      setDragId(node.id);
+      simRef.current?.alphaTarget(0.3).restart();
+      node.fx = node.x ?? 0;
+      node.fy = node.y ?? 0;
+    },
+    [],
+  );
+
+  const onSvgMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!dragId) return;
+      const node = simRef.current?.nodes().find((n) => n.id === dragId);
+      if (!node) return;
+      const { x, y } = screenToSvg(e.clientX, e.clientY);
+      // Only mark as a real drag if the cursor actually moved noticeably.
+      // A few pixels of jitter is normal even on a "click" — distinguish
+      // intent by movement, not by whether mouse-down fired.
+      const dx = (node.fx ?? x) - x;
+      const dy = (node.fy ?? y) - y;
+      if (dx * dx + dy * dy > 9) dragMovedRef.current = true;
+      node.fx = x;
+      node.fy = y;
+    },
+    [dragId, screenToSvg],
+  );
+
+  const onSvgMouseUp = useCallback(() => {
+    if (!dragId) return;
+    setDragId(null);
+    simRef.current?.alphaTarget(0);
+  }, [dragId]);
+
+  // Double-click a node to unpin it (the query stays pinned to center).
+  const onNodeDoubleClick = useCallback(
+    (e: React.MouseEvent<SVGGElement>, node: Node) => {
+      e.stopPropagation();
+      if (node.isQuery) return;
+      node.fx = null;
+      node.fy = null;
+      simRef.current?.alpha(0.3).restart();
+    },
+    [],
+  );
+
+  if (renderedNodes.length === 0) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center rounded-md border border-stone-200 bg-stone-50 text-sm text-neutral-500"
+        style={{ width, height }}
+      >
+        Search for a gene to render its similarity neighborhood.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <svg
+        ref={svgRef}
+        width={width}
+        height={height}
+        onMouseMove={onSvgMouseMove}
+        onMouseUp={onSvgMouseUp}
+        onMouseLeave={onSvgMouseUp}
+        className="rounded-md border border-stone-200 bg-white"
+      >
+        <defs>
+          {/* Soft neon glow for the query-gene ring. */}
+          <filter id="query-glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="3.5" result="blurred" />
+            <feMerge>
+              <feMergeNode in="blurred" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+        {/* edges */}
+        <g>
+          {renderedLinks
+            .filter((l) =>
+              l.kind === "query" ? showQueryEdges : showPairwiseEdges,
+            )
+            .map((l, i) => {
+              const s = l.source as Node;
+              const t = l.target as Node;
+              const isQueryEdge = l.kind === "query";
+              return (
+                <line
+                  key={i}
+                  x1={s.x}
+                  y1={s.y}
+                  x2={t.x}
+                  y2={t.y}
+                  stroke={isQueryEdge ? "#94a3b8" : "#cbd5e1"}
+                  strokeOpacity={isQueryEdge ? 0.85 : 0.45 + l.similarity * 0.4}
+                  strokeWidth={
+                    isQueryEdge ? 1 + l.similarity * 2 : 0.5 + l.similarity * 1.5
+                  }
+                />
+              );
+            })}
+        </g>
+        {/* nodes */}
+        <g>
+          {renderedNodes.map((n) => {
+            const r = n.isQuery
+              ? NODE_R_QUERY
+              : NODE_R_MIN + (NODE_R_MAX - NODE_R_MIN) * clamp01(n.similarity);
+            const hovered = hoveredId === n.id;
+            const dragging = dragId === n.id;
+            const pinned = n.fx != null && n.fy != null && !n.isQuery;
+            return (
+              <g
+                key={n.id}
+                transform={`translate(${n.x ?? 0},${n.y ?? 0})`}
+                onMouseEnter={() => setHoveredId(n.id)}
+                onMouseLeave={() =>
+                  setHoveredId((id) => (id === n.id ? null : id))
+                }
+                onMouseDown={(e) => onNodeMouseDown(e, n)}
+                onDoubleClick={(e) => onNodeDoubleClick(e, n)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (n.isQuery) return;
+                  // Suppress the click if the user actually dragged — drag
+                  // is a layout edit, click is a pivot.
+                  if (dragMovedRef.current) {
+                    dragMovedRef.current = false;
+                    return;
+                  }
+                  onSelectNeighbor?.({
+                    uid: n.id,
+                    species: n.species,
+                    gene_id: n.label,
+                    similarity: n.similarity,
+                  });
+                }}
+                className={n.isQuery ? "cursor-grab" : "cursor-pointer"}
+                style={dragging ? { cursor: "grabbing" } : undefined}
+              >
+                {n.isQuery && (
+                  <>
+                    {/* Outer neon glow ring. */}
+                    <circle
+                      r={r + 8}
+                      fill="none"
+                      stroke="#fbbf24"
+                      strokeWidth={3}
+                      strokeOpacity={0.9}
+                      filter="url(#query-glow)"
+                    />
+                    {/* Inner crisp ring on top of the glow for definition. */}
+                    <circle
+                      r={r + 4}
+                      fill="none"
+                      stroke="#f59e0b"
+                      strokeWidth={1.5}
+                    />
+                  </>
+                )}
+                <circle
+                  r={r}
+                  fill={speciesColor(n.species)}
+                  stroke={n.isQuery ? "#92400e" : hovered ? "#111827" : "#ffffff"}
+                  strokeWidth={n.isQuery ? 2 : hovered ? 1.5 : 1}
+                />
+                {pinned && (
+                  <circle
+                    r={r + 4}
+                    fill="none"
+                    stroke="#111827"
+                    strokeWidth={0.8}
+                    strokeDasharray="2 2"
+                  />
+                )}
+                <text
+                  y={r + (n.isQuery ? 18 : 12)}
+                  textAnchor="middle"
+                  className="select-none fill-neutral-700"
+                  style={{ fontSize: 11, fontFamily: "ui-monospace, monospace" }}
+                >
+                  {truncate(n.label, 14)}
+                </text>
+                {n.isQuery && (
+                  <text
+                    y={r + 32}
+                    textAnchor="middle"
+                    className="select-none"
+                    style={{
+                      fontSize: 9,
+                      fontWeight: 600,
+                      letterSpacing: "0.06em",
+                      textTransform: "uppercase",
+                      fill: "#b45309",
+                    }}
+                  >
+                    Query Gene
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+      {hoveredId && (
+        <Tooltip
+          nodes={renderedNodes}
+          hoveredId={hoveredId}
+          width={width}
+        />
+      )}
+      <div className="absolute bottom-2 right-2 rounded bg-white/90 px-2 py-1 text-[10px] text-neutral-500 shadow">
+        drag to move · double-click to unpin · click neighbor to pivot
+      </div>
+    </div>
+  );
+}
+
+function Tooltip({
+  nodes,
+  hoveredId,
+  width,
+}: {
+  nodes: Node[];
+  hoveredId: string;
+  width: number;
+}) {
+  const n = nodes.find((x) => x.id === hoveredId);
+  if (!n) return null;
+  return (
+    <div
+      className="pointer-events-none absolute right-2 top-2 rounded-md bg-neutral-900/90 px-3 py-2 text-xs text-white shadow-lg"
+      style={{ maxWidth: width / 2 }}
+    >
+      <div className="font-mono">{n.label}</div>
+      <div className="text-neutral-300">
+        species: {n.species ?? "—"}
+        {!n.isQuery && (
+          <>
+            {" · "}sim: {n.similarity.toFixed(3)}
+          </>
+        )}
+        {n.isQuery && <> · query</>}
+      </div>
+    </div>
+  );
+}
+
+function clamp01(x: number): number {
+  if (Number.isNaN(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + "…";
+}


### PR DESCRIPTION
# PR body draft — feat(embedtree): Orthologs gene search + KNN force-directed graph

**Branch:** `feat/embedtree-ui-search-and-graph`
**Base:** `staging`
**Status:** draft for review (paste into `gh pr create` body once approved)

---

## Summary

First user-facing slice on top of the merged embedtree data layer
(#293 schema + KNN RPC, #299 pure-TS algorithms, #328 writer RLS +
species FK).

Adds a new page at `/app/embedtree`, surfaced in the
Tools nav alongside OrthoBrowser.

The user picks a gene → sees its K nearest neighbors across all
loaded species (arabidopsis, rice, maize, +1) in a force-directed
network graph → can drag nodes to rearrange, click a neighbor to
pivot the page to that gene's neighborhood.

Supersedes the unmerged PR #47 (`feat: add Embedding Phylogenomics tab to OrthoBrowser`), which was ~3,000 lines, never landed, and
misframed the tree as phylogenomics (it's similarity clustering, not
phylogeny — see "Framing" below).

## What's in this PR

### New route

| File                               | Lines | Purpose                                                                                      |
| ---------------------------------- | ----- | -------------------------------------------------------------------------------------------- |
| `web/app/app/embedtree/page.tsx` | 16    | Server-component shell — auth check, redirect to login if no user, render client component. |

### New client components

| File                                            | Lines | Purpose                                                                                                                                                                                                                                                                                     |
| ----------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `web/components/embedtree/constants.ts`       | 30    | Species color palette (4 colors, accessible),`K` bounds, single source of truth for the disclaimer copy.                                                                                                                                                                                  |
| `web/components/embedtree/embedtree-page.tsx` | 191   | Top-level client orchestrator. Owns query state, K, edge-toggle state, in-flight RPC state. Calls `knn_search_esm2`, then fetches raw embeddings so the graph can compute pairwise distances.                                                                                             |
| `web/components/embedtree/gene-picker.tsx`    | 159   | Debounced (300 ms) autocomplete over `search_genes`. Race-condition handling via sequence numbers — out-of-order RPC responses don't overwrite the fresh dropdown. Keyboard nav (↑/↓/Enter/Esc), color chips by species.                                                               |
| `web/components/embedtree/knn-graph.tsx`      | 326   | d3 force-directed network. Query locked at center with neon golden ring + "QUERY GENE" label. Neighbors color-coded by species, edge length inversely proportional to similarity. Live simulation, drag-to-move (with click-vs-drag disambiguation), double-click to unpin, click-to-pivot. |

### Modified

| File                       | Change                                                              |
| -------------------------- | ------------------------------------------------------------------- |
| `web/app/app/layout.tsx` | +1 nav link under "Tools" — "AI / Orthologs" →`/app/embedtree`. |

## How it fits together

```
User opens /app/embedtree
        │
        ▼
   GenePicker
   (debounced search_genes RPC)
        │
        │  onSelect(uid)
        ▼
   EmbedtreePage state
        │
        │  knn_search_esm2(uid, K=20)
        ▼
   {neighbors, similarity scores}
        │
        │  SELECT embedding FROM protein_embeddings_esm2 IN (...)
        ▼
   embeddings: Map<uid, number[1280]>
        │
        ▼
   KnnGraph
   - query → neighbor edges (always shown)
   - pairwise neighbor edges (computed via cosineDistance, toggle-able)
   - drag, pivot-on-click
```

## Key design decisions

### Framing — "AI Orthologs"

PR #47 called this **"Embedding Phylogenomics"** throughout. That's
biologically misleading: NJ + cosine distance on ESM-2 embeddings
recovers latent-space proximity, not evolutionary history. A
biologist reading "Phylogenomics" will infer evolutionary
relationships the math doesn't support.

This PR uses **"AI Orthologs"** consistently — page title, H1, nav
label, browser tab title, metadata. The disclaimer banner reframes
the artifact as "predicted, not verified" and points users to
OrthoBrowser for sequence-alignment-based orthology.

The two tools sit side by side under Tools — biologists immediately
get the contrast: classical alignment vs ML embeddings, two ways to
answer the same biological question.

### One primary visualization — the graph

PR #47 stacked four visualizations vertically after a search:
species breakdown + KNN graph + ranked results + NJ tree. This PR
ships the graph only. Results panel + NJ tree are slated for the
next slice; species legend is implicit via per-node color chips.

### Pairwise edges OFF by default

Toggled OFF on initial render. Query → neighbor edges are the
primary signal; pairwise (neighbor-to-neighbor) is an opt-in second
layer. At K=20, pairwise alone is up to 190 edges — without the
threshold + opacity treatment + opt-in, the graph becomes a
hairball.

### Click-to-pivot, drag-to-rearrange

Both gestures start with mouse-down on a node — distinguished by
whether the cursor actually moves between down and up. Tracked via
a `useRef` (not state) so the click handler reads the latest value,
not a stale closure. Threshold is 3 px of movement.

## Known limitations (intentional in this slice)

1. **No ranked results panel** — coming in the next slice. For now,
   the hover tooltip shows the similarity to query.
2. **No NJ tree view** — that's a separate slice; algorithm files
   are already merged from #299, just need the renderer.
3. **No species legend** — color is consistent across the page
   (graph + autocomplete) but no standalone legend yet.

## Related PRs

| PR   | What it shipped                                                                                                 | Status                              |
| ---- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| #293 | `proteins`, `protein_embeddings_esm2`, `knn_search_esm2`, HNSW index                                      | ✅ merged                           |
| #299 | Pure-TS NJ + Newick + distance library (`web/components/embedtree/lib/`)                                      | ✅ merged                           |
| #328 | `bloom_writer` RLS policies + `proteins.species_id` FK + `scripts/uploaders/upload_protein_embeddings.py` | ✅ merged                           |
| #47  | Old "Embedding Phylogenomics" UI attempt                                                                        | 🪦 to be closed; this PR supersedes |
