### PR TITLE
chore(security): trivyignore kernel CVE-2026-53260 (unreachable in container)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -90,3 +90,11 @@ CVE-2026-8376
 # affected code path is unreachable at runtime. No fix available upstream. Reassess on the
 # next python:3.11-slim SHA bump. Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-43185
 CVE-2026-43185
+
+# linux-libc-dev (Debian 13 in python:3.11-slim) — affects: langchain-agent / bloommcp
+# kernel: TCP request-socket refcount underflow in reqsk_queue_hash_req() (use-after-free),
+# only reachable on PREEMPT_RT kernels. Kernel headers are a build-time-only transitive base
+# package; the container runs no kernel of its own (uses the host's), so the affected in-kernel
+# path is unreachable at runtime. No fixed Debian version available upstream. Reassess on the
+# next python:3.11-slim SHA bump. Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-53260
+CVE-2026-53260


### PR DESCRIPTION
## What

Adds `CVE-2026-53260` to `.trivyignore` so the **Build Docker Images & Scan for CVEs** check passes again.

## Why

Trivy's vuln DB just flagged **CVE-2026-53260 (CRITICAL)**, failing the `Check bloommcp for critical CVEs` step on every branch (no code change required — it's a base-image scan against a freshly-published advisory).

- **Package:** `linux-libc-dev` `6.12.94-1` (kernel headers) from `python:3.11-slim` (Debian 13.4).
- **Vuln:** Linux kernel TCP request-socket refcount underflow → use-after-free in `reqsk_queue_hash_req()`, reachable **only on PREEMPT_RT kernels**.
- **Not exploitable here:** the headers are a **build-time-only** transitive package; the container runs no kernel of its own (uses the host's), so the affected in-kernel path is unreachable at runtime.
- **No fix available:** Trivy reports an empty *Fixed Version* — a base-image SHA bump cannot resolve it today.

## Change

- `.trivyignore` — one entry for `CVE-2026-53260` with a justification comment, matching the existing `linux-libc-dev` suppression (`CVE-2026-43185`). Reassess on the next `python:3.11-slim` SHA bump.

## Impact / safety

- CI-only. No application, image, or dependency changes. Suppresses a single unreachable kernel-header CVE; all other severities/packages still gate the build.