### PR TITLE
fix(plate-videos): generate one time-lapse per plate per wave

### DIFF
--- a/scripts/render_plate_videos.py
+++ b/scripts/render_plate_videos.py
@@ -11,11 +11,13 @@
 """
 render_plate_videos.py — backfill time-lapse MP4s for plate-scanner experiments.
 
-Reads gravi_scans + gravi_images for each (experiment_id, plate_id) pair, pulls
-the TIFFs out of the graviscan-images bucket, encodes a sorted-by-capture_date
-MP4 with ffmpeg, uploads the result to the graviscan-videos bucket at
-{experiment_id}/{plate_id}.mp4, and upserts a row in gravi_plate_videos so the
-per-plate detail page can render it.
+Reads gravi_scans + gravi_images for each (experiment_id, plate_id, wave_number)
+group, pulls the TIFFs out of the graviscan-images bucket, encodes a
+sorted-by-capture_date MP4 with ffmpeg, uploads the result to the
+graviscan-videos bucket at {experiment_id}/wave-{wave}/{plate_id}.mp4, and
+upserts a row in gravi_plate_videos so the per-wave plate detail page can render
+it. (Plate IDs repeat across waves, so grouping by wave keeps each wave's
+time-lapse separate instead of merging them.)
 
 REQUIREMENTS
 ------------
@@ -119,6 +121,7 @@ class Config:
 class PlateJob:
     experiment_id: int
     plate_id: str
+    wave_number: int | None
     session_id: int | None
     frame_paths: list[str]  # object_paths from gravi_images, ordered by capture_date
 
@@ -126,11 +129,17 @@ class PlateJob:
 def list_plate_jobs(
     conn: psycopg.Connection, experiment_id: int, plate_id: str | None
 ) -> list[PlateJob]:
-    """Return one job per (experiment, plate) with the ordered list of frame paths."""
+    """Return one job per (experiment, plate, wave) with the ordered frame paths.
+
+    Grouping by wave (not plate alone) keeps each wave's frames in its own
+    video — plate IDs are reused across waves, so grouping by plate would merge
+    them into one mixed time-lapse.
+    """
     sql = """
         SELECT
             s.experiment_id,
             s.plate_id,
+            s.wave_number,
             MAX(s.session_id)   AS session_id,
             ARRAY_AGG(i.object_path ORDER BY s.capture_date) AS frame_paths
         FROM gravi_scans s
@@ -138,9 +147,9 @@ def list_plate_jobs(
         WHERE s.experiment_id = %s
           AND s.plate_id IS NOT NULL
           {plate_filter}
-        GROUP BY s.experiment_id, s.plate_id
+        GROUP BY s.experiment_id, s.plate_id, s.wave_number
         HAVING COUNT(*) >= 1
-        ORDER BY s.plate_id
+        ORDER BY s.plate_id, s.wave_number
     """
     if plate_id:
         sql = sql.format(plate_filter="AND s.plate_id = %s")
@@ -154,23 +163,31 @@ def list_plate_jobs(
         rows = cur.fetchall()
     return [
         PlateJob(
-            experiment_id=r[0], plate_id=r[1], session_id=r[2], frame_paths=list(r[3])
+            experiment_id=r[0],
+            plate_id=r[1],
+            wave_number=r[2],
+            session_id=r[3],
+            frame_paths=list(r[4]),
         )
         for r in rows
     ]
 
 
 def existing_video_row(
-    conn: psycopg.Connection, experiment_id: int, plate_id: str
+    conn: psycopg.Connection,
+    experiment_id: int,
+    plate_id: str,
+    wave_number: int | None,
 ) -> dict | None:
     sql = """
         SELECT id, object_path, frame_count
         FROM gravi_plate_videos
         WHERE experiment_id = %s AND plate_id = %s
+          AND COALESCE(wave_number, -1) = COALESCE(%s, -1)
         LIMIT 1
     """
     with conn.cursor() as cur:
-        cur.execute(sql, (experiment_id, plate_id))
+        cur.execute(sql, (experiment_id, plate_id, wave_number))
         row = cur.fetchone()
     if not row:
         return None
@@ -182,20 +199,22 @@ def upsert_video_row(
     *,
     experiment_id: int,
     plate_id: str,
+    wave_number: int | None,
     session_id: int | None,
     object_path: str,
     duration_seconds: int,
     frame_count: int,
     file_size_bytes: int,
 ) -> None:
-    """Upsert a row in gravi_plate_videos keyed on (experiment, plate, session?)."""
+    """Upsert a row in gravi_plate_videos keyed on (experiment, plate, wave)."""
     sql = """
         INSERT INTO gravi_plate_videos
-          (experiment_id, plate_id, session_id, object_path,
+          (experiment_id, plate_id, wave_number, session_id, object_path,
            duration_seconds, frame_count, file_size_bytes, generated_at)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, now())
-        ON CONFLICT (experiment_id, plate_id, COALESCE(session_id, -1)) DO UPDATE
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, now())
+        ON CONFLICT (experiment_id, plate_id, COALESCE(wave_number, -1)) DO UPDATE
           SET object_path     = EXCLUDED.object_path,
+              session_id      = EXCLUDED.session_id,
               duration_seconds = EXCLUDED.duration_seconds,
               frame_count     = EXCLUDED.frame_count,
               file_size_bytes = EXCLUDED.file_size_bytes,
@@ -207,6 +226,7 @@ def upsert_video_row(
             (
                 experiment_id,
                 plate_id,
+                wave_number,
                 session_id,
                 object_path,
                 duration_seconds,
@@ -335,9 +355,14 @@ def render_one(
     force: bool,
     dry_run: bool,
 ) -> None:
-    target_path = f"{job.experiment_id}/{job.plate_id}.mp4"
+    # Wave in the path so each wave's video is a distinct object (a plate_id
+    # reused across waves would otherwise overwrite the previous wave's file).
+    wave_seg = f"wave-{job.wave_number}" if job.wave_number is not None else "wave-none"
+    target_path = f"{job.experiment_id}/{wave_seg}/{job.plate_id}.mp4"
 
-    existing = existing_video_row(conn, job.experiment_id, job.plate_id)
+    existing = existing_video_row(
+        conn, job.experiment_id, job.plate_id, job.wave_number
+    )
     if existing and existing["frame_count"] == len(job.frame_paths) and not force:
         logger.info(
             "  skip — gravi_plate_videos already at %d frames; use --force to redo",
@@ -395,6 +420,7 @@ def render_one(
             conn,
             experiment_id=job.experiment_id,
             plate_id=job.plate_id,
+            wave_number=job.wave_number,
             session_id=job.session_id,
             object_path=target_path,
             duration_seconds=estimate_duration_seconds(
@@ -457,8 +483,9 @@ def main(argv: list[str]) -> int:
         logger.info("Found %d plate(s) to consider for experiment %d", len(jobs), args.experiment)
         for job in jobs:
             logger.info(
-                "[%s] %d frames%s",
+                "[%s wave=%s] %d frames%s",
                 job.plate_id,
+                job.wave_number if job.wave_number is not None else "none",
                 len(job.frame_paths),
                 " (DRY-RUN)" if args.dry_run else "",
             )

--- a/supabase/migrations/20260625000000_add_wave_number_to_gravi_plate_videos.sql
+++ b/supabase/migrations/20260625000000_add_wave_number_to_gravi_plate_videos.sql
@@ -1,0 +1,26 @@
+-- Add wave_number to gravi_plate_videos so a plate's time-lapse is identified
+-- per (experiment, plate, wave), not per (experiment, plate). Plate IDs are
+-- reused across waves (the scanner restarts numbering each wave), so the old
+-- key collapsed every wave's frames into a single video.
+
+ALTER TABLE gravi_plate_videos ADD COLUMN IF NOT EXISTS wave_number INT;
+
+-- Re-key uniqueness from (experiment, plate, session) to (experiment, plate,
+-- wave): one canonical video per wave. session_id is retained as informational.
+-- The COALESCE(...,-1) pattern keeps the index NULL-safe (mirrors
+-- gravi_scan_metadata_accession), so a genuinely wave-less plate stays unique.
+DROP INDEX IF EXISTS idx_gravi_plate_videos_unique;
+
+-- The new key drops session_id, so any pre-existing rows that differed only by
+-- session would now collide and block the unique index. Keep the most recent
+-- per (experiment, plate, wave) before enforcing uniqueness. These rows are
+-- regenerable metadata (the render job re-creates them per wave).
+DELETE FROM gravi_plate_videos a
+USING gravi_plate_videos b
+WHERE a.experiment_id = b.experiment_id
+  AND a.plate_id = b.plate_id
+  AND COALESCE(a.wave_number, -1) = COALESCE(b.wave_number, -1)
+  AND (a.generated_at, a.id) < (b.generated_at, b.id);
+
+CREATE UNIQUE INDEX idx_gravi_plate_videos_unique
+    ON gravi_plate_videos (experiment_id, plate_id, COALESCE(wave_number, -1));

--- a/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/wave/[waveNumber]/[plateId]/page.tsx
+++ b/web/app/app/plate-phenotypes/[speciesId]/[experimentId]/wave/[waveNumber]/[plateId]/page.tsx
@@ -71,7 +71,7 @@ export default async function WavePlateDetail({
     getExperiment(Number(experimentId)),
     getPlateMetadata(decodedPlateId, wave),
     getPlateScans(Number(experimentId), decodedPlateId, wave),
-    getPlateVideo(Number(experimentId), decodedPlateId),
+    getPlateVideo(Number(experimentId), decodedPlateId, wave),
   ]);
 
   const trail = [
@@ -222,18 +222,23 @@ async function getPlateMetadata(
   return (data as MetadataRow | null) ?? null;
 }
 
+// Growth video for one plate IN ONE WAVE — gravi_plate_videos is keyed
+// (experiment, plate, wave), so filtering on wave_number returns this wave's
+// time-lapse, not another wave's.
 async function getPlateVideo(
   experimentId: number,
   plateId: string,
+  wave: number | null,
 ): Promise<{ object_path: string } | null> {
   const supabase = await createServerSupabaseClient();
-  // gravi_plate_videos has no wave_number column — videos are keyed by
-  // (experiment, plate) only, so a plate reused across waves shares one video.
-  const { data, error } = await (supabase as unknown as SupabaseClient<unknown>)
+  let query = (supabase as unknown as SupabaseClient<unknown>)
     .from("gravi_plate_videos")
     .select("object_path, generated_at")
     .eq("experiment_id", experimentId)
-    .eq("plate_id", plateId)
+    .eq("plate_id", plateId);
+  query = wave === null ? query.is("wave_number", null) : query.eq("wave_number", wave);
+
+  const { data, error } = await query
     .order("generated_at", { ascending: false })
     .limit(1)
     .maybeSingle();


### PR DESCRIPTION
Follow-up to the plate-phenotypes wave fix (#358). That made the *pages* wave-aware; this makes the **growth time-lapse videos** wave-aware too.

## Problem

`scripts/render_plate_videos.py` grouped frames by `(experiment, plate)`, `gravi_plate_videos` had no `wave_number` column to tell them apart. So a wave-scoped plate page showed a video mixing all waves.

Three coordinated pieces:

1. **Migration** `20260625000000_add_wave_number_to_gravi_plate_videos.sql` — adds `wave_number`; re-keys the unique index from `(experiment, plate, session)` to `(experiment, plate, wave)`, with a defensive dedupe first (the new key drops `session_id`, so any session-only duplicates are collapsed to the most recent before the unique index is built).
2. **Script** — groups by `(experiment, plate, wave)`, uploads to `{experiment}/wave-{wave}/{plate}.mp4`, and the upsert + idempotency skip are keyed on `(plate, wave)`.
3. **Frontend** — the wave-scoped plate detail's `getPlateVideo` filters by `wave_number`, so each plate shows that wave's own time-lapse.

## Deploy / run sequence (important)

Because the backfill writes wave-keyed rows, do it in order:
1. migration applied (staging, then prod),
2. run the corrected script: `uv run scripts/render_plate_videos.py --experiment <id>` (idempotent; `--dry-run` to preview, `--force` to re-render the old merged videos).