### PR TITLE
feat(#360): qc_inspect — read-only NaN/missingness visualization at QC time (Tier 3)

### DIFF
--- a/bloommcp/src/bloom_mcp/server.py
+++ b/bloommcp/src/bloom_mcp/server.py
@@ -25,6 +25,8 @@ Discovery tools (always-on):
 Direct tools (granular, available for ad-hoc use):
   - qc_clean:          clean a raw trait table for analysis (delegates to
                        sleap_roots_analyze.clean_traits_for_analysis)
+  - qc_inspect:        read-only NaN/missingness report + threshold recommendation at
+                       QC time (delegates to sleap_roots_analyze EDA functions)
   - pca_analysis:      PCA on a cleaned experiment (require_clean; delegates to
                        sleap_roots_analyze.perform_pca_analysis)
   - correlation_tools: 8 cross-experiment correlation tools
@@ -58,6 +60,7 @@ from bloom_mcp.tools import (
     correlation_tools,
     storage_tools,
     qc_clean_tool,
+    qc_inspect_tool,
     pca_analysis_tool,
 )
 from bloom_mcp.tools.workflows import (
@@ -90,6 +93,7 @@ clustering_workflow.register(mcp)
 
 # Direct tools (granular)
 qc_clean_tool.register(mcp)
+qc_inspect_tool.register(mcp)
 pca_analysis_tool.register(mcp)
 correlation_tools.register(mcp)
 viz_tools.register(mcp)

--- a/bloommcp/src/bloom_mcp/tools/_qc_shared.py
+++ b/bloommcp/src/bloom_mcp/tools/_qc_shared.py
@@ -1,0 +1,55 @@
+"""Shared helpers for the granular QC tools (``qc_clean`` #338, ``qc_inspect`` #360).
+
+Both tools read the **raw** experiment frame and forward the adapter-detected role
+columns into ``sleap_roots_analyze`` delegates the same way, and both validate a
+caller-supplied ``trait_columns`` subset up front. Factoring these here keeps the
+two tools in lockstep rather than drifting as two copies.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from bloom_mcp.contract import BloomMCPError
+from bloom_mcp.data_access import ExperimentFrame
+
+
+def _role_kwargs(frame: ExperimentFrame) -> dict[str, str]:
+    """Forward the adapter-detected role columns to a cleanup/EDA delegate.
+
+    Omit any role that is ``None`` so the delegate applies its own default rather
+    than receiving ``None``.
+    """
+    roles = {
+        "barcode_col": frame.sample_id_col,
+        "genotype_col": frame.genotype_col,
+        "replicate_col": frame.replicate_col,
+    }
+    return {k: v for k, v in roles.items() if v is not None}
+
+
+def _validate_trait_subset(
+    frame: ExperimentFrame, requested: list[str], experiment: str
+) -> None:
+    """Reject a caller-supplied ``trait_columns`` subset up front with a clear remedy.
+
+    Without this an unknown column raises ``KeyError`` (→ opaque ``internal_error``)
+    and a non-numeric column silently corrupts the delegate's zero/NaN-fraction
+    filtering. Both surface here as a fixable ``invalid_input`` naming the columns.
+    """
+    missing = [c for c in requested if c not in frame.df.columns]
+    if missing:
+        raise BloomMCPError(
+            code="invalid_input",
+            message=f"trait_columns names columns not in {experiment!r}: {missing}.",
+            remedy="Use column names from load_experiment_data, or omit trait_columns to use all detected traits.",
+        )
+    non_numeric = [
+        c for c in requested if not pd.api.types.is_numeric_dtype(frame.df[c])
+    ]
+    if non_numeric:
+        raise BloomMCPError(
+            code="invalid_input",
+            message=f"trait_columns includes non-numeric columns: {non_numeric}.",
+            remedy="Pass only numeric trait columns; metadata/identifier columns cannot be used as traits.",
+        )

--- a/bloommcp/src/bloom_mcp/tools/_qc_shared.py
+++ b/bloommcp/src/bloom_mcp/tools/_qc_shared.py
@@ -13,6 +13,24 @@ import pandas as pd
 from bloom_mcp.contract import BloomMCPError
 from bloom_mcp.data_access import ExperimentFrame
 
+# Canonical cleanup-threshold defaults shared by qc_clean and qc_inspect — the values
+# ``sleap_roots_analyze``'s QC pipeline actually cleans with (``CleanupConfig`` in
+# ``pipeline/config/components.py``, and the ``_QC_DEFAULTS`` that
+# ``clean_traits_for_analysis`` injects) — NOT the looser ``apply_data_cleanup_filters``
+# *signature* defaults (``max_nans_per_trait=0.3`` / ``max_nans_per_sample=0.2``). Two
+# values differ: the pipeline is stricter — ``max_nans_per_trait=0.2`` drops NaN-heavier
+# traits sooner, and ``max_nans_per_sample=0.0`` drops any sample that still carries a NaN
+# in a kept trait. Both tools forward all four thresholds *explicitly*, so they must carry
+# the canonical values here — a default ``qc_clean`` reproduces the pipeline's clean, and
+# ``qc_inspect``'s overlays/recommendation reflect that same clean. Single-sourcing them
+# here keeps the two tools from silently desyncing. Source of truth:
+# talmolab/sleap-roots-analyze#167 + ``CleanupConfig`` (max_nan_fraction=0.0,
+# max_zeros_per_trait=0.5, max_nans_per_trait=0.2, min_samples_per_trait=10).
+_CANONICAL_MAX_ZEROS_PER_TRAIT = 0.5
+_CANONICAL_MAX_NANS_PER_TRAIT = 0.2
+_CANONICAL_MAX_NANS_PER_SAMPLE = 0.0
+_CANONICAL_MIN_SAMPLES_PER_TRAIT = 10
+
 
 def _role_kwargs(frame: ExperimentFrame) -> dict[str, str]:
     """Forward the adapter-detected role columns to a cleanup/EDA delegate.

--- a/bloommcp/src/bloom_mcp/tools/_qc_shared.py
+++ b/bloommcp/src/bloom_mcp/tools/_qc_shared.py
@@ -8,28 +8,45 @@ two tools in lockstep rather than drifting as two copies.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 
 from bloom_mcp.contract import BloomMCPError
 from bloom_mcp.data_access import ExperimentFrame
 
 # Canonical cleanup-threshold defaults shared by qc_clean and qc_inspect — the values
-# ``sleap_roots_analyze``'s QC pipeline actually cleans with (``CleanupConfig`` in
-# ``pipeline/config/components.py``, and the ``_QC_DEFAULTS`` that
-# ``clean_traits_for_analysis`` injects) — NOT the looser ``apply_data_cleanup_filters``
-# *signature* defaults (``max_nans_per_trait=0.3`` / ``max_nans_per_sample=0.2``). Two
-# values differ: the pipeline is stricter — ``max_nans_per_trait=0.2`` drops NaN-heavier
-# traits sooner, and ``max_nans_per_sample=0.0`` drops any sample that still carries a NaN
-# in a kept trait. Both tools forward all four thresholds *explicitly*, so they must carry
-# the canonical values here — a default ``qc_clean`` reproduces the pipeline's clean, and
-# ``qc_inspect``'s overlays/recommendation reflect that same clean. Single-sourcing them
-# here keeps the two tools from silently desyncing. Source of truth:
-# talmolab/sleap-roots-analyze#167 + ``CleanupConfig`` (max_nan_fraction=0.0,
-# max_zeros_per_trait=0.5, max_nans_per_trait=0.2, min_samples_per_trait=10).
+# ``sleap_roots_analyze``'s QC pipeline cleans with (``CleanupConfig`` / the ``_QC_DEFAULTS``
+# that ``clean_traits_for_analysis`` injects). On the pinned analyze version these coincide
+# with ``apply_data_cleanup_filters``'s own signature defaults (0.5 / 0.2 / 0.0 / 10) — a
+# `test_canonical_thresholds_match_upstream_delegate_defaults` tripwire pins that so an
+# upstream change to the delegate defaults trips CI (re-verify against the QC pipeline
+# canonical; earlier analyze versions shipped looser signature defaults, which is why both
+# tools still forward all four thresholds *explicitly*). Both tools import these so a default
+# ``qc_clean`` reproduces the pipeline's clean and ``qc_inspect``'s overlays/recommendation
+# reflect that same clean; single-sourcing here keeps them from silently desyncing.
+# Source of truth: talmolab/sleap-roots-analyze#167 + ``CleanupConfig``.
 _CANONICAL_MAX_ZEROS_PER_TRAIT = 0.5
 _CANONICAL_MAX_NANS_PER_TRAIT = 0.2
 _CANONICAL_MAX_NANS_PER_SAMPLE = 0.0
 _CANONICAL_MIN_SAMPLES_PER_TRAIT = 10
+
+
+def _validate_experiment_name(experiment: str) -> None:
+    """Reject an ``experiment`` that is anything but a bare filename.
+
+    ``experiment`` flows into ``TRAITS_DIR / experiment`` + ``pd.read_csv``, so a path with
+    separators or ``..`` (or an absolute path) would read outside ``TRAITS_DIR`` — and for a
+    read-and-persist tool like ``qc_inspect`` the contents could then surface in committed
+    artifacts. Require a bare basename. (The cross-tool fix is to centralize this in
+    ``load_experiment_data`` so the whole tool family is covered; this guards the QC tools now.)
+    """
+    if experiment in ("", ".", "..") or Path(experiment).name != experiment:
+        raise BloomMCPError(
+            code="invalid_input",
+            message="experiment must be a bare CSV filename (no path separators).",
+            remedy="Pass a filename from list_available_experiments, e.g. 'my_experiment.csv'.",
+        )
 
 
 def _role_kwargs(frame: ExperimentFrame) -> dict[str, str]:

--- a/bloommcp/src/bloom_mcp/tools/qc_clean_tool.py
+++ b/bloommcp/src/bloom_mcp/tools/qc_clean_tool.py
@@ -40,16 +40,16 @@ from __future__ import annotations
 import json
 from typing import Optional
 
-import pandas as pd
 from pydantic import BaseModel, Field
 from sleap_roots_analyze import clean_traits_for_analysis
 
 from bloom_mcp.contract import BloomMCPError, Provenance, as_mcp_tool
 from bloom_mcp.contract import register as _contract_register
-from bloom_mcp.data_access import ExperimentFrame, ExperimentReadError
+from bloom_mcp.data_access import ExperimentReadError
 from bloom_mcp.data_utils import convert_to_json_serializable
 from bloom_mcp.experiment_utils import CLEANED_CSV_NAME, TRAITS_DIR
 from bloom_mcp.tools import _ports
+from bloom_mcp.tools._qc_shared import _role_kwargs, _validate_trait_subset
 
 _TOOL_CLASS = "qc"
 _LOG_NAME = "cleanup_log.json"
@@ -147,47 +147,6 @@ class QCCleanResult(BaseModel):
     version_dir: str
     manifest_path: str
     outputs: dict[str, str]
-
-
-def _role_kwargs(frame: ExperimentFrame) -> dict[str, str]:
-    """Forward the adapter-detected role columns to the delegate.
-
-    Omit any role that is ``None`` so ``clean_traits_for_analysis`` applies its
-    own default rather than receiving ``None``.
-    """
-    roles = {
-        "barcode_col": frame.sample_id_col,
-        "genotype_col": frame.genotype_col,
-        "replicate_col": frame.replicate_col,
-    }
-    return {k: v for k, v in roles.items() if v is not None}
-
-
-def _validate_trait_subset(
-    frame: ExperimentFrame, requested: list[str], experiment: str
-) -> None:
-    """Reject a caller-supplied ``trait_columns`` subset up front with a clear remedy.
-
-    Without this an unknown column raises ``KeyError`` (→ opaque ``internal_error``)
-    and a non-numeric column silently corrupts the delegate's zero/NaN-fraction
-    filtering. Both surface here as a fixable ``invalid_input`` naming the columns.
-    """
-    missing = [c for c in requested if c not in frame.df.columns]
-    if missing:
-        raise BloomMCPError(
-            code="invalid_input",
-            message=f"trait_columns names columns not in {experiment!r}: {missing}.",
-            remedy="Use column names from load_experiment_data, or omit trait_columns to clean all detected traits.",
-        )
-    non_numeric = [
-        c for c in requested if not pd.api.types.is_numeric_dtype(frame.df[c])
-    ]
-    if non_numeric:
-        raise BloomMCPError(
-            code="invalid_input",
-            message=f"trait_columns includes non-numeric columns: {non_numeric}.",
-            remedy="Pass only numeric trait columns; metadata/identifier columns cannot be cleaned as traits.",
-        )
 
 
 @as_mcp_tool(

--- a/bloommcp/src/bloom_mcp/tools/qc_clean_tool.py
+++ b/bloommcp/src/bloom_mcp/tools/qc_clean_tool.py
@@ -49,30 +49,21 @@ from bloom_mcp.data_access import ExperimentReadError
 from bloom_mcp.data_utils import convert_to_json_serializable
 from bloom_mcp.experiment_utils import CLEANED_CSV_NAME, TRAITS_DIR
 from bloom_mcp.tools import _ports
-from bloom_mcp.tools._qc_shared import _role_kwargs, _validate_trait_subset
+from bloom_mcp.tools._qc_shared import (
+    _CANONICAL_MAX_NANS_PER_SAMPLE,
+    _CANONICAL_MAX_NANS_PER_TRAIT,
+    _CANONICAL_MAX_ZEROS_PER_TRAIT,
+    _CANONICAL_MIN_SAMPLES_PER_TRAIT,
+    _role_kwargs,
+    _validate_trait_subset,
+)
 
 _TOOL_CLASS = "qc"
 _LOG_NAME = "cleanup_log.json"
 
-# Default cleanup thresholds mirror the **canonical QC pipeline** defaults — the
-# values ``sleap_roots_analyze``'s QC pipeline actually cleans with
-# (``CleanupConfig`` in ``pipeline/config/components.py``, and the ``_QC_DEFAULTS``
-# that ``clean_traits_for_analysis`` injects) — NOT the looser
-# ``apply_data_cleanup_filters`` *signature* defaults
-# (``max_nans_per_trait=0.3`` / ``max_nans_per_sample=0.2``). Two values differ:
-# the pipeline is stricter — ``max_nans_per_trait=0.2`` drops NaN-heavier traits
-# sooner, and ``max_nans_per_sample=0.0`` drops any sample that still carries a NaN
-# in a kept trait. Mirroring the pipeline means a default ``qc_clean`` reproduces
-# the QC pipeline's clean rather than shipping a looser one. Because ``qc_clean``
-# forwards all four thresholds *explicitly*, they must carry the canonical values
-# here — otherwise our looser defaults would override the delegate's own canonical
-# injection. Source of truth: talmolab/sleap-roots-analyze#167 +
-# ``CleanupConfig`` (max_nan_fraction=0.0, max_zeros_per_trait=0.5,
-# max_nans_per_trait=0.2, min_samples_per_trait=10).
-_CANONICAL_MAX_ZEROS_PER_TRAIT = 0.5
-_CANONICAL_MAX_NANS_PER_TRAIT = 0.2
-_CANONICAL_MAX_NANS_PER_SAMPLE = 0.0
-_CANONICAL_MIN_SAMPLES_PER_TRAIT = 10
+# Default cleanup thresholds mirror the **canonical QC pipeline** defaults, shared with
+# qc_inspect and single-sourced in ``_qc_shared`` (``_CANONICAL_*``) so the two tools
+# cannot silently desync — see that module for the full rationale.
 
 
 class QCCleanParams(BaseModel):

--- a/bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py
+++ b/bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py
@@ -1,0 +1,369 @@
+"""qc_inspect — read-only NaN / missingness visualization at QC time (Tier 3 / #360).
+
+The read-only sibling of ``qc_clean``. Where ``qc_clean`` *produces* a cleaned run,
+``qc_inspect`` *produces a report* that helps the agent choose ``qc_clean``'s
+thresholds before committing a clean — so it does not run blind on the defaults.
+
+On each call it reads the **raw** frame via the :class:`ExperimentReader` port (no
+``require_clean``), then delegates **all** EDA to ``sleap_roots_analyze``: it runs
+``apply_data_cleanup_filters`` to get the cleanup log, feeds it to
+``create_trait_eda_plots`` (per-trait NaN/zero/outlier bar charts with the threshold
+lines drawn + the traits-actually-removed panel), takes the ``missing_data_pattern``
+heatmap from ``create_exploratory_summary_plots``, and ``inspect_nan_samples`` for the
+per-sample NaN table. The MCP contains **no** EDA/plotting logic and never calls the
+vendored ``bloom_mcp.data_cleanup``.
+
+It persists a versioned **report** run via the :class:`ResultStore` port under tool
+class ``qc_inspect`` — deliberately **not** ``qc`` — so the reader never resolves it as
+a cleaned version: ``qc_inspect`` is read-only and produces no cleaned table. The result
+returns a small inline summary + a structured **recommendation** (which traits to drop
+and the sample loss avoided) + links to the persisted figures / CSV / recommendation
+JSON — never inline blobs.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless: pin Agg before importing the analyze viz funcs below
+import matplotlib.pyplot as plt
+from sleap_roots_analyze import (
+    apply_data_cleanup_filters,
+    create_exploratory_summary_plots,
+    create_trait_eda_plots,
+    inspect_nan_samples,
+)
+
+from bloom_mcp.contract import Provenance, as_mcp_tool
+from bloom_mcp.contract import register as _contract_register
+from bloom_mcp.data_access import ExperimentReadError
+from bloom_mcp.data_utils import convert_to_json_serializable
+from bloom_mcp.experiment_utils import TRAITS_DIR
+from bloom_mcp.tools import _ports
+from bloom_mcp.tools._qc_shared import _role_kwargs, _validate_trait_subset
+
+_TOOL_CLASS = "qc_inspect"
+_NAN_SAMPLES_CSV = "nan_samples.csv"
+_RECOMMENDATION_JSON = "recommendation.json"
+_HEATMAP_PNG = "missing_data_pattern.png"
+
+# Canonical QC-pipeline defaults — identical to qc_clean's, so qc_inspect's overlay
+# lines and recommendation reflect the clean a default qc_clean would actually apply.
+_CANONICAL_MAX_ZEROS_PER_TRAIT = 0.5
+_CANONICAL_MAX_NANS_PER_TRAIT = 0.2
+_CANONICAL_MAX_NANS_PER_SAMPLE = 0.0
+_CANONICAL_MIN_SAMPLES_PER_TRAIT = 10
+
+
+class QCInspectParams(BaseModel):
+    """Inputs for ``qc_inspect`` — the same threshold knobs as ``qc_clean`` (no ``seed``)."""
+
+    experiment: str = Field(
+        ..., description="CSV filename from list_available_experiments."
+    )
+    trait_columns: Optional[list[str]] = Field(
+        default=None,
+        description="Subset of trait columns to inspect; omit to inspect all detected traits.",
+    )
+    max_zeros_per_trait: float = Field(
+        default=_CANONICAL_MAX_ZEROS_PER_TRAIT,
+        ge=0.0,
+        le=1.0,
+        description="Zero-fraction threshold drawn on the overlay (same default as qc_clean).",
+    )
+    max_nans_per_trait: float = Field(
+        default=_CANONICAL_MAX_NANS_PER_TRAIT,
+        ge=0.0,
+        le=1.0,
+        description="NaN-fraction threshold drawn on the overlay (same default as qc_clean).",
+    )
+    max_nans_per_sample: float = Field(
+        default=_CANONICAL_MAX_NANS_PER_SAMPLE,
+        ge=0.0,
+        le=1.0,
+        description="Per-sample NaN-fraction threshold used to model sample drops "
+        "(same default as qc_clean).",
+    )
+    min_samples_per_trait: int = Field(
+        default=_CANONICAL_MIN_SAMPLES_PER_TRAIT,
+        ge=1,
+        description="Min valid samples to keep a trait (same default as qc_clean).",
+    )
+    user_label: Optional[str] = Field(
+        default=None,
+        description="Optional slug appended to the version directory name.",
+    )
+
+
+class QCInspectRecommendation(BaseModel):
+    """A threshold recommendation derived from the supplied params (delegate-driven)."""
+
+    no_change_needed: bool
+    recommended_max_nans_per_trait: Optional[float]
+    would_remove_traits: list[str]
+    samples_lost_at_recommendation: int
+    samples_lost_at_current_params: int
+    naive_dropna_samples_lost: int
+    rationale: str
+
+
+class QCInspectResult(BaseModel):
+    """A small inline summary + recommendation + links to the persisted report run."""
+
+    experiment: str
+    source: str
+    n_samples: int
+    n_traits: int
+    per_trait_nan_fraction: dict[str, float]
+    traits_exceeding_thresholds: list[str]
+    traits_would_be_removed: list[str]
+    samples_lost_at_current_params: int
+    residual_nan_cells_at_current_params: int
+    recommendation: QCInspectRecommendation
+    run_ref: str
+    version_dir: str
+    manifest_path: str
+    outputs: dict[str, str]
+
+
+def _filter(df, trait_cols, params, role_kwargs, *, max_nans_per_trait):
+    """Run the analyze cleanup filter at the given NaN-per-trait threshold."""
+    return apply_data_cleanup_filters(
+        df,
+        trait_cols,
+        max_zeros_per_trait=params.max_zeros_per_trait,
+        max_nans_per_trait=max_nans_per_trait,
+        max_nans_per_sample=params.max_nans_per_sample,
+        min_samples_per_trait=params.min_samples_per_trait,
+        **role_kwargs,
+    )
+
+
+def _removed_traits(log: dict) -> list[str]:
+    return [t["trait"] for t in log.get("removed_traits", []) if isinstance(t, dict)]
+
+
+def _build_recommendation(
+    df,
+    trait_cols,
+    params,
+    role_kwargs,
+    nan_frac,
+    current_log,
+    naive_dropna_lost: int,
+) -> QCInspectRecommendation:
+    """Recommend a ``max_nans_per_trait`` that drops NaN-bearing traits to cut sample loss.
+
+    Delegate-driven: the consequence of the recommended threshold is measured by
+    re-running ``apply_data_cleanup_filters`` at that threshold — no filtering logic
+    is re-implemented here.
+    """
+    samples_lost_current = int(
+        current_log.get("original_samples", len(df))
+        - current_log.get("final_samples", len(df))
+    )
+    removed_now = set(_removed_traits(current_log))
+    # Traits the current params KEEP but that still carry NaN — these are what force
+    # the sample loss (or leave residual NaN at a looser max_nans_per_sample).
+    offending = {
+        t: float(nan_frac[t])
+        for t in trait_cols
+        if t not in removed_now and nan_frac[t] > 0
+    }
+
+    if not offending:
+        return QCInspectRecommendation(
+            no_change_needed=True,
+            recommended_max_nans_per_trait=None,
+            would_remove_traits=[],
+            samples_lost_at_recommendation=samples_lost_current,
+            samples_lost_at_current_params=samples_lost_current,
+            naive_dropna_samples_lost=naive_dropna_lost,
+            rationale=(
+                "No NaN-bearing trait survives the current thresholds, so the current "
+                "settings lose no samples to missingness — no change recommended."
+            ),
+        )
+
+    min_frac = min(offending.values())
+    rec = (
+        math.floor(min_frac * 100) / 100
+    )  # largest 0.01 step strictly below the fraction
+    if rec >= min_frac:
+        rec = round(min_frac - 0.01, 4)
+    rec = max(rec, 0.0)
+
+    _, rec_log = _filter(df, trait_cols, params, role_kwargs, max_nans_per_trait=rec)
+    would_remove = _removed_traits(rec_log)
+    samples_lost_rec = int(
+        rec_log.get("original_samples", len(df)) - rec_log.get("final_samples", len(df))
+    )
+    return QCInspectRecommendation(
+        no_change_needed=False,
+        recommended_max_nans_per_trait=rec,
+        would_remove_traits=would_remove,
+        samples_lost_at_recommendation=samples_lost_rec,
+        samples_lost_at_current_params=samples_lost_current,
+        naive_dropna_samples_lost=naive_dropna_lost,
+        rationale=(
+            f"At the current max_nans_per_trait={params.max_nans_per_trait}, the "
+            f"NaN-heavy trait(s) {sorted(offending)} are kept and {samples_lost_current} "
+            f"sample(s) are lost. Lowering max_nans_per_trait to {rec} drops "
+            f"{would_remove or 'them'} instead, leaving {samples_lost_rec} sample(s) lost."
+        ),
+    )
+
+
+def _render_report(df, trait_cols, params, current_log, role_kwargs, staging_dir):
+    """Render + persist the delegated EDA figures and the NaN-samples table.
+
+    Returns the ``{logical_name: relative_path}`` map for the figures/CSV. All
+    matplotlib figures the delegates create are closed before returning (no handle
+    leak in a long-lived server process).
+    """
+    outputs: dict[str, str] = {}
+
+    # 1. Per-trait NaN/zero/outlier overlay charts + the traits-actually-removed panel.
+    eda_figs = create_trait_eda_plots(
+        df,
+        trait_cols,
+        thresholds={
+            "nan": params.max_nans_per_trait,
+            "zero": params.max_zeros_per_trait,
+        },
+        cleanup_log=current_log,
+        min_samples_per_trait=params.min_samples_per_trait,
+    )
+    try:
+        for name, fig in eda_figs.items():
+            fname = f"{name}.png"
+            fig.savefig(staging_dir / fname, dpi=120, bbox_inches="tight")
+            outputs[fname] = fname
+    finally:
+        for fig in eda_figs.values():
+            plt.close(fig)
+
+    # 2. The sample x trait missingness heatmap (best-effort — the secondary panels of
+    #    create_exploratory_summary_plots can be fragile on tiny/degenerate frames; the
+    #    overview + recommendation are the load-bearing outputs).
+    try:
+        summary_figs = create_exploratory_summary_plots(
+            df, trait_cols, genotype_col=role_kwargs.get("genotype_col", "geno")
+        )
+    except Exception:
+        summary_figs = {}
+    try:
+        heatmap = summary_figs.get("missing_data_pattern")
+        if heatmap is not None:
+            heatmap.savefig(staging_dir / _HEATMAP_PNG, dpi=120, bbox_inches="tight")
+            outputs[_HEATMAP_PNG] = _HEATMAP_PNG
+    finally:
+        for fig in summary_figs.values():
+            plt.close(fig)
+
+    # 3. Per-sample NaN report (which samples, which traits, nan_fraction).
+    nan_samples = inspect_nan_samples(df, trait_cols, verbose=False, **role_kwargs)
+    nan_samples.to_csv(staging_dir / _NAN_SAMPLES_CSV, index=False)
+    outputs[_NAN_SAMPLES_CSV] = _NAN_SAMPLES_CSV
+
+    return outputs
+
+
+@as_mcp_tool(
+    input_model=QCInspectParams,
+    output_model=QCInspectResult,
+    errors=(ExperimentReadError,),
+)
+def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectResult:
+    """Inspect raw ``experiment`` missingness and recommend a cleanup threshold."""
+    reader = _ports.reader()
+    store = _ports.store()
+
+    # Read the RAW frame — qc_inspect inspects the raw missingness (no require_clean).
+    frame = reader.load_experiment(params.experiment)
+    if params.trait_columns is not None:
+        _validate_trait_subset(frame, params.trait_columns, params.experiment)
+    trait_cols = list(params.trait_columns or frame.trait_cols)
+    role_kwargs = _role_kwargs(frame)
+
+    nan_frac = frame.df[trait_cols].isna().mean()
+    per_trait_nan = {c: round(float(nan_frac[c]), 4) for c in trait_cols}
+    traits_exceeding = [
+        c for c in trait_cols if nan_frac[c] > params.max_nans_per_trait
+    ]
+    naive_dropna_lost = int(len(frame.df) - len(frame.df.dropna(subset=trait_cols)))
+
+    # One cleanup-filter call at the supplied params drives both the overlay's
+    # "traits actually removed" panel and the recommendation.
+    cleaned_current, current_log = _filter(
+        frame.df,
+        trait_cols,
+        params,
+        role_kwargs,
+        max_nans_per_trait=params.max_nans_per_trait,
+    )
+    removed_now = _removed_traits(current_log)
+    kept_now = [c for c in trait_cols if c not in set(removed_now)]
+    residual_now = int(cleaned_current[kept_now].isna().sum().sum()) if kept_now else 0
+    samples_lost_now = int(
+        current_log.get("original_samples", len(frame.df))
+        - current_log.get("final_samples", len(frame.df))
+    )
+
+    recommendation = _build_recommendation(
+        frame.df,
+        trait_cols,
+        params,
+        role_kwargs,
+        nan_frac,
+        current_log,
+        naive_dropna_lost,
+    )
+
+    # Persist a versioned REPORT run under tool class `qc_inspect` (never `qc`, never
+    # CLEANED_CSV_NAME) so the reader cannot resolve it as a cleaned version.
+    local_src = TRAITS_DIR / params.experiment
+    run = store.create_run(
+        experiment=params.experiment,
+        tool_class=_TOOL_CLASS,
+        provenance=provenance,
+        user_label=params.user_label,
+        source_csv=local_src if local_src.exists() else None,
+    )
+    outputs = _render_report(
+        frame.df, trait_cols, params, current_log, role_kwargs, run.staging_dir
+    )
+    (run.staging_dir / _RECOMMENDATION_JSON).write_text(
+        json.dumps(convert_to_json_serializable(recommendation.model_dump()), indent=2)
+    )
+    outputs[_RECOMMENDATION_JSON] = _RECOMMENDATION_JSON
+
+    stored = store.commit(run, outputs)
+
+    return QCInspectResult(
+        experiment=params.experiment,
+        source=frame.source,
+        n_samples=len(frame.df),
+        n_traits=len(trait_cols),
+        per_trait_nan_fraction=per_trait_nan,
+        traits_exceeding_thresholds=traits_exceeding,
+        traits_would_be_removed=removed_now,
+        samples_lost_at_current_params=samples_lost_now,
+        residual_nan_cells_at_current_params=residual_now,
+        recommendation=recommendation,
+        run_ref=stored.run_ref,
+        version_dir=stored.version_dir,
+        manifest_path=stored.manifest_path,
+        outputs=dict(stored.output_keys),
+    )
+
+
+def register(mcp):
+    """Register qc_inspect with the MCP server."""
+    return _contract_register(mcp, qc_inspect)

--- a/bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py
+++ b/bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py
@@ -19,14 +19,21 @@ a cleaned version: ``qc_inspect`` is read-only and produces no cleaned table. Th
 returns a small inline summary + a structured **recommendation** (which traits to drop
 and the sample loss avoided) + links to the persisted figures / CSV / recommendation
 JSON — never inline blobs.
+
+Caveat: missingness is measured with ``pandas.isna`` (matching the delegate), so ``inf`` /
+``-inf`` are **not** counted as missing — an all-``inf`` trait reports ``nan_fraction=0.0``
+and is kept. Genuine infinities in a trait are a data-quality concern this tool does not flag.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import math
+from shutil import rmtree
 from typing import Optional
 
+import pandas as pd
 from pydantic import BaseModel, Field
 
 import matplotlib
@@ -40,25 +47,30 @@ from sleap_roots_analyze import (
     inspect_nan_samples,
 )
 
-from bloom_mcp.contract import Provenance, as_mcp_tool
+from bloom_mcp.contract import BloomMCPError, Provenance, as_mcp_tool
 from bloom_mcp.contract import register as _contract_register
 from bloom_mcp.data_access import ExperimentReadError
 from bloom_mcp.data_utils import convert_to_json_serializable
 from bloom_mcp.experiment_utils import TRAITS_DIR
 from bloom_mcp.tools import _ports
-from bloom_mcp.tools._qc_shared import _role_kwargs, _validate_trait_subset
+
+# Canonical thresholds + shared helpers are single-sourced in _qc_shared so qc_inspect's
+# overlays/recommendation cannot silently desync from the clean qc_clean would apply.
+from bloom_mcp.tools._qc_shared import (
+    _CANONICAL_MAX_NANS_PER_SAMPLE,
+    _CANONICAL_MAX_NANS_PER_TRAIT,
+    _CANONICAL_MAX_ZEROS_PER_TRAIT,
+    _CANONICAL_MIN_SAMPLES_PER_TRAIT,
+    _role_kwargs,
+    _validate_trait_subset,
+)
+
+logger = logging.getLogger(__name__)
 
 _TOOL_CLASS = "qc_inspect"
 _NAN_SAMPLES_CSV = "nan_samples.csv"
 _RECOMMENDATION_JSON = "recommendation.json"
 _HEATMAP_PNG = "missing_data_pattern.png"
-
-# Canonical QC-pipeline defaults — identical to qc_clean's, so qc_inspect's overlay
-# lines and recommendation reflect the clean a default qc_clean would actually apply.
-_CANONICAL_MAX_ZEROS_PER_TRAIT = 0.5
-_CANONICAL_MAX_NANS_PER_TRAIT = 0.2
-_CANONICAL_MAX_NANS_PER_SAMPLE = 0.0
-_CANONICAL_MIN_SAMPLES_PER_TRAIT = 10
 
 
 class QCInspectParams(BaseModel):
@@ -102,11 +114,24 @@ class QCInspectParams(BaseModel):
 
 
 class QCInspectRecommendation(BaseModel):
-    """A threshold recommendation derived from the supplied params (delegate-driven)."""
+    """A threshold recommendation derived from the supplied params (delegate-driven).
+
+    ``no_change_needed`` is ``True`` whenever lowering ``max_nans_per_trait`` would not
+    reduce sample loss below the current settings — either because no NaN-bearing trait
+    survives the current thresholds, or because the current per-sample threshold already
+    tolerates the missingness so dropping the trait buys no samples. In that case
+    ``recommended_max_nans_per_trait`` is ``None`` and ``would_remove_traits`` is empty.
+    """
 
     no_change_needed: bool
     recommended_max_nans_per_trait: Optional[float]
     would_remove_traits: list[str]
+    # The recommended threshold drops EVERY kept NaN-bearing trait at once (it is derived
+    # from the smallest offending NaN fraction). This maps each such trait to the number
+    # of samples that carry a NaN in it — its individual missingness footprint — so the
+    # agent can weigh keeping a low-missingness trait instead of accepting the all-or-nothing
+    # drop. Empty when no change is recommended.
+    offending_trait_nan_counts: dict[str, int]
     samples_lost_at_recommendation: int
     samples_lost_at_current_params: int
     naive_dropna_samples_lost: int
@@ -121,8 +146,13 @@ class QCInspectResult(BaseModel):
     n_samples: int
     n_traits: int
     per_trait_nan_fraction: dict[str, float]
+    # NaN-only view: traits whose NaN fraction alone exceeds max_nans_per_trait. This can
+    # differ from ``traits_would_be_removed`` below, which is the delegate's FULL removal
+    # set — it also drops traits for too-many-zeros or too-few-samples. ``removed_trait_reasons``
+    # explains each removal so the two fields never look contradictory without cause.
     traits_exceeding_thresholds: list[str]
     traits_would_be_removed: list[str]
+    removed_trait_reasons: dict[str, str]
     samples_lost_at_current_params: int
     residual_nan_cells_at_current_params: int
     recommendation: QCInspectRecommendation
@@ -132,7 +162,14 @@ class QCInspectResult(BaseModel):
     outputs: dict[str, str]
 
 
-def _filter(df, trait_cols, params, role_kwargs, *, max_nans_per_trait):
+def _filter(
+    df: pd.DataFrame,
+    trait_cols: list[str],
+    params: "QCInspectParams",
+    role_kwargs: dict[str, str],
+    *,
+    max_nans_per_trait: float,
+) -> tuple:
     """Run the analyze cleanup filter at the given NaN-per-trait threshold."""
     return apply_data_cleanup_filters(
         df,
@@ -149,20 +186,37 @@ def _removed_traits(log: dict) -> list[str]:
     return [t["trait"] for t in log.get("removed_traits", []) if isinstance(t, dict)]
 
 
+def _removed_reasons(log: dict) -> dict[str, str]:
+    """Map each delegate-removed trait to the delegate's removal reason.
+
+    The delegate log tags every removed trait with why (``too_many_nans`` /
+    ``too_many_zeros`` / ``too_few_samples``). Surfacing it explains why a trait can be in
+    ``traits_would_be_removed`` yet absent from the NaN-only ``traits_exceeding_thresholds``.
+    """
+    return {
+        t["trait"]: str(t.get("reason", "removed"))
+        for t in log.get("removed_traits", [])
+        if isinstance(t, dict)
+    }
+
+
 def _build_recommendation(
-    df,
-    trait_cols,
-    params,
-    role_kwargs,
-    nan_frac,
-    current_log,
+    df: pd.DataFrame,
+    trait_cols: list[str],
+    params: "QCInspectParams",
+    role_kwargs: dict[str, str],
+    nan_frac: "pd.Series",
+    current_log: dict,
     naive_dropna_lost: int,
 ) -> QCInspectRecommendation:
     """Recommend a ``max_nans_per_trait`` that drops NaN-bearing traits to cut sample loss.
 
-    Delegate-driven: the consequence of the recommended threshold is measured by
-    re-running ``apply_data_cleanup_filters`` at that threshold — no filtering logic
-    is re-implemented here.
+    Delegate-driven: the consequence of any threshold is measured by re-running
+    ``apply_data_cleanup_filters`` at it — no filtering logic is re-implemented here. A
+    change is recommended ONLY when it strictly reduces sample loss; if the current
+    per-sample threshold already tolerates the missingness (so dropping the trait would
+    save no samples), the honest answer is ``no_change_needed`` rather than advising a drop
+    that buys nothing on the metric this tool optimizes.
     """
     samples_lost_current = int(
         current_log.get("original_samples", len(df))
@@ -176,12 +230,16 @@ def _build_recommendation(
         for t in trait_cols
         if t not in removed_now and nan_frac[t] > 0
     }
+    # Per-offending-trait missingness footprint: how many samples carry a NaN in each.
+    # Lets the agent weigh keeping a low-footprint trait vs the all-or-nothing drop below.
+    offending_counts = {t: int(df[t].isna().sum()) for t in offending}
 
     if not offending:
         return QCInspectRecommendation(
             no_change_needed=True,
             recommended_max_nans_per_trait=None,
             would_remove_traits=[],
+            offending_trait_nan_counts={},
             samples_lost_at_recommendation=samples_lost_current,
             samples_lost_at_current_params=samples_lost_current,
             naive_dropna_samples_lost=naive_dropna_lost,
@@ -204,10 +262,35 @@ def _build_recommendation(
     samples_lost_rec = int(
         rec_log.get("original_samples", len(df)) - rec_log.get("final_samples", len(df))
     )
+
+    # Benefit gate: recommend a change only if it strictly reduces sample loss. When the
+    # current max_nans_per_sample already tolerates the missingness, lowering
+    # max_nans_per_trait drops the trait but frees no samples — so do not advise it.
+    if samples_lost_rec >= samples_lost_current:
+        return QCInspectRecommendation(
+            no_change_needed=True,
+            recommended_max_nans_per_trait=None,
+            would_remove_traits=[],
+            offending_trait_nan_counts=offending_counts,
+            samples_lost_at_recommendation=samples_lost_current,
+            samples_lost_at_current_params=samples_lost_current,
+            naive_dropna_samples_lost=naive_dropna_lost,
+            rationale=(
+                f"The NaN-bearing trait(s) {sorted(offending)} are kept, but the current "
+                f"max_nans_per_sample={params.max_nans_per_sample} already tolerates their "
+                f"missingness — only {samples_lost_current} sample(s) are lost and lowering "
+                f"max_nans_per_trait would not reduce that. No change recommended for sample "
+                f"loss; tighten max_nans_per_sample if you instead want those NaN-bearing "
+                f"samples (or traits) removed. See offending_trait_nan_counts for each trait's "
+                f"missingness footprint."
+            ),
+        )
+
     return QCInspectRecommendation(
         no_change_needed=False,
         recommended_max_nans_per_trait=rec,
         would_remove_traits=would_remove,
+        offending_trait_nan_counts=offending_counts,
         samples_lost_at_recommendation=samples_lost_rec,
         samples_lost_at_current_params=samples_lost_current,
         naive_dropna_samples_lost=naive_dropna_lost,
@@ -215,17 +298,28 @@ def _build_recommendation(
             f"At the current max_nans_per_trait={params.max_nans_per_trait}, the "
             f"NaN-heavy trait(s) {sorted(offending)} are kept and {samples_lost_current} "
             f"sample(s) are lost. Lowering max_nans_per_trait to {rec} drops "
-            f"{would_remove or 'them'} instead, leaving {samples_lost_rec} sample(s) lost."
+            f"{would_remove or 'them'} instead, leaving {samples_lost_rec} sample(s) lost. "
+            f"The recommended threshold drops EVERY trait above it at once; weigh "
+            f"offending_trait_nan_counts before keeping a low-missingness trait."
         ),
     )
 
 
-def _render_report(df, trait_cols, params, current_log, role_kwargs, staging_dir):
+def _render_report(
+    df: pd.DataFrame,
+    trait_cols: list[str],
+    params: "QCInspectParams",
+    current_log: dict,
+    role_kwargs: dict[str, str],
+    staging_dir,
+) -> dict[str, str]:
     """Render + persist the delegated EDA figures and the NaN-samples table.
 
     Returns the ``{logical_name: relative_path}`` map for the figures/CSV. All
     matplotlib figures the delegates create are closed before returning (no handle
-    leak in a long-lived server process).
+    leak in a long-lived server process). The missingness heatmap is best-effort: on
+    a degenerate frame it may be absent from the output set (logged, never raised), so
+    consumers must treat ``missing_data_pattern.png`` as optional.
     """
     outputs: dict[str, str] = {}
 
@@ -256,13 +350,25 @@ def _render_report(df, trait_cols, params, current_log, role_kwargs, staging_dir
         summary_figs = create_exploratory_summary_plots(
             df, trait_cols, genotype_col=role_kwargs.get("genotype_col", "geno")
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "qc_inspect: missingness heatmap unavailable (create_exploratory_summary_plots "
+            "failed on this frame: %s); the report omits %s.",
+            exc,
+            _HEATMAP_PNG,
+        )
         summary_figs = {}
     try:
         heatmap = summary_figs.get("missing_data_pattern")
         if heatmap is not None:
             heatmap.savefig(staging_dir / _HEATMAP_PNG, dpi=120, bbox_inches="tight")
             outputs[_HEATMAP_PNG] = _HEATMAP_PNG
+        else:
+            logger.warning(
+                "qc_inspect: missingness heatmap not produced for this frame; "
+                "the report omits %s.",
+                _HEATMAP_PNG,
+            )
     finally:
         for fig in summary_figs.values():
             plt.close(fig)
@@ -288,6 +394,14 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
     # Read the RAW frame — qc_inspect inspects the raw missingness (no require_clean).
     frame = reader.load_experiment(params.experiment)
     if params.trait_columns is not None:
+        # An empty list is a caller mistake, not "inspect everything" — reject it
+        # explicitly rather than silently falling through to all traits.
+        if not params.trait_columns:
+            raise BloomMCPError(
+                code="invalid_input",
+                message="trait_columns was an empty list.",
+                remedy="Omit trait_columns to inspect all detected traits, or name at least one trait column.",
+            )
         _validate_trait_subset(frame, params.trait_columns, params.experiment)
     trait_cols = list(params.trait_columns or frame.trait_cols)
     role_kwargs = _role_kwargs(frame)
@@ -309,6 +423,7 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
         max_nans_per_trait=params.max_nans_per_trait,
     )
     removed_now = _removed_traits(current_log)
+    removed_reasons = _removed_reasons(current_log)
     kept_now = [c for c in trait_cols if c not in set(removed_now)]
     residual_now = int(cleaned_current[kept_now].isna().sum().sum()) if kept_now else 0
     samples_lost_now = int(
@@ -336,15 +451,22 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
         user_label=params.user_label,
         source_csv=local_src if local_src.exists() else None,
     )
-    outputs = _render_report(
-        frame.df, trait_cols, params, current_log, role_kwargs, run.staging_dir
-    )
-    (run.staging_dir / _RECOMMENDATION_JSON).write_text(
-        json.dumps(convert_to_json_serializable(recommendation.model_dump()), indent=2)
-    )
-    outputs[_RECOMMENDATION_JSON] = _RECOMMENDATION_JSON
-
-    stored = store.commit(run, outputs)
+    # Render + persist under the run's staging dir; on any partial failure remove the
+    # staging dir so a long-lived server does not leak a half-written temp run.
+    try:
+        outputs = _render_report(
+            frame.df, trait_cols, params, current_log, role_kwargs, run.staging_dir
+        )
+        (run.staging_dir / _RECOMMENDATION_JSON).write_text(
+            json.dumps(
+                convert_to_json_serializable(recommendation.model_dump()), indent=2
+            )
+        )
+        outputs[_RECOMMENDATION_JSON] = _RECOMMENDATION_JSON
+        stored = store.commit(run, outputs)
+    except Exception:
+        rmtree(run.staging_dir, ignore_errors=True)
+        raise
 
     return QCInspectResult(
         experiment=params.experiment,
@@ -354,6 +476,7 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
         per_trait_nan_fraction=per_trait_nan,
         traits_exceeding_thresholds=traits_exceeding,
         traits_would_be_removed=removed_now,
+        removed_trait_reasons=removed_reasons,
         samples_lost_at_current_params=samples_lost_now,
         residual_nan_cells_at_current_params=residual_now,
         recommendation=recommendation,

--- a/bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py
+++ b/bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py
@@ -21,8 +21,10 @@ and the sample loss avoided) + links to the persisted figures / CSV / recommenda
 JSON — never inline blobs.
 
 Caveat: missingness is measured with ``pandas.isna`` (matching the delegate), so ``inf`` /
-``-inf`` are **not** counted as missing — an all-``inf`` trait reports ``nan_fraction=0.0``
-and is kept. Genuine infinities in a trait are a data-quality concern this tool does not flag.
+``-inf`` are **not** counted as missing — an all-``inf`` trait reports ``nan_fraction=0.0`` and
+is kept, which would otherwise pass silently into a downstream PCA. Because that is exactly the
+silent-bias class this tool exists to surface, the result reports ``per_trait_inf_count`` and
+prepends a warning to the recommendation rationale whenever a trait carries non-finite values.
 """
 
 from __future__ import annotations
@@ -30,15 +32,23 @@ from __future__ import annotations
 import json
 import logging
 import math
+from pathlib import Path
 from shutil import rmtree
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 from pydantic import BaseModel, Field
 
 import matplotlib
 
-matplotlib.use("Agg")  # headless: pin Agg before importing the analyze viz funcs below
+# Headless: pin Agg before importing the analyze viz funcs below. NOTE: the analyze
+# delegates render on matplotlib's *global* pyplot state (`plt.subplots`), so figure
+# handling here (and the no-leak test's global `get_fignums()` baseline) assumes a
+# single in-flight render — i.e. one bloom-mcp writer at a time. Concurrent qc_inspect
+# calls in one process share that global registry; that is the same single-writer
+# assumption the versioned ResultStore already makes (see qc_clean).
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from sleap_roots_analyze import (
     apply_data_cleanup_filters,
@@ -62,6 +72,7 @@ from bloom_mcp.tools._qc_shared import (
     _CANONICAL_MAX_ZEROS_PER_TRAIT,
     _CANONICAL_MIN_SAMPLES_PER_TRAIT,
     _role_kwargs,
+    _validate_experiment_name,
     _validate_trait_subset,
 )
 
@@ -146,6 +157,10 @@ class QCInspectResult(BaseModel):
     n_samples: int
     n_traits: int
     per_trait_nan_fraction: dict[str, float]
+    # Non-finite (inf/-inf) counts per trait, restricted to traits that carry any (empty =
+    # all finite). isna() treats inf as present, so an inf-heavy trait reports nan_fraction≈0
+    # and would be kept — this surfaces that silent bias before it flows into a PCA.
+    per_trait_inf_count: dict[str, int]
     # NaN-only view: traits whose NaN fraction alone exceeds max_nans_per_trait. This can
     # differ from ``traits_would_be_removed`` below, which is the delegate's FULL removal
     # set — it also drops traits for too-many-zeros or too-few-samples. ``removed_trait_reasons``
@@ -169,7 +184,7 @@ def _filter(
     role_kwargs: dict[str, str],
     *,
     max_nans_per_trait: float,
-) -> tuple:
+) -> tuple[pd.DataFrame, dict]:
     """Run the analyze cleanup filter at the given NaN-per-trait threshold."""
     return apply_data_cleanup_filters(
         df,
@@ -180,6 +195,23 @@ def _filter(
         min_samples_per_trait=params.min_samples_per_trait,
         **role_kwargs,
     )
+
+
+def _samples_lost(log: dict) -> int:
+    """Samples the delegate dropped = ``original_samples - final_samples``.
+
+    Requires both keys rather than falling back to ``len(df) - len(df) == 0``: a silent 0
+    would flip the benefit gate to ``no_change_needed`` on every input if the upstream log
+    ever renamed these keys. A missing key is delegate contract-drift, surfaced structurally.
+    """
+    try:
+        return int(log["original_samples"] - log["final_samples"])
+    except (KeyError, TypeError) as exc:
+        raise BloomMCPError(
+            code="internal_error",
+            message="Cleanup log is missing expected sample-count keys.",
+            remedy="Verify the pinned sleap-roots-analyze version; its cleanup-log shape changed.",
+        ) from exc
 
 
 def _removed_traits(log: dict) -> list[str]:
@@ -218,10 +250,7 @@ def _build_recommendation(
     save no samples), the honest answer is ``no_change_needed`` rather than advising a drop
     that buys nothing on the metric this tool optimizes.
     """
-    samples_lost_current = int(
-        current_log.get("original_samples", len(df))
-        - current_log.get("final_samples", len(df))
-    )
+    samples_lost_current = _samples_lost(current_log)
     removed_now = set(_removed_traits(current_log))
     # Traits the current params KEEP but that still carry NaN — these are what force
     # the sample loss (or leave residual NaN at a looser max_nans_per_sample).
@@ -259,9 +288,7 @@ def _build_recommendation(
 
     _, rec_log = _filter(df, trait_cols, params, role_kwargs, max_nans_per_trait=rec)
     would_remove = _removed_traits(rec_log)
-    samples_lost_rec = int(
-        rec_log.get("original_samples", len(df)) - rec_log.get("final_samples", len(df))
-    )
+    samples_lost_rec = _samples_lost(rec_log)
 
     # Benefit gate: recommend a change only if it strictly reduces sample loss. When the
     # current max_nans_per_sample already tolerates the missingness, lowering
@@ -311,7 +338,7 @@ def _render_report(
     params: "QCInspectParams",
     current_log: dict,
     role_kwargs: dict[str, str],
-    staging_dir,
+    staging_dir: Path,
 ) -> dict[str, str]:
     """Render + persist the delegated EDA figures and the NaN-samples table.
 
@@ -391,6 +418,9 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
     reader = _ports.reader()
     store = _ports.store()
 
+    # Bare-filename guard before any read — experiment flows into TRAITS_DIR / experiment.
+    _validate_experiment_name(params.experiment)
+
     # Read the RAW frame — qc_inspect inspects the raw missingness (no require_clean).
     frame = reader.load_experiment(params.experiment)
     if params.trait_columns is not None:
@@ -404,10 +434,27 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
             )
         _validate_trait_subset(frame, params.trait_columns, params.experiment)
     trait_cols = list(params.trait_columns or frame.trait_cols)
+    if not trait_cols:
+        # No caller subset and the adapter detected no numeric traits (metadata-only frame,
+        # or duplicate columns collapsing) — there is nothing to inspect; don't commit an
+        # empty report run.
+        raise BloomMCPError(
+            code="invalid_input",
+            message=f"No numeric trait columns detected in {params.experiment!r}.",
+            remedy="Check the experiment has numeric trait columns, or pass trait_columns explicitly.",
+        )
     role_kwargs = _role_kwargs(frame)
 
     nan_frac = frame.df[trait_cols].isna().mean()
     per_trait_nan = {c: round(float(nan_frac[c]), 4) for c in trait_cols}
+    # Non-finite (inf/-inf) footprint — isna() ignores inf, so this surfaces the silent bias
+    # of an inf-heavy trait reading as ~0% missing (restricted to traits that carry any).
+    inf_by_trait = np.isinf(
+        frame.df[trait_cols].to_numpy(dtype="float64", na_value=np.nan)
+    )
+    per_trait_inf = {
+        c: int(n) for c, n in zip(trait_cols, inf_by_trait.sum(axis=0)) if n
+    }
     traits_exceeding = [
         c for c in trait_cols if nan_frac[c] > params.max_nans_per_trait
     ]
@@ -426,10 +473,7 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
     removed_reasons = _removed_reasons(current_log)
     kept_now = [c for c in trait_cols if c not in set(removed_now)]
     residual_now = int(cleaned_current[kept_now].isna().sum().sum()) if kept_now else 0
-    samples_lost_now = int(
-        current_log.get("original_samples", len(frame.df))
-        - current_log.get("final_samples", len(frame.df))
-    )
+    samples_lost_now = _samples_lost(current_log)
 
     recommendation = _build_recommendation(
         frame.df,
@@ -440,6 +484,19 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
         current_log,
         naive_dropna_lost,
     )
+    # Non-finite values defeat the NaN-based recommendation (they read as ~0% missing and are
+    # kept); warn loudly and stamp the caveat into the rationale the agent will act on.
+    if per_trait_inf:
+        logger.warning(
+            "qc_inspect: %s trait(s) carry non-finite (inf) values not counted as missing: %s",
+            len(per_trait_inf),
+            per_trait_inf,
+        )
+        recommendation.rationale = (
+            f"⚠️ Non-finite (inf) values present in {sorted(per_trait_inf)} "
+            f"(counts {per_trait_inf}); these are NOT counted as missing, so the "
+            f"missingness recommendation below understates their data-quality risk. "
+        ) + recommendation.rationale
 
     # Persist a versioned REPORT run under tool class `qc_inspect` (never `qc`, never
     # CLEANED_CSV_NAME) so the reader cannot resolve it as a cleaned version.
@@ -474,6 +531,7 @@ def qc_inspect(params: QCInspectParams, *, provenance: Provenance) -> QCInspectR
         n_samples=len(frame.df),
         n_traits=len(trait_cols),
         per_trait_nan_fraction=per_trait_nan,
+        per_trait_inf_count=per_trait_inf,
         traits_exceeding_thresholds=traits_exceeding,
         traits_would_be_removed=removed_now,
         removed_trait_reasons=removed_reasons,

--- a/bloommcp/tests/fixtures/README.md
+++ b/bloommcp/tests/fixtures/README.md
@@ -24,6 +24,17 @@ code under test — so the oracle is a genuine cross-tier regression check.
   naive `dropna()` that would discard 29 samples (158 left). This is the tool's oracle:
   no-NaN output with strictly less sample loss than `dropna()`. Reproduced-by version is
   recorded in the `_reproduced_by_sleap_roots_analyze_version` key.
+- `turface_19_qc_inspect_golden.json` — independently-computed oracle for the **read-only
+  `qc_inspect`** tool (#360), using `sleap_roots_analyze.apply_data_cleanup_filters` (the
+  delegate `qc_inspect` wraps) on `turface_19_raw_data.csv` at the **canonical defaults**
+  (`max_zeros=0.5, max_nans_per_trait=0.2, max_nans_per_sample=0.0, min_samples=10`, i.e.
+  `qc_clean`'s defaults). It records the consequence the agent must see: at the defaults the
+  two NaN-heavy traits (see the `turface_19_raw_data.csv` entry above for the shared 187×20 /
+  58-NaN / 29-sample facts) are **kept** and, because `max_nans_per_sample=0.0`, their 29
+  NaN-bearing samples are **dropped** — whereas lowering `max_nans_per_trait` to `≤0.15`
+  drops the two traits instead and **retains all 187 samples (0 lost)**. The recommendation
+  block pins `recommended_max_nans_per_trait=0.15`, `would_remove_traits=[Root_Biomass_mg,
+  Root_Shoot_Ratio]`, `samples_lost_at_recommendation=0`. **Not** re-derived from the tool.
 - `turface_19_pca_golden.json` — recorded golden + drift snapshots for that table.
   The keys carry **distinct provenance** (see the `_*_source` fields):
 

--- a/bloommcp/tests/fixtures/turface_19_qc_inspect_golden.json
+++ b/bloommcp/tests/fixtures/turface_19_qc_inspect_golden.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "Independently-computed oracle for qc_inspect on the RAW turface_19 input, using sleap_roots_analyze.apply_data_cleanup_filters (the same delegate the tool wraps) at qc_inspect's CANONICAL defaults — identical to qc_clean's: max_zeros_per_trait=0.5, max_nans_per_trait=0.2, max_nans_per_sample=0.0, min_samples_per_trait=10. Demonstrates the uncontrolled sample loss qc_inspect helps the agent avoid: at the defaults the two NaN-heavy traits (each 15.5% NaN) are KEPT (0.155 < 0.2) and, because max_nans_per_sample=0.0, their 29 NaN-bearing samples are DROPPED (final 158x20). Lowering max_nans_per_trait to <=0.15 instead DROPS the two traits, retaining all 187 samples (final 187x18) with ZERO sample loss. NOT re-derived from the qc_inspect tool. Cross-references turface_19_qc_golden.json for the shared raw-fixture facts (187x20 raw, naive dropna 158).",
+  "_raw_source": "see turface_19_qc_golden.json (talmolab/sleap-roots-analyze turface_19 raw input)",
+  "_reproduced_by_sleap_roots_analyze_version": "0.1.0a3",
+  "role_columns": {
+    "barcode_col": "Barcode",
+    "genotype_col": "geno",
+    "replicate_col": "rep"
+  },
+  "raw_samples": 187,
+  "raw_traits": 20,
+  "naive_dropna_samples": 158,
+  "naive_dropna_samples_lost": 29,
+  "nan_traits": {
+    "Root_Biomass_mg": 0.1551,
+    "Root_Shoot_Ratio": 0.1551
+  },
+  "default_params": {
+    "max_zeros_per_trait": 0.5,
+    "max_nans_per_trait": 0.2,
+    "max_nans_per_sample": 0.0,
+    "min_samples_per_trait": 10
+  },
+  "at_default_params": {
+    "traits_would_be_removed": [],
+    "samples_lost": 29,
+    "residual_nan_cells": 0
+  },
+  "recommendation": {
+    "recommended_max_nans_per_trait": 0.15,
+    "would_remove_traits": ["Root_Biomass_mg", "Root_Shoot_Ratio"],
+    "samples_lost_at_recommendation": 0
+  }
+}

--- a/bloommcp/tests/tools/test_qc_inspect_tool.py
+++ b/bloommcp/tests/tools/test_qc_inspect_tool.py
@@ -1,0 +1,449 @@
+"""Contract + oracle tests for the read-only ``qc_inspect`` tool (Tier 3 / #360).
+
+The turface_19 recommendation oracle + the 5 contract patterns + the read-only
+guarantee (a qc_inspect run is never resolved by ``require_clean=True``) + a real-bytes
+figure round-trip. The tool delegates ALL EDA to ``sleap_roots_analyze`` and persists a
+versioned **report** run under tool class ``qc_inspect`` — no EDA logic in the MCP, and
+it produces no cleaned version.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bloom_mcp.contract import BloomMCPError
+from bloom_mcp.data_access import (
+    CleanedVersionRequiredError,
+    FakeReader,
+    SupabaseReader,
+)
+from bloom_mcp.result_store import FakeResultStore, SupabaseResultStore
+from bloom_mcp.tools import _ports
+from bloom_mcp.tools import qc_inspect_tool
+from bloom_mcp.tools.qc_inspect_tool import (
+    QCInspectParams,
+    QCInspectResult,
+    qc_inspect,
+)
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_RAW = _FIXTURES / "turface_19_raw_data.csv"
+_GOLDEN = json.loads((_FIXTURES / "turface_19_qc_inspect_golden.json").read_text())
+
+_EXPERIMENT = "turface_19_raw.csv"
+
+
+def _raw_df() -> pd.DataFrame:
+    return pd.read_csv(_RAW)
+
+
+@pytest.fixture
+def injected_ports():
+    """FakeReader serving the raw fixture + FakeResultStore, via the _ports seam."""
+    reader = FakeReader()
+    store = FakeResultStore()
+    reader.add_experiment(_EXPERIMENT, _raw_df())
+    _ports.configure(reader=reader, store=store)
+    try:
+        yield reader, store
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def _run(**overrides) -> QCInspectResult:
+    return qc_inspect(QCInspectParams(experiment=_EXPERIMENT, **overrides))
+
+
+# ── 2.2 / 2.3 recommendation oracle through the tool ────────────────────────
+
+
+def test_recommendation_oracle_at_default_params(injected_ports):
+    """2.2 — at the canonical defaults the two 15.5%-NaN traits are KEPT and 29 samples
+    are dropped; the recommendation drops the traits instead for ZERO sample loss."""
+    result = (
+        _run()
+    )  # canonical defaults (max_nans_per_trait=0.2, max_nans_per_sample=0.0)
+
+    nf = result.per_trait_nan_fraction
+    assert nf["Root_Biomass_mg"] == pytest.approx(0.1551, abs=1e-3)
+    assert nf["Root_Shoot_Ratio"] == pytest.approx(0.1551, abs=1e-3)
+    # Neither trait exceeds the 0.2 default, so the cleanup keeps them...
+    assert result.traits_would_be_removed == []
+    # ...and dropping their NaN-bearing samples is the uncontrolled loss qc_inspect warns of.
+    assert (
+        result.samples_lost_at_current_params
+        == _GOLDEN["at_default_params"]["samples_lost"]
+    )
+    assert result.samples_lost_at_current_params == 29
+
+    rec = result.recommendation
+    assert rec.no_change_needed is False
+    assert (
+        sorted(rec.would_remove_traits)
+        == _GOLDEN["recommendation"]["would_remove_traits"]
+    )
+    assert rec.samples_lost_at_recommendation == 0
+    assert (
+        rec.recommended_max_nans_per_trait < 0.1551
+    )  # strictly below the trait NaN fraction
+    assert rec.naive_dropna_samples_lost == _GOLDEN["naive_dropna_samples_lost"] == 29
+
+
+def test_recommendation_tracks_supplied_thresholds(injected_ports):
+    """2.3 — at max_nans_per_trait=0.1 the two traits already drop, so no sample is lost
+    and no further change is recommended."""
+    result = _run(max_nans_per_trait=0.1)
+    assert "Root_Biomass_mg" in result.traits_would_be_removed
+    assert "Root_Shoot_Ratio" in result.traits_would_be_removed
+    assert result.samples_lost_at_current_params == 0
+    assert result.recommendation.no_change_needed is True
+
+
+def test_zero_nan_frame_recommends_no_change():
+    """2.4 — a frame with no NaNs yields a no-change recommendation (not a spurious
+    lower threshold)."""
+    df = pd.DataFrame(
+        {
+            "Barcode": [f"b{i}" for i in range(16)],
+            "geno": ["g1", "g2"] * 8,
+            "rep": list(range(16)),
+            "t1": [float(i + 1) for i in range(16)],
+            "t2": [float(2 * (i + 1)) for i in range(16)],
+        }
+    )
+    reader = FakeReader()
+    reader.add_experiment("clean.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+    try:
+        result = qc_inspect(QCInspectParams(experiment="clean.csv"))
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    assert result.samples_lost_at_current_params == 0
+    assert result.traits_would_be_removed == []
+    rec = result.recommendation
+    assert rec.no_change_needed is True
+    assert rec.recommended_max_nans_per_trait is None
+    assert rec.would_remove_traits == []
+    assert rec.samples_lost_at_recommendation == 0
+
+
+def test_all_nan_trait_is_reported_not_rejected():
+    """2.5 — an entirely-NaN trait is reported (fraction 1.0, flagged for removal), not
+    an error: qc_inspect inspects missingness rather than gating on it."""
+    df = pd.DataFrame(
+        {
+            "Barcode": [f"b{i}" for i in range(16)],
+            "geno": ["g1", "g2"] * 8,
+            "rep": list(range(16)),
+            "t1": [float(i + 1) for i in range(16)],
+            "t2": [float(2 * (i + 1)) for i in range(16)],
+            "t_allnan": [float("nan")] * 16,
+        }
+    )
+    reader = FakeReader()
+    reader.add_experiment("allnan.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+    try:
+        result = qc_inspect(
+            QCInspectParams(
+                experiment="allnan.csv", trait_columns=["t1", "t2", "t_allnan"]
+            )
+        )
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    assert result.per_trait_nan_fraction["t_allnan"] == pytest.approx(1.0)
+    assert "t_allnan" in result.traits_would_be_removed
+
+
+# ── 3.1 tools/list presence ─────────────────────────────────────────────────
+
+
+def test_qc_inspect_appears_in_tools_list_and_siblings_preserved():
+    """3.1 — qc_inspect is discoverable; qc_clean + run_qc_workflow are still registered."""
+    from fastmcp import Client
+
+    from bloom_mcp import server
+
+    async def _list():
+        async with Client(server.mcp) as client:
+            return await client.list_tools()
+
+    tools = {t.name: t for t in asyncio.run(_list())}
+    assert "qc_inspect" in tools
+    assert tools["qc_inspect"].inputSchema is not None
+    assert "qc_clean" in tools  # additive — sibling not removed
+    assert "run_qc_workflow" in tools
+
+
+# ── 3.2 schema round-trip ───────────────────────────────────────────────────
+
+
+def test_valid_input_output_round_trip(injected_ports):
+    result = _run()
+    again = QCInspectResult.model_validate(json.loads(result.model_dump_json()))
+    assert (
+        again.recommendation.would_remove_traits
+        == result.recommendation.would_remove_traits
+    )
+
+
+def test_invalid_threshold_is_input_validation_error(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        qc_inspect({"experiment": _EXPERIMENT, "max_nans_per_trait": 1.5})
+    assert exc.value.code == "invalid_input"
+
+
+def test_default_thresholds_mirror_qc_clean_canonical():
+    """qc_inspect's defaults must match qc_clean's canonical QC-pipeline defaults so the
+    overlays/recommendation reflect the clean a default qc_clean would apply."""
+    p = QCInspectParams(experiment="x.csv")
+    assert p.max_zeros_per_trait == 0.5
+    assert p.max_nans_per_trait == 0.2
+    assert p.max_nans_per_sample == 0.0
+    assert p.min_samples_per_trait == 10
+
+
+# ── 3.3 provenance + links (not blobs) ──────────────────────────────────────
+
+
+def test_provenance_stamped_seed_none_and_links_returned(injected_ports):
+    _reader, store = injected_ports
+    result = _run()
+
+    stored = store.get_run(_EXPERIMENT, "qc_inspect", "latest")
+    assert stored.tool == "qc_inspect"
+    assert stored.seed is None  # QC inspection is deterministic — no random_state
+    expected = {
+        "trait_eda_overview.png",
+        "variance_distribution.png",
+        "missing_data_pattern.png",
+        "nan_samples.csv",
+        "recommendation.json",
+    }
+    assert set(stored.output_keys) == expected
+
+    assert result.run_ref == stored.run_ref
+    assert result.manifest_path == stored.manifest_path
+    assert set(result.outputs) == expected
+    # Links, not blobs: no inline field carries a large payload.
+    dumped = result.model_dump()
+    assert not any(
+        isinstance(v, (list, dict)) and len(str(v)) > 5000 for v in dumped.values()
+    )
+
+
+# ── 3.4 delegation pinning (spy) ────────────────────────────────────────────
+
+
+def test_delegates_to_analyze_and_never_calls_vendored_cleanup(
+    injected_ports, monkeypatch
+):
+    calls = {"filter": 0, "eda": 0, "inspect": 0}
+    real_filter = qc_inspect_tool.apply_data_cleanup_filters
+    real_eda = qc_inspect_tool.create_trait_eda_plots
+    real_inspect = qc_inspect_tool.inspect_nan_samples
+
+    def _spy_filter(df, trait_cols=None, **kwargs):
+        calls["filter"] += 1
+        calls["kwargs"] = kwargs
+        return real_filter(df, trait_cols, **kwargs)
+
+    def _spy_eda(*a, **k):
+        calls["eda"] += 1
+        return real_eda(*a, **k)
+
+    def _spy_inspect(df, trait_cols=None, **kwargs):
+        calls["inspect"] += 1
+        calls["inspect_kwargs"] = kwargs
+        return real_inspect(df, trait_cols, **kwargs)
+
+    monkeypatch.setattr(qc_inspect_tool, "apply_data_cleanup_filters", _spy_filter)
+    monkeypatch.setattr(qc_inspect_tool, "create_trait_eda_plots", _spy_eda)
+    monkeypatch.setattr(qc_inspect_tool, "inspect_nan_samples", _spy_inspect)
+
+    import bloom_mcp.data_cleanup as vendored
+
+    def _boom(*a, **k):  # pragma: no cover
+        raise AssertionError("qc_inspect called the vendored bloom_mcp.data_cleanup")
+
+    monkeypatch.setattr(vendored, "apply_data_cleanup_filters", _boom)
+
+    _run()
+
+    assert calls["eda"] == 1
+    assert calls["inspect"] == 1
+    assert calls["filter"] >= 1  # current params (+ once more for the recommendation)
+    # Detected roles forwarded to the cleanup + inspection delegates.
+    assert calls["kwargs"]["barcode_col"] == "Barcode"
+    assert calls["kwargs"]["genotype_col"] == "geno"
+    assert calls["kwargs"]["replicate_col"] == "rep"
+    assert calls["inspect_kwargs"]["genotype_col"] == "geno"
+
+
+# ── 3.4b no figure-handle leak + headless backend ───────────────────────────
+
+
+def test_no_figure_handle_leak_and_agg_backend(injected_ports):
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    assert matplotlib.get_backend().lower() == "agg"
+    before = len(plt.get_fignums())
+    _run()
+    assert len(plt.get_fignums()) == before  # every delegate figure was closed
+
+
+# ── 3.5 role-column fallback (None must not be forwarded) ────────────────────
+
+
+def test_undetected_role_columns_fall_back_to_delegate_defaults(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "t1": [float(i + 1) for i in range(16)],
+            "t2": [float(2 * (i + 1)) for i in range(16)],
+        }
+    )
+    reader = FakeReader()
+    reader.add_experiment("roleless.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+
+    captured = {}
+    real_filter = qc_inspect_tool.apply_data_cleanup_filters
+
+    def _spy(df_, trait_cols=None, **kwargs):
+        captured["kwargs"] = kwargs
+        return real_filter(df_, trait_cols, **kwargs)
+
+    monkeypatch.setattr(qc_inspect_tool, "apply_data_cleanup_filters", _spy)
+    try:
+        qc_inspect(QCInspectParams(experiment="roleless.csv"))
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    # None is never forwarded — the kwarg is omitted so the delegate default applies.
+    for role in ("genotype_col", "replicate_col", "barcode_col"):
+        assert captured["kwargs"].get(role, "x") is not None
+
+
+# ── 3.6 error envelope ──────────────────────────────────────────────────────
+
+
+def test_unresolvable_experiment_errors_with_no_run(injected_ports):
+    _reader, store = injected_ports
+    with pytest.raises(BloomMCPError):
+        qc_inspect(QCInspectParams(experiment="does_not_exist.csv"))
+    assert store.list_runs("does_not_exist.csv", "qc_inspect") == []
+
+
+def test_delegate_raise_is_structured_without_leaking(injected_ports, monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("secret path /var/secrets/key and host db.internal")
+
+    monkeypatch.setattr(qc_inspect_tool, "apply_data_cleanup_filters", _boom)
+    with pytest.raises(BloomMCPError) as exc:
+        _run()
+    msg = f"{exc.value.message} {exc.value.remedy}"
+    assert "secret" not in msg and "/var" not in msg and "db.internal" not in msg
+
+
+# ── 3.7 trait_columns validation ────────────────────────────────────────────
+
+
+def test_unknown_trait_column_is_invalid_input_naming_it(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        qc_inspect(
+            QCInspectParams(experiment=_EXPERIMENT, trait_columns=["NoSuchTrait"])
+        )
+    assert exc.value.code == "invalid_input"
+    assert "NoSuchTrait" in exc.value.message
+
+
+def test_non_numeric_trait_column_is_invalid_input(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        qc_inspect(QCInspectParams(experiment=_EXPERIMENT, trait_columns=["geno"]))
+    assert exc.value.code == "invalid_input"
+    assert "geno" in exc.value.message
+
+
+# ── 3.8 read-only: structural (no cleaned artifact under tool class qc) ──────
+
+
+def test_report_run_is_under_qc_inspect_class_with_no_cleaned_artifact(injected_ports):
+    _reader, store = injected_ports
+    result = _run()
+    # Persisted under qc_inspect, never under qc, and never writes a cleaned CSV.
+    assert store.list_runs(_EXPERIMENT, "qc") == []
+    assert store.list_runs(_EXPERIMENT, "qc_inspect")
+    assert not any(name.endswith("_cleaned.csv") for name in result.outputs)
+
+
+# ── 3.8b read-only over the real resolver (negative composition) ────────────
+
+
+def test_qc_inspect_run_is_not_resolved_as_cleaned_version(fake_supabase_storage):
+    """A committed qc_inspect run must NOT satisfy require_clean=True. Driven through the
+    Supabase adapters over the shared in-memory object store — the fakes' reader/store
+    are disjoint and cannot exercise the resolver."""
+    reader = FakeReader()
+    reader.add_experiment(_EXPERIMENT, _raw_df())
+    store = SupabaseResultStore()
+    _ports.configure(reader=reader, store=store)
+    try:
+        _run()
+        with pytest.raises(CleanedVersionRequiredError):
+            SupabaseReader().load_experiment(_EXPERIMENT, require_clean=True)
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+# ── 3.9 figure-persistence round-trip (real bytes, via the adapters) ────────
+
+
+def test_persisted_figures_round_trip_as_real_bytes(fake_supabase_storage):
+    """The FakeResultStore retains no bytes, so commit through SupabaseResultStore over the
+    shared object store and read the stored PNG/JSON bytes back."""
+    reader = FakeReader()
+    reader.add_experiment(_EXPERIMENT, _raw_df())
+    store = SupabaseResultStore()
+    _ports.configure(reader=reader, store=store)
+    try:
+        _run()
+        stored = store.get_run(_EXPERIMENT, "qc_inspect", "latest")
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    png_names = [n for n in stored.output_keys if n.endswith(".png")]
+    assert png_names  # at least the trait_eda_overview heat/bar charts
+    for name in png_names:
+        data = fake_supabase_storage.objects[stored.output_keys[name]]
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"  # real PNG, non-empty
+        assert hashlib.sha256(data).hexdigest() == stored.output_sha256[name]
+
+    rec_bytes = fake_supabase_storage.objects[stored.output_keys["recommendation.json"]]
+    rec = json.loads(rec_bytes.decode("utf-8"))
+    assert (
+        rec["would_remove_traits"] == _GOLDEN["recommendation"]["would_remove_traits"]
+    )
+    assert rec["samples_lost_at_recommendation"] == 0
+
+
+# ── 3.10 second run increments version ──────────────────────────────────────
+
+
+def test_second_run_increments_version(injected_ports):
+    _reader, store = injected_ports
+    _run()
+    _run()
+    assert [r.run_ref for r in store.list_runs(_EXPERIMENT, "qc_inspect")] == [
+        "v1",
+        "v2",
+    ]
+    assert store.get_run(_EXPERIMENT, "qc_inspect", "latest").run_ref == "v2"

--- a/bloommcp/tests/tools/test_qc_inspect_tool.py
+++ b/bloommcp/tests/tools/test_qc_inspect_tool.py
@@ -92,6 +92,17 @@ def test_recommendation_oracle_at_default_params(injected_ports):
     assert (
         rec.recommended_max_nans_per_trait < 0.1551
     )  # strictly below the trait NaN fraction
+    # Pin the golden's headline value exactly (floor of 15.51% to the 0.01 step below).
+    assert (
+        rec.recommended_max_nans_per_trait
+        == _GOLDEN["recommendation"]["recommended_max_nans_per_trait"]
+        == 0.15
+    )
+    # Per-offending-trait missingness footprint: each 15.5%-NaN trait touches 29 samples.
+    assert rec.offending_trait_nan_counts == {
+        "Root_Biomass_mg": 29,
+        "Root_Shoot_Ratio": 29,
+    }
     assert rec.naive_dropna_samples_lost == _GOLDEN["naive_dropna_samples_lost"] == 29
 
 
@@ -203,12 +214,17 @@ def test_invalid_threshold_is_input_validation_error(injected_ports):
 
 def test_default_thresholds_mirror_qc_clean_canonical():
     """qc_inspect's defaults must match qc_clean's canonical QC-pipeline defaults so the
-    overlays/recommendation reflect the clean a default qc_clean would apply."""
-    p = QCInspectParams(experiment="x.csv")
-    assert p.max_zeros_per_trait == 0.5
-    assert p.max_nans_per_trait == 0.2
-    assert p.max_nans_per_sample == 0.0
-    assert p.min_samples_per_trait == 10
+    overlays/recommendation reflect the clean a default qc_clean would apply. Compared
+    field-by-field against QCCleanParams (not just literals) so a future qc_clean bump that
+    isn't mirrored here fails — the thresholds are single-sourced in _qc_shared."""
+    from bloom_mcp.tools.qc_clean_tool import QCCleanParams
+
+    qi = QCInspectParams(experiment="x.csv")
+    qc = QCCleanParams(experiment="x.csv")
+    assert qi.max_zeros_per_trait == qc.max_zeros_per_trait == 0.5
+    assert qi.max_nans_per_trait == qc.max_nans_per_trait == 0.2
+    assert qi.max_nans_per_sample == qc.max_nans_per_sample == 0.0
+    assert qi.min_samples_per_trait == qc.min_samples_per_trait == 10
 
 
 # ── 3.3 provenance + links (not blobs) ──────────────────────────────────────
@@ -221,18 +237,22 @@ def test_provenance_stamped_seed_none_and_links_returned(injected_ports):
     stored = store.get_run(_EXPERIMENT, "qc_inspect", "latest")
     assert stored.tool == "qc_inspect"
     assert stored.seed is None  # QC inspection is deterministic — no random_state
-    expected = {
+    # Load-bearing outputs the report always commits (the recommendation + the per-trait
+    # overlay + the NaN-samples table). The missingness heatmap is best-effort (it can be
+    # absent on a degenerate frame — see _render_report), so it is NOT asserted here.
+    load_bearing = {
         "trait_eda_overview.png",
         "variance_distribution.png",
-        "missing_data_pattern.png",
         "nan_samples.csv",
         "recommendation.json",
     }
-    assert set(stored.output_keys) == expected
+    assert load_bearing <= set(stored.output_keys)
+    # On this (non-degenerate) fixture the heatmap IS produced.
+    assert "missing_data_pattern.png" in stored.output_keys
 
     assert result.run_ref == stored.run_ref
     assert result.manifest_path == stored.manifest_path
-    assert set(result.outputs) == expected
+    assert load_bearing <= set(result.outputs)
     # Links, not blobs: no inline field carries a large payload.
     dumped = result.model_dump()
     assert not any(
@@ -447,3 +467,167 @@ def test_second_run_increments_version(injected_ports):
         "v2",
     ]
     assert store.get_run(_EXPERIMENT, "qc_inspect", "latest").run_ref == "v2"
+
+
+# ── recommendation is benefit-aware: no drop advised when it frees no samples ───
+
+
+def test_no_drop_recommended_when_it_would_save_no_samples():
+    """Blocking regression: a kept NaN-bearing trait under a LOOSE max_nans_per_sample
+    loses zero samples, so lowering max_nans_per_trait to drop it buys nothing on sample
+    loss. The recommendation must say no_change_needed (not advise a 0→0 drop), while still
+    reporting the trait's missingness footprint so the agent isn't blind to it."""
+    n = 50
+    df = pd.DataFrame(
+        {
+            "Barcode": [f"b{i}" for i in range(n)],
+            "geno": ["g1", "g2"] * (n // 2),
+            "rep": list(range(n)),
+            "t_ok": [float(i + 1) for i in range(n)],
+            "t_nan": [float(i + 1) for i in range(n)],
+        }
+    )
+    df.loc[[3, 17], "t_nan"] = float("nan")  # 2/50 = 0.04 NaN, kept at default 0.2
+
+    reader = FakeReader()
+    reader.add_experiment("loose.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+    try:
+        result = qc_inspect(
+            QCInspectParams(
+                experiment="loose.csv",
+                max_nans_per_sample=0.5,  # tolerates the missingness → 0 samples lost
+                trait_columns=["t_ok", "t_nan"],
+            )
+        )
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    assert result.samples_lost_at_current_params == 0
+    rec = result.recommendation
+    assert rec.no_change_needed is True
+    assert rec.recommended_max_nans_per_trait is None
+    assert rec.would_remove_traits == []
+    assert rec.samples_lost_at_recommendation == 0
+    # The offending trait's footprint is still surfaced (2 samples carry its NaN).
+    assert rec.offending_trait_nan_counts == {"t_nan": 2}
+
+
+# ── traits_would_be_removed carries a per-trait removal reason (NaN vs zeros/min) ──
+
+
+def test_removed_trait_reasons_explains_non_nan_removals():
+    """A trait removed by the ZERO filter is in traits_would_be_removed but NOT in the
+    NaN-only traits_exceeding_thresholds; removed_trait_reasons explains the difference so
+    the two fields never look contradictory without cause."""
+    n = 50
+    df = pd.DataFrame(
+        {
+            "Barcode": [f"b{i}" for i in range(n)],
+            "geno": ["g1", "g2"] * (n // 2),
+            "rep": list(range(n)),
+            "t_ok": [float(i + 1) for i in range(n)],
+            "t_zeros": [0.0] * 30
+            + [float(i + 1) for i in range(20)],  # 60% zeros > 0.5
+        }
+    )
+    reader = FakeReader()
+    reader.add_experiment("zeros.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+    try:
+        result = qc_inspect(
+            QCInspectParams(experiment="zeros.csv", trait_columns=["t_ok", "t_zeros"])
+        )
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    assert result.per_trait_nan_fraction["t_zeros"] == 0.0  # no NaN...
+    assert "t_zeros" not in result.traits_exceeding_thresholds  # ...so not NaN-flagged
+    assert "t_zeros" in result.traits_would_be_removed  # ...but the delegate drops it
+    assert result.removed_trait_reasons["t_zeros"] == "too_many_zeros"
+
+
+# ── detected roles are forwarded (proven with non-default capitalized roles) ────
+
+
+def test_detected_roles_are_forwarded_overriding_delegate_defaults(monkeypatch):
+    """Capitalized Genotype/Replicate differ from the delegate defaults geno/rep, so this
+    distinguishes 'forwards detected roles' from 'delegate applied its own defaults' — the
+    same guard qc_clean's suite uses (the geno/rep/Barcode spy alone cannot prove it).
+    """
+    df = pd.DataFrame(
+        {
+            "Genotype": (["g1", "g2"] * 8),
+            "Replicate": list(range(16)),
+            "tA": [float(i) for i in range(16)],
+            "tB": [float(2 * i) for i in range(16)],
+        }
+    )
+    reader = FakeReader()
+    reader.add_experiment("caps.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+
+    captured = {}
+    real_filter = qc_inspect_tool.apply_data_cleanup_filters
+
+    def _spy(df_, trait_cols=None, **kwargs):
+        captured["kwargs"] = kwargs
+        return real_filter(df_, trait_cols, **kwargs)
+
+    monkeypatch.setattr(qc_inspect_tool, "apply_data_cleanup_filters", _spy)
+    try:
+        qc_inspect(QCInspectParams(experiment="caps.csv"))
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    assert captured["kwargs"]["genotype_col"] == "Genotype"
+    assert captured["kwargs"]["replicate_col"] == "Replicate"
+    # sample_id undetected here → barcode_col omitted (not forwarded as a wrong default).
+    assert captured["kwargs"].get("barcode_col") != "Genotype"
+
+
+# ── recommendation threshold: exact 0.01-boundary branch ────────────────────────
+
+
+def test_recommendation_at_exact_hundredth_boundary_steps_down_one():
+    """When the smallest offending NaN fraction lands exactly on a 0.01 step (0.15), the
+    floor equals the fraction, so the recommendation must step one 0.01 below it (0.14) to
+    strictly drop the trait — exercising the round(min_frac - 0.01) branch."""
+    n = 20
+    df = pd.DataFrame(
+        {
+            "Barcode": [f"b{i}" for i in range(n)],
+            "geno": ["g1", "g2"] * (n // 2),
+            "rep": list(range(n)),
+            "t_ok": [float(i + 1) for i in range(n)],
+            "t_nan": [float(i + 1) for i in range(n)],
+        }
+    )
+    df.loc[[1, 5, 9], "t_nan"] = float(
+        "nan"
+    )  # 3/20 = 0.15 exactly, kept at default 0.2
+
+    reader = FakeReader()
+    reader.add_experiment("boundary.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+    try:
+        result = qc_inspect(
+            QCInspectParams(experiment="boundary.csv", trait_columns=["t_ok", "t_nan"])
+        )
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    assert result.per_trait_nan_fraction["t_nan"] == 0.15
+    rec = result.recommendation
+    assert rec.no_change_needed is False
+    assert rec.recommended_max_nans_per_trait == 0.14  # one 0.01 step below 0.15
+    assert "t_nan" in rec.would_remove_traits
+
+
+# ── empty trait_columns is a caller mistake, not "inspect everything" ────────────
+
+
+def test_empty_trait_columns_is_invalid_input(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        qc_inspect(QCInspectParams(experiment=_EXPERIMENT, trait_columns=[]))
+    assert exc.value.code == "invalid_input"

--- a/bloommcp/tests/tools/test_qc_inspect_tool.py
+++ b/bloommcp/tests/tools/test_qc_inspect_tool.py
@@ -81,6 +81,13 @@ def test_recommendation_oracle_at_default_params(injected_ports):
         == _GOLDEN["at_default_params"]["samples_lost"]
     )
     assert result.samples_lost_at_current_params == 29
+    # No non-finite values in turface; residual NaN in kept cols is 0 at the defaults.
+    assert result.per_trait_inf_count == {}
+    assert (
+        result.residual_nan_cells_at_current_params
+        == _GOLDEN["at_default_params"]["residual_nan_cells"]
+        == 0
+    )
 
     rec = result.recommendation
     assert rec.no_change_needed is False
@@ -225,6 +232,30 @@ def test_default_thresholds_mirror_qc_clean_canonical():
     assert qi.max_nans_per_trait == qc.max_nans_per_trait == 0.2
     assert qi.max_nans_per_sample == qc.max_nans_per_sample == 0.0
     assert qi.min_samples_per_trait == qc.min_samples_per_trait == 10
+
+
+def test_canonical_thresholds_match_upstream_delegate_defaults():
+    """Drift tripwire pinning the hardcoded _CANONICAL_* constants to the LIVE upstream
+    delegate rather than to each other (the mirror test above only proves lockstep). On the
+    pinned analyze version the delegate's own signature defaults coincide with the canonical
+    QC-pipeline values; if a future bump changes them this fails, prompting a re-verify against
+    the pipeline canonical instead of a silent desync."""
+    import inspect
+
+    from bloom_mcp.tools import _qc_shared
+
+    sig = inspect.signature(qc_inspect_tool.apply_data_cleanup_filters).parameters
+    assert (
+        _qc_shared._CANONICAL_MAX_ZEROS_PER_TRAIT == sig["max_zeros_per_trait"].default
+    )
+    assert _qc_shared._CANONICAL_MAX_NANS_PER_TRAIT == sig["max_nans_per_trait"].default
+    assert (
+        _qc_shared._CANONICAL_MAX_NANS_PER_SAMPLE == sig["max_nans_per_sample"].default
+    )
+    assert (
+        _qc_shared._CANONICAL_MIN_SAMPLES_PER_TRAIT
+        == sig["min_samples_per_trait"].default
+    )
 
 
 # ── 3.3 provenance + links (not blobs) ──────────────────────────────────────
@@ -631,3 +662,146 @@ def test_empty_trait_columns_is_invalid_input(injected_ports):
     with pytest.raises(BloomMCPError) as exc:
         qc_inspect(QCInspectParams(experiment=_EXPERIMENT, trait_columns=[]))
     assert exc.value.code == "invalid_input"
+
+
+def test_metadata_only_frame_with_no_traits_is_invalid_input():
+    """An auto-detected empty trait set (no numeric traits) is rejected up front, not
+    committed as a useless empty report run."""
+    df = pd.DataFrame(
+        {"Barcode": ["b0", "b1"], "geno": ["g1", "g2"], "note": ["x", "y"]}
+    )
+    reader = FakeReader()
+    reader.add_experiment("meta_only.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+    try:
+        with pytest.raises(BloomMCPError) as exc:
+            qc_inspect(QCInspectParams(experiment="meta_only.csv"))
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+    assert exc.value.code == "invalid_input"
+
+
+# ── experiment must be a bare filename (path-traversal guard) ────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad", ["../../app/.env", "/etc/passwd", "sub/dir/x.csv", "..", ".", ""]
+)
+def test_experiment_path_traversal_is_rejected(injected_ports, bad):
+    """A non-bare experiment (separators / .. / absolute / empty) is rejected before any
+    read, so this read-and-persist tool can't be turned into an arbitrary-file exfil path.
+    """
+    with pytest.raises(BloomMCPError) as exc:
+        qc_inspect(QCInspectParams(experiment=bad))
+    assert exc.value.code == "invalid_input"
+
+
+# ── inf / -inf is surfaced, not silently read as 0% missing ─────────────────────
+
+
+def test_infinite_values_are_flagged_not_counted_as_missing():
+    """A trait that is 40% inf reads as ~0% NaN (isna ignores inf) and is kept — the result
+    must surface per_trait_inf_count and prepend an inf warning to the recommendation
+    rationale, since this is exactly the silent bias the tool exists to catch."""
+    n = 20
+    df = pd.DataFrame(
+        {
+            "Barcode": [f"b{i}" for i in range(n)],
+            "geno": ["g1", "g2"] * (n // 2),
+            "rep": list(range(n)),
+            "t_ok": [float(i + 1) for i in range(n)],
+            "t_inf": [float(i + 1) for i in range(n)],
+        }
+    )
+    df.loc[list(range(8)), "t_inf"] = float("inf")  # 8/20 = 40% inf, 0% NaN
+
+    reader = FakeReader()
+    reader.add_experiment("inf.csv", df)
+    _ports.configure(reader=reader, store=FakeResultStore())
+    try:
+        result = qc_inspect(
+            QCInspectParams(experiment="inf.csv", trait_columns=["t_ok", "t_inf"])
+        )
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    assert result.per_trait_nan_fraction["t_inf"] == 0.0  # isna ignores inf
+    assert result.per_trait_inf_count == {"t_inf": 8}
+    assert "inf" in result.recommendation.rationale.lower()
+
+
+# ── delegate cleanup-log contract drift surfaces structurally, not as silent 0 ──
+
+
+def test_cleanup_log_missing_keys_is_structured_internal_error(
+    injected_ports, monkeypatch
+):
+    """If the delegate log ever drops original_samples/final_samples, samples-lost must NOT
+    silently become 0 (which would flip every recommendation to no_change_needed) — it
+    surfaces as a structured internal_error."""
+
+    def _bad_log(df, trait_cols=None, **kwargs):
+        return df[list(trait_cols or [])].copy(), {
+            "removed_traits": []
+        }  # no sample keys
+
+    monkeypatch.setattr(qc_inspect_tool, "apply_data_cleanup_filters", _bad_log)
+    with pytest.raises(BloomMCPError) as exc:
+        _run()
+    assert exc.value.code == "internal_error"
+
+
+# ── render/commit failure cleans up its staging dir (no leaked temp run) ────────
+
+
+def test_render_failure_cleans_staging_and_commits_nothing(injected_ports, monkeypatch):
+    """A failure AFTER create_run (inside _render_report) must remove the staging dir and
+    commit no run — the existing delegate-raise test injects BEFORE create_run, so this path
+    was untested."""
+    _reader, store = injected_ports
+
+    captured = {}
+    real_create = store.create_run
+
+    def _spy_create(*a, **k):
+        run = real_create(*a, **k)
+        captured["staging_dir"] = run.staging_dir
+        return run
+
+    monkeypatch.setattr(store, "create_run", _spy_create)
+
+    def _boom_eda(*a, **k):
+        raise RuntimeError("render failed after the run dir was created")
+
+    monkeypatch.setattr(qc_inspect_tool, "create_trait_eda_plots", _boom_eda)
+
+    with pytest.raises(BloomMCPError):
+        _run()
+    assert store.list_runs(_EXPERIMENT, "qc_inspect") == []  # nothing committed
+    assert not captured["staging_dir"].exists()  # staging dir removed
+
+
+# ── heatmap is best-effort: run still commits when it can't be produced ─────────
+
+
+def test_run_commits_without_heatmap_when_summary_plots_fail(
+    injected_ports, monkeypatch
+):
+    """When create_exploratory_summary_plots raises, the report still commits its
+    load-bearing outputs, just without missing_data_pattern.png (best-effort heatmap).
+    """
+    _reader, store = injected_ports
+
+    def _boom_summary(*a, **k):
+        raise RuntimeError("degenerate frame: heatmap unavailable")
+
+    monkeypatch.setattr(
+        qc_inspect_tool, "create_exploratory_summary_plots", _boom_summary
+    )
+
+    result = _run()
+    assert "missing_data_pattern.png" not in result.outputs
+    assert {"trait_eda_overview.png", "nan_samples.csv", "recommendation.json"} <= set(
+        result.outputs
+    )
+    assert store.get_run(_EXPERIMENT, "qc_inspect", "latest").run_ref == "v1"

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/design.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/design.md
@@ -1,0 +1,150 @@
+## Context
+
+`qc_inspect` is the **read-only** Tier-3 sibling of `qc_clean`. It reuses the same seams
+`qc_clean` bound (the contract decorator, the `ExperimentReader` / `ResultStore` ports, the
+`_ports` composition root) and the same upstream library — but where `qc_clean` *produces* a
+cleaned run, `qc_inspect` *produces a report* that helps the agent choose `qc_clean`'s
+thresholds. The constraints are fixed by the shipped code:
+
+- `@as_mcp_tool(input_model=, output_model=, errors=)` validates Pydantic I/O, maps exceptions
+  to `BloomMCPError`, resolves the seed, and stamps one `Provenance`. A tool that declares no
+  `random_state` records `seed=None`. `contract/wrap.py`
+- `ExperimentReader.load_experiment(name, *, version="latest", require_clean=False)` returns an
+  `ExperimentFrame` exposing `df`, `trait_cols`, the detected role columns, and a `source`
+  label. `qc_inspect` calls it with the defaults (raw, no `require_clean`). `data_access/ports.py`
+- The `SupabaseReader` resolves a *cleaned* version only from **`qc` tool-class runs that wrote
+  `_cleaned.csv`**. A run under any other tool class is never resolved by `require_clean=True` —
+  which is exactly how `qc_inspect`'s read-only guarantee is enforced structurally.
+  `data_access/supabase_reader.py`
+- `ResultStore.create_run(*, experiment, tool_class, provenance, …) -> RunHandle` then
+  `commit(run, outputs) -> StoredRun`. `commit` hashes the exact staged bytes and uploads each
+  staged file, so **binary PNGs persist as faithfully as text CSVs** (it is content-agnostic).
+  `result_store/ports.py`, `result_store/supabase_store.py`
+- The upstream delegates (all public in `sleap_roots_analyze 0.1.0a3`, already pinned by #356):
+  `apply_data_cleanup_filters(df, trait_cols, …thresholds…, barcode_col, genotype_col,
+  replicate_col) -> (filtered_df, cleanup_log)`; `create_trait_eda_plots(df, trait_cols,
+  thresholds: {"nan","zero","outlier"}, cleanup_log, min_samples_per_trait) -> {name: Figure}`;
+  `create_exploratory_summary_plots(df, trait_cols, genotype_col) -> {..., "missing_data_pattern":
+  Figure}`; `inspect_nan_samples(df, trait_cols, barcode_col, genotype_col, replicate_col) ->
+  DataFrame`.
+- `qc_clean` already implements `_role_kwargs(frame)` (forward detected roles, omit `None`) and
+  `_validate_trait_subset(frame, requested, experiment)` (existence + numeric → `invalid_input`).
+  These are identical to what `qc_inspect` needs. `tools/qc_clean_tool.py`
+
+## Goals / Non-Goals
+
+- **Goals:** one contract-wrapped, **read-only** `qc_inspect` tool, registered + discoverable,
+  delegating all EDA to the analyze functions, producing a per-trait missingness report + a
+  threshold recommendation through the MCP boundary, persisting a **versioned report run** that
+  is **not** a cleaned version, with the 5 contract patterns + the turface_19 recommendation
+  oracle + a figure round-trip under test.
+- **Non-Goals:** any EDA/plotting logic in the MCP; calling `bloom_mcp.data_cleanup`; producing
+  a cleaned table or anything resolvable by `require_clean=True`; seed threading (inspection is
+  deterministic); changing `qc_clean`'s cleanup behavior or its defaults; the live-persistence
+  smoke leg (deferred — see Open Questions); a new dependency or fixture.
+
+## Decisions
+
+- **Decision: persist-and-link the figures (the issue's proposed default), not transient image
+  content.** `qc_inspect` writes the EDA figures + NaN-samples CSV + `recommendation.json` as a
+  versioned `ResultStore` run and returns `resource_link`s — same reproducibility contract as
+  `qc_clean` (small structured results inline + links, **never inline blobs**). A persisted run
+  gives the recommendation a citable, versioned artifact the agent (and a human) can revisit,
+  and keeps `qc_inspect` symmetric with every other persisting tool.
+  - *Alternative considered:* return transient MCP image content for the agent to display
+    without persisting a run (lighter, no versioned artifact). Rejected as the default: it
+    breaks the links-not-blobs contract and leaves the recommendation un-citable. The **wrap is
+    identical either way**, so this is reversible if a transient "preview" mode is later wanted.
+    Surfaced as the one decision a reviewer may want to flip before implementation.
+- **Decision: persist under a distinct tool class `qc_inspect`, never `qc`.** The reader resolves
+  cleaned versions only from `qc`-class runs writing `_cleaned.csv`. Writing under `qc_inspect`
+  makes the read-only guarantee **structural** (not a convention): a `qc_inspect` run can never
+  be mistaken for a cleaned version, so `require_clean=True` never resolves it.
+- **Decision: read raw, do not set `require_clean`.** The point is to show the *raw* missingness
+  the agent must reason about. Loading a cleaned frame would hide the very NaNs being inspected.
+- **Decision: accept the same thresholds as `qc_clean` and drive both the overlay and the
+  recommendation from one `apply_data_cleanup_filters` call.** The cleanup log that
+  `create_trait_eda_plots` overlays as "traits actually removed" is the same log the
+  recommendation reasons over — computing them from one delegate call keeps the picture and the
+  advice consistent, and mirrors how analyze's own `exploratory_analysis` step feeds the plots.
+- **Decision: the recommendation is derived, simple, and pins consequences not a formula.** Given
+  the supplied thresholds, the recommended `max_nans_per_trait` is the largest value strictly
+  below the smallest NaN fraction among traits that still carry NaNs after the current filters
+  (so it drops exactly the offending traits) — and the tool reports the *consequence*
+  (`would_remove_traits`, `samples_lost_at_recommendation`, `samples_lost_naive_dropna`). The
+  spec oracle pins the **consequence** on turface_19 (drops the two 0.155 traits, 0 samples lost
+  vs naive 29), not the exact arithmetic, so the formula can be refined without a spec churn.
+- **Decision: declare `provenance`, not `random_state`; seed is `None`.** Inspection is
+  deterministic (fraction thresholds, no `random_state`). The thresholds + trait selection are
+  the determinism-governing params captured in provenance.
+- **Decision: reuse `qc_clean`'s role-forwarding + trait-validation via a shared `_qc_shared`
+  module, with the extraction landing in #356.** Both tools forward detected roles (omitting
+  `None`) and reject unknown / non-numeric `trait_columns` identically; a single `_qc_shared`
+  module both import keeps them in lockstep rather than drifting as two copies. The pure move
+  **should land in #356** (which already owns and tests `qc_clean_tool.py`), so qc_inspect only
+  *imports* `_qc_shared` — avoiding a guaranteed `qc_clean_tool.py` merge conflict between two
+  open PRs editing the same hunks. If #356 declines, qc_inspect's branch carries the move as a
+  separate `refactor(#360)` commit, keeping `qc_clean`'s suite green.
+- **Decision: set the Agg matplotlib backend at module top, before importing the analyze viz
+  functions, and close every figure.** analyze's `visualization.py` does a bare
+  `import matplotlib.pyplot` with **no** `use("Agg")`, so whichever backend is active at first
+  import wins — importing the analyze EDA functions first resolves to interactive `tkagg` and
+  crashes `savefig` in a headless container (verified). So `qc_inspect_tool.py` must do
+  `import matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt` at the very top
+  (the `viz_tools.py:14-17` pattern) *before* `from sleap_roots_analyze import …`, and
+  `plt.close(fig)` after staging each figure — including the unused
+  `create_exploratory_summary_plots` panels — so a server process leaks no figure handles. A
+  `get_backend() == "Agg"` import-time assertion guards the headless guarantee from regressing.
+  (The server is headless-safe *today* only incidentally, because `viz_tools` runs `use("Agg")`
+  during boot; qc_inspect must not depend on that ordering.)
+- **Decision: the `qc_clean` tie-in is message-only and lands with #356, not here.** #356's
+  no-NaN guard means the *cleaned output* never carries residual NaNs, so the issue's "residual
+  NaNs in the cleaned output > 0" trigger is stale; the honest trigger is **sample loss**
+  (`n_samples_dropped > 0`). The nudge is one behavior-compatible line in `qc_clean`'s result;
+  because `bloommcp-qc-clean-tool` is still in-flight (not in `specs/`), keeping the nudge in
+  #356's branch keeps the spec change with its capability and avoids a MODIFIED delta against a
+  not-yet-archived capability.
+
+## Risks / Trade-offs
+
+- **Figure determinism / size.** Persisted PNGs vary byte-for-byte across matplotlib/font
+  versions, so the round-trip test asserts *non-empty image + sha matches the recorded bytes of
+  that run*, not equality to a golden PNG. The recommendation JSON (the agent-facing payload) is
+  the value-pinned oracle.
+- **Fakes prove the per-port contract; the read-only guarantee and the figure round-trip need
+  the adapters.** Drive provenance + links through the `_ports` seam with
+  `FakeReader`/`FakeResultStore`. But two claims the fakes **cannot** prove:
+  (1) the read-only *resolver* behavior — `FakeReader._cleaned` and `FakeResultStore._runs` are
+  disjoint, so a committed `qc_inspect` run is invisible to the fake reader; the structural
+  check (tool class `qc_inspect`, no `CLEANED_CSV_NAME`) is necessary but **not sufficient**.
+  (2) the figure byte round-trip — `FakeResultStore.commit()` `rmtree`s its staging dir and
+  retains no bytes. Both must run through `SupabaseResultStore` over the shared
+  `_InMemoryObjectStore` (the harness #356 stood up): a *negative* composition test asserting
+  `SupabaseReader.load_experiment(require_clean=True)` raises `CleanedVersionRequiredError`
+  (the mirror of #356's *positive* composition), and a real-bytes readback asserting PNG magic +
+  `sha256 == output_sha256`. The fakes path asserts the per-port contracts; the
+  adapters-over-object-store path asserts the resolver handoff and the persisted bytes.
+- **`create_exploratory_summary_plots` builds extra figures** (histograms, correlations) we do
+  not need. Take only its `missing_data_pattern` figure and close the rest, or build just the
+  heatmap if its surface lets us — avoid persisting unused panels.
+- **Recommendation when nothing crosses.** If no trait carries NaN after the current filters,
+  the recommendation reports "no change recommended" (current thresholds already lose no
+  samples), not a spurious lower threshold.
+
+## Migration Plan
+
+Additive only — a new read-only tool + one registration line + a pure-move refactor of two
+helpers. No schema, data, or dependency change; existing manifests are unaffected. Rollback =
+unregister the tool (the helper extraction is independently safe).
+
+## Open Questions
+
+- **Persist-and-link vs transient figures** — proposal recommends persist-and-link (above); a
+  reviewer may opt for transient/preview content. The wrap is identical; settle before §4.
+- **Live-persistence smoke leg.** #356 added a Tier-3 `qc_clean` smoke leg; a parallel
+  `qc_inspect` leg (report run persists + figures round-trip through the real Supabase ports) is
+  reasonable but heavier and not in the issue's test list. Deferred to a follow-up unless a
+  reviewer wants it in-scope.
+- **Exact recommended-threshold arithmetic** vs only reporting consequences — settle when the
+  inspection golden is recorded (§1), keeping the spec oracle on consequences.
+</content>

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/design.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/design.md
@@ -78,13 +78,14 @@ thresholds. The constraints are fixed by the shipped code:
   deterministic (fraction thresholds, no `random_state`). The thresholds + trait selection are
   the determinism-governing params captured in provenance.
 - **Decision: reuse `qc_clean`'s role-forwarding + trait-validation via a shared `_qc_shared`
-  module, with the extraction landing in #356.** Both tools forward detected roles (omitting
-  `None`) and reject unknown / non-numeric `trait_columns` identically; a single `_qc_shared`
-  module both import keeps them in lockstep rather than drifting as two copies. The pure move
-  **should land in #356** (which already owns and tests `qc_clean_tool.py`), so qc_inspect only
-  *imports* `_qc_shared` — avoiding a guaranteed `qc_clean_tool.py` merge conflict between two
-  open PRs editing the same hunks. If #356 declines, qc_inspect's branch carries the move as a
-  separate `refactor(#360)` commit, keeping `qc_clean`'s suite green.
+  module.** Both tools forward detected roles (omitting `None`) and reject unknown / non-numeric
+  `trait_columns` identically; a single `_qc_shared` module both import keeps them in lockstep
+  rather than drifting as two copies. The canonical cleanup thresholds (`_CANONICAL_*`) are
+  single-sourced there too, so the two tools cannot silently desync. #356 merged without taking
+  the extraction, so **this branch carries the move** as a `refactor(#360)` commit; `qc_clean`'s
+  suite stays green. Note this is *behaviour-preserving*, not a byte-for-byte pure move: two
+  `qc_clean` `trait_columns` remedy strings were reworded ("clean" → "use") since the helper now
+  serves both tools — no test asserts the old wording, and no runtime behaviour changes.
 - **Decision: set the Agg matplotlib backend at module top, before importing the analyze viz
   functions, and close every figure.** analyze's `visualization.py` does a bare
   `import matplotlib.pyplot` with **no** `use("Agg")`, so whichever backend is active at first
@@ -133,9 +134,10 @@ thresholds. The constraints are fixed by the shipped code:
 
 ## Migration Plan
 
-Additive only — a new read-only tool + one registration line + a pure-move refactor of two
-helpers. No schema, data, or dependency change; existing manifests are unaffected. Rollback =
-unregister the tool (the helper extraction is independently safe).
+Additive only — a new read-only tool + one registration line + a behaviour-preserving
+extraction of the shared helpers/thresholds into `_qc_shared` (two `qc_clean` remedy strings
+reworded, no runtime change). No schema, data, or dependency change; existing manifests are
+unaffected. Rollback = unregister the tool (the helper extraction is independently safe).
 
 ## Open Questions
 

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/proposal.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/proposal.md
@@ -1,0 +1,132 @@
+## Why
+
+`qc_clean` (#338 / #356) is **agent-driven**, and its cleanup thresholds are
+**data-dependent**, not one-size-fits-all. Today the agent has no way to *see* the
+missingness pattern or know which trait crosses which threshold, so it runs `qc_clean` on the
+canonical defaults (`max_nans_per_trait = 0.2`, `max_nans_per_sample = 0.0`, …). On the raw
+`turface_19` fixture that is the wrong
+call: the two NaN-heavy traits (`Root_Biomass_mg`, `Root_Shoot_Ratio`) sit at **15.5 % NaN**,
+*under* the canonical `max_nans_per_trait = 0.2` default, so they are **kept** — and because
+the canonical `max_nans_per_sample = 0.0` then drops any sample with a residual NaN, keeping
+those traits silently discards their **29 samples** (187 → 158). That is the exact
+uncontrolled sample loss the QC tier exists to prevent. **The fix is not to change the
+defaults** — it is to give the agent a read-only feedback loop so it can pick a good threshold
+(here `≤ 0.15`, which drops the two offending traits and loses **zero** samples) *before*
+committing a `qc_clean` run.
+
+This adds `qc_inspect`, a Tier-3 **read-only** sibling to `qc_clean`: it visualizes trait
+**missingness / NaN structure at QC time** and returns a structured **threshold
+recommendation**, so the agent runs `qc_clean` with eyes open instead of blind on defaults.
+
+## What to wrap (already exists upstream — public; analyze's own EDA pipeline uses it)
+
+`sleap-roots-analyze` (`>=0.1.0a3`, **already pinned** by #356 — no new dependency) ships the
+threshold-aware EDA visualization its `exploratory_analysis` pipeline step uses. This is a
+**wrap, not an upstream addition** (all four are in `sleap_roots_analyze.__all__`, verified on
+`0.1.0a3`):
+
+- **`create_trait_eda_plots(df, trait_cols, thresholds, cleanup_log, min_samples_per_trait)`**
+  — *primary*. Per-trait **NaN / zero / outlier fractions** as bar charts with the cleanup
+  **threshold lines drawn**, plus the "traits actually removed" panel fed by the
+  `apply_data_cleanup_filters` cleanup log.
+- **`apply_data_cleanup_filters(df, trait_cols, …thresholds…, role_cols)`** — produces the
+  `(filtered_df, cleanup_log)` the overlay's `traits_actually_removed` and the recommendation
+  are computed from (exactly how analyze's own EDA step feeds the plots — it is **not** the
+  vendored `bloom_mcp.data_cleanup`).
+- **`create_exploratory_summary_plots(...)["missing_data_pattern"]`** — the sample × trait
+  **missingness heatmap** (`sns.heatmap(df[trait_cols].isna().T)`).
+- **`inspect_nan_samples(df, trait_cols, role_cols)`** — tabular per-sample report (which
+  samples, which traits, `nan_fraction`).
+
+## What Changes
+
+- **ADD** a granular, **read-only** `qc_inspect` MCP tool: Pydantic input/output models, a
+  tool function wrapped by `@as_mcp_tool`, that
+  - reads the **raw** experiment frame through the injected `ExperimentReader` port (no
+    `require_clean` — it inspects the *raw* missingness), forwarding the adapter-detected role
+    columns (`genotype_col` / `replicate_col` / `sample_id_col`) into the delegates the same
+    way `qc_clean` does (the shared `_role_kwargs` helper);
+  - accepts the **same threshold params as `qc_clean`** (`max_zeros_per_trait`,
+    `max_nans_per_trait`, `max_nans_per_sample`, `min_samples_per_trait`, optional
+    `trait_columns`) so the threshold overlays and the recommendation reflect what a subsequent
+    `qc_clean` would apply — runs `apply_data_cleanup_filters` to get the `cleanup_log`, then
+    feeds it to `create_trait_eda_plots`;
+  - delegates **all** plotting / NaN-inspection to the three analyze functions above and
+    contains **no EDA or plotting logic of its own** — and, like `qc_clean`, **never** calls
+    the vendored `bloom_mcp.data_cleanup`;
+  - validates a caller-supplied `trait_columns` subset up front (existence + numeric) →
+    `invalid_input` naming the bad columns (the shared `_validate_trait_subset` helper),
+    rather than an opaque `KeyError` / `internal_error`;
+  - returns a small inline summary **plus a structured `recommendation`**: per-trait NaN
+    fractions, `traits_exceeding_thresholds` (at the supplied params), `traits_would_be_removed`
+    (from the cleanup log), and a `recommended_max_nans_per_trait` with its rationale
+    (`would_remove_traits`, `samples_lost_at_recommendation`, `samples_lost_naive_dropna`,
+    `residual_nan_cells_at_current_params`) — the agent reads this to pick a threshold;
+  - is wrapped by `@as_mcp_tool` (Pydantic I/O, structured `BloomMCPError`, one `Provenance`
+    per call); QC inspection is deterministic, so it declares `provenance` but **not**
+    `random_state` and records `seed = None`.
+- **PERSIST a versioned *report* run via the `ResultStore` port** under a **distinct tool
+  class `qc_inspect`** (deliberately **not** `qc`): the EDA figures (PNG) +
+  `inspect_nan_samples` CSV + a `recommendation.json`, returned as **links** (`run_ref`,
+  `manifest_path`, object keys) — **never inline blobs / base64 figures**, mirroring
+  `qc_clean`'s reproducibility contract. (See the design's persist-vs-transient decision.)
+- **READ-ONLY guarantee:** `qc_inspect` writes a *report* artifact set and **does not** write
+  `CLEANED_CSV_NAME` under tool class `qc`, so a later `load_experiment(require_clean=True)`
+  **does not** resolve a `qc_inspect` run — it produces no cleaned version and mutates no data.
+- **REGISTER** the tool in `src/bloom_mcp/server.py` under "Direct tools (granular)" so it
+  appears in MCP `tools/list`.
+- **EXTRACT** the role-forwarding (`_role_kwargs`) and trait-subset validation
+  (`_validate_trait_subset`) helpers `qc_clean` introduced into a small shared module both
+  tools import, so the two tools forward roles and reject bad columns identically (reuse, not
+  a second copy).
+- **`qc_clean` tie-in (message-only, lands in #356 — not a deliverable here):** `qc_clean`'s
+  result nudges to `qc_inspect` when it dropped samples (`n_samples_dropped > 0`). This corrects
+  the issue's stale "residual NaNs in the cleaned output > 0" trigger — #356's no-NaN guard means
+  that never fires; the honest trigger is **sample loss**. It is an additive, behavior-compatible
+  message with **no spec delta**, owned by #356 (which keeps the change with its capability). See
+  tasks §6.1.
+- Tests cover the **oracle on the raw `turface_19` fixture + the 5 contract patterns + the
+  read-only assertion + a figure-persistence round-trip**: the recommendation flags the two
+  15.5 %-NaN traits and recommends `≤ 0.15` (0 samples lost vs naive `dropna` = 29); `tools/list`
+  presence; schema round-trip + invalid-input envelope; provenance (`seed = None`); structured
+  error envelope; links-not-blobs; and a `qc_inspect` run is **not** resolvable as a cleaned
+  version by `require_clean=True`.
+- **No new fixture, no new dependency:** reuses the raw `turface_19_raw_data.csv` +
+  `turface_19_qc_golden.json` #356 already vendored; records the inspection oracle
+  (per-trait NaN fractions, recommended threshold, naive-dropna loss) into a small golden.
+
+## Impact
+
+- **Affected specs:** `bloommcp-qc-inspect-tool` (**new** capability). Builds on (does not
+  modify) the existing `bloommcp-tool-contract`, `bloommcp-experiment-read`, and
+  `bloommcp-result-store` capabilities, and depends on the in-flight `bloommcp-qc-clean-tool`
+  (#356) for the raw fixture, the shared role/validation helpers, and the persistence shape.
+- **Affected code:**
+  - new `bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py` (tool + I/O models + `register`);
+  - new shared helper module (e.g. `bloommcp/src/bloom_mcp/tools/_qc_shared.py`) holding
+    `_role_kwargs` + `_validate_trait_subset`, with `qc_clean_tool.py` updated to import them
+    (no behavior change to `qc_clean`);
+  - `bloommcp/src/bloom_mcp/server.py` (register the tool; update the module docstring);
+  - new `bloommcp/tests/tools/test_qc_inspect_tool.py` (oracle + 5 patterns + read-only +
+    figure round-trip);
+  - extend `bloommcp/tests/fixtures/README.md` + add `turface_19_qc_inspect_golden.json`
+    (per-trait NaN fractions + recommendation oracle, computed from the LF-normalized raw
+    fixture — an explicit asserted value, not re-derived from the code under test);
+  - **roadmap reshape stays owned by PR #339** (`eberrigan/bloommcp-tier3-qc`), so
+    `bloommcp/docs/roadmap.md` is **not** edited here, to avoid a conflict. **Safeguard:** #339
+    owns the Tier-row edit for *both* `qc_clean` and `qc_inspect` and has not landed — confirm
+    `qc_inspect` is in #339's scope, and file a follow-up if #339 stalls (tasks §6.2);
+  - **no edit needed** to `bloommcp/README.md` (it lists tool *categories*, not individual tools,
+    and `qc_inspect` is QC) or `DEV_SETUP.md` (`qc_inspect` ships **no** `make bloommcp-smoke`
+    leg, so the existing clustering + `qc_clean` smoke pointers are unaffected) — noted explicitly
+    so the omission reads as deliberate, not an oversight;
+  - the `qc_clean` nudge (message-only) is owned by **#356**, not this change — see What Changes.
+- **Dependencies:** none new — `create_trait_eda_plots`, `create_exploratory_summary_plots`,
+  `inspect_nan_samples`, `apply_data_cleanup_filters` are all public in
+  `sleap_roots_analyze 0.1.0a3` (already pinned by #356).
+- **Sequencing (branch base is load-bearing):** Tier-3 companion to `qc_clean` (#356) → feeds
+  `pca_analysis` (#308). Base this change on **#356's branch** while #356 is open (the raw
+  fixture and shared helpers exist only there, not on `staging`); **rebase onto `origin/staging`
+  once #356 merges**; **never merge `qc_inspect` before #356**. PR targets `staging` (not `main`).
+- **Implements #360.** Parent: #338 · Sibling: #356 (`qc_clean`) · Consumer: #308 (`pca_analysis`).
+</content>

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/proposal.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/proposal.md
@@ -104,8 +104,10 @@ threshold-aware EDA visualization its `exploratory_analysis` pipeline step uses.
 - **Affected code:**
   - new `bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py` (tool + I/O models + `register`);
   - new shared helper module (e.g. `bloommcp/src/bloom_mcp/tools/_qc_shared.py`) holding
-    `_role_kwargs` + `_validate_trait_subset`, with `qc_clean_tool.py` updated to import them
-    (no behavior change to `qc_clean`);
+    `_role_kwargs` + `_validate_trait_subset` + the canonical `_CANONICAL_*` thresholds, with
+    `qc_clean_tool.py` updated to import them (behaviour-preserving — two `qc_clean` remedy
+    strings were reworded "clean" → "use" now that the helper serves both tools; no runtime
+    behaviour or tested-string change);
   - `bloommcp/src/bloom_mcp/server.py` (register the tool; update the module docstring);
   - new `bloommcp/tests/tools/test_qc_inspect_tool.py` (oracle + 5 patterns + read-only +
     figure round-trip);

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/specs/bloommcp-qc-inspect-tool/spec.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/specs/bloommcp-qc-inspect-tool/spec.md
@@ -1,0 +1,204 @@
+## ADDED Requirements
+
+### Requirement: QC Inspect Tool Registration and Discovery
+
+The system SHALL expose a `qc_inspect` MCP tool registered on the FastMCP server so it is
+discoverable via the MCP `tools/list` operation. The tool name SHALL be stable (`qc_inspect`,
+never versioned in the name) and SHALL NOT remove or rename the existing `qc_clean` or
+`run_qc_workflow` tools or the vendored `bloom_mcp.data_cleanup` module.
+
+#### Scenario: Tool appears in tools/list
+
+- **WHEN** a FastMCP `Client` connects to the server and calls `tools/list`
+- **THEN** a tool named `qc_inspect` is present with a description and an input schema derived
+  from its Pydantic input model
+
+#### Scenario: Sibling QC tools are preserved
+
+- **WHEN** the server registers `qc_inspect`
+- **THEN** `qc_clean` and `run_qc_workflow` remain registered and `bloom_mcp.data_cleanup`
+  remains importable, so server boot is unaffected
+
+### Requirement: QC Inspect Wraps the Tested Upstream EDA Functions
+
+The `qc_inspect` tool SHALL produce its missingness report by delegating to
+`sleap_roots_analyze`'s EDA functions — `apply_data_cleanup_filters` (to obtain the
+`cleanup_log`), `create_trait_eda_plots` (per-trait NaN/zero/outlier bar charts with the
+threshold lines and the "traits actually removed" panel), the `missing_data_pattern` figure
+from `create_exploratory_summary_plots`, and `inspect_nan_samples` (the per-sample NaN report)
+— and SHALL contain no EDA, plotting, or NaN-tabulation logic of its own. It SHALL NOT call
+the vendored `bloom_mcp.data_cleanup`. It SHALL pass the adapter-detected role columns
+(genotype / replicate / sample-id) from the `ExperimentFrame` into each delegate that accepts
+them rather than relying on the delegate's `geno` / `rep` / `Barcode` defaults.
+
+#### Scenario: EDA is delegated, not re-implemented
+
+- **WHEN** `qc_inspect` runs on a raw experiment frame
+- **THEN** the per-trait fraction charts, the missingness heatmap, the cleanup log, and the
+  per-sample NaN table are produced by the upstream analyze functions
+- **AND** the tool performs no per-trait or per-sample fraction computation, plotting, or
+  filtering itself, and does not call `bloom_mcp.data_cleanup`
+
+#### Scenario: Detected role columns are forwarded to the delegates
+
+- **WHEN** the experiment's role columns differ from the delegate defaults (e.g. `Genotype` /
+  `Replicate` rather than `geno` / `rep`)
+- **THEN** `qc_inspect` passes the `ExperimentFrame`'s detected `genotype_col`,
+  `replicate_col`, and `sample_id_col` into the delegates that accept them
+
+#### Scenario: An undetected role column falls back to the delegate default
+
+- **WHEN** the `ExperimentFrame` reports a role column (e.g. `genotype_col`) as `None`
+- **THEN** `qc_inspect` lets the delegate use its default for that role rather than
+  forwarding `None`
+
+### Requirement: QC Inspect Operates on Raw Input and Reads via the Port
+
+The `qc_inspect` tool SHALL load its experiment frame through the injected `ExperimentReader`
+port as a **read-only inspector** of the raw missingness — it SHALL NOT request
+`require_clean=True` — and SHALL surface an unresolvable experiment as a structured error
+rather than a raw backend message.
+
+#### Scenario: Raw experiment is loaded for inspection
+
+- **WHEN** `qc_inspect` is invoked on an experiment that has a raw input
+- **THEN** the tool loads the raw frame and inspects its missingness, including any NaN-bearing
+  traits (an all-NaN or NaN-heavy trait is reportable, not an error)
+
+#### Scenario: Missing experiment is rejected with a structured error
+
+- **WHEN** the requested experiment cannot be resolved by the reader
+- **THEN** the tool returns a `BloomMCPError` with a code and remedy, and no run is produced
+
+### Requirement: QC Inspect Honors the Contract Envelope
+
+The `qc_inspect` tool SHALL be wrapped by `@as_mcp_tool` so that inputs and outputs are
+validated against declared Pydantic models, every declared/undeclared failure is mapped to a
+structured `BloomMCPError` (never a raw traceback or leaked backend internals), and a single
+`Provenance` is stamped per call. It SHALL accept the **same threshold parameters as
+`qc_clean`** (`max_zeros_per_trait`, `max_nans_per_trait`, `max_nans_per_sample`,
+`min_samples_per_trait`, optional `trait_columns`) so its threshold overlays and its
+recommendation reflect what a subsequent `qc_clean` would apply (the NaN/zero overlay lines
+reflect `max_nans_per_trait` / `max_zeros_per_trait`; `max_nans_per_sample` and
+`min_samples_per_trait` shape the cleanup log and therefore `traits_would_be_removed`).
+
+#### Scenario: Input/output schema round-trip
+
+- **WHEN** a valid request is serialized to the tool's input schema and the result is
+  validated against the output schema
+- **THEN** both validate without loss, and an invalid input (e.g. missing experiment, or a
+  threshold outside `[0,1]`) yields a `BloomMCPError` with an `input`/validation code
+
+#### Scenario: A caller-supplied trait column that is unknown or non-numeric is rejected
+
+- **WHEN** `trait_columns` names a column absent from the experiment, or a non-numeric
+  (metadata/identifier) column
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` whose message names
+  the offending column(s), rather than an opaque internal error
+
+#### Scenario: Errors surface as a structured envelope
+
+- **WHEN** a delegated computation or backend read/write raises
+- **THEN** the caller receives a `BloomMCPError` with a code and remedy, and no raw traceback
+  or backend path is leaked
+
+#### Scenario: Provenance is stamped and seed recorded as None
+
+- **WHEN** `qc_inspect` completes
+- **THEN** the stamped `Provenance` records the tool name, the threshold and trait-selection
+  params, and `seed = None` (QC inspection applies no `random_state`)
+
+### Requirement: QC Inspect Produces a Threshold-Aware Missingness Recommendation
+
+The `qc_inspect` tool SHALL return, inline, a structured recommendation that reports per-trait
+NaN fractions, the traits that exceed the supplied thresholds, the traits a `qc_clean` at
+those thresholds would remove (from the cleanup log), and a recommended `max_nans_per_trait`
+together with its consequence — which traits it would drop, the samples it would lose, and the
+samples a naive row-wise `dropna()` would lose instead — so the agent can pick a threshold
+before committing a `qc_clean` run.
+
+#### Scenario: Recommendation flags the NaN-heavy traits and minimizes sample loss (turface_19 oracle)
+
+- **WHEN** `qc_inspect` runs on the raw `turface_19` experiment (187 samples × 20 traits) at
+  the canonical `qc_clean` defaults (`max_nans_per_trait = 0.2`, `max_nans_per_sample = 0.0`)
+- **THEN** the per-trait NaN fractions report `Root_Biomass_mg` and `Root_Shoot_Ratio` at
+  ~0.155, both **under** the 0.2 default so neither is in `traits_would_be_removed` — and
+  because `max_nans_per_sample = 0.0`, keeping them drops their 29 NaN-bearing samples
+  (`samples_lost_at_current_params == 29`)
+- **AND** the recommendation proposes a `recommended_max_nans_per_trait` strictly below 0.155
+  whose `would_remove_traits` is exactly `{Root_Biomass_mg, Root_Shoot_Ratio}`, with
+  `samples_lost_at_recommendation == 0` versus `naive_dropna_samples_lost == 29`
+
+#### Scenario: Recommendation tracks the supplied thresholds
+
+- **WHEN** `qc_inspect` is invoked with `max_nans_per_trait = 0.1`
+- **THEN** `traits_would_be_removed` already contains `Root_Biomass_mg` and `Root_Shoot_Ratio`
+  (they exceed 0.1), and the recommendation reports zero additional residual-NaN traits and
+  zero sample loss at the supplied threshold
+
+#### Scenario: No NaN-bearing trait yields a no-change recommendation
+
+- **WHEN** `qc_inspect` runs on an experiment whose trait columns carry no NaNs that the
+  supplied thresholds would leave behind
+- **THEN** the recommendation reports "no change recommended" — `would_remove_traits` is empty
+  and `samples_lost_at_recommendation == 0` — rather than proposing a spurious lower threshold
+
+#### Scenario: An all-NaN trait is reported, not rejected
+
+- **WHEN** a trait column is entirely NaN
+- **THEN** the report lists that trait with a NaN fraction of 1.0 and includes it in
+  `traits_would_be_removed`, and the tool returns a report (it does not raise), because
+  `qc_inspect` inspects missingness rather than gating on it
+
+### Requirement: QC Inspect Persists a Versioned Report Run and Returns Links
+
+The `qc_inspect` tool SHALL persist its outputs as a versioned run via the `ResultStore` port
+under tool class `qc_inspect`, carrying the contract-stamped `Provenance` into the manifest,
+writing the EDA figures (PNG), the `inspect_nan_samples` CSV, and a `recommendation.json`, and
+SHALL return the small inline summary and recommendation together with **links** to the
+persisted artifacts (the `run_ref`, the `manifest_path`, and the per-output object keys) —
+never the figures or tables inline as blobs / base64.
+
+#### Scenario: Run is committed with provenance
+
+- **WHEN** `qc_inspect` completes successfully
+- **THEN** a `StoredRun` is recorded for `(experiment, "qc_inspect")` with a `run_ref`, a
+  manifest path, and the same `Provenance` (including `seed = None`) the contract stamped
+- **AND** the committed outputs include the EDA figure(s), the NaN-samples CSV, and the
+  recommendation JSON
+
+#### Scenario: Result returns links and a summary, not blobs
+
+- **WHEN** the tool returns its result
+- **THEN** the per-trait NaN summary and the structured recommendation are inline
+- **AND** the figures and the NaN-samples table are referenced via links (object keys +
+  manifest path) to the persisted run rather than embedded inline
+
+#### Scenario: Persisted figures round-trip as real bytes
+
+- **WHEN** the committed run's recorded artifacts are read back from the store
+- **THEN** each persisted PNG is a non-empty image whose stored bytes match the recorded
+  `output_sha256`, and the recommendation JSON deserializes to the same recommendation
+  returned inline
+
+### Requirement: QC Inspect Is Read-Only and Does Not Produce a Cleaned Version
+
+The `qc_inspect` tool SHALL be read-only with respect to the experiment data: it SHALL NOT
+write `CLEANED_CSV_NAME`, SHALL NOT persist under tool class `qc`, and SHALL NOT mutate the
+input frame. Its report run SHALL NOT be resolvable by the `ExperimentReader` as a cleaned
+version, so a later `load_experiment(require_clean=True)` never resolves a `qc_inspect` run.
+
+#### Scenario: A qc_inspect run is not a cleaned version
+
+- **WHEN** `qc_inspect` has committed a report run for an experiment that has no `qc_clean`
+  run, and a downstream caller loads it with `require_clean=True`
+- **THEN** the reader does **not** resolve the `qc_inspect` run as a cleaned version (it
+  surfaces the no-cleaned-version outcome the experiment-read capability already defines),
+  because `qc_inspect` wrote no `qc`-class `_cleaned.csv`
+
+#### Scenario: Report artifacts are distinct from a cleaned run
+
+- **WHEN** the `qc_inspect` run's committed outputs are listed
+- **THEN** they are the report artifact set (EDA figures, NaN-samples CSV, recommendation
+  JSON) under tool class `qc_inspect`, and contain no `CLEANED_CSV_NAME` artifact
+</content>

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/specs/bloommcp-qc-inspect-tool/spec.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/specs/bloommcp-qc-inspect-tool/spec.md
@@ -111,11 +111,23 @@ reflect `max_nans_per_trait` / `max_zeros_per_trait`; `max_nans_per_sample` and
 ### Requirement: QC Inspect Produces a Threshold-Aware Missingness Recommendation
 
 The `qc_inspect` tool SHALL return, inline, a structured recommendation that reports per-trait
-NaN fractions, the traits that exceed the supplied thresholds, the traits a `qc_clean` at
-those thresholds would remove (from the cleanup log), and a recommended `max_nans_per_trait`
-together with its consequence — which traits it would drop, the samples it would lose, and the
-samples a naive row-wise `dropna()` would lose instead — so the agent can pick a threshold
-before committing a `qc_clean` run.
+NaN fractions, the traits whose NaN fraction alone exceeds the supplied threshold
+(`traits_exceeding_thresholds`), the traits a `qc_clean` at those thresholds would remove (from
+the cleanup log, `traits_would_be_removed`) each with the delegate's removal reason
+(`removed_trait_reasons`, e.g. `too_many_nans` / `too_many_zeros` / `too_few_samples`, so the
+NaN-only and full-removal views never look contradictory without cause), and a recommended
+`max_nans_per_trait` together with its consequence — which traits it would drop, the samples it
+would lose, and the samples a naive row-wise `dropna()` would lose instead — so the agent can
+pick a threshold before committing a `qc_clean` run.
+
+The recommendation SHALL be **benefit-aware**: it recommends lowering `max_nans_per_trait` only
+when doing so strictly reduces sample loss below the current settings. When the current
+`max_nans_per_sample` already tolerates the missingness (so a drop would free no samples), it
+SHALL report `no_change_needed = True` with `recommended_max_nans_per_trait = None` rather than
+advise a drop that buys nothing. The recommended threshold drops **every** kept NaN-bearing
+trait above it at once; the recommendation SHALL therefore also report each such trait's
+individual missingness footprint (`offending_trait_nan_counts`) so the agent can weigh keeping a
+low-missingness trait instead of accepting the all-or-nothing drop.
 
 #### Scenario: Recommendation flags the NaN-heavy traits and minimizes sample loss (turface_19 oracle)
 
@@ -142,6 +154,16 @@ before committing a `qc_clean` run.
   supplied thresholds would leave behind
 - **THEN** the recommendation reports "no change recommended" — `would_remove_traits` is empty
   and `samples_lost_at_recommendation == 0` — rather than proposing a spurious lower threshold
+
+#### Scenario: A drop that frees no samples is not recommended
+
+- **WHEN** a kept trait still carries NaN but the supplied `max_nans_per_sample` is loose enough
+  that no sample is dropped (`samples_lost_at_current_params == 0`)
+- **THEN** the recommendation reports `no_change_needed = True` with
+  `recommended_max_nans_per_trait = None` and empty `would_remove_traits` — it does **not** advise
+  lowering `max_nans_per_trait` to drop the trait, because that would not reduce sample loss
+- **AND** it still reports the trait's `offending_trait_nan_counts` so the agent can see the
+  missingness it is choosing to keep
 
 #### Scenario: An all-NaN trait is reported, not rejected
 

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/specs/bloommcp-qc-inspect-tool/spec.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/specs/bloommcp-qc-inspect-tool/spec.md
@@ -70,6 +70,13 @@ rather than a raw backend message.
 - **WHEN** the requested experiment cannot be resolved by the reader
 - **THEN** the tool returns a `BloomMCPError` with a code and remedy, and no run is produced
 
+#### Scenario: Experiment must be a bare filename
+
+- **WHEN** `experiment` contains a path separator, a `..` segment, or is absolute/empty
+- **THEN** the tool rejects it with an `invalid_input` `BloomMCPError` **before any file read**,
+  so this read-and-persist tool cannot be turned into an arbitrary-file read whose contents
+  surface in committed artifacts
+
 ### Requirement: QC Inspect Honors the Contract Envelope
 
 The `qc_inspect` tool SHALL be wrapped by `@as_mcp_tool` so that inputs and outputs are
@@ -171,6 +178,14 @@ low-missingness trait instead of accepting the all-or-nothing drop.
 - **THEN** the report lists that trait with a NaN fraction of 1.0 and includes it in
   `traits_would_be_removed`, and the tool returns a report (it does not raise), because
   `qc_inspect` inspects missingness rather than gating on it
+
+#### Scenario: Non-finite values are surfaced, not silently read as complete
+
+- **WHEN** a trait carries `inf` / `-inf` values (which `isna` does not count as missing, so the
+  trait reads as ~0% NaN and would be kept)
+- **THEN** the result reports `per_trait_inf_count` for the affected traits and prepends an
+  explicit non-finite-values warning to the recommendation `rationale`, so the silent bias is
+  visible before it flows into a downstream analysis
 
 ### Requirement: QC Inspect Persists a Versioned Report Run and Returns Links
 

--- a/openspec/changes/add-bloommcp-qc-inspect-tool/tasks.md
+++ b/openspec/changes/add-bloommcp-qc-inspect-tool/tasks.md
@@ -1,0 +1,187 @@
+> **TDD note:** the RED steps (§2–§3) are a *local* working-tree rhythm — confirm each fails,
+> then make it pass. Do **not** push a RED-only commit (CI gates the PR head). Commit RED+GREEN
+> together. The tool module + its `register()` + the `server.py` registration line are **one
+> atomic commit** — never commit the server registration before the module exists (boot import
+> error → red head). Suggested commits: `chore(#360)` golden + fixture docs (green) →
+> `feat(#360)` tool + tests, atomic (green) → optional `refactor(#360)`.
+>
+> **Branch base & merge order (load-bearing — verified: #356 is OPEN and the fixture/helpers
+> exist only on its branch).** Base this change on **#356's branch** (`qc_clean`) while #356 is
+> open; **rebase onto `origin/staging` once #356 merges**; **never merge `qc_inspect` before
+> #356** — `turface_19_raw_data.csv` and the shared role/validation helpers do not exist on
+> `staging` until #356 lands, so a premature rebase reds the `python-audit` job. PR targets
+> `staging` (not `main`). Before #356 merges, reviewers review qc_inspect's diff **against the
+> #356 branch**, not against staging.
+
+## 1. Pre-work — reuse the raw fixture + record the inspection golden + share the helpers
+
+- [x] 1.1 Confirm the analyze pin already provides the EDA functions: `from sleap_roots_analyze
+      import create_trait_eda_plots, create_exploratory_summary_plots, inspect_nan_samples,
+      apply_data_cleanup_filters` imports on the pinned `0.1.0a3` (no `pyproject`/`uv.lock`
+      change — #356 already bumped it). Acceptance: import succeeds under `uv run --frozen`, and
+      `uv lock --check` stays **byte-identical** (the test/golden additions add no transitive, so
+      `scripts/check-uv-locks.py` must report no drift).
+- [x] 1.2 Reuse #356's raw fixture `bloommcp/tests/fixtures/turface_19_raw_data.csv` (no new
+      fixture). Record `bloommcp/tests/fixtures/turface_19_qc_inspect_golden.json` (LF, per
+      `.gitattributes`) from the LF-normalized raw fixture, computed **independently of the tool**:
+      full-precision per-trait NaN fractions for `Root_Biomass_mg` / `Root_Shoot_Ratio`
+      (**0.1551**, i.e. 29/187), and — at the canonical `max_nans_per_trait = 0.2` /
+      `max_nans_per_sample = 0.0` defaults — `traits_would_be_removed = []`, `samples_lost = 29`
+      (kept NaN-heavy traits force the sample drop), `residual_nan_cells = 0`,
+      `recommended_max_nans_per_trait` strictly `< 0.1551`, `would_remove_traits =
+      [Root_Biomass_mg, Root_Shoot_Ratio]`, `samples_lost_at_recommendation = 0`. **Do not**
+      restate the `naive_dropna = 29` /
+      two-trait facts — the existing `turface_19_qc_golden.json` README paragraph already owns
+      them; the new entry **cross-references** it (avoids a third drifting copy). Document the new
+      golden in `tests/fixtures/README.md` in the existing house style ("independently sourced,
+      not re-derived from the code under test").
+- [x] 1.3 Shared role/validation helpers. **Preferred:** the pure-move extraction of
+      `_role_kwargs` + `_validate_trait_subset` from `qc_clean_tool.py` into
+      `tools/_qc_shared.py` lands **in #356** (`refactor(#338)`), where that file is already
+      owned and tested — qc_inspect then simply **imports** `_qc_shared`, zero `qc_clean_tool.py`
+      conflict. **Fallback only if #356 won't take it:** perform the pure move here as a separate
+      `refactor(#360)` commit; acceptance: the existing `qc_clean` suite stays green (no behavior
+      change). Either way, qc_inspect depends on `_qc_shared`, not on `qc_clean`'s private symbols.
+
+## 2. RED — the recommendation oracle through the tool (north star, write first)
+
+- [x] 2.1 Add `bloommcp/tests/tools/test_qc_inspect_tool.py`; wire `_ports.configure(...)` with a
+      `FakeReader` serving the **raw** turface_19 fixture and a `FakeResultStore`.
+- [x] 2.2 Write the **recommendation oracle** test FIRST: invoke `qc_inspect` at the canonical
+      defaults (`max_nans_per_trait = 0.2`, `max_nans_per_sample = 0.0`); assert the per-trait NaN
+      fractions report the two traits at 0.1551, `traits_would_be_removed == []`,
+      `samples_lost_at_current_params == 29`, the recommendation's `would_remove_traits ==
+      {Root_Biomass_mg, Root_Shoot_Ratio}`, `samples_lost_at_recommendation == 0`, and
+      `recommended_max_nans_per_trait < 0.1551` (strict-less-than, full precision — guards an
+      off-by-epsilon flake). Confirm it fails (no tool yet).
+- [x] 2.3 Write the **threshold-tracking** assertion: at `max_nans_per_trait = 0.1` the two traits
+      are already in `traits_would_be_removed` and the recommendation reports zero residual sample
+      loss. Confirm RED.
+- [x] 2.4 **Zero-NaN "no-change" branch** (spec scenario + design Risk, currently untested): seed a
+      `FakeReader` frame with no NaNs in any trait; assert the recommendation reports "no change
+      recommended" (current thresholds lose zero samples), `would_remove_traits == []`, and
+      `samples_lost_at_recommendation == 0` — not a spurious lower threshold. Confirm RED.
+- [x] 2.5 **All-NaN / NaN-heavy trait is reportable, not an error** (spec "Raw experiment is loaded
+      for inspection"): seed a frame with one all-NaN trait; assert `qc_inspect` returns a report
+      (that trait's NaN fraction == 1.0 and it appears in `traits_would_be_removed`) and does
+      **not** raise. Confirm RED.
+
+## 3. RED — the remaining contract patterns + read-only + figure round-trip
+
+- [x] 3.1 `tools/list` presence: a FastMCP `Client` (the `asyncio.run(async with Client(server.mcp)
+      ...)` idiom from `test_package_baseline.py`) lists `qc_inspect` with an input schema;
+      `qc_clean` and `run_qc_workflow` still listed.
+- [x] 3.2 Schema round-trip: valid input/output validate; an invalid input (missing experiment, or
+      a threshold outside `[0,1]`) → `BloomMCPError`; assert the **code** is the input/validation
+      code (e.g. `exc.value.code == "invalid_input"`), not just that an error is raised.
+- [x] 3.3 Provenance + links: a successful call stamps `Provenance` with the tool name, the
+      threshold + trait-selection params, and `seed = None`; the persisted `StoredRun` for
+      `(experiment, "qc_inspect")` carries the same provenance and includes the EDA figure(s),
+      the NaN-samples CSV, and `recommendation.json`; the returned result references those via
+      links (object keys + manifest path) and embeds **no** figure/table blob inline.
+- [x] 3.4 Delegation pinning (spy on the analyze functions): assert `qc_inspect` calls
+      `create_trait_eda_plots` and `inspect_nan_samples` **exactly once** each and
+      `apply_data_cleanup_filters` **at least once** (it is also called to evaluate the recommended
+      threshold), forwards `barcode_col=frame.sample_id_col` / `genotype_col=…` / `replicate_col=…`
+      where accepted, and **never** calls the vendored `bloom_mcp.data_cleanup` filters.
+- [x] 3.4b **No figure-handle leak + headless backend** (guards the design's "close the rest" and
+      "Agg" decisions): record `len(matplotlib.pyplot.get_fignums())` before the call and assert it
+      returns to that baseline after `qc_inspect` (every created figure — including the unused
+      `create_exploratory_summary_plots` panels — was closed). Plus an import-time guard:
+      `assert matplotlib.get_backend().lower() == "agg"` after importing the tool module, so a
+      headless CI runner never trips a Tk backend.
+- [x] 3.5 Role-column fallback: seed a `FakeReader` frame whose role columns detect as `None`;
+      assert `qc_inspect` does **not** forward `None` (omits the kwarg / uses the default) and
+      still produces a report run.
+- [x] 3.6 Error envelope: an unresolvable experiment → `BloomMCPError` with a remedy and no run; a
+      delegate raise → structured error, no leaked traceback/path. **Plus a real-delegate
+      degenerate case (no mock):** pathological thresholds passed into `apply_data_cleanup_filters`
+      surface as a structured `BloomMCPError`, not the contract's opaque `internal_error` (the
+      distinction #356 found load-bearing for `qc_clean`).
+- [x] 3.7 `trait_columns` validation: an unknown column → `invalid_input` naming it; a non-numeric
+      column (e.g. `geno`) → `invalid_input` (shared `_validate_trait_subset`).
+- [x] 3.8 **Read-only structural assertion (fakes):** the committed run is under tool class
+      `qc_inspect` and its outputs contain **no** `CLEANED_CSV_NAME`. Necessary but **not
+      sufficient** for the resolver guarantee — see 3.8b.
+- [x] 3.8b **Read-only over the real resolver (negative composition — the load-bearing one):**
+      drive a `qc_inspect` run through `SupabaseResultStore` over the shared `_InMemoryObjectStore`
+      (the harness #356 stood up; `tests/conftest.py:41`), then assert a fresh
+      `SupabaseReader().load_experiment(_EXPERIMENT, require_clean=True)` raises
+      `CleanedVersionRequiredError` — the committed `qc_inspect` run is **not** resolved as a
+      cleaned version. The fakes' reader/store are disjoint and cannot exercise the resolver, so
+      this mirrors #356's *positive* composition test as its negative twin.
+- [x] 3.9 **Figure-persistence round-trip (real bytes, via the adapters — NOT the fake):** the
+      `FakeResultStore` deletes its staging dir at commit and retains no bytes, so commit a
+      `qc_inspect` run through `SupabaseResultStore` over the shared `_InMemoryObjectStore`. For
+      each committed PNG, read the stored bytes back by `output_keys[name]` and assert: non-empty,
+      begins with the PNG magic `b"\x89PNG\r\n\x1a\n"`, and `hashlib.sha256(bytes).hexdigest() ==
+      stored.output_sha256[name]`. Read back `recommendation.json` and assert it deserializes to
+      the recommendation returned inline.
+- [x] 3.10 Second run increments version: two `qc_inspect` runs → `v1`, `v2`; `latest` → `v2`.
+
+## 4. GREEN — implement the tool
+
+- [x] 4.1 Add `bloommcp/src/bloom_mcp/tools/qc_inspect_tool.py`: `QCInspectParams(BaseModel)`
+      (experiment, optional `trait_columns`, the same four cleanup thresholds as `qc_clean` with
+      `[0,1]` / positive-int validation, optional `user_label` — **no `seed`**) and a
+      `QCInspectResult` output model (raw `n_samples` / `n_traits`, per-trait NaN summary, the
+      nested `recommendation`, and links — object keys + `manifest_path` + `run_ref`).
+- [x] 4.2 **At the very top of the module, before any `from sleap_roots_analyze import …` and
+      before importing pyplot:** `import matplotlib; matplotlib.use("Agg"); import
+      matplotlib.pyplot as plt` (the `viz_tools.py:14-17` pattern — analyze's `visualization.py`
+      does a bare pyplot import with no backend set, so importing it first resolves to interactive
+      `tkagg` and crashes `savefig` headless). Implement `qc_inspect(params, *, provenance)`
+      wrapped by `@as_mcp_tool` (declares `provenance`, **not** `random_state`): load the **raw**
+      frame via `_ports.reader().load_experiment(name)` (no `require_clean`), mapping
+      `ExperimentReadError` → `BloomMCPError`; validate any `trait_columns` subset via the shared
+      helper.
+- [x] 4.3 Compute the report by delegation: one `apply_data_cleanup_filters(df, trait_cols,
+      **thresholds, **_role_kwargs(frame))` → `cleanup_log`; `create_trait_eda_plots(df,
+      trait_cols, thresholds={"nan": max_nans_per_trait, "zero": max_zeros_per_trait},
+      cleanup_log, min_samples_per_trait)`; the `missing_data_pattern` figure from
+      `create_exploratory_summary_plots`; `inspect_nan_samples` → CSV. Derive the recommendation
+      (see design). **`plt.close()` every figure, including the unused
+      `create_exploratory_summary_plots` panels** (no handle leak). **No EDA logic in the MCP**;
+      **no** `bloom_mcp.data_cleanup` call.
+- [x] 4.4 Persist via `_ports.store().create_run(experiment=…, tool_class="qc_inspect",
+      provenance=provenance, …)` → save the figure PNGs + `nan_samples.csv` + `recommendation.json`
+      into the run's staging dir → `commit(...)`; return the inline summary + recommendation +
+      links from the `StoredRun`. **Never** write `CLEANED_CSV_NAME` and **never** use tool class
+      `qc`.
+- [x] 4.5 Add `register(mcp)` using `bloom_mcp.contract.register(mcp, qc_inspect)`.
+- [x] 4.6 Register the module in `src/bloom_mcp/server.py` under "Direct tools (granular)" and add
+      `qc_inspect` to its module-docstring tool list — **in the same commit as 4.1–4.5** (the
+      registration line imports the module; splitting it reds the head).
+- [x] 4.7 Run the suite; debug to GREEN **without** weakening the recommendation oracle, the
+      read-only guarantee, or the figure round-trip.
+
+## 5. Refactor & verify
+
+- [x] 5.1 Refactor for clarity; keep the delegate → output-model mapping isolated. Confirm
+      `qc_clean` (now importing `_qc_shared`), `bloom_mcp.data_cleanup`, and `run_qc_workflow` are
+      untouched in behavior and the server still boots headless.
+- [x] 5.2 `/pre-merge`: lint (`black --check` + `ruff check`) + the exact CI suite command
+      `cd bloommcp && uv run --frozen --extra test pytest tests/` + `uv run --frozen` import +
+      `python scripts/check-uv-locks.py` (lock byte-identical) + the clean-env wheel import (the
+      new `_qc_shared.py` / `qc_inspect_tool.py` must import from the built wheel) +
+      `openspec validate add-bloommcp-qc-inspect-tool --strict` all green.
+- [ ] 5.3 Validate on **Claude Desktop** (capable model): `qc_inspect` is selectable, returns the
+      missingness recommendation, the figure links resolve, and a follow-up `qc_clean` run uses the
+      recommended threshold; sanity-check on the small-model surface that the structured result is
+      sane.
+
+## 6. Coordination / follow-ups (out of this change's spec deltas)
+
+- [ ] 6.1 `qc_clean` tie-in (message-only nudge to call `qc_inspect` when `n_samples_dropped > 0`):
+      **lands in #356's branch** — it modifies `qc_clean`'s tested output and keeps the spec change
+      with its capability. **This is NOT a deliverable of this change** (tracked here only as an
+      upstream dependency, so qc_inspect carries no dangling task).
+- [ ] 6.2 Roadmap Tier-table edit stays owned by **PR #339** (`eberrigan/bloommcp-tier3-qc`) — do
+      **not** edit `bloommcp/docs/roadmap.md` here. **Safeguard:** #339 currently owns the Tier-row
+      edit for *both* `qc_clean` and `qc_inspect` and has not landed; confirm `qc_inspect` is in
+      #339's scope, and if #339 stalls, file a follow-up so the roadmap is not left without either
+      tool.
+- [ ] 6.3 Optional live-persistence smoke leg for `qc_inspect` (report run + figure round-trip
+      through the real Supabase ports) — deferred unless a reviewer wants it in-scope (see design
+      Open Questions). `local-validation.md` correctly does not claim qc_inspect smoke coverage.
+</content>


### PR DESCRIPTION
## Summary

Adds **`qc_inspect`**, the read-only Tier-3 sibling of `qc_clean`: it visualizes trait
**NaN/missingness at QC time** and returns a structured **threshold recommendation**, so the
agent picks `qc_clean`'s cleanup thresholds with eyes open instead of running blind on the
defaults. Closes #360.

It reads the **raw** frame (no `require_clean`) and delegates **all** EDA to
`sleap-roots-analyze` — `apply_data_cleanup_filters` (cleanup log), `create_trait_eda_plots`,
the `missing_data_pattern` heatmap from `create_exploratory_summary_plots`, and
`inspect_nan_samples`. The MCP contains **no** EDA/plotting logic and never touches the vendored
`bloom_mcp.data_cleanup`. **No new dependency** (all four are public in the pinned
`sleap_roots_analyze`).

## Base branch

Targets **`staging`**. #356 (`qc_clean`) has **merged**, so this branch is rebased onto current
staging and its diff is self-contained — `qc_inspect`'s files plus the shared-helper extraction.
Since #356 merged *without* the `_qc_shared` extraction, this branch carries it (the fallback the
plan called for). **No pending dependency — do not hold on #356.**

## What's added

- `tools/qc_inspect_tool.py` — the contract-wrapped (`@as_mcp_tool`) tool: Pydantic I/O, one
  `Provenance` per call (`seed=None`), structured `BloomMCPError`s. Persists a versioned
  **report** run (per-trait EDA overview + variance + best-effort missingness heatmap +
  `nan_samples.csv` + `recommendation.json`) under a **distinct tool class `qc_inspect`** and
  returns the summary + recommendation inline with **links** — never inline blobs.
- `tools/_qc_shared.py` — `_role_kwargs` + `_validate_trait_subset` + `_validate_experiment_name`
  + the canonical `_CANONICAL_*` thresholds, single-sourced and imported by both tools so they
  cannot silently desync. Behaviour-preserving extraction (`qc_clean` imports them); two
  `qc_clean` remedy strings were reworded "clean" → "use" now that the helper serves both tools.
- `server.py` — registers `qc_inspect` under "Direct tools (granular)".
- `tests/tools/test_qc_inspect_tool.py` (~40 tests) + `turface_19_qc_inspect_golden.json` +
  fixtures README entry.

## Recommendation oracle (turface_19)

At qc_clean's canonical defaults (`max_nans_per_trait=0.2`, `max_nans_per_sample=0.0`), the two
15.5%-NaN traits (`Root_Biomass_mg`, `Root_Shoot_Ratio`) are *kept* and their **29 NaN-bearing
samples are dropped** (187 → 158) — the uncontrolled sample loss the QC tier prevents.
`qc_inspect` recommends `max_nans_per_trait == 0.15`, which drops the two traits instead and
**retains all 187 samples**. The golden pins this consequence (independently computed).

The recommendation is **benefit-aware**: it only advises lowering `max_nans_per_trait` when that
strictly reduces sample loss. If the current `max_nans_per_sample` already tolerates the
missingness (a drop frees no samples), it returns `no_change_needed=True` / `recommended=None`.
It reports each kept NaN-bearing trait's `offending_trait_nan_counts` (its sample footprint),
since the recommended threshold drops them all-or-nothing.

## Read-only guarantee

Writes a *report* under tool class `qc_inspect` — never `qc`, never `CLEANED_CSV_NAME` — so
`load_experiment(require_clean=True)` can never resolve it. Proven by a **negative composition
test** (real `SupabaseReader` over the in-memory object store raises `CleanedVersionRequiredError`).

## Review response (two 5-lens passes)

**First pass** (blocking + important): benefit-aware recommendation (no longer advises a
zero-sample drop); `removed_trait_reasons` (delegate's per-trait removal reason);
best-effort heatmap logged + subset-asserted; capitalized-roles forwarding test; corrected the
"pure move" claim; single-sourced canonical thresholds; golden `0.15` + 0.01-boundary test;
empty `trait_columns` rejected.

**Second pass** (approve-with-follow-ups):
- **Security** — `experiment` is guarded by a bare-filename check before any read
  (`_validate_experiment_name`), closing the path-traversal read-and-persist surface. Centralizing
  the same guard in `load_experiment_data` for the whole tool family is the noted cross-tool follow-up.
- **Data integrity** — `per_trait_inf_count` surfaces `inf`/`-inf` (which `isna` ignores), with a
  non-finite warning prepended to the recommendation rationale.
- **Robustness** — `_samples_lost` requires the delegate log keys (structured `internal_error` on
  drift, not a silent `0`); a tripwire test pins `_CANONICAL_*` to the live delegate signature
  defaults; documented the single-writer/global-pyplot assumption.
- **Coverage** — added tests for the rmtree-on-render-failure path, best-effort heatmap omission,
  `residual_nan_cells`, the auto-detected empty trait set, and the path guard.

## Verification

- **Full bloommcp suite: 284 passed** (`uv run --frozen --extra test pytest tests/`).
- ruff (0.9.9) + black (26.3.1) clean on changed files; `uv lock --check` clean — **no dependency change**.
- `matplotlib.use("Agg")` pinned before the analyze viz import; backend guard + figure-leak assertion.
- Figure round-trip asserts real PNG bytes (magic + `sha256`) through the Supabase adapters.

## Out of scope / follow-ups

- `qc_clean` → `qc_inspect` nudge (`n_samples_dropped > 0`): #356 merged without it, so it lands in
  follow-up **#401**, not here.
- Central `experiment` path guard in `load_experiment_data` for the whole tool family (cross-tool).
- Roadmap Tier-table edit stays owned by **#339**.
- Claude Desktop manual validation pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
