### PR TITLE
chore(ci): require CVE/.trivyignore changes to ship in their own PR

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -364,6 +364,21 @@ jobs:
       - name: Run migration lint
         run: ./scripts/lint_migrations.sh origin/${{ github.base_ref }}
 
+  lint-cve-isolation:
+    name: Lint CVE changes are isolated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Need history on both sides so the lint can diff against the base ref
+          fetch-depth: 0
+
+      # Fails if a PR folds a .trivyignore (CVE-suppression) change into
+      # unrelated work — CVE/security changes must ship in their own PR.
+      - name: Enforce CVE-change PR isolation
+        run: ./scripts/lint_cve_isolation.sh origin/${{ github.base_ref }}
+
   # Runs the new web/ Vitest suite added by the openspec change
   # add-ghcr-image-publishing (proposal/tasks/specs already on this branch).
   # No `needs:` block — runs in parallel with the rest of pr-checks so a

--- a/scripts/lint_cve_isolation.sh
+++ b/scripts/lint_cve_isolation.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Enforce that CVE-remediation changes ship in their own PR.
+#
+# CVE work (Trivy suppressions, security base-image bumps) must not be folded
+# into unrelated feature/fix PRs — it hides security-relevant edits in noisy
+# diffs and couples a security decision to unrelated review. The unambiguous
+# CVE artifact is `.trivyignore`; if a PR touches it, every other changed file
+# must be part of the CVE-fix surface (Dockerfiles + dependency lockfiles).
+#
+# Rule:
+#   If a PR modifies `.trivyignore`, it may modify ONLY:
+#     - .trivyignore
+#     - any Dockerfile (Dockerfile, *.Dockerfile)
+#     - dependency lockfiles (package-lock.json, uv.lock, poetry.lock)
+#   Any other changed file fails the check.
+#
+# A PR that does NOT touch `.trivyignore` is never flagged.
+#
+# Usage:
+#   scripts/lint_cve_isolation.sh [BASE_REF]
+#     BASE_REF defaults to origin/main. Pass a different ref for testing.
+#
+# Exit codes:
+#   0  isolated (or .trivyignore untouched)
+#   1  .trivyignore changed alongside non-CVE files
+#   2  could not fetch BASE_REF to compare (misconfiguration)
+# =============================================================================
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+# Fetch only if it's a remote ref. Fail fast if missing — a silent fallback
+# would make every PR pass the check trivially.
+if [[ "$BASE_REF" == origin/* ]]; then
+  remote_branch="${BASE_REF#origin/}"
+  if ! git fetch origin "$remote_branch" --depth=1 2>/dev/null; then
+    echo "::error title=lint_cve_isolation: cannot fetch base ref::git fetch origin ${remote_branch} failed. Cannot diff changed files."
+    exit 2
+  fi
+fi
+
+# Files changed on the PR side since it diverged from BASE_REF.
+CHANGED=$(git diff --name-only "${BASE_REF}...HEAD")
+
+# A change to .trivyignore is the trigger; no trivyignore change → nothing to enforce.
+if ! grep -qx '\.trivyignore' <<<"$CHANGED"; then
+  echo "CVE-isolation check passed (.trivyignore not modified)."
+  exit 0
+fi
+
+# Whitelist of paths allowed alongside a .trivyignore change — the CVE-fix surface.
+_is_cve_surface() {
+  local f="$1"
+  [ "$f" = ".trivyignore" ] && return 0
+  case "$(basename "$f")" in
+    Dockerfile | *.Dockerfile | package-lock.json | uv.lock | poetry.lock) return 0 ;;
+  esac
+  return 1
+}
+
+violations=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if ! _is_cve_surface "$f"; then
+    violations+=("$f")
+  fi
+done <<<"$CHANGED"
+
+if [ "${#violations[@]}" -ne 0 ]; then
+  echo "::error title=CVE change not isolated::This PR modifies .trivyignore but also changes files outside the CVE-fix surface. CVE/security suppressions must ship in their own PR. Offending files:"
+  for f in "${violations[@]}"; do
+    echo "::error::  $f"
+  done
+  echo "Allowed alongside .trivyignore: Dockerfiles (Dockerfile, *.Dockerfile) and lockfiles (package-lock.json, uv.lock, poetry.lock). Move the .trivyignore change to its own PR."
+  exit 1
+fi
+
+echo "CVE-isolation check passed (.trivyignore changed alongside only CVE-fix-surface files)."

--- a/tests/integration/test_lint_cve_isolation.py
+++ b/tests/integration/test_lint_cve_isolation.py
@@ -1,0 +1,134 @@
+"""
+Tests for scripts/lint_cve_isolation.sh.
+
+Creates scratch git repos with a base 'main' branch and a 'feature' branch
+carrying a set of changes, then runs the lint against them. The lint only
+fires when `.trivyignore` is among the changed files; alongside it, only the
+CVE-fix surface (Dockerfiles, lockfiles) is permitted.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+LINT_SCRIPT = REPO_ROOT / "scripts" / "lint_cve_isolation.sh"
+
+
+def _run(cmd, cwd, env=None, check=True):
+    """Run a shell command; return CompletedProcess. `check=False` to inspect a non-zero exit."""
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        cmd, cwd=cwd, env=full_env, capture_output=True, text=True, check=check
+    )
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "--initial-branch=main"], cwd=root)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=root)
+    _run(["git", "config", "user.name", "Test"], cwd=root)
+
+
+def _commit_file(root: Path, relative: str, content: str, message: str) -> None:
+    full = root / relative
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content)
+    _run(["git", "add", relative], cwd=root)
+    _run(["git", "commit", "-m", message], cwd=root)
+
+
+def _set_up_base(root: Path) -> None:
+    """A 'main' branch with a seed .trivyignore, a Dockerfile, a lockfile, and app code."""
+    _init_repo(root)
+    _commit_file(root, ".trivyignore", "# seed\nCVE-0000-0000\n", "seed trivyignore")
+    _commit_file(root, "bloommcp/Dockerfile", "FROM python:3.11-slim\n", "seed dockerfile")
+    _commit_file(root, "uv.lock", "# lock v1\n", "seed lockfile")
+    _commit_file(root, "web/app/page.tsx", "export default function P(){}\n", "seed app code")
+    # Copy the lint script in so the test is independent of cwd.
+    dest = root / "scripts" / "lint_cve_isolation.sh"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(LINT_SCRIPT.read_text())
+    dest.chmod(0o755)
+    _run(["git", "add", "scripts/lint_cve_isolation.sh"], cwd=root)
+    _run(["git", "commit", "-m", "add lint script"], cwd=root)
+
+
+def _feature_branch(root: Path) -> None:
+    _run(["git", "checkout", "-b", "feature"], cwd=root)
+
+
+def _modify(root: Path, relative: str, content: str) -> None:
+    full = root / relative
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content)
+    _run(["git", "add", relative], cwd=root)
+
+
+def _commit(root: Path, message: str) -> None:
+    _run(["git", "commit", "-m", message], cwd=root)
+
+
+def _run_lint(root: Path, base_ref: str = "main"):
+    return _run(["bash", "./scripts/lint_cve_isolation.sh", base_ref], cwd=root, check=False)
+
+
+# -----------------------------------------------------------------------------
+
+
+def test_trivyignore_only_passes(tmp_path):
+    """A PR that changes only .trivyignore is allowed."""
+    _set_up_base(tmp_path)
+    _feature_branch(tmp_path)
+    _modify(tmp_path, ".trivyignore", "# seed\nCVE-0000-0000\nCVE-2026-53260\n")
+    _commit(tmp_path, "suppress CVE")
+    result = _run_lint(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_trivyignore_with_dockerfile_and_lockfile_passes(tmp_path):
+    """.trivyignore alongside a base-image bump + lockfile (the CVE-fix surface) is allowed."""
+    _set_up_base(tmp_path)
+    _feature_branch(tmp_path)
+    _modify(tmp_path, ".trivyignore", "# seed\n")  # entry removed after a bump
+    _modify(tmp_path, "bloommcp/Dockerfile", "FROM python:3.11-slim@sha256:newer\n")
+    _modify(tmp_path, "uv.lock", "# lock v2\n")
+    _commit(tmp_path, "bump base image, drop suppression")
+    result = _run_lint(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_trivyignore_with_app_code_fails(tmp_path):
+    """.trivyignore folded into an unrelated app change is rejected."""
+    _set_up_base(tmp_path)
+    _feature_branch(tmp_path)
+    _modify(tmp_path, ".trivyignore", "# seed\nCVE-2026-53260\n")
+    _modify(tmp_path, "web/app/page.tsx", "export default function P(){return null}\n")
+    _commit(tmp_path, "feature + sneaky suppression")
+    result = _run_lint(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "web/app/page.tsx" in result.stdout
+
+
+def test_no_trivyignore_change_passes(tmp_path):
+    """A PR that never touches .trivyignore is not flagged, regardless of files changed."""
+    _set_up_base(tmp_path)
+    _feature_branch(tmp_path)
+    _modify(tmp_path, "web/app/page.tsx", "export default function P(){return null}\n")
+    _modify(tmp_path, "bloommcp/Dockerfile", "FROM python:3.11-slim@sha256:other\n")
+    _commit(tmp_path, "normal feature work")
+    result = _run_lint(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_missing_base_ref_errors(tmp_path):
+    """An unreachable origin/* base ref fails loudly (exit 2), never a silent pass."""
+    _set_up_base(tmp_path)
+    _feature_branch(tmp_path)
+    _modify(tmp_path, ".trivyignore", "# seed\nCVE-2026-53260\n")
+    _commit(tmp_path, "suppress CVE")
+    result = _run_lint(tmp_path, base_ref="origin/does-not-exist")
+    assert result.returncode == 2, result.stdout + result.stderr


### PR DESCRIPTION
## What

Adds a CI check that fails any PR which folds a `.trivyignore` (CVE-suppression) change into unrelated feature/fix work. CVE remediation must ship in its own PR.

## Why

A `.trivyignore` suppression is a security decision; buried in a large feature diff it gets rubber-stamped. Isolating CVE work makes each suppression independently reviewable and keeps an unrelated PR from silently changing the project's vulnerability posture.

## Change

- **`scripts/lint_cve_isolation.sh`** — diffs the PR against its base. If `.trivyignore` is modified, every other changed file must be part of the **CVE-fix surface**; otherwise the check fails. A PR that doesn't touch `.trivyignore` is never flagged.
  - Allowed alongside `.trivyignore`: Dockerfiles (`Dockerfile`, `*.Dockerfile`) and lockfiles (`package-lock.json`, `uv.lock`, `poetry.lock`) — so a base-image-bump CVE fix that also drops a suppression still passes.
  - Fails loudly (exit 2) if the base ref can't be fetched — never a silent pass.
- **`.github/workflows/pr-checks.yml`** — new `Lint CVE changes are isolated` job (mirrors the migration-lint job: `fetch-depth: 0`, diff against `origin/${{ github.base_ref }}`).
- **`tests/integration/test_lint_cve_isolation.py`** — 5 tests: trivyignore-only passes; trivyignore + Dockerfile + lockfile passes; trivyignore + app code fails; no-trivyignore-change passes; missing base ref errors.

## Impact / safety

- CI-only; no application/runtime change. This PR touches no `.trivyignore`, so the new check passes on it.
- Scope is the unambiguous CVE artifact (`.trivyignore`); dependency/base bumps done purely for CVEs are covered by the allowlist, not hard-blocked, to avoid false positives on normal Dockerfile/lockfile edits.