### PR TITLE
ci: durable runner disk-headroom for the stack jobs (closes #334)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,52 @@
+name: "Free up runner disk space"
+description: >
+  Reclaim disk on GitHub-hosted ubuntu runners by removing preinstalled
+  language SDKs / toolchains the Bloom CI jobs never use, then log free space.
+  ubuntu-latest ships only ~14 GB free on /, which the stack-build + Playwright
+  jobs can exhaust ("No space left on device", see issue #334). This is the
+  single source of truth so compose-health-check and dev-stack-smoke can't
+  drift apart. Inline `rm` (no third-party action) keeps it under our control,
+  consistent with the SHA-pinning posture of the rest of the workflow.
+
+inputs:
+  min-free-gb:
+    description: >
+      If > 0, fail the step when free space on / after cleanup is below this
+      many GB — a fast, visible signal that runner headroom regressed instead
+      of a silent disk-full hang later. Default "0" is log-only.
+    required: false
+    default: "0"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Free up disk space
+      shell: bash
+      run: |
+        echo "::group::Disk before cleanup"
+        df -h /
+        echo "::endgroup::"
+
+        # Remove preinstalled SDKs/toolchains this repo's CI never uses.
+        # hostedtoolcache is left intact (minus CodeQL) so setup-uv /
+        # setup-node still resolve their runtimes.
+        sudo rm -rf \
+          /usr/local/lib/android \
+          /usr/share/dotnet \
+          /opt/ghc /usr/local/.ghcup \
+          /usr/share/swift \
+          /usr/local/share/powershell \
+          /opt/hostedtoolcache/CodeQL || true
+        sudo apt-get clean || true
+
+        echo "::group::Disk after cleanup"
+        df -h /
+        echo "::endgroup::"
+
+        free_gb=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        echo "Free space on / after cleanup: ${free_gb} GB"
+        min='${{ inputs.min-free-gb }}'
+        if [ "${min}" -gt 0 ] && [ "${free_gb}" -lt "${min}" ]; then
+          echo "::error::Only ${free_gb} GB free on / after cleanup (need >= ${min} GB). Runner disk headroom regressed — see issue #334."
+          exit 1
+        fi

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -22,6 +22,10 @@ runs:
   steps:
     - name: Free up disk space
       shell: bash
+      # Map the input through env: so the run: block never embeds a ${{ }}
+      # expression directly (GHA hygiene — keeps interpolation out of the shell).
+      env:
+        MIN_FREE_GB: ${{ inputs.min-free-gb }}
       run: |
         echo "::group::Disk before cleanup"
         df -h /
@@ -43,10 +47,13 @@ runs:
         df -h /
         echo "::endgroup::"
 
+        # Default both values so an empty parse never trips `[ -lt ]` with
+        # "integer expression expected".
         free_gb=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        : "${free_gb:=0}"
+        : "${MIN_FREE_GB:=0}"
         echo "Free space on / after cleanup: ${free_gb} GB"
-        min='${{ inputs.min-free-gb }}'
-        if [ "${min}" -gt 0 ] && [ "${free_gb}" -lt "${min}" ]; then
-          echo "::error::Only ${free_gb} GB free on / after cleanup (need >= ${min} GB). Runner disk headroom regressed — see issue #334."
+        if [ "${MIN_FREE_GB}" -gt 0 ] && [ "${free_gb}" -lt "${MIN_FREE_GB}" ]; then
+          echo "::error::Only ${free_gb} GB free on / after cleanup (need >= ${MIN_FREE_GB} GB). Runner disk headroom regressed — see issue #334."
           exit 1
         fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -380,6 +380,10 @@ jobs:
     name: Docker Compose Health Check
     needs: docker-build
     runs-on: ubuntu-latest
+    # Cap the job. The GitHub default is 6h; a "No space left on device" fill
+    # once left this job hanging for the full 6h before failing (issue #334).
+    # Normal runtime is ~8-15 min, so 30 fails fast on any future hang.
+    timeout-minutes: 30
     env:
       # Single source of truth for the compose file pair. Hoisted here so
       # the 6+ docker compose commands below don't drift apart. The CI
@@ -390,6 +394,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # This job builds the full prod compose stack (web/langchain/bloommcp/
+      # caddy) AND installs the Supabase CLI + Playwright/Chromium — which
+      # overflowed the runner's ~14 GB free on / (issue #334). Reclaim ~25 GB
+      # right after checkout (the local composite action needs the repo
+      # present), well before any heavy disk use. The 20 GB floor fails fast if
+      # the runner layout ever stops yielding the expected headroom.
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          min-free-gb: "20"
 
       # Setup uv BEFORE compose starts — the compose stack creates
       # root-owned `volumes/db/data/` (postgres bind mount), and setup-uv's
@@ -758,9 +773,20 @@ jobs:
   dev-stack-smoke:
     name: Dev stack smoke (init -> dev-up -> migrate-local -> check)
     runs-on: ubuntu-latest
+    # Parity with compose-health-check: cap the job so a wedged build/health
+    # wait fails fast instead of running to the 6h default (issue #334).
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # Parity / defense-in-depth: this job builds the dev compose stack, which
+      # is lighter than compose-health-check (no Playwright) but shares the same
+      # ~14 GB-free runner. Reclaim the unused SDKs and log headroom so a future
+      # regression is visible (issue #334). Log-only floor — this job has slack
+      # today, so no hard minimum that could flake.
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
 
       # Setup uv BEFORE compose starts (the dev stack creates a root-owned
       # volumes/db/data bind mount; setup-uv's lockfile glob would EACCES on it).

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -192,9 +192,20 @@ jobs:
   docker-build:
     name: Build Docker Images & Scan for CVEs
     runs-on: ubuntu-latest
+    # compose-health-check `needs: docker-build`, and this job builds all four
+    # images (bloom-web/langchain/bloommcp/caddy) + Trivy-scans them on the same
+    # ~14 GB-free runner — the same disk-heavy pattern as compose-health-check
+    # (issue #334). Protect it too: a disk-out here would skip the very job the
+    # cleanup is meant to guard. Cap the runtime so a wedge can't hang for 6h.
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          min-free-gb: "20"
 
       - name: Build bloom-web image
         # NEXT_PUBLIC_* build args are still REQUIRED until PR-3 §6 of the


### PR DESCRIPTION
## What & why

Fixes the runner disk-exhaustion that took down the **Docker Compose Health Check** job: it builds the full prod compose stack (`web` / `langchain-agent` / `bloommcp` / `caddy`) plus the Supabase CLI and Playwright/Chromium on a `ubuntu-latest` runner with only **~14 GB free on `/`**. The disk filled (`No space left on device`), and once full the job **hung for the 6 h default timeout** before failing.

A one-off inline `rm` stopgap already shipped on PR #323's branch; per issue #334 this is **structural, not one-time**, so this PR makes it durable and shared.

Closes #334.

## Changes

- **New composite action `.github/actions/free-disk-space`** — single source of truth. Removes preinstalled SDKs the CI never uses (`android` / `dotnet` / `ghc` / `ghcup` / `swift` / `powershell` + the CodeQL toolcache, **~25 GB**), logs `df -h` before/after, and optionally **asserts a minimum free GB** (fast, visible failure instead of a silent disk-full hang). `hostedtoolcache` is left intact (minus CodeQL) so `setup-uv` / `setup-node` still resolve. Inline `rm`, no third-party action — consistent with the workflow's SHA-pinning posture.
- **`compose-health-check`** — runs the action (`min-free-gb: 20`) right after checkout, and gets `timeout-minutes: 30`.
- **`dev-stack-smoke`** — runs the action (log-only) for parity/defense-in-depth, and gets `timeout-minutes: 20`.

## Acceptance criteria (from #334)

- [x] Cleanup defined in **one** shared place (the composite action), used by both stack jobs.
- [x] A hard **job timeout** on both so nothing can hang for hours again.
- [x] Disk headroom **observable in the log** (`df -h` before/after) + an optional min-free assertion.

## Notes / reconciliation

- The local composite action requires the repo checked out first, so the cleanup runs immediately **after** `Checkout` — still well before any heavy disk use.
- PR #323 carries the earlier **inline** stopgap on its branch. When both land on `staging`, expect a small merge reconciliation in the `compose-health-check` block — this PR's composite-action version should win (delete the inline `rm` + duplicate `timeout-minutes`).

## Test plan

- This PR's own `pr-checks.yml` run exercises both jobs with the action: confirm `compose-health-check` and `dev-stack-smoke` go green, and check the `Free up disk space` step logs the reclaimed space (`df -h` before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)