### PR TITLE
feat(scheduled-jobs): weekly Box backup of Postgres + MinIO

### DIFF
--- a/.env.prod.defaults
+++ b/.env.prod.defaults
@@ -114,3 +114,13 @@ LOCAL_LLM_MODEL=Qwen/Qwen3.5-9B
 # this host to langchain-agent:5002; the URL is baked into the bloom-web
 # JS bundle at build time (NEXT_PUBLIC_*) so the browser can hit it.
 NEXT_PUBLIC_MCP_URL=https://bloom.salk.edu
+
+# ─── Weekly backup (bloom-weekly-backup systemd timer) ─────────────────────
+# Configures the per-env backup that pg_dumps Postgres + mc-mirrors the
+# MinIO buckets and pushes a tarball to Box via rclone. See
+# _WIKI/SCHEDULEDJOBS/weekly-backup.md for the rclone Box setup.
+BACKUP_BUCKETS=images,videos,scrna,scrna-secondary,gene-candidates,bloommcp-data
+BACKUP_MC_ALIAS=local
+BACKUP_RCLONE_REMOTE=box
+BACKUP_RCLONE_DEST_DIR=bloom-backups/prod
+BACKUP_RETENTION_WEEKS=8

--- a/.env.staging.defaults
+++ b/.env.staging.defaults
@@ -111,3 +111,13 @@ LOCAL_LLM_MODEL=Qwen/Qwen3.5-9B
 # this host to langchain-agent:5002; the URL is baked into the bloom-web
 # JS bundle at build time (NEXT_PUBLIC_*) so the browser can hit it.
 NEXT_PUBLIC_MCP_URL=https://staging.bloom.salk.edu:8443
+
+# ─── Weekly backup (bloom-weekly-backup systemd timer) ─────────────────────
+# Configures the per-env backup that pg_dumps Postgres + mc-mirrors the
+# MinIO buckets and pushes a tarball to Box via rclone. See
+# _WIKI/SCHEDULEDJOBS/weekly-backup.md for the rclone Box setup.
+BACKUP_BUCKETS=images,videos,scrna,scrna-secondary,gene-candidates,bloommcp-data
+BACKUP_MC_ALIAS=local
+BACKUP_RCLONE_REMOTE=box
+BACKUP_RCLONE_DEST_DIR=bloom-backups/staging
+BACKUP_RETENTION_WEEKS=4

--- a/_WIKI/SCHEDULEDJOBS/weekly-backup.md
+++ b/_WIKI/SCHEDULEDJOBS/weekly-backup.md
@@ -1,0 +1,176 @@
+# Weekly backup (`bloom-weekly-backup.timer`)
+
+Per-environment systemd timer that runs once a week and ships a tarball of
+Bloom's state to Box for disaster-recovery purposes. Replaces the
+previous "we'll figure it out when we need it" backup posture for V2.
+
+## What gets backed up
+
+1. **Postgres** — full `pg_dump` of the bloom database, gzipped, emitted
+   via `docker exec` into the running `db-prod` container so the dump
+   uses a matched server/client version.
+2. **MinIO buckets** — `mc mirror` against every bucket listed in
+   `BACKUP_BUCKETS` (`.env.{env}.defaults`). Each bucket lands in its
+   own subdirectory under the tarball.
+
+Both are wrapped into a single timestamped tarball
+(`bloom-{env}-backup-YYYYMMDDTHHMMSSZ.tar.gz`) and pushed to a
+preconfigured rclone Box remote.
+
+## Schedule
+
+Sunday 00:00 server time, weekly. Configured in
+`bloom-weekly-backup-{env}.timer`. Adjust `OnCalendar` if needed.
+
+## Retention
+
+Configurable via `BACKUP_RETENTION_WEEKS` in `.env.{env}.defaults`.
+After the upload succeeds, `rclone delete --min-age <weeks>d` prunes
+older tarballs from the remote. Default: 8 weeks on prod, 4 weeks on
+staging.
+
+Retention failure is non-fatal — backup itself is the priority; an
+operator gets paged later if Box fills up.
+
+## Box setup (one-time, before install)
+
+The systemd service runs as `bloom-deploy`, so the rclone remote must
+be configured under that user's home dir.
+
+```bash
+# As an admin on the bloom server:
+sudo -u bloom-deploy rclone config
+```
+
+In the interactive prompts:
+
+1. **n** (new remote)
+2. **name**: `box` (must match `BACKUP_RCLONE_REMOTE` in env-defaults)
+3. **storage**: search/select `Box`
+4. **client_id / client_secret**: leave blank to use rclone's default
+   OAuth app (fine for non-commercial / lab use), OR enter values from
+   your Box developer console for a dedicated app.
+5. **box_sub_type**: `user` (unless you're using a Service Account)
+6. **Use auto config**: `Y` if the server has a browser available;
+   otherwise `N` and follow the headless instructions rclone prints
+   (paste the URL into a browser on your laptop, complete the OAuth,
+   paste the token back).
+7. Accept the rest of the defaults.
+
+After the config completes, verify:
+
+```bash
+sudo -u bloom-deploy rclone listremotes
+# Should print: box:
+sudo -u bloom-deploy rclone lsd box:
+# Should list your Box root folders without errors.
+```
+
+Once `box:` resolves, install.sh's preflight check passes and the
+backup can run.
+
+## Install
+
+Same pattern as the cert renewal monitor — run manually on the bloom
+server.
+
+```bash
+# As admin:
+sudo bash /data/bloom/prod/scheduled-jobs/weekly-backup/install.sh --env prod
+
+# After install, exercise the pipeline without burning a real backup:
+sudo bash /data/bloom/prod/scheduled-jobs/weekly-backup/install.sh --env prod --dry-run
+```
+
+The installer:
+
+1. Validates `--env` and sudo
+2. Confirms `docker`, `mc`, `rclone`, `gzip` are on PATH for root
+3. Confirms `bloom-deploy` has at least one rclone remote configured
+4. Creates `/var/lib/bloom-weekly-backup` (mode 0700, owned by
+   `bloom-deploy`) for the temporary backup workspace
+5. Renders `bloom-weekly-backup-{env}.service` and `.timer` from the
+   templates by substituting `__ENV_NAME__`, `__ENV_FILE__`,
+   `__DEPLOY_DIR__`
+6. Reloads systemd if the unit files changed
+7. Enables and starts the timer
+8. Verifies the timer appears in `systemctl list-timers`
+
+Per-env naming (`bloom-weekly-backup-staging` vs `-prod`) lets staging
+and prod coexist on the same host.
+
+## Manually trigger a backup
+
+```bash
+# Force one run now without waiting for Sunday:
+sudo systemctl start bloom-weekly-backup-prod.service
+
+# Watch logs:
+sudo journalctl -u bloom-weekly-backup-prod.service -f
+```
+
+## Restoring from a backup
+
+The tarball contains:
+
+```
+bloom-prod-backup-20260628T000000Z.tar.gz
+├── postgres-postgres.sql.gz       ← full pg_dump (gzipped)
+└── minio/
+    ├── images/
+    ├── videos/
+    ├── scrna/
+    └── ...
+```
+
+To restore the database:
+
+```bash
+# Stream the gzipped dump back into the running container:
+gunzip -c postgres-postgres.sql.gz | \
+  docker exec -i bloom_v2_prod-db-prod-1 psql -U supabase_admin -d postgres
+```
+
+To restore a MinIO bucket:
+
+```bash
+mc mirror --overwrite ./minio/images/ local/images/
+```
+
+(Or full restore: iterate over every subdirectory of `minio/`.)
+
+**Always restore to a fresh stack, then validate, before pointing
+production traffic at it.** Restoring in-place on a live stack is
+dangerous and not the intended use of these backups.
+
+## Config surface (env-defaults)
+
+| Var | Default (prod) | Notes |
+| --- | --- | --- |
+| `BACKUP_BUCKETS` | `bloom-storage,images,...` | Comma-separated list of MinIO buckets to snapshot |
+| `BACKUP_MC_ALIAS` | `local` | The `mc` alias for the in-container MinIO (set by `minio/init/create-buckets.sh`) |
+| `BACKUP_RCLONE_REMOTE` | `box` | Must match the name used in `rclone config` |
+| `BACKUP_RCLONE_DEST_DIR` | `bloom-backups/prod` | Path inside Box where tarballs land |
+| `BACKUP_RETENTION_WEEKS` | `8` (prod) / `4` (staging) | How long to keep old tarballs on Box |
+| `BACKUP_STATE_DIR` | `/var/lib/bloom-weekly-backup` | Where the backup is assembled before upload |
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Clean backup uploaded to Box |
+| 1 | Subprocess failure (`pg_dump` / `mc` / `rclone`) |
+| 2 | Configuration error (missing env var, no rclone remote) |
+| 3 | Upload succeeded but retention prune failed |
+
+## Operational notes
+
+- The backup uses `docker exec` to invoke `pg_dump` inside the running
+  postgres container. If the container is down at the scheduled time,
+  the backup fails with exit code 1 — the timer's `Persistent=true`
+  will re-run on next boot, but won't catch up missed runs.
+- `mc mirror --overwrite` copies the **current** bucket contents at
+  the moment the timer fires — it's a snapshot, not an incremental.
+- The tarball lives in `/var/lib/bloom-weekly-backup/` only during the
+  run; on success it's removed and only the remote (Box) copy
+  persists.

--- a/scheduled-jobs/weekly-backup/backup.py
+++ b/scheduled-jobs/weekly-backup/backup.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Weekly backup of Bloom's Postgres database and MinIO buckets to Box.
+
+Runs from a per-env systemd timer (see bloom-weekly-backup.timer). Reads the
+deploy's `.env.<env>` for credentials, dumps Postgres with `pg_dump`, mirrors
+the MinIO buckets with `mc`, tarballs the result with a timestamped name,
+and pushes the bundle to Box via a pre-configured rclone remote. Local
+working copy is removed once the upload succeeds; the rclone remote
+applies retention (configurable, default keep last 8 weeks).
+
+Exit codes:
+  0 = clean backup uploaded
+  1 = subprocess failure (pg_dump / mc / rclone)
+  2 = configuration error (missing env, no rclone remote)
+  3 = upload succeeded but retention prune failed (non-fatal but flagged)
+
+See `.env.{staging,prod}.defaults` for the BACKUP_* config surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger("bloom_weekly_backup")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+def _run(cmd: list[str], cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+    """Run a subprocess, stream output to the journal, raise on non-zero exit."""
+    logger.info("running: %s", " ".join(cmd))
+    result = subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.rstrip().splitlines():
+            logger.info("  stdout: %s", line)
+    if result.stderr:
+        for line in result.stderr.rstrip().splitlines():
+            logger.warning("  stderr: %s", line)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, output=result.stdout, stderr=result.stderr
+        )
+
+
+def _which(name: str) -> str:
+    """Resolve a binary, raise if missing — surfaces missing tooling early."""
+    found = shutil.which(name)
+    if not found:
+        raise FileNotFoundError(f"required binary not on PATH: {name}")
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Backup steps
+# ---------------------------------------------------------------------------
+
+def dump_postgres(work_dir: Path, env_name: str) -> Path:
+    """pg_dump the bloom Postgres database via the local container exec path.
+
+    We exec into the running db-prod container rather than connecting from the
+    host so we don't need to expose Postgres or duplicate credentials. The
+    container always has its own pg client at the matching server version.
+    """
+    container = f"bloom_v2_{env_name}-db-prod-1"
+    pg_user = _env("POSTGRES_USER", "supabase_admin")
+    pg_db = _env("POSTGRES_DB", "postgres")
+    out = work_dir / f"postgres-{pg_db}.sql.gz"
+    logger.info("dumping Postgres from container %s -> %s", container, out.name)
+    cmd = [
+        _which("docker"), "exec", "-i", container,
+        "pg_dump",
+        "-U", pg_user,
+        "-d", pg_db,
+        "--format=plain",
+        "--no-owner",
+        "--no-privileges",
+    ]
+    # Stream pg_dump | gzip into the output file so we never materialize the
+    # full uncompressed dump on disk.
+    with out.open("wb") as f:
+        gzip_proc = subprocess.Popen([_which("gzip"), "-c"], stdin=subprocess.PIPE, stdout=f)
+        dump_proc = subprocess.Popen(cmd, stdout=gzip_proc.stdin, stderr=subprocess.PIPE)
+        gzip_proc.stdin.close()  # type: ignore[union-attr]
+        _, dump_err = dump_proc.communicate()
+        gzip_proc.wait()
+        if dump_proc.returncode != 0:
+            raise subprocess.CalledProcessError(
+                dump_proc.returncode, cmd, stderr=dump_err.decode()
+            )
+        if gzip_proc.returncode != 0:
+            raise subprocess.CalledProcessError(gzip_proc.returncode, ["gzip"])
+    logger.info("postgres dump: %s bytes", out.stat().st_size)
+    return out
+
+
+def mirror_minio(work_dir: Path, env_name: str) -> Path:
+    """Snapshot the MinIO buckets using mc mirror.
+
+    Iterates the buckets advertised in BACKUP_BUCKETS (comma-separated). Each
+    bucket lands in its own subdirectory under <work_dir>/minio/<bucket>/.
+    `mc mirror` is content-aware — re-runs are fast on unchanged data — but
+    we always run with --overwrite so the snapshot is a true point-in-time
+    copy, not an incremental.
+    """
+    buckets = [b.strip() for b in _env("BACKUP_BUCKETS", "images,videos,scrna").split(",") if b.strip()]
+    minio_alias = _env("BACKUP_MC_ALIAS", "local")
+    out = work_dir / "minio"
+    out.mkdir(parents=True, exist_ok=True)
+    logger.info("mirroring %d MinIO bucket(s): %s", len(buckets), buckets)
+    for bucket in buckets:
+        dest = out / bucket
+        dest.mkdir(parents=True, exist_ok=True)
+        _run([_which("mc"), "mirror", "--overwrite", f"{minio_alias}/{bucket}", str(dest)])
+    return out
+
+
+def make_tarball(work_dir: Path, env_name: str, timestamp: str) -> Path:
+    """Wrap the postgres dump + minio mirror in one timestamped tarball."""
+    tarball = work_dir.parent / f"bloom-{env_name}-backup-{timestamp}.tar.gz"
+    logger.info("packing tarball: %s", tarball.name)
+    with tarfile.open(tarball, "w:gz") as tf:
+        # Add the entire work_dir, preserving the postgres-*.sql.gz and minio/<bucket>/ structure.
+        for item in work_dir.iterdir():
+            tf.add(item, arcname=item.name)
+    logger.info("tarball: %s bytes", tarball.stat().st_size)
+    return tarball
+
+
+def upload_to_box(tarball: Path, env_name: str) -> None:
+    """Push the tarball to the configured rclone Box remote."""
+    remote = _env("BACKUP_RCLONE_REMOTE", "")
+    if not remote:
+        raise RuntimeError("BACKUP_RCLONE_REMOTE not set")
+    dest_dir = _env("BACKUP_RCLONE_DEST_DIR", f"bloom-backups/{env_name}")
+    logger.info("uploading to %s:%s/", remote, dest_dir)
+    _run([
+        _which("rclone"), "copy",
+        str(tarball),
+        f"{remote}:{dest_dir}/",
+        "--progress",
+    ])
+
+
+def prune_old_backups(env_name: str, keep_weeks: int) -> None:
+    """Delete remote tarballs older than keep_weeks weeks.
+
+    Uses rclone's --min-age to skip the deletion check on recent files, then
+    delete-older-than for the actual prune. Failure is non-fatal — we don't
+    want a retention hiccup to mask the success of the actual backup.
+    """
+    remote = _env("BACKUP_RCLONE_REMOTE", "")
+    dest_dir = _env("BACKUP_RCLONE_DEST_DIR", f"bloom-backups/{env_name}")
+    min_age = f"{keep_weeks * 7}d"
+    logger.info("pruning remote backups older than %s under %s:%s", min_age, remote, dest_dir)
+    try:
+        _run([
+            _which("rclone"), "delete",
+            f"{remote}:{dest_dir}/",
+            "--min-age", min_age,
+        ])
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        logger.error("retention prune failed: %s", exc)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", required=True, choices=["staging", "prod"],
+                        help="Which deploy environment to back up.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Build the tarball but skip the rclone upload.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    keep_weeks = int(_env("BACKUP_RETENTION_WEEKS", "8"))
+    if keep_weeks < 1:
+        logger.error("BACKUP_RETENTION_WEEKS=%d is invalid (must be >= 1)", keep_weeks)
+        return 2
+
+    # State dir created by install.sh, mode 0700, owned by bloom-deploy.
+    state_dir = Path(_env("BACKUP_STATE_DIR", "/var/lib/bloom-weekly-backup"))
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    logger.info("starting bloom-weekly-backup env=%s timestamp=%s", args.env, timestamp)
+
+    with tempfile.TemporaryDirectory(prefix="bloom-backup-", dir=str(state_dir)) as tmp:
+        work_dir = Path(tmp) / "payload"
+        work_dir.mkdir()
+        try:
+            dump_postgres(work_dir, args.env)
+            mirror_minio(work_dir, args.env)
+            tarball = make_tarball(work_dir, args.env, timestamp)
+        except subprocess.CalledProcessError as exc:
+            logger.error("backup step failed: %s", exc)
+            return 1
+        except (RuntimeError, FileNotFoundError) as exc:
+            logger.error("configuration error: %s", exc)
+            return 2
+
+        if args.dry_run:
+            logger.info("DRY RUN — tarball at %s, skipping upload + retention", tarball)
+            return 0
+
+        try:
+            upload_to_box(tarball, args.env)
+        except subprocess.CalledProcessError as exc:
+            logger.error("upload failed: %s", exc)
+            return 1
+        except RuntimeError as exc:
+            logger.error("configuration error: %s", exc)
+            return 2
+
+    # Retention runs against the remote, not the local working tree.
+    try:
+        prune_old_backups(args.env, keep_weeks)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return 3
+
+    logger.info("bloom-weekly-backup env=%s timestamp=%s complete", args.env, timestamp)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scheduled-jobs/weekly-backup/bloom-weekly-backup.service
+++ b/scheduled-jobs/weekly-backup/bloom-weekly-backup.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Bloom weekly backup (__ENV_NAME__) — dumps Postgres + mirrors MinIO buckets and pushes the bundle to Box via rclone.
+Documentation=https://github.com/Salk-Harnessing-Plants-Initiative/bloom/blob/staging/_WIKI/SCHEDULEDJOBS/weekly-backup.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=bloom-deploy
+EnvironmentFile=__ENV_FILE__
+ExecStart=/usr/bin/python3 __DEPLOY_DIR__/scheduled-jobs/weekly-backup/backup.py --env __ENV_NAME__
+StandardOutput=journal
+StandardError=journal
+
+# Hardening (defense-in-depth). The backup needs network egress (rclone to
+# Box), Docker socket access (pg_dump via `docker exec`), and writable space
+# under /var/lib/bloom-weekly-backup for the temporary tarball.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/var/lib/bloom-weekly-backup
+ProtectHome=yes
+PrivateTmp=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes

--- a/scheduled-jobs/weekly-backup/bloom-weekly-backup.timer
+++ b/scheduled-jobs/weekly-backup/bloom-weekly-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run bloom-weekly-backup-__ENV_NAME__ weekly (Sunday 00:00 server time)
+Documentation=https://github.com/Salk-Harnessing-Plants-Initiative/bloom/blob/staging/_WIKI/SCHEDULEDJOBS/weekly-backup.md
+
+[Timer]
+OnCalendar=Sun 00:00
+Persistent=true
+Unit=bloom-weekly-backup-__ENV_NAME__.service
+
+[Install]
+WantedBy=timers.target

--- a/scheduled-jobs/weekly-backup/install.sh
+++ b/scheduled-jobs/weekly-backup/install.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Idempotent installer for the bloom-weekly-backup systemd timer + service.
+# Runs MANUALLY on the bloom server. See _WIKI/SCHEDULEDJOBS/weekly-backup.md
+# for the rclone Box setup steps that must be done BEFORE this script runs.
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: sudo bash $0 --env <staging|prod> [--dry-run]
+
+  --env <staging|prod>   Required. Determines which deploy tree's .env file
+                         the service reads at runtime.
+  --dry-run              After install, invoke backup.py with --dry-run to
+                         verify pg_dump + mc mirror succeed end-to-end
+                         (skips the rclone upload to Box).
+EOF
+    exit 1
+}
+
+ENV_NAME=""
+DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env) ENV_NAME="${2:-}"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown arg: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$ENV_NAME" ]]; then
+    echo "ERROR: --env is required" >&2
+    usage
+fi
+if [[ "$ENV_NAME" != "staging" && "$ENV_NAME" != "prod" ]]; then
+    echo "ERROR: --env must be 'staging' or 'prod', got '$ENV_NAME'" >&2
+    exit 1
+fi
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "ERROR: must run with sudo" >&2
+    exit 1
+fi
+
+if ! id -nG bloom-deploy 2>/dev/null | tr ' ' '\n' | grep -qw docker; then
+    echo "ERROR: user 'bloom-deploy' is not in the 'docker' group." >&2
+    echo "       Run: sudo usermod -aG docker bloom-deploy" >&2
+    exit 1
+fi
+
+# Prerequisites for the backup script — surfaced here rather than at first
+# scheduled run so the install fails fast with a clear error.
+for bin in docker pg_dump mc rclone gzip; do
+    # pg_dump runs inside the container, so we don't strictly need it on the
+    # host — but mc, rclone, gzip, docker we do.
+    if [[ "$bin" == "pg_dump" ]]; then continue; fi
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "ERROR: required binary '$bin' not on PATH for root" >&2
+        echo "       Install before running this script. See WIKI for rclone." >&2
+        exit 1
+    fi
+done
+
+# rclone config sanity: confirm there's a remote configured for bloom-deploy.
+# Box auth is interactive; this script does not attempt to set it up.
+RCLONE_REMOTES=$(sudo -u bloom-deploy rclone listremotes 2>/dev/null || true)
+if [[ -z "$RCLONE_REMOTES" ]]; then
+    echo "ERROR: bloom-deploy has no rclone remotes configured." >&2
+    echo "       Run: sudo -u bloom-deploy rclone config" >&2
+    echo "       See _WIKI/SCHEDULEDJOBS/weekly-backup.md for the Box setup." >&2
+    exit 1
+fi
+
+DEPLOY_DIR="/data/bloom/${ENV_NAME}"
+ENV_FILE="${DEPLOY_DIR}/.env.${ENV_NAME}"
+
+if [[ ! -d "$DEPLOY_DIR" ]]; then
+    echo "ERROR: deploy dir $DEPLOY_DIR does not exist" >&2
+    exit 1
+fi
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "ERROR: env file $ENV_FILE does not exist" >&2
+    exit 1
+fi
+
+# State dir for the temporary backup-build workspace.
+# Mode 0700: only bloom-deploy can read/write. The systemd service runs as
+# bloom-deploy; nothing else needs access.
+STATE_DIR="/var/lib/bloom-weekly-backup"
+if [[ ! -d "$STATE_DIR" ]]; then
+    install -d -m 0700 -o bloom-deploy -g bloom-deploy "$STATE_DIR"
+    echo "Created $STATE_DIR"
+elif [[ "$(stat -c '%a' "$STATE_DIR")" != "700" ]]; then
+    chmod 0700 "$STATE_DIR"
+    echo "Tightened $STATE_DIR to mode 0700"
+fi
+
+# Render the unit files from the templates checked into the repo.
+# Per-env naming so staging + prod can coexist on the same host —
+# `bloom-weekly-backup-staging.{service,timer}` + `bloom-weekly-backup-prod.{service,timer}`.
+TEMPLATE_DIR="${DEPLOY_DIR}/scheduled-jobs/weekly-backup"
+UNIT_BASE="bloom-weekly-backup-${ENV_NAME}"
+SERVICE_DEST="/etc/systemd/system/${UNIT_BASE}.service"
+TIMER_DEST="/etc/systemd/system/${UNIT_BASE}.timer"
+
+SERVICE_RENDERED=$(mktemp)
+TIMER_RENDERED=$(mktemp)
+trap 'rm -f "$SERVICE_RENDERED" "$TIMER_RENDERED"' EXIT
+
+sed -e "s|__ENV_FILE__|${ENV_FILE}|g" \
+    -e "s|__DEPLOY_DIR__|${DEPLOY_DIR}|g" \
+    -e "s|__ENV_NAME__|${ENV_NAME}|g" \
+    "${TEMPLATE_DIR}/bloom-weekly-backup.service" > "$SERVICE_RENDERED"
+sed -e "s|__ENV_NAME__|${ENV_NAME}|g" \
+    "${TEMPLATE_DIR}/bloom-weekly-backup.timer" > "$TIMER_RENDERED"
+
+UNITS_CHANGED=0
+if ! cmp -s "$SERVICE_RENDERED" "$SERVICE_DEST" 2>/dev/null; then
+    install -m 0644 -o root -g root "$SERVICE_RENDERED" "$SERVICE_DEST"
+    echo "Wrote $SERVICE_DEST"
+    UNITS_CHANGED=1
+fi
+if ! cmp -s "$TIMER_RENDERED" "$TIMER_DEST" 2>/dev/null; then
+    install -m 0644 -o root -g root "$TIMER_RENDERED" "$TIMER_DEST"
+    echo "Wrote $TIMER_DEST"
+    UNITS_CHANGED=1
+fi
+
+if [[ "$UNITS_CHANGED" -eq 1 ]]; then
+    systemctl daemon-reload
+    echo "systemctl daemon-reload done"
+fi
+
+systemctl enable --now "${UNIT_BASE}.timer"
+echo "Timer ${UNIT_BASE}.timer enabled and started"
+
+if ! systemctl list-timers --all 2>/dev/null | grep -q "${UNIT_BASE}"; then
+    echo "ERROR: ${UNIT_BASE}.timer not listed by systemctl after install" >&2
+    exit 1
+fi
+echo "Install verified — ${UNIT_BASE}.timer is scheduled."
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "Running a dry-run backup (pg_dump + mc mirror, skipping upload)..."
+    # Pass ONLY the BACKUP_* + POSTGRES_* env vars to the dry-run subprocess.
+    # `set -a; source $ENV_FILE` would expose every secret the bloom stack
+    # uses; extract just what backup.py reads.
+    BACKUP_VARS=()
+    while IFS= read -r line; do
+        BACKUP_VARS+=("$line")
+    done < <(grep -E '^(BACKUP_[A-Z_]+|POSTGRES_[A-Z_]+)=' "$ENV_FILE")
+    sudo -u bloom-deploy env -i \
+        PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+        HOME=/home/bloom-deploy \
+        "${BACKUP_VARS[@]}" \
+        /usr/bin/python3 \
+        "${DEPLOY_DIR}/scheduled-jobs/weekly-backup/backup.py" \
+        --env "${ENV_NAME}" --dry-run
+    echo "Dry-run complete."
+fi


### PR DESCRIPTION
## Summary

Adds a per-env systemd timer that runs once a week (Sunday 00:00) and ships a tarball of Bloom's state to Box for disaster recovery. Mirrors the `cert-monitor` pattern from #288 (same `scheduled-jobs/<job>/` layout, same `install.sh` shape, same per-env timer naming, same systemd hardening posture).

## What gets backed up

1. **Postgres** — full `pg_dump` of the bloom DB via `docker exec` into the running `db-prod` container. Gzip-streamed so the full uncompressed dump never materializes on disk.
2. **MinIO buckets** — every bucket listed in `BACKUP_BUCKETS` (.env.{env}.defaults) snapshotted via `mc mirror --overwrite`.

Wrapped into a single timestamped tarball, pushed to a pre-configured rclone Box remote, then pruned per `BACKUP_RETENTION_WEEKS`.

## Files

| File | Purpose |
| --- | --- |
| `scheduled-jobs/weekly-backup/backup.py` | Main script: `dump_postgres()` → `mirror_minio()` → `make_tarball()` → `upload_to_box()` → `prune_old_backups()` |
| `scheduled-jobs/weekly-backup/bloom-weekly-backup.timer` | Sunday 00:00, `Persistent=true` |
| `scheduled-jobs/weekly-backup/bloom-weekly-backup.service` | `oneshot`, runs as `bloom-deploy`, full hardening directives |
| `scheduled-jobs/weekly-backup/install.sh` | Idempotent installer — validates docker/mc/rclone/gzip + rclone remote, renders unit files via sed substitution, enables timer |
| `_WIKI/SCHEDULEDJOBS/weekly-backup.md` | Box setup, install, manual-trigger, restore, retention |
| `.env.{prod,staging}.defaults` | New `BACKUP_*` block (6 vars) |

## Exit codes

| Code | Meaning |
| --- | --- |
| 0 | Clean backup uploaded |
| 1 | Subprocess failure (pg_dump / mc / rclone) |
| 2 | Configuration error (missing env, no rclone remote) |
| 3 | Upload succeeded but retention prune failed (non-fatal) |

## Box setup (one-time, before install)

Interactive — documented in `_WIKI/SCHEDULEDJOBS/weekly-backup.md`. Runs once per host as the `bloom-deploy` user via `sudo -u bloom-deploy rclone config` to create the `box:` remote.

## Test plan

- [ ] On staging server, run `sudo -u bloom-deploy rclone config` to set up `box:` remote
- [ ] Verify with `sudo -u bloom-deploy rclone lsd box:`
- [ ] Run `sudo bash install.sh --env staging --dry-run` — verifies pg_dump + mc mirror end-to-end without burning a real upload
- [ ] After dry-run passes, drop `--dry-run` for full pipeline + first real upload
- [ ] Verify tarball appears under `box:bloom-backups/staging/`
- [ ] `sudo systemctl list-timers --all | grep weekly-backup` confirms timer scheduled
- [ ] Force a run: `sudo systemctl start bloom-weekly-backup-staging.service`, watch `journalctl -u bloom-weekly-backup-staging.service -f`

## Coordination with #288

This PR's structure intentionally mirrors PR #288 (`cert-monitor`). The `_WIKI/SCHEDULEDJOBS/README.md` index is **not** included in this PR — #288 already creates it. Whichever lands first owns the README; the other does a one-line rebase to add its row.

## Out of scope (follow-ups)

- Slack/email alerting on failed runs (today, failures land in journalctl only)
- Periodic restore drill against staging
- Incremental MinIO backups (today: full snapshot every week, simple but bigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)