### PR TITLE
feat(embedtree): ranked results table with cross-component hover

### DIFF
--- a/web/components/embedtree/embedtree-page.tsx
+++ b/web/components/embedtree/embedtree-page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 import { GenePicker, type GeneRow } from "./gene-picker";
 import { KnnGraph, type KnnNeighbor } from "./knn-graph";
+import { ResultsPanel } from "./results-panel";
 import { DEFAULT_K, K_MAX, K_MIN, SIMILARITY_DISCLAIMER } from "./constants";
 
 // Loose RPC + table types until web/lib/database.types.ts is regenerated to
@@ -80,6 +81,9 @@ export function EmbedtreePage() {
   // Default off — query→neighbor edges are the primary signal; pairwise
   // edges are an optional second layer the user opts into.
   const [showPairwiseEdges, setShowPairwiseEdges] = useState(false);
+  // Lifted hover state — graph and results table share it so hovering
+  // one surface highlights the matching item in the other.
+  const [hoveredUid, setHoveredUid] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -194,20 +198,35 @@ export function EmbedtreePage() {
         )}
       </section>
 
-      <section className="flex flex-1 items-start justify-center overflow-hidden">
+      <section className="flex flex-1 flex-col items-stretch gap-4 overflow-y-auto">
         {query ? (
-          <KnnGraph
-            queryUid={query.uid}
-            querySpecies={query.species}
-            queryGeneId={query.gene_id}
-            neighbors={neighbors}
-            embeddings={embeddings}
-            showQueryEdges={showQueryEdges}
-            showPairwiseEdges={showPairwiseEdges}
-            onSelectNeighbor={(n) => handleSelect(n)}
-          />
+          <>
+            <div className="flex items-start justify-center">
+              <KnnGraph
+                queryUid={query.uid}
+                querySpecies={query.species}
+                queryGeneId={query.gene_id}
+                neighbors={neighbors}
+                embeddings={embeddings}
+                showQueryEdges={showQueryEdges}
+                showPairwiseEdges={showPairwiseEdges}
+                onSelectNeighbor={(n) => handleSelect(n)}
+                hoveredUid={hoveredUid}
+                onHoverNode={setHoveredUid}
+              />
+            </div>
+            <ResultsPanel
+              queryUid={query.uid}
+              querySpecies={query.species}
+              queryGeneId={query.gene_id}
+              neighbors={neighbors}
+              onSelectNeighbor={(n) => handleSelect(n)}
+              hoveredUid={hoveredUid}
+              onHoverRow={setHoveredUid}
+            />
+          </>
         ) : (
-          <div className="flex h-96 w-full max-w-3xl items-center justify-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-neutral-500">
+          <div className="flex h-96 w-full max-w-3xl items-center justify-center self-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-neutral-500">
             Search for a gene above to see its similarity neighborhood.
           </div>
         )}

--- a/web/components/embedtree/knn-graph.tsx
+++ b/web/components/embedtree/knn-graph.tsx
@@ -21,6 +21,8 @@ type Props = {
   showQueryEdges?: boolean;
   showPairwiseEdges?: boolean;
   onSelectNeighbor?: (n: KnnNeighbor) => void;
+  hoveredUid?: string | null;
+  onHoverNode?: (uid: string | null) => void;
   width?: number;
   height?: number;
 };
@@ -69,6 +71,8 @@ export function KnnGraph({
   showQueryEdges = true,
   showPairwiseEdges = true,
   onSelectNeighbor,
+  hoveredUid = null,
+  onHoverNode,
   width = 760,
   height = 520,
 }: Props) {
@@ -81,8 +85,18 @@ export function KnnGraph({
   const dragMovedRef = useRef(false);
   const [renderedNodes, setRenderedNodes] = useState<Node[]>([]);
   const [renderedLinks, setRenderedLinks] = useState<Link[]>([]);
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [dragId, setDragId] = useState<string | null>(null);
+  const hoveredId = hoveredUid;
+  const setHoveredId = useCallback(
+    (next: string | null | ((prev: string | null) => string | null)) => {
+      onHoverNode?.(
+        typeof next === "function"
+          ? (next as (prev: string | null) => string | null)(hoveredUid)
+          : next,
+      );
+    },
+    [hoveredUid, onHoverNode],
+  );
 
   // Build nodes + links from props. Pairwise edges are computed only if we
   // have embeddings for both endpoints — otherwise we silently degrade to

--- a/web/components/embedtree/results-panel.tsx
+++ b/web/components/embedtree/results-panel.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { speciesColor } from "./constants";
+import type { KnnNeighbor } from "./knn-graph";
+
+type Props = {
+  queryUid: string;
+  querySpecies: string | null;
+  queryGeneId: string | null;
+  neighbors: KnnNeighbor[];
+  onSelectNeighbor?: (n: KnnNeighbor) => void;
+  hoveredUid?: string | null;
+  onHoverRow?: (uid: string | null) => void;
+};
+
+/**
+ * Ranked KNN results table. Renders the query gene pinned at the top
+ * with a "QUERY" badge, then the K neighbors ordered by descending
+ * cosine similarity (the order PostgREST returns them in).
+ *
+ * Row click pivots the page to that neighbor — same behavior as
+ * clicking a graph node. Row hover fires `onHoverRow` so the parent
+ * can highlight the matching graph node in lockstep.
+ */
+export function ResultsPanel({
+  queryUid,
+  querySpecies,
+  queryGeneId,
+  neighbors,
+  onSelectNeighbor,
+  hoveredUid,
+  onHoverRow,
+}: Props) {
+  if (neighbors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="w-full overflow-hidden rounded-md border border-stone-200 bg-white">
+      <div className="border-b border-stone-200 px-3 py-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+        Ranked neighbors
+      </div>
+      <div className="max-h-72 overflow-y-auto">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 bg-stone-50 text-xs uppercase tracking-wider text-neutral-500">
+            <tr>
+              <th className="w-12 px-3 py-2 text-right font-medium">Rank</th>
+              <th className="px-3 py-2 text-left font-medium">Gene</th>
+              <th className="px-3 py-2 text-left font-medium">Species</th>
+              <th className="w-32 px-3 py-2 text-right font-medium">
+                Cosine similarity
+              </th>
+              <th className="w-32 px-3 py-2 text-right font-medium">
+                Cosine distance
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {/* Query row, pinned at the top. */}
+            <tr
+              className={`border-t border-stone-100 bg-amber-50/40 ${
+                hoveredUid === queryUid ? "bg-amber-100/60" : ""
+              }`}
+              onMouseEnter={() => onHoverRow?.(queryUid)}
+              onMouseLeave={() => onHoverRow?.(null)}
+            >
+              <td className="px-3 py-1.5 text-right font-mono text-xs text-neutral-400">
+                —
+              </td>
+              <td className="px-3 py-1.5 font-mono text-neutral-800">
+                {queryGeneId ?? queryUid}
+                <span className="ml-2 rounded bg-amber-200 px-1.5 py-[1px] text-[10px] font-semibold uppercase tracking-wider text-amber-900">
+                  Query
+                </span>
+              </td>
+              <td className="px-3 py-1.5">
+                <SpeciesCell species={querySpecies} />
+              </td>
+              <td className="px-3 py-1.5 text-right font-mono text-neutral-500">
+                1.000
+              </td>
+              <td className="px-3 py-1.5 text-right font-mono text-neutral-500">
+                0.000
+              </td>
+            </tr>
+            {neighbors.map((n, i) => {
+              const distance = 1 - n.similarity;
+              const isHover = hoveredUid === n.uid;
+              return (
+                <tr
+                  key={n.uid}
+                  onClick={() => onSelectNeighbor?.(n)}
+                  onMouseEnter={() => onHoverRow?.(n.uid)}
+                  onMouseLeave={() => onHoverRow?.(null)}
+                  className={`cursor-pointer border-t border-stone-100 transition-colors ${
+                    isHover ? "bg-blue-50" : "hover:bg-stone-50"
+                  }`}
+                >
+                  <td className="px-3 py-1.5 text-right font-mono text-xs text-neutral-500">
+                    {i + 1}
+                  </td>
+                  <td className="px-3 py-1.5 font-mono text-neutral-800">
+                    {n.gene_id ?? n.uid}
+                  </td>
+                  <td className="px-3 py-1.5">
+                    <SpeciesCell species={n.species} />
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono text-neutral-700">
+                    {n.similarity.toFixed(3)}
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono text-neutral-700">
+                    {distance.toFixed(3)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function SpeciesCell({ species }: { species: string | null }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-neutral-700">
+      <span
+        className="inline-block h-2.5 w-2.5 rounded-full"
+        style={{ backgroundColor: speciesColor(species) }}
+        aria-hidden
+      />
+      {species ?? "—"}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a ranked KNN results table below the force-directed graph from #331.

**Stacked on #331.** Base is set to \`feat/embedtree-ui-search-and-graph\`. When #331 merges to staging, this PR auto-rebases to staging.

## What's in this PR

| File | Purpose |
| --- | --- |
| \`web/components/embedtree/results-panel.tsx\` (NEW) | Ranked KNN table: rank, gene id, species (color chip + name), cosine similarity, cosine distance. Query gene pinned at top with "QUERY" badge. |
| \`web/components/embedtree/embedtree-page.tsx\` (modified) | Lifts \`hoveredUid\` state to the parent so the graph and the table can highlight in lockstep. Restructured the body to stack graph + table vertically. |
| \`web/components/embedtree/knn-graph.tsx\` (modified) | Accepts \`hoveredUid\` + \`onHoverNode\` props. The previous internal hover state is now a thin shim delegating to the parent. |

## Behavior

- **Click a row** → pivots the page to that neighbor (same as clicking a graph node).
- **Hover a row** → matching graph node gets a darker stroke, table row tints.
- **Hover a graph node** → matching table row tints in lockstep.
- Query row pinned at the top with amber tint that mirrors the graph's golden ring.
- Table is sticky-headered, scrollable up to \`max-h-72\` so long K values don't push the graph off the viewport.