### PR TITLE
feat(#298): source-aware cyl trait read path (A2 read-path)

### DIFF
--- a/_WIKI/BLOOMMCP/README.md
+++ b/_WIKI/BLOOMMCP/README.md
@@ -109,7 +109,7 @@ source-disambiguated views instead:
 
 ```python
 # Latest source per scan (the default you almost always want)
-traits = client.table("cyl_scan_traits_latest").select("trait_id, value").limit(1000).execute()
+traits = client.table("cyl_scan_traits_latest").select("scan_id, trait_name, value").limit(1000).execute()
 
 # Full source/run dimension when you need it: source_id, source_name,
 # pipeline_run_id (the batch key), and an is_latest flag. Group/filter by

--- a/_WIKI/BLOOMMCP/README.md
+++ b/_WIKI/BLOOMMCP/README.md
@@ -7,7 +7,7 @@ What bloommcp is
 A Python-based [Model Context Protocol](https://modelcontextprotocol.io) server, implemented on top of [FastMCP](https://github.com/jlowin/fastmcp).
 It exposes plant-phenotyping analysis tools to LLM clients (today: the Langchain-agent running in this same stack) over MCP's streamable-HTTP transport on port 8811.
 
-Concretely it ports analysis routines from Elizabeth Berrigan's  `sleap-roots-analyze` workflow into MCP tools (QC, outlier detection, descriptive stats, PCA/UMAP, clustering, correlation, heritability, ANOVA).
+Concretely it ports analysis routines from Elizabeth Berrigan's `sleap-roots-analyze` workflow into MCP tools (QC, outlier detection, descriptive stats, PCA/UMAP, clustering, correlation, heritability, ANOVA).
 
 The LLM picks a workflow tool, bloommcp runs the analysis, and returns a structured payload — manifest path, summary stats, and a plot URL when applicable.
 
@@ -36,8 +36,8 @@ bloommcp/
 │   ├── cross_experiment_correlations.py
 │   ├── visualization.py
 │   ├── experiment_utils.py
-│   └── supabase_client.py   
-├── storage/   
+│   └── supabase_client.py
+├── storage/
 └── tools/
     ├── qc_tools.py
     ├── viz_tools.py
@@ -100,8 +100,32 @@ client = get_postgrest_client()
 # Read any public.* table
 species = client.table("species").select("*").execute()
 plants = client.table("plants").select("id, accession_id, sown_at").eq("experiment_id", 42).execute()
-traits = client.table("cyl_scan_traits").select("trait_id, value").limit(1000).execute()
 ```
+
+**Source-aware cyl trait reads.** A scan can carry multiple `cyl_trait_sources`
+(one per pipeline run — reprocessing mints a new `source_id`), so reading
+`cyl_scan_traits` **directly returns duplicate/cross-source rows**. Read the
+source-disambiguated views instead:
+
+```python
+# Latest source per scan (the default you almost always want)
+traits = client.table("cyl_scan_traits_latest").select("trait_id, value").limit(1000).execute()
+
+# Full source/run dimension when you need it: source_id, source_name,
+# pipeline_run_id (the batch key), and an is_latest flag. Group/filter by
+# pipeline_run_id for experiment-level "as of run X" analyses.
+runs = (
+    client.table("cyl_scan_traits_source")
+    .select("scan_id, trait_name, value, source_id, pipeline_run_id, is_latest")
+    .execute()
+)
+```
+
+The `get_scan_traits(experiment_id_, trait_name_, source_id_, run_id_)` RPC
+exposes the same selection (latest by default; pin a `source_id_`; group by
+`run_id_`). "Latest" = `max(source_id)` per scan; the rule lives once in
+`cyl_scan_traits_source` — see the `cyl-trait-read` spec and its migration for
+the definition (not restated here).
 
 See [`_WIKI/SUPABASE/README.md`](../SUPABASE/README.md) for the full
 role / RLS picture.
@@ -114,8 +138,8 @@ role / RLS picture.
 class** (from [`bloommcp/src/bloom_mcp/storage/writer.py`](../../bloommcp/src/bloom_mcp/storage/writer.py)), constructed via the `build_writer` factory in
 [`_helpers.py`](../../bloommcp/src/bloom_mcp/tools/workflows/_helpers.py).
 
-`AnalysisWriter` implements a versioned write contract: each  `(experiment, tool_class)` pair gets one folder in the `bloommcp-data` bucket containing a `manifest.json` that catalogs every run for that
-pair. 
+`AnalysisWriter` implements a versioned write contract: each `(experiment, tool_class)` pair gets one folder in the `bloommcp-data` bucket containing a `manifest.json` that catalogs every run for that
+pair.
 
 Each tool call appends a new `VersionEntry` to the same manifest and a new `v<N>_<date>_<slug>/` subfolder for its outputs.
 
@@ -136,7 +160,7 @@ Each tool's outputs land in a folder named after its `tool_class`.
 [`CANONICAL_TOOL_CLASSES`](../../bloommcp/src/bloom_mcp/storage/__init__.py).
 
 For the step-by-step guide to write a new workflow tool, see
-[writing-a-new-tool.md](./writing-a-new-tool.md). 
+[writing-a-new-tool.md](./writing-a-new-tool.md).
 
 For the underlying schema and the manifest's data model, see
 [storage-workflow.md](./storage-workflow.md).

--- a/openspec/changes/add-cyl-trait-read-source-aware/design.md
+++ b/openspec/changes/add-cyl-trait-read-source-aware/design.md
@@ -1,0 +1,163 @@
+## Context
+
+Changes D+E (merged #371) made `insert_cyl_result_envelope` the sole writer of `cyl_scan_traits` and
+mint one `cyl_trait_sources` row per pipeline run (`idempotency_key` UNIQUE; provenance in `metadata`
+jsonb). Schema relevant here:
+
+- `cyl_scan_traits(id, scan_id NOT NULL, value real, source_id BIGINT NULL → cyl_trait_sources(id),
+trait_id INT → cyl_traits(id))`, `UNIQUE (scan_id, source_id, trait_id)`, index on `scan_id`.
+- `cyl_trait_sources(id, name NOT NULL, metadata jsonb, idempotency_key text UNIQUE)`. **There is no
+  `created_at`/timestamp column** (confirmed) — so "latest" must be `max(id)`, which is monotonic
+  because identity ids increase as reprocessing mints new sources.
+- `cyl_traits(id, name UNIQUE)` — the trait-name registry.
+
+The contract `Provenance` (pinned `v0.1.0a2`, `contracts/schema/result_envelope.schema.json`) carries
+an **optional, nullable** `pipeline_run_id` that the schema documents as a batch key: _"One per-scan
+result: 1 envelope : 1 source row : 1 scan"_, and one pipeline run emits many such envelopes that share
+`pipeline_run_id`. The write-back RPC stores the whole provenance in `metadata` and sets
+`cyl_trait_sources.name = coalesce(metadata->>'pipeline_run_id', 'sleap-roots:' || idempotency_key)`.
+
+Current read surface (all source-blind):
+
+- `get_scan_traits(experiment_id_ BIGINT, trait_name_ TEXT)` — plain SQL, SECURITY INVOKER, joins
+  `cyl_scan_traits → cyl_traits`; sole caller `web/app/app/traits/[speciesId]/[experimentId]/TraitExplorer.tsx:194`.
+- `cyl_scan_trait_names` = `SELECT name FROM cyl_traits` — no runtime consumer (only generated types).
+- `cyl_trait_by_experiment_wave` (20260521140000) aggregates `cyl_scan_traits` and is the heavily-used
+  read path (langchain `cyl_tools.py`, web traits page) — **out of scope here** (deferred follow-up).
+
+## Goals / Non-Goals
+
+- **Goals:** latest-source-by-default reads with no duplicate rows and no cross-source mixing; a single
+  shared substrate so the "latest = max(id)" rule is defined once; optional pin-by-source and
+  group-by-run; full backward compatibility for the 2-arg caller; forward-only migration + rollback.
+- **Non-Goals (one broadened sibling issue, "repoint source-blind cyl trait readers"):** rebuilding
+  `cyl_trait_by_experiment_wave` (double-counts across sources; consumed by langchain + web traits
+  page); repointing `langchain/tools/cyl_tools.py` `get_scan_traits_tool` (source-blind direct read of
+  `cyl_scan_traits`, and **already broken** — it selects `trait_name`, dropped from `cyl_scan_traits`
+  in 20241119) at the new scan-grain surface, and refreshing `context_tools.py` `CONTEXT_CYL` (stale
+  schema: lists the dropped `trait_name`, omits `source_id`); image-grain reads (change B); a UI for
+  source selection. The substrate view is built so these repoints are trivial follow-ups.
+
+## Decisions
+
+- **D1 — "latest" = `max(source_id)` per scan, computed once in `cyl_scan_traits_source.is_latest`
+  with a window function.** `is_latest := source_id IS NOT DISTINCT FROM max(source_id) OVER (PARTITION
+BY scan_id)`. A window aggregate is a single pass (vs. a correlated subquery per row), which matters
+  for the predicate-less `cyl_scan_trait_names` consumer; the semantics are identical. `IS NOT DISTINCT
+FROM` makes the NULL≡NULL case true, so a **legacy scan whose rows all have `source_id IS NULL`**
+  (window max = NULL) keeps its rows (backward compat). When a scan has any non-null source, that
+  scan's window max is that non-null value for every row in the partition, so the NULL-source legacy
+  rows are correctly superseded. The view also exposes `trait_name` (LEFT JOIN `cyl_traits`) so the
+  function and the names view read it from the substrate and the view is self-sufficient for a future
+  scan-grain repoint of source-blind readers.
+- **D2 — latest is chosen at SCAN grain, then we take exactly that source's traits — no per-trait
+  "latest".** If the latest run produced fewer traits than an older run, the missing traits are simply
+  absent (we do **not** backfill from older sources). This is the explicit "no cross-source mixing"
+  guarantee; a per-`(scan, trait)` "latest" would Frankenstein values across runs.
+- **D3 — `get_scan_traits` is a single 4-arg function, old 2-arg dropped.** `CREATE OR REPLACE` cannot
+  add a parameter, and keeping two overloads makes a 2-named-arg PostgREST call ambiguous (PGRST203).
+  Dropping the 2-arg and creating one function with `source_id_ BIGINT DEFAULT NULL, run_id_ TEXT
+DEFAULT NULL` means exactly one candidate; a 2-arg call binds the defaults (verified over PostgREST
+  HTTP, not only direct SQL — the ambiguity only manifests in PostgREST's named-arg resolution).
+  Implemented in PL/pgSQL (needs `RAISE` for the both-args guard), `STABLE` (an intentional improvement
+  over the legacy function's default `VOLATILE`; it is read-only), SECURITY INVOKER (unchanged
+  posture). It reads `trait_name`/`value` from `cyl_scan_traits_source src` and joins
+  `cyl_scans → … → accessions` for the other output columns. The three-mode disjunction MUST be wrapped
+  as a **single parenthesized AND-operand** so the `source_id_`/`run_id_` branches stay conjoined with
+  the experiment+trait filter (`AND` binds tighter than `OR`; dropping the parens leaks rows from other
+  experiments):
+  `WHERE cyl_experiments.id = experiment_id_ AND src.trait_name = trait_name_ AND (
+   (source_id_ IS NULL AND run_id_ IS NULL AND src.is_latest)
+   OR (source_id_ IS NOT NULL AND src.source_id = source_id_)
+   OR (run_id_ IS NOT NULL AND src.source_id = (SELECT max(s2.source_id)
+         FROM cyl_scan_traits_source s2
+         WHERE s2.scan_id = src.scan_id AND s2.trait_id = src.trait_id
+           AND s2.pipeline_run_id = run_id_)) )`,
+  with a leading `IF source_id_ IS NOT NULL AND run_id_ IS NOT NULL THEN RAISE EXCEPTION`. The `run_id_`
+  branch selects each `(scan, trait)`'s **latest delivery within that run** (`max(source_id)` among that
+  run's rows) so a run with duplicate deliveries yields at most one row per `(scan, trait)` (no
+  `is_latest` filter — "as of run X" may return a scan's superseded run values by design). Result
+  columns keep their exact names/types/order, including `trait_value FLOAT` (the implicit `real→float8`
+  widening of `value`, which stays nullable) and `date_scanned` (the raw `cyl_scans.date_scanned`
+  `date` coerced to `text` — not reformatted via `to_char`, which would change the string the TS caller
+  parses). The `ORDER BY` MUST be **table-qualified** — `ORDER BY accessions.name, cyl_plants.id` — not
+  the legacy `ORDER BY accession_name, plant_id`: in a `LANGUAGE plpgsql` `RETURNS TABLE` function the
+  OUT columns are variables, and `cyl_scans.plant_id` is in scope, so bare `plant_id` is ambiguous and
+  (under the default `variable_conflict = error`) raises on **every** call. Qualify all sort/select
+  identifiers to their source tables to avoid OUT-variable/column collisions.
+- **D4 — `cyl_scan_traits_latest` and `cyl_scan_trait_names` are thin views on the substrate.**
+  `cyl_scan_traits_latest := SELECT scan_id, trait_id, trait_name, source_id, value FROM
+cyl_scan_traits_source WHERE is_latest`. `cyl_scan_trait_names := SELECT DISTINCT trait_name FROM
+cyl_scan_traits_latest WHERE trait_name IS NOT NULL ORDER BY trait_name` (the `IS NOT NULL` guard
+  stops an unresolved legacy row with `NULL` `trait_id` from surfacing a `NULL` name). No duplicated
+  max() logic anywhere.
+- **D5 — Grants are issued explicitly per object; `bloom_*` roles are load-bearing.** Each view uses
+  `WITH (security_invoker = on)` and an explicit `GRANT SELECT … TO bloom_agent, bloom_user,
+bloom_admin, authenticated`, mirroring the `cyl_trait_by_experiment_wave` precedent — but the grants
+  that actually gate the PostgREST read path are the **`bloom_*`** ones (the session role is
+  `bloom_user`/`bloom_agent` via `custom_access_token_hook`, not `authenticated`), so role tests use
+  `SET LOCAL ROLE bloom_user`/`bloom_agent` and assert reads of the **joined** `source_name` column
+  (a `security_invoker` view over a second table fails for a role lacking `SELECT` on
+  `cyl_trait_sources` even if the view grant succeeded). Critically, recreating `cyl_scan_trait_names`
+  via `DROP VIEW … CREATE VIEW …` **loses** its prior object-level grant (it relied on the one-time
+  `GRANT SELECT ON ALL TABLES` snapshot), so the migration MUST re-issue `GRANT SELECT ON
+public.cyl_scan_trait_names …` or the view becomes unreadable. `get_scan_traits` keeps the prior
+  default `PUBLIC` `EXECUTE` (the legacy 2-arg had no explicit grant); the migration MUST NOT copy the
+  adjacent write-back RPC's `REVOKE EXECUTE … FROM PUBLIC` block, which would break the read path. No
+  RLS or write policy changes.
+- **D6 — `pipeline_run_id` is exposed but treated as graceful-degrade.** It is optional/nullable in the
+  contract; when a producer omits it the source's `name` is a per-scan `sleap-roots:<key>` fallback, so
+  `run_id_`/`pipeline_run_id` grouping only returns rows for data whose producer set it. Latest and
+  pin-by-source paths are unaffected. The read path reads the one provenance attribute it needs
+  (`pipeline_run_id`); it does not otherwise depend on the opaque `metadata` shape.
+
+## Migration / Rollback
+
+Single forward-only migration `supabase/migrations/<ts>_cyl_trait_read_source_aware.sql`, in
+dependency order inside one transaction: (1) `CREATE OR REPLACE VIEW cyl_scan_traits_source` (+ grants);
+(2) `CREATE OR REPLACE VIEW cyl_scan_traits_latest` (+ grants); (3) `DROP VIEW IF EXISTS
+cyl_scan_trait_names; CREATE VIEW cyl_scan_trait_names …` (+ grants — the DROP+CREATE is needed here
+because the column set changes from the prior definition); (4) `DROP FUNCTION IF EXISTS
+public.get_scan_traits(bigint, text); CREATE FUNCTION public.get_scan_traits(bigint, text, bigint, text)`.
+Additive/non-destructive — no table or data is dropped or rewritten, so a single `supabase db push`
+applies it. Each created/recreated view re-issues its explicit `GRANT SELECT`. Companion
+`supabase/rollbacks/<ts>_cyl_trait_read_source_aware_rollback.sql` drops the two new views (dependents
+before the substrate), `DROP`s the four-argument `get_scan_traits` **before** restoring the prior
+`get_scan_traits(bigint, text)` body verbatim (`LANGUAGE SQL`) — otherwise both overloads coexist and
+reintroduce the PGRST203 ambiguity this change removes — and restores `cyl_scan_trait_names = SELECT
+name FROM cyl_traits`. The timestamp must be strictly greater than `20260630180000` (e.g.
+`20260701000000`). All five tracked `database.types.ts` copies are regenerated (hand-edited mirroring
+#371, since the local dev DB has a known migration gap; CI's `compose-health-check` is the authoritative
+signal that the migration applies), keeping the two new function args optional so the sole 2-arg TS
+caller still typechecks under `tsc --noEmit`.
+
+## Risks / Trade-offs
+
+- **`is_latest` is a `max(source_id) OVER (PARTITION BY scan_id)` window aggregate** in
+  `cyl_scan_traits_source` — a single partition/sort pass, not a per-row correlated subquery; the
+  predicate-less `cyl_scan_trait_names` consumer scans the whole table, mitigated by the existing
+  `cyl_scan_traits(scan_id)` index and modest scan-grain volume. `is_latest` is recomputed by readers
+  (a view column, not materialized) — acceptable at this scale; the substrate view is the single place
+  to optimize (e.g. materialize) if it ever isn't.
+- **The `run_id_` branch uses one correlated `max(source_id)` subquery** (evaluated only when `run_id_`
+  is set) to pick the latest delivery within a run — bounded by the `(scan, trait)` rows sharing that
+  run; acceptable.
+- **Dropping then recreating `get_scan_traits`** is atomic within the migration transaction, so no
+  window where the function is missing for live callers. The two new views use `CREATE OR REPLACE VIEW`
+  so the migration body is re-runnable (idempotent).
+
+## Testing (TDD)
+
+Integration tests in `tests/integration/test_cyl_read_path.py` using the `pg_conn` fixture
+(`supabase_admin`, BYPASSRLS, per-test rollback). Seed two sources for one scan by calling
+`insert_cyl_result_envelope` twice with the same `image_ids` but different `idempotency_key`,
+`pipeline_run_id`, and trait values; for `get_scan_traits` build the full
+species→experiment→wave→plant→accession→scan→images chain. Oracle: default returns the latest source's
+values (no duplicate rows, no mixing); pinning the older `source_id` returns the older values; `run_id_`
+returns a run's values across scans; both args error; a 2-arg call still works; a legacy NULL-source
+scan is still returned; `cyl_scan_trait_names` lists distinct latest names. Tests are written RED first.
+
+## Open Questions
+
+- None blocking. Producer population of `pipeline_run_id` (D6) is a sleap-roots-pipeline concern tracked
+  on the roadmap, not by this change.

--- a/openspec/changes/add-cyl-trait-read-source-aware/design.md
+++ b/openspec/changes/add-cyl-trait-read-source-aware/design.md
@@ -88,9 +88,10 @@ DEFAULT NULL` means exactly one candidate; a 2-arg call binds the defaults (veri
 - **D4 — `cyl_scan_traits_latest` and `cyl_scan_trait_names` are thin views on the substrate.**
   `cyl_scan_traits_latest := SELECT scan_id, trait_id, trait_name, source_id, value FROM
 cyl_scan_traits_source WHERE is_latest`. `cyl_scan_trait_names := SELECT DISTINCT trait_name FROM
-cyl_scan_traits_latest WHERE trait_name IS NOT NULL ORDER BY trait_name` (the `IS NOT NULL` guard
-  stops an unresolved legacy row with `NULL` `trait_id` from surfacing a `NULL` name). No duplicated
-  max() logic anywhere.
+cyl_scan_traits_latest WHERE trait_name IS NOT NULL ORDER BY trait_name`, emitted `AS name` so the
+  view's output column stays `name` (its stable contract, unchanged from the prior definition). The
+  `IS NOT NULL` guard stops an unresolved legacy row with `NULL` `trait_id` from surfacing a `NULL`
+  name. No duplicated max() logic anywhere.
 - **D5 — Grants are issued explicitly per object; `bloom_*` roles are load-bearing.** Each view uses
   `WITH (security_invoker = on)` and an explicit `GRANT SELECT … TO bloom_agent, bloom_user,
 bloom_admin, authenticated`, mirroring the `cyl_trait_by_experiment_wave` precedent — but the grants
@@ -145,6 +146,14 @@ caller still typechecks under `tsc --noEmit`.
 - **Dropping then recreating `get_scan_traits`** is atomic within the migration transaction, so no
   window where the function is missing for live callers. The two new views use `CREATE OR REPLACE VIEW`
   so the migration body is re-runnable (idempotent).
+- **Known coupling — `cyl_scan_traits_source` reads `cyl_trait_sources.metadata`** (for
+  `pipeline_run_id`), so the change-A break-glass rollback
+  (`supabase/rollbacks/20260609000000_add_cyl_trait_source_provenance_rollback.sql`), which
+  `DROP COLUMN metadata`, must use `CASCADE` — otherwise it errors with `DependentObjectsStillExist`
+  while these read-path views exist. That rollback therefore cascade-drops the three read-path views;
+  restore them by re-running this migration. A regression test
+  (`test_change_a_rollback_cascades_read_views`) pins this invariant. To roll back _this_ change alone,
+  use its own rollback, which drops the views before touching the base tables.
 
 ## Testing (TDD)
 

--- a/openspec/changes/add-cyl-trait-read-source-aware/proposal.md
+++ b/openspec/changes/add-cyl-trait-read-source-aware/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The write-back RPC (`insert_cyl_result_envelope`, merged #371) mints a **new** `cyl_trait_sources` row
+per pipeline run, so a reprocessed scan now carries **multiple** sources and the source-blind
+`get_scan_traits(experiment_id_, trait_name_)` returns **duplicate/ambiguous rows** (one per source).
+This change makes the cyl trait READ path source-aware — latest source per scan by default, with
+optional source-pin and pipeline-run grouping — and is backward-compatible for existing callers
+(roadmap A2 "read-path", bloom#298; read-path ≡ bloom-mcp data-access "Supabase data access" section,
+"shared source-aware reads, latest = max(id)"). No source-aware read view/RPC exists yet, so this
+builds the **single shared** read surface rather than a divergent second one.
+
+## What Changes
+
+- **New shared substrate view `cyl_scan_traits_source`** — the single source of truth for source-aware
+  reads. One row per `cyl_scan_traits` row, exposing `scan_id, trait_id, trait_name, value, source_id,
+source_name, pipeline_run_id (= cyl_trait_sources.metadata->>'pipeline_run_id'), is_latest`, where
+  `is_latest = source_id IS NOT DISTINCT FROM max(source_id) OVER (PARTITION BY scan_id)` (single-pass;
+  legacy NULL-source rows count as latest). Every other read object is defined on top of this view, so
+  the "latest = max(id)" rule lives in exactly one place. Carrying `trait_name`/`source_id`/`is_latest`
+  also makes the view directly usable for a future scan-grain repoint of source-blind readers.
+- **New `cyl_scan_traits_latest` view** = `cyl_scan_traits_source WHERE is_latest` — the canonical
+  latest-per-scan surface for direct PostgREST readers.
+- **MODIFY `get_scan_traits`** to a single function
+  `get_scan_traits(experiment_id_ BIGINT, trait_name_ TEXT, source_id_ BIGINT DEFAULT NULL,
+run_id_ TEXT DEFAULT NULL)`: both NULL ⇒ latest per scan; `source_id_` ⇒ pin one source (scan
+  grain); `run_id_` ⇒ each scan's values from one pipeline run (experiment grain, "as of run X" — the
+  latest delivery per scan within that run, so a run that delivered a scan twice does not duplicate
+  rows); both set ⇒ error. The legacy 2-arg function is dropped and replaced by this one (no PostgREST
+  overload ambiguity); 2-arg callers keep working via the defaults.
+- **MODIFY `cyl_scan_trait_names`** to list `DISTINCT` trait names present in
+  `cyl_scan_traits_latest` (source-disambiguated; restores its "names actually measured" intent).
+- **Forward-only migration** + companion manual rollback under `supabase/rollbacks/`; regenerate the
+  tracked `database.types.ts` files.
+
+## Impact
+
+- Affected specs: **new** capability `cyl-trait-read`.
+- Affected code:
+  - `supabase/migrations/` (new read-path migration), `supabase/rollbacks/` (companion rollback).
+  - Five tracked `database.types.ts` copies (hand-edited, mirroring #371): `web/lib/database.types.ts`,
+    `web/types/database.types.ts`, `packages/bloom-js/src/types/database.types.ts`,
+    `packages/bloom-fs/src/types/database.types.ts`,
+    `packages/bloom-nextjs-auth/src/lib/database.types.ts`.
+  - `_WIKI/BLOOMMCP/README.md` — in the **"Supabase data access"** section, **rewrite** the
+    `client.table("cyl_scan_traits")` read example to read `cyl_scan_traits_latest` (and mention
+    `cyl_scan_traits_source` for the source/run dimension), so the doc stops teaching the source-blind
+    pattern. Cross-reference the spec/migration for the latest-selection rule; do not restate it.
+- Backward compatible: the only 2-arg `get_scan_traits` call site
+  (`web/app/app/traits/[speciesId]/[experimentId]/TraitExplorer.tsx:194`) is unchanged — the two new
+  args are optional, so it binds the defaults; for single-source scans behaviour is identical, and for
+  multi-source scans it now returns the latest instead of duplicates. Reads stay open to the existing
+  read roles (no RLS or write-grant change).
+- **Non-goals (deferred), tracked in one broadened sibling issue** "repoint source-blind cyl trait
+  readers at the latest-source surface":
+  - Rebuilding the `cyl_trait_by_experiment_wave` aggregate view (langchain `cyl_tools.py` + web traits
+    page) to be source/run-aware — it currently **double-counts across sources**.
+  - Repointing `langchain/tools/cyl_tools.py` `get_scan_traits_tool` (a source-blind direct read of
+    `cyl_scan_traits`) at the new scan-grain surface. Note it is **already broken** independent of this
+    change — it selects `trait_name`, a column dropped from `cyl_scan_traits` in the 20241119 refactor —
+    and `context_tools.py` `CONTEXT_CYL` documents that stale schema (lists the dropped `trait_name`,
+    omits `source_id`). The substrate view exposes `trait_name`/`source_id`/`is_latest` to make this
+    repoint a trivial follow-up.
+  - Change B (image-grain `source_id`) stays deferred and is not a blocker — this read path is for
+    `cyl_scan_traits`, which already has `source_id`.

--- a/openspec/changes/add-cyl-trait-read-source-aware/specs/cyl-trait-read/spec.md
+++ b/openspec/changes/add-cyl-trait-read-source-aware/specs/cyl-trait-read/spec.md
@@ -1,0 +1,225 @@
+## ADDED Requirements
+
+### Requirement: Canonical source-aware trait view
+
+Bloom SHALL provide a `cyl_scan_traits_source` view that is the single source of truth for
+source-aware cyl scan-trait reads. It SHALL expose one row per `cyl_scan_traits` row with the columns
+`scan_id`, `trait_id`, `trait_name` (the resolved `cyl_traits.name`), `value`, `source_id`,
+`source_name` (the producing `cyl_trait_sources.name`), `pipeline_run_id` (the batch key
+`cyl_trait_sources.metadata->>'pipeline_run_id'`, nullable), and a boolean `is_latest`. `is_latest`
+SHALL be true exactly when the row's `source_id` equals `max(source_id) OVER (PARTITION BY scan_id)`,
+compared with `IS NOT DISTINCT FROM` so that a scan whose rows all have a `NULL` `source_id` (legacy
+data) is treated as latest. "Latest" is defined as `max(source_id)` per scan because
+`cyl_trait_sources` has no timestamp column and identity ids increase monotonically as reprocessing
+mints new sources. The view SHALL use `security_invoker`, SHALL be granted `SELECT` to the read roles,
+and SHALL be the only place the latest-selection rule is defined; every other read object is built on
+it. Exposing `trait_name`/`source_id`/`is_latest` makes the view directly usable for scan-grain reads.
+
+#### Scenario: View exposes the source dimension for each trait row
+
+- **WHEN** a scan has trait rows written by a source
+- **THEN** `cyl_scan_traits_source` returns those rows with `source_id`, `source_name`, and
+  `pipeline_run_id` populated from that source, and `value`/`scan_id`/`trait_id` unchanged
+
+#### Scenario: is_latest marks the max-source rows per scan
+
+- **WHEN** a scan has trait rows from two sources (an original and a higher-id reprocess)
+- **THEN** only the rows from the higher `source_id` have `is_latest = true`, and the original
+  source's rows have `is_latest = false`
+
+#### Scenario: Legacy NULL-source rows are treated as latest
+
+- **WHEN** a scan has only trait rows whose `source_id` is `NULL`
+- **THEN** those rows have `is_latest = true` (so legacy scans remain readable by default)
+
+#### Scenario: pipeline_run_id is surfaced from source metadata
+
+- **WHEN** a source row's `metadata` contains a `pipeline_run_id`
+- **THEN** every `cyl_scan_traits_source` row for that source exposes that value in `pipeline_run_id`,
+  and rows whose source has no `pipeline_run_id` expose `NULL`
+
+### Requirement: Latest-source-by-default scan trait reads
+
+Bloom SHALL provide a `cyl_scan_traits_latest` view equal to the `is_latest` rows of
+`cyl_scan_traits_source`, and the default read path SHALL return, per scan, only the latest source's
+traits. A scan with multiple sources SHALL NOT yield duplicate or cross-source-mixed rows: the latest
+source is chosen at scan grain and exactly that source's traits are returned (traits the latest run did
+not produce are absent rather than backfilled from an older source). For **source-bearing** data the
+latest view yields at most one row per `(scan, trait)`, because `cyl_scan_traits` is
+`UNIQUE (scan_id, source_id, trait_id)` and a single latest source is chosen per scan. Pre-existing
+**legacy `NULL`-source** rows are surfaced as-is (the legacy schema's `UNIQUE` is vacuous for `NULL`
+`source_id`, so it could permit two `NULL`-source rows for one `(scan, trait)`; the sole-writer RPC can
+no longer create such rows). A latest-source trait whose `value` is `NULL` (the write-back RPC stores
+`NULL` for non-finite values) SHALL still be returned as a `NULL`-valued row — the trait was measured;
+non-finite is not absent — matching the legacy function's no-value-filter behavior.
+
+#### Scenario: Default read returns the latest source's values only
+
+- **WHEN** a scan has two sources carrying different values for the same trait and the default path is
+  read (no source argument)
+- **THEN** only the latest source's value is returned for that scan, with no duplicate rows for the
+  trait
+
+#### Scenario: No cross-source mixing when the latest run dropped a trait
+
+- **WHEN** an older source wrote traits A and B for a scan and the latest source wrote only trait A
+- **THEN** the default read returns A from the latest source and does **not** return B (no backfill
+  from the older source)
+
+#### Scenario: Latest view has no duplicate rows per scan and trait
+
+- **WHEN** `cyl_scan_traits_latest` is queried for a source-bearing scan with multiple sources
+- **THEN** it returns at most one row per `(scan_id, trait_id)`
+
+#### Scenario: A non-finite latest value is surfaced as NULL, not dropped
+
+- **WHEN** the latest source for a scan stored a `NULL` `value` for a trait (a non-finite measurement)
+- **THEN** the default read returns that trait as a row with `trait_value = NULL` (it is not omitted)
+
+### Requirement: Source-pinned and run-grouped get_scan_traits
+
+Bloom SHALL replace `get_scan_traits` with a single function
+`get_scan_traits(experiment_id_ BIGINT, trait_name_ TEXT, source_id_ BIGINT DEFAULT NULL,
+run_id_ TEXT DEFAULT NULL)` returning the same result columns as before
+(`scan_id, date_scanned, plant_age_days, wave_number, plant_id, germ_day, plant_qr_code,
+accession_name, trait_name, trait_value`). The legacy two-argument function SHALL be dropped so exactly
+one candidate exists (no PostgREST overload ambiguity), and a caller passing only `experiment_id_` and
+`trait_name_` SHALL behave as before via the defaults. With both optional arguments `NULL` the function
+SHALL return the latest source per scan; with `source_id_` set it SHALL return only that source's rows
+(scan-grain pin); with `run_id_` set it SHALL return each scan's values from the pipeline run whose
+`pipeline_run_id` equals `run_id_` (experiment-grain "as of run X"). The `run_id_` path selects rows by
+the run, **not** by the global latest — so a scan that a newer run has since superseded still
+contributes its `run_id_` values (no implicit latest filter), which is the point of "as of run X". To
+keep the result unambiguous, when a run delivered the same `(scan, trait)` more than once (distinct
+`idempotency_key`/`source_id` but the same `pipeline_run_id`), the `run_id_` path SHALL return only the
+**latest delivery within that run** (`max(source_id)` among that run's rows for the `(scan, trait)`),
+yielding at most one row per `(scan, trait)`. Supplying both `source_id_` and `run_id_` SHALL raise an
+error rather than return an ambiguous result.
+
+#### Scenario: Backward-compatible two-argument call returns latest
+
+- **WHEN** an existing caller invokes `get_scan_traits(experiment_id_, trait_name_)` with no source
+  argument for an experiment whose scans have multiple sources
+- **THEN** the call succeeds and returns the latest source per scan, one row per scan for the trait
+
+#### Scenario: Pinning an older source returns the older values
+
+- **WHEN** `get_scan_traits` is called with `source_id_` set to a scan's older source
+- **THEN** it returns that source's (older) trait values for that scan
+
+#### Scenario: Run id groups an experiment by pipeline run
+
+- **WHEN** `get_scan_traits` is called with `run_id_` set to a `pipeline_run_id` shared by several
+  scans' sources in the same experiment
+- **THEN** it returns those scans' values from the matching run (one row per such scan)
+
+#### Scenario: Run id returns a scan's run values even after a newer run superseded it
+
+- **WHEN** scan A was processed by `run-1` then reprocessed by a newer `run-2`, scan B only by `run-1`,
+  and `get_scan_traits` is called with `run_id_ = 'run-1'`
+- **THEN** it returns scan A's `run-1` values (not A's newer `run-2` values) together with scan B's
+  `run-1` values — selection is by run, without an implicit global-latest filter
+
+#### Scenario: Duplicate deliveries within one run do not duplicate rows
+
+- **WHEN** one pipeline run delivered the same `(scan, trait)` twice (two sources with distinct
+  `source_id` but the same `pipeline_run_id`) and `get_scan_traits` is called with that `run_id_`
+- **THEN** it returns a single row for that `(scan, trait)` — the latest delivery within the run
+  (`max(source_id)`)
+
+#### Scenario: A run id matching no source returns no rows
+
+- **WHEN** `get_scan_traits` is called with `run_id_` set to a value that no source's `pipeline_run_id`
+  carries (e.g. the producer omitted `pipeline_run_id`, so the source's `pipeline_run_id` is `NULL`)
+- **THEN** the call returns zero rows and does not raise
+
+#### Scenario: Supplying both source*id* and run*id* is rejected
+
+- **WHEN** `get_scan_traits` is called with both `source_id_` and `run_id_` non-null
+- **THEN** the call raises an error and returns no rows
+
+#### Scenario: Result columns and ordering are preserved
+
+- **WHEN** `get_scan_traits` returns rows for an experiment whose accessions are not in insertion order
+- **THEN** the result columns are exactly `scan_id, date_scanned, plant_age_days, wave_number,
+plant_id, germ_day, plant_qr_code, accession_name, trait_name, trait_value` (same names, types, and
+  order as before) and rows are ordered by `accession_name, plant_id`
+
+#### Scenario: An experiment with no matching traits returns cleanly
+
+- **WHEN** `get_scan_traits` is called for an experiment/trait combination that has no trait rows
+- **THEN** the call returns zero rows without error
+
+### Requirement: Source-disambiguated trait-name listing
+
+The `cyl_scan_trait_names` view SHALL list the non-null `DISTINCT` trait names present in the
+latest-source data (the `trait_name` column of `cyl_scan_traits_latest`, filtered `WHERE trait_name IS
+NOT NULL` so an unresolved legacy row with a `NULL` `trait_id` cannot surface a `NULL` name), so the
+trait-name listing reflects traits actually measured in current (latest-source) data rather than every
+registered name. Because the view is dropped and recreated, the migration SHALL re-issue its
+`GRANT SELECT` to the read roles (the prior object-level read access does not survive `DROP VIEW`).
+
+#### Scenario: Lists distinct names present in latest data
+
+- **WHEN** the latest sources across scans have measured a set of trait names
+- **THEN** `cyl_scan_trait_names` returns each such name exactly once
+
+#### Scenario: A name only in a superseded source is excluded
+
+- **WHEN** a trait name was measured only by an older source that a later source has superseded (the
+  latest source did not measure it)
+- **THEN** that name is absent from `cyl_scan_trait_names`
+
+### Requirement: Read path stays open to read roles with no RLS change
+
+The new views SHALL grant `SELECT` to the existing read roles (`bloom_agent`, `bloom_user`,
+`bloom_admin`, `authenticated`) using `security_invoker`, and `get_scan_traits` SHALL remain callable by
+the existing read roles. This change SHALL NOT add, drop, or alter any row-level-security policy or any
+write grant on `cyl_scan_traits`, `cyl_trait_sources`, or `cyl_traits`; it is read-only and does not
+widen write access.
+
+#### Scenario: Read roles can use the new read surface
+
+- **WHEN** a session assumes each of `bloom_agent`, `bloom_user`, `bloom_admin`, and `authenticated`
+  and selects from `cyl_scan_traits_source`, `cyl_scan_traits_latest`, and `cyl_scan_trait_names`
+  (including the joined `source_name` column), and calls `get_scan_traits`
+- **THEN** each read and call is permitted
+
+#### Scenario: No write capability is added
+
+- **WHEN** the change is applied
+- **THEN** no new policy or grant permits any role to write `cyl_scan_traits`, `cyl_trait_sources`, or
+  `cyl_traits` that could not already do so before the change
+
+### Requirement: Additive, non-destructive read-path migration
+
+The read-path migration SHALL be **additive only** — it MUST NOT drop or rewrite any table, column, or
+data — so a single forward `supabase db push` applies it. Replacing `get_scan_traits` and
+`cyl_scan_trait_names` SHALL recreate them within the same migration transaction so live callers see no
+missing-object window, and each created/recreated view SHALL re-issue its `GRANT SELECT` to the read
+roles. The migration SHALL NOT `REVOKE` the function's default `PUBLIC` `EXECUTE` (the read RPC stays
+callable as before). A companion manual rollback script SHALL be provided under `supabase/rollbacks/`
+that drops the two new views (dependents before the substrate), `DROP`s the four-argument
+`get_scan_traits` **before** restoring the prior two-argument `LANGUAGE SQL` definition (so no overload
+ambiguity is reintroduced), and restores `cyl_scan_trait_names = SELECT name FROM cyl_traits`. All five
+tracked Supabase `database.types.ts` copies SHALL be regenerated to include the new views and the
+updated four-argument function signature, with the two new arguments optional.
+
+#### Scenario: Forward migration adds the read surface without touching data
+
+- **WHEN** the migration is applied to a database that already has `cyl_scan_traits`,
+  `cyl_trait_sources`, and `cyl_traits`
+- **THEN** `cyl_scan_traits_source` and `cyl_scan_traits_latest` are created, `get_scan_traits` and
+  `cyl_scan_trait_names` are redefined, and no pre-existing table or data is altered
+
+#### Scenario: Recreated trait-names view stays readable by read roles
+
+- **WHEN** a session assumes `bloom_agent` (and likewise `bloom_user`) after the migration and selects
+  from the recreated `cyl_scan_trait_names`
+- **THEN** the read is permitted (the migration re-issued the view's `GRANT SELECT`)
+
+#### Scenario: Rollback restores the prior read surface without overload ambiguity
+
+- **WHEN** the companion rollback script is applied to a database where the migration had been applied
+- **THEN** the two new views no longer exist, exactly one `get_scan_traits` function remains and it has
+  the two-argument signature, and `cyl_scan_trait_names` is back to `SELECT name FROM cyl_traits`

--- a/openspec/changes/add-cyl-trait-read-source-aware/tasks.md
+++ b/openspec/changes/add-cyl-trait-read-source-aware/tasks.md
@@ -181,7 +181,7 @@
       `client.table("cyl_scan_traits").select(...)` example to read `cyl_scan_traits_latest` (note
       `cyl_scan_traits_source` for the source/run dimension); cross-reference the spec/migration for the
       latest-selection rule rather than restating it. Cite the section by name (it is unnumbered).
-- [ ] 6.2 File the broadened sibling issue "repoint source-blind cyl trait readers at the latest-source
+- [x] 6.2 File the broadened sibling issue "repoint source-blind cyl trait readers at the latest-source
       surface" (covering: rebuild `cyl_trait_by_experiment_wave` on `cyl_scan_traits_latest`; repoint +
       fix `cyl_tools.py` `get_scan_traits_tool`; refresh `context_tools.py` `CONTEXT_CYL`). Reference it
       from the PR body so the deferral is durably tracked before the change folder is archived.

--- a/openspec/changes/add-cyl-trait-read-source-aware/tasks.md
+++ b/openspec/changes/add-cyl-trait-read-source-aware/tasks.md
@@ -1,0 +1,187 @@
+## 1. Test scaffolding (RED first)
+
+- [x] 1.1 Add `tests/integration/test_cyl_read_path.py` using the `pg_conn` fixture (supabase_admin,
+      BYPASSRLS, per-test rollback). Add helpers mirroring `test_cyl_writeback_rpc.py`
+      (`_envelope`/`_trait`/`_call`, `_sql_body` for stripping `BEGIN;/COMMIT;` CRLF-safely) and a
+      `_seed_experiment_scan(cur, *, accession=None)` building the full join chain. The bare
+      writeback `_seed_scan` (just `INSERT INTO cyl_scans DEFAULT VALUES`) gives `plant_id = NULL`, which
+      `get_scan_traits`'s INNER joins exclude → **empty result sets that make tests falsely green**. The
+      required INSERT recipe (satisfy every NOT-NULL and required-for-join FK; nullable-in-DDL FKs still
+      must be set):
+      `species DEFAULT VALUES` → `cyl_experiments(name NOT NULL, species_id)` →
+      `cyl_waves(experiment_id, number)` → `accessions(name)` (**`name` is NOT NULL + UNIQUE** — generate
+      distinct names per accession, needed for the 2.13 two-accession ordering test) →
+      `cyl_plants(wave_id, accession_id, germ_day, qr_code)` →
+      `cyl_scans(plant_id, date_scanned, plant_age_days)` → `cyl_images(scan_id)`. Return
+      `(experiment_id, scan_id, image_ids)`; generalize to seed **N scans (and N accessions) under one
+      experiment**.
+- [x] 1.2 Helper `_seed_two_sources(cur, image_ids, *, run_ids=(...), values=(...))` calls
+      `insert_cyl_result_envelope` twice with the **same** `image_ids` but **distinct**
+      `idempotency_key` (else the 2nd call is a pure no-op) and distinct `pipeline_run_id`/trait values;
+      the higher (second) `source_id` is "latest". Keep each trait's `scan_key` equal to the envelope's
+      `provenance.scan_key` (the RPC rejects a mismatch; the mirrored `_trait`/`_envelope` helpers both
+      default to `SK1`, so this holds unless overridden).
+
+## 2. Failing tests covering every spec scenario (RED; one `def test_...` per assertion)
+
+- [x] 2.0 `test_two_sources_one_scan_seed` — after `_seed_two_sources`, assert exactly 2 distinct
+      `cyl_trait_sources` rows, both `cyl_scan_traits.scan_id` = the seeded scan, `max(source_id)` = the
+      2nd source (the linchpin every is_latest test stands on).
+- [x] 2.1 `cyl_scan_traits_source` exposes `source_id`/`source_name`/`pipeline_run_id`/`trait_name` with
+      `value`/`scan_id`/`trait_id` unchanged. (Scenario: View exposes the source dimension)
+- [x] 2.2 `is_latest = true` only for the higher-`source_id` rows; original-source rows `false`.
+      (Scenario: is_latest marks the max-source rows per scan)
+- [x] 2.3 A scan whose rows all have `source_id IS NULL` has `is_latest = true`. Seed via
+      `_seed_experiment_scan` (a real plant-chained scan, so 2.15 can read it through `get_scan_traits`)
+      then **direct INSERT** the NULL-`source_id` `cyl_scan_traits` rows against that `scan_id` as
+      supabase_admin (BYPASSRLS; no FORCE RLS, so the change-E lockdown does not block it) — the RPC
+      always mints a source, so a NULL-source row can only be seeded directly. (Scenario: Legacy
+      NULL-source rows)
+- [x] 2.4 `pipeline_run_id` surfaced from `metadata`; `NULL` when the source omitted it (seed with
+      `_envelope(..., pipeline_run_id=None)`). (Scenario: pipeline_run_id is surfaced)
+- [x] 2.5 Default path returns the latest source's value only, no duplicate rows. (Scenario: Default
+      read returns the latest source's values only)
+- [x] 2.6 Latest run wrote only trait A while an older source wrote A+B → default returns A, not B.
+      (Scenario: No cross-source mixing when the latest run dropped a trait)
+- [x] 2.7 `cyl_scan_traits_latest` returns ≤1 row per `(scan_id, trait_id)` for **source-bearing** data.
+      (Scenario: Latest view has no duplicate rows)
+- [x] 2.7a Non-finite latest value: seed a latest-source trait whose stored `value` is NULL via the RPC
+      with `_trait(name, None)` or `_trait(name, "NaN")` (JSON-legal tokens the RPC stores as NULL) — do
+      **not** pass `float('nan')` (`json.dumps` emits the invalid-JSON token `NaN`, which the `::jsonb`
+      cast rejects); a direct `INSERT … value=NULL` is the alternative. Assert the default read returns it
+      as a `trait_value = NULL` row (not omitted). (Scenario: A non-finite latest value is surfaced as NULL)
+- [x] 2.8 `get_scan_traits(exp, trait)` (2-arg) returns latest per scan — **via direct SQL AND via
+      PostgREST HTTP** using the `api` fixture with an api*key: `api("/api/rest/v1/rpc/get_scan_traits",
+      api_key=service_role_key, method="POST", data={"experiment_id*": ..., "trait*name*": ...})`⇒ 200,
+    **not** PGRST203 (this is what proves the no-overload design). Note the harness path prefix is
+   `/api/rest/v1/...` and the call MUST pass a key or it 401s. (Scenario: Backward-compatible
+      two-argument call returns latest)
+- [x] 2.9 `source_id_` set to the older source returns the older values. (Scenario: Pinning an older
+      source returns the older values)
+- [x] 2.9a `source_id_` set to a source from a **different** experiment returns zero rows (regression
+      guard: the experiment filter must stay conjoined with the pin branch — no cross-experiment leak).
+- [x] 2.10 Two scans in one experiment share a `pipeline_run_id`; `run_id_` returns rows for **both**
+      scans. (Scenario: Run id groups an experiment by pipeline run)
+- [x] 2.10a Seed scan A (`run-1` then newer `run-2`) + scan B (`run-1` only); `run_id_='run-1'` returns
+      A's `run-1` values (not A's `run-2`) and B's `run-1` values — selection is by run, no implicit
+      latest filter. (Scenario: Run id returns a scan's run values even after a newer run superseded it)
+- [x] 2.10b Seed one scan/trait delivered twice under the same `pipeline_run_id` (two sources, distinct
+      `idempotency_key`); `run_id_` returns a **single** row for that `(scan, trait)` — the latest
+      delivery within the run (`max(source_id)`). (Scenario: Duplicate deliveries within one run do not
+      duplicate rows)
+- [x] 2.10c `run_id_` set to a run in a **different** experiment returns zero rows (regression guard for
+      the run branch — the experiment filter must stay conjoined with the parenthesized disjunction).
+- [x] 2.11a A legacy NULL-`pipeline_run_id` scan is absent from any `run_id_` query (its
+      `pipeline_run_id IS NULL` never equals `run_id_`), confirming run grouping ignores unrun data.
+- [x] 2.11 `run_id_` set to a value no source carries (incl. a `pipeline_run_id IS NULL` source) returns
+      zero rows, no error. (Scenario: A run id matching no source returns no rows)
+- [x] 2.12 Both `source_id_` and `run_id_` non-null → raises. (Scenario: Supplying both is rejected)
+- [x] 2.13 Result column names/types/order are byte-identical to the legacy function (assert via
+      `pg_get_function_result` or a 1-row call's `cur.description`); rows ordered by
+      `accession_name, plant_id` (seed two accessions out of order). (Scenario: Result columns and
+      ordering are preserved)
+- [x] 2.14 An experiment/trait with no trait rows returns zero rows, no error. (Scenario: An experiment
+      with no matching traits returns cleanly)
+- [x] 2.15 Legacy NULL-source scan (direct-insert seed) is returned by the default `get_scan_traits`
+      path (exercises the `IS NOT DISTINCT FROM` NULL branch end-to-end through the function).
+- [x] 2.16 `cyl_scan_trait_names` lists distinct latest names; a name only in a superseded older source
+      is excluded. (Scenarios: Lists distinct names present in latest data / A name only in a superseded
+      source is excluded)
+- [x] 2.16a Seed a latest-source row with `trait_id = NULL` (direct insert); assert `cyl_scan_trait_names`
+      contains no `NULL` entry (the `WHERE trait_name IS NOT NULL` guard).
+- [x] 2.17 Role reads: `SET LOCAL ROLE` to `bloom_agent`/`bloom_user`/`bloom_admin` can SELECT all three
+      views **including the joined `source_name` column** and call `get_scan_traits`. Guard with a
+      standalone non-BYPASSRLS assertion mirroring the writeback suite's `test_bloom_roles_are_not_bypassrls`
+      (there is no combined set-role+assert helper — use the two idioms: inline `SET LOCAL ROLE` and a
+      separate `pg_roles.rolbypassrls` check). No new write policy/grant on the three tables (drift check).
+      (Requirement: Read path stays open to read roles with no RLS change)
+- [x] 2.18 `test_migration_body_is_idempotent` — re-apply the migration body on already-applied state;
+      the two views and the 4-arg function still exist (catches non-idempotent CREATE). (Scenario:
+      Forward migration adds the read surface)
+- [x] 2.19 `test_rollback_restores_prior_read_surface` — apply the rollback body; assert the two new
+      views are gone, exactly **one** `get_scan_traits` remains with `(bigint, text)` identity args, and
+      `cyl_scan_trait_names` is back to `SELECT name FROM cyl_traits` (assert it returns a
+      registered-but-unmeasured name the latest-only view would have excluded). Also assert recreated
+      `cyl_scan_trait_names` is readable by `bloom_agent` post-migration (grant re-issued). (Scenarios:
+      Rollback restores the prior read surface without overload ambiguity / Recreated trait-names view
+      stays readable)
+- [x] 2.20 Confirm every 2.x test above FAILS before implementation — views/function absent raise
+      `psycopg.errors.UndefinedTable` / `UndefinedFunction`; the 4-arg call raises `UndefinedFunction`.
+
+## 3. Implementation — migration (GREEN)
+
+- [x] 3.1 Create `supabase/migrations/20260701000000_cyl_trait_read_source_aware.sql` (timestamp > the
+      writeback migration 20260630180000), wrapped in `BEGIN; … COMMIT;`, dependency-ordered.
+- [x] 3.2 `CREATE OR REPLACE VIEW public.cyl_scan_traits_source WITH (security_invoker = on)` (idempotent
+      re-run) selecting the **8 spec columns, no `id`**: `cst.scan_id, cst.trait_id, t.name AS trait_name,
+    cst.value, cst.source_id, s.name AS source_name, s.metadata->>'pipeline_run_id' AS pipeline_run_id,
+    (cst.source_id IS NOT DISTINCT FROM max(cst.source_id) OVER (PARTITION BY cst.scan_id)) AS is_latest`
+      from `cyl_scan_traits cst LEFT JOIN cyl_trait_sources s ON s.id = cst.source_id LEFT JOIN cyl_traits
+    t ON t.id = cst.trait_id`. Then literal `GRANT SELECT ON public.cyl_scan_traits_source TO
+    bloom_agent, bloom_user, bloom_admin, authenticated;`.
+- [x] 3.3 `CREATE OR REPLACE VIEW public.cyl_scan_traits_latest WITH (security_invoker = on) AS SELECT
+    scan_id, trait_id, trait_name, source_id, value FROM public.cyl_scan_traits_source WHERE is_latest;` + literal `GRANT SELECT … TO bloom_agent, bloom_user, bloom_admin, authenticated;`.
+- [x] 3.4 `DROP VIEW IF EXISTS public.cyl_scan_trait_names; CREATE VIEW public.cyl_scan_trait_names WITH
+    (security_invoker = on) AS SELECT DISTINCT trait_name FROM public.cyl_scan_traits_latest WHERE
+    trait_name IS NOT NULL ORDER BY trait_name;` + **re-issue** literal `GRANT SELECT ON
+    public.cyl_scan_trait_names TO bloom_agent, bloom_user, bloom_admin, authenticated;` (the prior grant
+      does not survive DROP). (DROP+CREATE, not OR REPLACE, because the column set changes.)
+- [x] 3.5 `DROP FUNCTION IF EXISTS public.get_scan_traits(bigint, text);` then `CREATE FUNCTION
+    public.get_scan_traits(experiment_id_ bigint, trait_name_ text, source_id_ bigint DEFAULT NULL,
+    run_id_ text DEFAULT NULL) RETURNS TABLE (scan_id bigint, date_scanned text, plant_age_days int,
+    wave_number int, plant_id bigint, germ_day int, plant_qr_code text, accession_name text,
+    trait_name text, trait_value float) LANGUAGE plpgsql STABLE`. Leading guard
+      `IF source_id_ IS NOT NULL AND run_id_ IS NOT NULL THEN RAISE EXCEPTION …`. `RETURN QUERY` selecting
+      `src.trait_name`/`src.value` from `cyl_scan_traits_source src` joined `cyl_scans ON cyl_scans.id =
+    src.scan_id → … → accessions`; project `cyl_scans.date_scanned` **raw** (coerced `date→text`, not
+      `to_char`). WHERE, with the disjunction **wrapped in one parenthesized AND-operand** (else the
+      run/pin branches detach from the experiment filter → cross-experiment leak):
+      `WHERE cyl_experiments.id = experiment_id_ AND src.trait_name = trait_name_ AND (
+       (source_id_ IS NULL AND run_id_ IS NULL AND src.is_latest)
+       OR (source_id_ IS NOT NULL AND src.source_id = source_id_)
+       OR (run_id_ IS NOT NULL AND src.source_id = (SELECT max(s2.source_id)
+             FROM public.cyl_scan_traits_source s2
+             WHERE s2.scan_id = src.scan_id AND s2.trait_id = src.trait_id
+               AND s2.pipeline_run_id = run_id_)) )`
+      `ORDER BY accessions.name, cyl_plants.id` — **table-qualified**, NOT the legacy
+      `ORDER BY accession_name, plant_id`: in a `plpgsql` `RETURNS TABLE` function bare `plant_id` is
+      ambiguous (OUT var vs `cyl_scans.plant_id`) and raises on every call under
+      `variable_conflict = error`. Qualify all select/sort identifiers to their tables. **Do NOT** add
+      `REVOKE EXECUTE … FROM PUBLIC` (keep prior PUBLIC-execute posture).
+
+## 4. Rollback + types (GREEN)
+
+- [x] 4.1 Add `supabase/rollbacks/20260701000000_cyl_trait_read_source_aware_rollback.sql`: `DROP VIEW IF
+    EXISTS cyl_scan_trait_names; DROP VIEW IF EXISTS cyl_scan_traits_latest; DROP VIEW IF EXISTS
+    cyl_scan_traits_source;` (dependents first); `DROP FUNCTION IF EXISTS get_scan_traits(bigint, text,
+    bigint, text);` **then** recreate the prior 2-arg `get_scan_traits(bigint, text)` `LANGUAGE SQL`
+      verbatim — copy the 20241119232238 body exactly, **including its `AS accession_name`/`AS plant_id`
+      SELECT-list aliases** (its `ORDER BY accession_name, plant_id` is a SQL-function output-alias
+      reference that fails if the aliases are dropped); recreate `cyl_scan_trait_names AS SELECT name FROM
+    cyl_traits` + its grant.
+- [x] 4.2 Hand-edit all **five** tracked `database.types.ts` copies (mirroring #371; local regen will
+      fail per the known dev-DB gap): `web/lib`, `web/types`, `packages/bloom-js/src/types`,
+      `packages/bloom-fs/src/types`, `packages/bloom-nextjs-auth/src/lib`. Add the two new views and the
+      4-arg `get_scan_traits` with `source_id_`/`run_id_` **optional** in `Args` so `TraitExplorer.tsx`'s
+      2-arg call still typechecks; keep `Returns` columns identical.
+
+## 5. Validate (GREEN)
+
+- [x] 5.1 Run `tests/integration/test_cyl_read_path.py` against the compose stack — all green. CI's
+      `compose-health-check` (db push → pytest) is the authoritative signal; local DB may lack roles.
+- [x] 5.2 `openspec validate add-cyl-trait-read-source-aware --strict` passes.
+- [x] 5.3 `cd web && npx tsc --noEmit` and the Next.js build pass against the edited types (catches a
+      stale `get_scan_traits` arg list); `packages/bloom-js` + `bloom-fs` `tsc -p` clean.
+- [ ] 5.4 Migration lint clean (filename `^[0-9]{14}_[a-z0-9_]+\.sql$`, timestamp > 20260630180000);
+      ruff/black/prettier and full pre-merge suite green.
+
+## 6. Docs + follow-up
+
+- [x] 6.1 In `_WIKI/BLOOMMCP/README.md` "Supabase data access" section, **rewrite** the
+      `client.table("cyl_scan_traits").select(...)` example to read `cyl_scan_traits_latest` (note
+      `cyl_scan_traits_source` for the source/run dimension); cross-reference the spec/migration for the
+      latest-selection rule rather than restating it. Cite the section by name (it is unnumbered).
+- [ ] 6.2 File the broadened sibling issue "repoint source-blind cyl trait readers at the latest-source
+      surface" (covering: rebuild `cyl_trait_by_experiment_wave` on `cyl_scan_traits_latest`; repoint +
+      fix `cyl_tools.py` `get_scan_traits_tool`; refresh `context_tools.py` `CONTEXT_CYL`). Reference it
+      from the PR body so the deferral is durably tracked before the change folder is archived.

--- a/packages/bloom-fs/src/types/database.types.ts
+++ b/packages/bloom-fs/src/types/database.types.ts
@@ -2286,6 +2286,29 @@ export type Database = {
         }
         Relationships: []
       }
+      cyl_scan_traits_latest: {
+        Row: {
+          scan_id: number | null
+          source_id: number | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
+      cyl_scan_traits_source: {
+        Row: {
+          is_latest: boolean | null
+          pipeline_run_id: string | null
+          scan_id: number | null
+          source_id: number | null
+          source_name: string | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
       cyl_scans_extended: {
         Row: {
           accession_id: number | null
@@ -2397,7 +2420,7 @@ export type Database = {
       }
       dblink_is_busy: { Args: { "": string }; Returns: number }
       get_scan_traits: {
-        Args: { experiment_id_: number; trait_name_: string }
+        Args: { experiment_id_: number; run_id_?: string; source_id_?: number; trait_name_: string }
         Returns: {
           accession_name: string
           date_scanned: string

--- a/packages/bloom-js/src/types/database.types.ts
+++ b/packages/bloom-js/src/types/database.types.ts
@@ -2286,6 +2286,29 @@ export type Database = {
         }
         Relationships: []
       }
+      cyl_scan_traits_latest: {
+        Row: {
+          scan_id: number | null
+          source_id: number | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
+      cyl_scan_traits_source: {
+        Row: {
+          is_latest: boolean | null
+          pipeline_run_id: string | null
+          scan_id: number | null
+          source_id: number | null
+          source_name: string | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
       cyl_scans_extended: {
         Row: {
           accession_id: number | null
@@ -2397,7 +2420,7 @@ export type Database = {
       }
       dblink_is_busy: { Args: { "": string }; Returns: number }
       get_scan_traits: {
-        Args: { experiment_id_: number; trait_name_: string }
+        Args: { experiment_id_: number; run_id_?: string; source_id_?: number; trait_name_: string }
         Returns: {
           accession_name: string
           date_scanned: string

--- a/packages/bloom-nextjs-auth/src/lib/database.types.ts
+++ b/packages/bloom-nextjs-auth/src/lib/database.types.ts
@@ -2286,6 +2286,29 @@ export type Database = {
         }
         Relationships: []
       }
+      cyl_scan_traits_latest: {
+        Row: {
+          scan_id: number | null
+          source_id: number | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
+      cyl_scan_traits_source: {
+        Row: {
+          is_latest: boolean | null
+          pipeline_run_id: string | null
+          scan_id: number | null
+          source_id: number | null
+          source_name: string | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
       cyl_scans_extended: {
         Row: {
           accession_id: number | null
@@ -2397,7 +2420,7 @@ export type Database = {
       }
       dblink_is_busy: { Args: { "": string }; Returns: number }
       get_scan_traits: {
-        Args: { experiment_id_: number; trait_name_: string }
+        Args: { experiment_id_: number; run_id_?: string; source_id_?: number; trait_name_: string }
         Returns: {
           accession_name: string
           date_scanned: string

--- a/supabase/migrations/20260701000000_cyl_trait_read_source_aware.sql
+++ b/supabase/migrations/20260701000000_cyl_trait_read_source_aware.sql
@@ -1,0 +1,136 @@
+-- A2 read-path (bloom#298): make the cyl trait READ path source-aware.
+--
+-- The write-back RPC (#371) mints one cyl_trait_sources row per pipeline run, so a
+-- reprocessed scan carries MULTIPLE sources and the source-blind get_scan_traits
+-- returned duplicate/ambiguous rows. This adds a single shared read surface:
+--
+--   cyl_scan_traits_source  substrate view; one row per cyl_scan_traits row exposing
+--                           the source dimension + is_latest = max(source_id) per scan
+--                           (window aggregate; legacy NULL-source rows count as latest).
+--   cyl_scan_traits_latest  the is_latest rows (canonical latest-per-scan surface).
+--   get_scan_traits(...)    latest by default; pin a source_id; group by pipeline run
+--                           (run_id_, "as of run X", deduped to the latest delivery within
+--                           the run); both optional args set -> error. The legacy 2-arg
+--                           function is dropped so exactly one candidate exists (no PostgREST
+--                           overload ambiguity, PGRST203); 2-arg callers bind the defaults.
+--   cyl_scan_trait_names    distinct non-null trait names present in latest data.
+--
+-- Additive/forward-only: creates/redefines read objects, touches no table or data. Reads
+-- stay open to the existing read roles; no RLS or write-grant change. "Latest" = max(source_id)
+-- because cyl_trait_sources has no timestamp and identity ids increase as reprocessing runs.
+--
+-- Manual rollback: supabase/rollbacks/20260701000000_cyl_trait_read_source_aware_rollback.sql
+
+BEGIN;
+
+-- 1. Substrate: the single source of truth for the latest-selection rule.
+CREATE OR REPLACE VIEW public.cyl_scan_traits_source
+WITH (security_invoker = on) AS
+SELECT
+    cst.scan_id,
+    cst.trait_id,
+    t.name                                AS trait_name,
+    cst.value,
+    cst.source_id,
+    s.name                                AS source_name,
+    s.metadata ->> 'pipeline_run_id'      AS pipeline_run_id,
+    (cst.source_id IS NOT DISTINCT FROM
+        max(cst.source_id) OVER (PARTITION BY cst.scan_id)) AS is_latest
+FROM public.cyl_scan_traits cst
+LEFT JOIN public.cyl_trait_sources s ON s.id = cst.source_id
+LEFT JOIN public.cyl_traits       t ON t.id = cst.trait_id;
+
+GRANT SELECT ON public.cyl_scan_traits_source
+    TO bloom_agent, bloom_user, bloom_admin, authenticated;
+
+-- 2. Canonical latest-per-scan surface.
+CREATE OR REPLACE VIEW public.cyl_scan_traits_latest
+WITH (security_invoker = on) AS
+SELECT scan_id, trait_id, trait_name, source_id, value
+FROM public.cyl_scan_traits_source
+WHERE is_latest;
+
+GRANT SELECT ON public.cyl_scan_traits_latest
+    TO bloom_agent, bloom_user, bloom_admin, authenticated;
+
+-- 3. Source-disambiguated trait-name listing (distinct non-null latest names). The DROP+CREATE
+--    (not OR REPLACE) is required because the row content changes; re-issue the grant since the
+--    prior object-level read access does not survive DROP VIEW.
+DROP VIEW IF EXISTS public.cyl_scan_trait_names;
+CREATE VIEW public.cyl_scan_trait_names
+WITH (security_invoker = on) AS
+SELECT DISTINCT trait_name AS name
+FROM public.cyl_scan_traits_latest
+WHERE trait_name IS NOT NULL
+ORDER BY name;
+
+GRANT SELECT ON public.cyl_scan_trait_names
+    TO bloom_agent, bloom_user, bloom_admin, authenticated;
+
+-- 4. Source-aware get_scan_traits. Drop the legacy 2-arg function first so only one candidate
+--    remains, then create the 4-arg form. plpgsql (needs RAISE for the both-args guard), STABLE,
+--    SECURITY INVOKER. All select/sort identifiers are table-qualified so the RETURNS TABLE OUT
+--    columns cannot collide with same-named table columns (e.g. plant_id) under variable_conflict.
+DROP FUNCTION IF EXISTS public.get_scan_traits(bigint, text);
+
+CREATE OR REPLACE FUNCTION public.get_scan_traits(
+    experiment_id_ bigint,
+    trait_name_    text,
+    source_id_     bigint DEFAULT NULL,
+    run_id_        text   DEFAULT NULL
+) RETURNS TABLE (
+    scan_id        bigint,
+    date_scanned   text,
+    plant_age_days int,
+    wave_number    int,
+    plant_id       bigint,
+    germ_day       int,
+    plant_qr_code  text,
+    accession_name text,
+    trait_name     text,
+    trait_value    float
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    IF source_id_ IS NOT NULL AND run_id_ IS NOT NULL THEN
+        RAISE EXCEPTION 'get_scan_traits: specify at most one of source_id_ and run_id_';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        cyl_scans.id::bigint,
+        cyl_scans.date_scanned::text,
+        cyl_scans.plant_age_days::int,
+        cyl_waves.number::int,
+        cyl_plants.id::bigint,
+        cyl_plants.germ_day::int,
+        cyl_plants.qr_code::text,
+        accessions.name::text,
+        src.trait_name::text,
+        src.value::float
+    FROM species
+    JOIN cyl_experiments ON cyl_experiments.species_id = species.id
+    JOIN cyl_waves       ON cyl_waves.experiment_id = cyl_experiments.id
+    JOIN cyl_plants      ON cyl_plants.wave_id = cyl_waves.id
+    JOIN accessions      ON cyl_plants.accession_id = accessions.id
+    JOIN cyl_scans       ON cyl_scans.plant_id = cyl_plants.id
+    JOIN public.cyl_scan_traits_source src ON src.scan_id = cyl_scans.id
+    WHERE cyl_experiments.id = experiment_id_
+      AND src.trait_name = trait_name_
+      AND (
+            (source_id_ IS NULL AND run_id_ IS NULL AND src.is_latest)
+         OR (source_id_ IS NOT NULL AND src.source_id = source_id_)
+         OR (run_id_ IS NOT NULL AND src.source_id = (
+                SELECT max(s2.source_id)
+                FROM public.cyl_scan_traits_source s2
+                WHERE s2.scan_id = src.scan_id
+                  AND s2.trait_id = src.trait_id
+                  AND s2.pipeline_run_id = run_id_))
+          )
+    ORDER BY accessions.name, cyl_plants.id;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260701000000_cyl_trait_read_source_aware.sql
+++ b/supabase/migrations/20260701000000_cyl_trait_read_source_aware.sql
@@ -92,6 +92,7 @@ CREATE OR REPLACE FUNCTION public.get_scan_traits(
 )
 LANGUAGE plpgsql
 STABLE
+SECURITY INVOKER
 AS $$
 BEGIN
     IF source_id_ IS NOT NULL AND run_id_ IS NOT NULL THEN

--- a/supabase/rollbacks/20260609000000_add_cyl_trait_source_provenance_rollback.sql
+++ b/supabase/rollbacks/20260609000000_add_cyl_trait_source_provenance_rollback.sql
@@ -8,7 +8,11 @@ BEGIN;
 
 ALTER TABLE cyl_trait_sources DROP CONSTRAINT IF EXISTS cyl_trait_sources_idempotency_key_nonempty;
 ALTER TABLE cyl_trait_sources DROP CONSTRAINT IF EXISTS cyl_trait_sources_idempotency_key_key;
-ALTER TABLE cyl_trait_sources DROP COLUMN IF EXISTS idempotency_key;
-ALTER TABLE cyl_trait_sources DROP COLUMN IF EXISTS metadata;
+ALTER TABLE cyl_trait_sources DROP COLUMN IF EXISTS idempotency_key CASCADE;
+-- CASCADE: the cyl-trait-read views (cyl_scan_traits_source and the views built on it,
+-- added 20260701000000) read cyl_trait_sources.metadata, so this break-glass rollback
+-- must also remove those dependents (they read the column being removed). Without CASCADE
+-- the drop errors with DependentObjectsStillExist while the read-path views exist.
+ALTER TABLE cyl_trait_sources DROP COLUMN IF EXISTS metadata CASCADE;
 
 COMMIT;

--- a/supabase/rollbacks/20260701000000_cyl_trait_read_source_aware_rollback.sql
+++ b/supabase/rollbacks/20260701000000_cyl_trait_read_source_aware_rollback.sql
@@ -1,0 +1,66 @@
+-- Manual rollback for 20260701000000_cyl_trait_read_source_aware.sql
+--
+-- Drops the two new views and the source-aware get_scan_traits, and restores the prior
+-- read surface: the legacy 2-arg get_scan_traits (LANGUAGE SQL, from 20241119232238) and
+-- cyl_scan_trait_names = SELECT name FROM cyl_traits. Dependents are dropped before the
+-- substrate view, and the 4-arg function is dropped BEFORE recreating the 2-arg one so no
+-- overload ambiguity (PGRST203) is reintroduced.
+
+BEGIN;
+
+DROP VIEW IF EXISTS public.cyl_scan_trait_names;
+DROP VIEW IF EXISTS public.cyl_scan_traits_latest;
+DROP VIEW IF EXISTS public.cyl_scan_traits_source;
+
+DROP FUNCTION IF EXISTS public.get_scan_traits(bigint, text, bigint, text);
+
+-- Restore the prior 2-arg function verbatim (LANGUAGE SQL; its ORDER BY references the
+-- SELECT-list output aliases, so the AS aliases must be preserved).
+CREATE OR REPLACE FUNCTION get_scan_traits(experiment_id_ BIGINT, trait_name_ TEXT) RETURNS TABLE (
+    scan_id BIGINT,
+    date_scanned TEXT,
+    plant_age_days INT,
+    wave_number INT,
+    plant_id BIGINT,
+    germ_day INT,
+    plant_qr_code TEXT,
+    accession_name TEXT,
+    trait_name TEXT,
+    trait_value FLOAT
+)
+AS $$
+    SELECT
+    cyl_scans.id as scan_id,
+    cyl_scans.date_scanned as date_scanned,
+    cyl_scans.plant_age_days as plant_age_days,
+    cyl_waves.number as wave_number,
+    cyl_plants.id as plant_id,
+    cyl_plants.germ_day as germ_day,
+    cyl_plants.qr_code as plant_qr_code,
+    accessions.name as accession_name,
+    cyl_traits.name as trait_name,
+    cyl_scan_traits.value as trait_value
+    FROM
+    species
+    JOIN cyl_experiments on cyl_experiments.species_id = species.id
+    JOIN cyl_waves on cyl_waves.experiment_id = cyl_experiments.id
+    JOIN cyl_plants on cyl_plants.wave_id = cyl_waves.id
+    JOIN accessions on cyl_plants.accession_id = accessions.id
+    JOIN cyl_scans on cyl_scans.plant_id = cyl_plants.id
+    JOIN cyl_scan_traits on cyl_scan_traits.scan_id = cyl_scans.id
+    JOIN cyl_traits on cyl_scan_traits.trait_id = cyl_traits.id
+    WHERE
+    cyl_experiments.id = experiment_id_ AND
+    cyl_traits.name = trait_name_
+    ORDER BY
+    accession_name, plant_id;
+$$ LANGUAGE SQL;
+
+-- Restore the prior registry-passthrough view + its read grant.
+CREATE VIEW public.cyl_scan_trait_names AS
+SELECT name FROM public.cyl_traits;
+
+GRANT SELECT ON public.cyl_scan_trait_names
+    TO bloom_agent, bloom_user, bloom_admin, authenticated;
+
+COMMIT;

--- a/tests/integration/test_cyl_read_path.py
+++ b/tests/integration/test_cyl_read_path.py
@@ -1,0 +1,628 @@
+"""
+Integration tests for the A2 read-path change (`add-cyl-trait-read-source-aware`).
+
+Makes the cyl trait READ path source-aware now that reprocessing a scan mints a new
+`cyl_trait_sources` row (write-back RPC, #371), so a scan can carry MULTIPLE sources:
+
+- `cyl_scan_traits_source` — substrate view exposing the source dimension + `is_latest`
+  (`source_id IS NOT DISTINCT FROM max(source_id) OVER (PARTITION BY scan_id)`).
+- `cyl_scan_traits_latest` — `is_latest` rows (canonical latest-per-scan surface).
+- `get_scan_traits(experiment_id_, trait_name_, source_id_ DEFAULT NULL, run_id_ DEFAULT NULL)`
+  — latest by default; pin a source; group by pipeline run ("as of run X", deduped to the
+  latest delivery within the run); both optional args set → error.
+- `cyl_scan_trait_names` — distinct non-null trait names present in latest data.
+
+LOCAL ONLY: the `pg_conn` fixture connects to 127.0.0.1 on POSTGRES_HOST_PORT as
+`supabase_admin` (BYPASSRLS) and every test rolls back. RLS is exercised with `SET LOCAL
+ROLE`. The PostgREST HTTP sub-test skips when the gateway is unreachable (dev has none); CI's
+`compose-health-check` runs it against the full stack. Sources are seeded through the
+write-back RPC (`insert_cyl_result_envelope`); legacy NULL-source / NULL-trait rows are seeded
+by direct INSERT (allowed for supabase_admin, which bypasses the change-E lockdown).
+"""
+
+import itertools
+import json
+import re
+import uuid
+from pathlib import Path
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+RPC = "public.insert_cyl_result_envelope"
+PINNED_VERSION = "v0.1.0a2"
+
+_TS = "20260701000000_cyl_trait_read_source_aware"
+MIGRATION = REPO_ROOT / "supabase" / "migrations" / f"{_TS}.sql"
+ROLLBACK = REPO_ROOT / "supabase" / "rollbacks" / f"{_TS}_rollback.sql"
+
+# The 10 result columns get_scan_traits has always returned, in order.
+RESULT_COLUMNS = [
+    "scan_id",
+    "date_scanned",
+    "plant_age_days",
+    "wave_number",
+    "plant_id",
+    "germ_day",
+    "plant_qr_code",
+    "accession_name",
+    "trait_name",
+    "trait_value",
+]
+
+_uniq = itertools.count(1)
+
+
+# --------------------------------------------------------------------------- #
+# Seeding helpers
+# --------------------------------------------------------------------------- #
+
+
+def _seed_experiment(cur):
+    """species → cyl_experiments → cyl_waves. Returns (experiment_id, wave_id)."""
+    n = next(_uniq)
+    cur.execute("INSERT INTO species DEFAULT VALUES RETURNING id")
+    species_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO cyl_experiments (name, species_id) VALUES (%s, %s) RETURNING id",
+        (f"exp-{n}", species_id),
+    )
+    experiment_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO cyl_waves (experiment_id, number) VALUES (%s, %s) RETURNING id",
+        (experiment_id, 1),
+    )
+    return experiment_id, cur.fetchone()[0]
+
+
+def _seed_scan_in(cur, wave_id, *, accession=None, n_images=2, plant_age_days=10):
+    """accessions → cyl_plants → cyl_scans → cyl_images under an existing wave.
+
+    accessions.name is NOT NULL + UNIQUE, so distinct names are generated per scan.
+    Returns (scan_id, image_ids).
+    """
+    # accessions.name is UNIQUE; a uuid token keeps it collision-proof across runs (some
+    # committed leftovers can exist), while `accession` lets a test pin a name for ordering.
+    tok = uuid.uuid4().hex[:12]
+    acc = accession if accession is not None else f"acc-{tok}"
+    cur.execute("INSERT INTO accessions (name) VALUES (%s) RETURNING id", (acc,))
+    accession_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO cyl_plants (wave_id, accession_id, germ_day, qr_code) "
+        "VALUES (%s, %s, %s, %s) RETURNING id",
+        (wave_id, accession_id, 5, f"qr-{tok}"),
+    )
+    plant_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO cyl_scans (plant_id, date_scanned, plant_age_days) "
+        "VALUES (%s, %s, %s) RETURNING id",
+        (plant_id, "2026-01-01", plant_age_days),
+    )
+    scan_id = cur.fetchone()[0]
+    img_ids = []
+    for _ in range(n_images):
+        cur.execute(
+            "INSERT INTO cyl_images (scan_id) VALUES (%s) RETURNING id", (scan_id,)
+        )
+        img_ids.append(cur.fetchone()[0])
+    return scan_id, img_ids
+
+
+def _seed_experiment_scan(cur, *, accession=None):
+    """Convenience: one experiment with one scan. Returns (experiment_id, scan_id, image_ids)."""
+    experiment_id, wave_id = _seed_experiment(cur)
+    scan_id, img_ids = _seed_scan_in(cur, wave_id, accession=accession)
+    return experiment_id, scan_id, img_ids
+
+
+def _trait(name, value, *, scan_key="SK1"):
+    return {"name": name, "scan_key": scan_key, "value": value}
+
+
+def _envelope(
+    image_ids, *, idempotency_key, pipeline_run_id=None, scan_key="SK1", traits=None
+):
+    prov = {
+        "contract_version": PINNED_VERSION,
+        "scan_key": scan_key,
+        "idempotency_key": idempotency_key,
+        "inputs": {"image_ids": [str(i) for i in image_ids]},
+    }
+    if pipeline_run_id is not None:
+        prov["pipeline_run_id"] = pipeline_run_id
+    return {"provenance": prov, "traits": traits or [], "blobs": []}
+
+
+def _call(cur, envelope):
+    cur.execute(f"SELECT {RPC}(%s::jsonb)", (json.dumps(envelope),))
+    res = cur.fetchone()[0]
+    return json.loads(res) if isinstance(res, str) else res
+
+
+def _deliver(cur, img_ids, label, *, run=None, traits):
+    """One write-back delivery; returns its source_id. The idempotency key is made globally
+    unique (uuid) so a delivery never no-ops against a committed key from an earlier run;
+    `label` is just a readable prefix. Distinct calls => distinct sources."""
+    key = f"{label}-{uuid.uuid4().hex}"
+    _call(
+        cur, _envelope(img_ids, idempotency_key=key, pipeline_run_id=run, traits=traits)
+    )
+    cur.execute("SELECT id FROM cyl_trait_sources WHERE idempotency_key=%s", (key,))
+    return cur.fetchone()[0]
+
+
+def _register_trait(cur, name):
+    cur.execute(
+        "INSERT INTO cyl_traits (name) VALUES (%s) ON CONFLICT (name) DO NOTHING",
+        (name,),
+    )
+    cur.execute("SELECT id FROM cyl_traits WHERE name=%s", (name,))
+    return cur.fetchone()[0]
+
+
+def _get_scan_traits(cur, experiment_id, trait_name, *, source_id=None, run_id=None):
+    cur.execute(
+        "SELECT scan_id, trait_value FROM get_scan_traits(%s, %s, %s, %s)",
+        (experiment_id, trait_name, source_id, run_id),
+    )
+    return cur.fetchall()
+
+
+def _sql_body(path: Path) -> str:
+    """Migration/rollback body minus its BEGIN;/COMMIT; wrapper (CRLF-safe)."""
+    return "\n".join(
+        line
+        for line in path.read_text().splitlines()
+        if not re.match(r"^\s*(BEGIN|COMMIT)\s*;\s*$", line, re.IGNORECASE)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Seeding linchpin
+# --------------------------------------------------------------------------- #
+
+
+def test_two_sources_one_scan_seed(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, scan_id, imgs = _seed_experiment_scan(cur)
+        s1 = _deliver(cur, imgs, "orig", run="run-1", traits=[_trait("length", 10.0)])
+        s2 = _deliver(cur, imgs, "reproc", run="run-2", traits=[_trait("length", 20.0)])
+        cur.execute(
+            "SELECT count(DISTINCT source_id), max(source_id) FROM cyl_scan_traits WHERE scan_id=%s",
+            (scan_id,),
+        )
+        n_sources, max_src = cur.fetchone()
+        assert n_sources == 2 and s1 < s2 and max_src == s2
+    pg_conn.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Requirement: Canonical source-aware trait view
+# --------------------------------------------------------------------------- #
+
+
+def test_source_view_exposes_source_dimension(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, scan_id, imgs = _seed_experiment_scan(cur)
+        src = _deliver(cur, imgs, "k", run="run-9", traits=[_trait("length", 3.5)])
+        cur.execute(
+            "SELECT scan_id, trait_name, value, source_id, source_name, pipeline_run_id "
+            "FROM cyl_scan_traits_source WHERE scan_id=%s",
+            (scan_id,),
+        )
+        row = cur.fetchone()
+        assert row == (scan_id, "length", 3.5, src, "run-9", "run-9")
+    pg_conn.rollback()
+
+
+def test_is_latest_marks_max_source(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, scan_id, imgs = _seed_experiment_scan(cur)
+        s1 = _deliver(cur, imgs, "old", traits=[_trait("length", 1.0)])
+        s2 = _deliver(cur, imgs, "new", traits=[_trait("length", 2.0)])
+        cur.execute(
+            "SELECT source_id, is_latest FROM cyl_scan_traits_source WHERE scan_id=%s ORDER BY source_id",
+            (scan_id,),
+        )
+        assert cur.fetchall() == [(s1, False), (s2, True)]
+    pg_conn.rollback()
+
+
+def test_legacy_null_source_is_latest(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, scan_id, _ = _seed_experiment_scan(cur)
+        tid = _register_trait(cur, "legacy")
+        cur.execute(
+            "INSERT INTO cyl_scan_traits (scan_id, source_id, trait_id, value) VALUES (%s, NULL, %s, %s)",
+            (scan_id, tid, 4.2),
+        )
+        cur.execute(
+            "SELECT is_latest FROM cyl_scan_traits_source WHERE scan_id=%s AND source_id IS NULL",
+            (scan_id,),
+        )
+        assert cur.fetchone() == (True,)
+    pg_conn.rollback()
+
+
+def test_pipeline_run_id_null_when_absent(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, scan_id, imgs = _seed_experiment_scan(cur)
+        _deliver(cur, imgs, "nopr", run=None, traits=[_trait("length", 1.0)])
+        cur.execute(
+            "SELECT pipeline_run_id FROM cyl_scan_traits_source WHERE scan_id=%s",
+            (scan_id,),
+        )
+        assert cur.fetchone() == (None,)
+    pg_conn.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Requirement: Latest-source-by-default scan trait reads
+# --------------------------------------------------------------------------- #
+
+
+def test_default_returns_latest_value_only(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, scan_id, imgs = _seed_experiment_scan(cur)
+        _deliver(cur, imgs, "old", run="r1", traits=[_trait("length", 10.0)])
+        _deliver(cur, imgs, "new", run="r2", traits=[_trait("length", 20.0)])
+        rows = _get_scan_traits(cur, exp, "length")
+        assert rows == [(scan_id, 20.0)]  # latest only, no duplicate
+    pg_conn.rollback()
+
+
+def test_no_cross_source_mixing(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, scan_id, imgs = _seed_experiment_scan(cur)
+        _deliver(
+            cur, imgs, "old", run="r1", traits=[_trait("A", 1.0), _trait("B", 2.0)]
+        )
+        _deliver(
+            cur, imgs, "new", run="r2", traits=[_trait("A", 10.0)]
+        )  # latest lacks B
+        assert _get_scan_traits(cur, exp, "A") == [(scan_id, 10.0)]
+        assert (
+            _get_scan_traits(cur, exp, "B") == []
+        )  # not backfilled from the older source
+    pg_conn.rollback()
+
+
+def test_latest_view_no_duplicate_rows(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, scan_id, imgs = _seed_experiment_scan(cur)
+        _deliver(cur, imgs, "old", traits=[_trait("length", 1.0)])
+        _deliver(cur, imgs, "new", traits=[_trait("length", 2.0)])
+        cur.execute(
+            "SELECT count(*) FROM cyl_scan_traits_latest WHERE scan_id=%s AND trait_name='length'",
+            (scan_id,),
+        )
+        assert cur.fetchone()[0] == 1
+    pg_conn.rollback()
+
+
+def test_non_finite_latest_value_surfaced_as_null(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, scan_id, imgs = _seed_experiment_scan(cur)
+        # JSON null -> RPC stores NULL (do not use float('nan'): json.dumps emits invalid JSON).
+        _deliver(cur, imgs, "k", traits=[_trait("length", None)])
+        assert _get_scan_traits(cur, exp, "length") == [(scan_id, None)]
+    pg_conn.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Requirement: Source-pinned and run-grouped get_scan_traits
+# --------------------------------------------------------------------------- #
+
+
+def test_backward_compatible_two_arg_call_returns_latest(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, scan_id, imgs = _seed_experiment_scan(cur)
+        _deliver(cur, imgs, "old", traits=[_trait("length", 10.0)])
+        _deliver(cur, imgs, "new", traits=[_trait("length", 20.0)])
+        cur.execute(
+            "SELECT scan_id, trait_value FROM get_scan_traits(%s, %s)", (exp, "length")
+        )
+        assert cur.fetchall() == [(scan_id, 20.0)]
+    pg_conn.rollback()
+
+
+def test_backward_compatible_two_arg_call_over_postgrest(api, service_role_key):
+    """Proves no PostgREST overload ambiguity (PGRST203) — the reason the 2-arg fn is dropped.
+    PGRST203 is a function-resolution error that fires regardless of data, so no seeding/commit
+    is needed. Only meaningful against the PostgREST gateway (CI compose-health-check); skips
+    when the gateway is unreachable (dev has none)."""
+    import urllib.error
+
+    try:
+        status, body = api(
+            "/api/rest/v1/rpc/get_scan_traits",
+            api_key=service_role_key,
+            method="POST",
+            data={"experiment_id_": 1, "trait_name_": "length"},
+        )
+    except (urllib.error.URLError, OSError) as e:
+        pytest.skip(
+            f"PostgREST gateway not reachable ({e}); CI compose-health-check covers this"
+        )
+    assert (
+        status == 200
+    ), f"expected 200 (2 named args bind the defaults), got {status}: {body}"
+    # PGRST203 = "Could not choose the best candidate function" (overload ambiguity)
+    assert not (isinstance(body, dict) and body.get("code") == "PGRST203"), body
+
+
+def test_pin_older_source_returns_older_values(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, scan_id, imgs = _seed_experiment_scan(cur)
+        old = _deliver(cur, imgs, "old", traits=[_trait("length", 10.0)])
+        _deliver(cur, imgs, "new", traits=[_trait("length", 20.0)])
+        assert _get_scan_traits(cur, exp, "length", source_id=old) == [(scan_id, 10.0)]
+    pg_conn.rollback()
+
+
+def test_pin_source_from_other_experiment_returns_nothing(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp1, _, imgs1 = _seed_experiment_scan(cur)
+        src1 = _deliver(cur, imgs1, "e1", traits=[_trait("length", 1.0)])
+        exp2, _, imgs2 = _seed_experiment_scan(cur)
+        _deliver(cur, imgs2, "e2", traits=[_trait("length", 2.0)])
+        # pin exp1's source but query exp2 -> experiment filter must exclude it
+        assert _get_scan_traits(cur, exp2, "length", source_id=src1) == []
+    pg_conn.rollback()
+
+
+def test_run_id_groups_experiment_by_pipeline_run(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, wave = _seed_experiment(cur)
+        a, imgs_a = _seed_scan_in(cur, wave)
+        b, imgs_b = _seed_scan_in(cur, wave)
+        _deliver(cur, imgs_a, "a", run="run-1", traits=[_trait("length", 1.0)])
+        _deliver(cur, imgs_b, "b", run="run-1", traits=[_trait("length", 2.0)])
+        rows = _get_scan_traits(cur, exp, "length", run_id="run-1")
+        assert sorted(rows) == sorted([(a, 1.0), (b, 2.0)])
+    pg_conn.rollback()
+
+
+def test_run_id_returns_run_values_even_after_supersede(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, wave = _seed_experiment(cur)
+        a, imgs_a = _seed_scan_in(cur, wave)
+        b, imgs_b = _seed_scan_in(cur, wave)
+        _deliver(cur, imgs_a, "a1", run="run-1", traits=[_trait("length", 1.0)])
+        _deliver(
+            cur, imgs_a, "a2", run="run-2", traits=[_trait("length", 99.0)]
+        )  # supersedes A
+        _deliver(cur, imgs_b, "b1", run="run-1", traits=[_trait("length", 2.0)])
+        rows = _get_scan_traits(cur, exp, "length", run_id="run-1")
+        # A's run-1 value (1.0), NOT its newer run-2 value (99.0); plus B's run-1
+        assert sorted(rows) == sorted([(a, 1.0), (b, 2.0)])
+    pg_conn.rollback()
+
+
+def test_run_id_dedups_duplicate_deliveries(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, scan_id, imgs = _seed_experiment_scan(cur)
+        _deliver(cur, imgs, "d1", run="run-x", traits=[_trait("length", 1.0)])
+        _deliver(
+            cur, imgs, "d2", run="run-x", traits=[_trait("length", 2.0)]
+        )  # 2nd delivery, same run
+        rows = _get_scan_traits(cur, exp, "length", run_id="run-x")
+        assert rows == [(scan_id, 2.0)]  # single row = latest delivery within the run
+    pg_conn.rollback()
+
+
+def test_run_id_in_other_experiment_returns_nothing(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp1, _, imgs1 = _seed_experiment_scan(cur)
+        _deliver(cur, imgs1, "e1", run="shared-run", traits=[_trait("length", 1.0)])
+        exp2, _, imgs2 = _seed_experiment_scan(cur)
+        _deliver(cur, imgs2, "e2", run="other-run", traits=[_trait("length", 2.0)])
+        # run in exp1; querying exp2 with exp1's run -> experiment filter excludes it
+        assert _get_scan_traits(cur, exp2, "length", run_id="shared-run") == []
+    pg_conn.rollback()
+
+
+def test_run_id_matching_no_source_returns_no_rows(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, _, imgs = _seed_experiment_scan(cur)
+        _deliver(
+            cur, imgs, "k", run=None, traits=[_trait("length", 1.0)]
+        )  # no pipeline_run_id
+        assert _get_scan_traits(cur, exp, "length", run_id="ghost") == []
+    pg_conn.rollback()
+
+
+def test_both_source_and_run_rejected(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, _, imgs = _seed_experiment_scan(cur)
+        src = _deliver(cur, imgs, "k", run="r", traits=[_trait("length", 1.0)])
+        with pytest.raises(psycopg.errors.RaiseException):
+            cur.execute(
+                "SELECT * FROM get_scan_traits(%s, %s, %s, %s)",
+                (exp, "length", src, "r"),
+            )
+    pg_conn.rollback()
+
+
+def test_ordering_preserved(pg_conn):
+    with pg_conn.cursor() as cur:
+        # two accessions seeded out of alphabetical order -> returned Alpha before Zulu
+        exp, wave = _seed_experiment(cur)
+        _, imgs_z = _seed_scan_in(cur, wave, accession="Zulu")
+        _, imgs_a = _seed_scan_in(cur, wave, accession="Alpha")
+        _deliver(cur, imgs_z, "z", traits=[_trait("length", 1.0)])
+        _deliver(cur, imgs_a, "a", traits=[_trait("length", 2.0)])
+        cur.execute(
+            "SELECT accession_name FROM get_scan_traits(%s, %s)", (exp, "length")
+        )
+        assert [r[0] for r in cur.fetchall()] == [
+            "Alpha",
+            "Zulu",
+        ]  # ORDER BY accession_name
+    pg_conn.rollback()
+
+
+def test_result_column_names_are_exact(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT * FROM get_scan_traits(NULL::bigint, NULL::text) LIMIT 0")
+        assert [d.name for d in cur.description] == RESULT_COLUMNS
+    pg_conn.rollback()
+
+
+def test_empty_experiment_returns_cleanly(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, _ = _seed_experiment(cur)  # experiment with no scans/traits
+        assert _get_scan_traits(cur, exp, "length") == []
+    pg_conn.rollback()
+
+
+def test_legacy_null_source_scan_returned_by_default(pg_conn):
+    with pg_conn.cursor() as cur:
+        exp, scan_id, _ = _seed_experiment_scan(cur)
+        tid = _register_trait(cur, "legacy")
+        cur.execute(
+            "INSERT INTO cyl_scan_traits (scan_id, source_id, trait_id, value) VALUES (%s, NULL, %s, %s)",
+            (
+                scan_id,
+                tid,
+                7.5,
+            ),  # dyadic: exact in real, so no float4->float8 widening drift
+        )
+        assert _get_scan_traits(cur, exp, "legacy") == [(scan_id, 7.5)]
+    pg_conn.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Requirement: Source-disambiguated trait-name listing
+# --------------------------------------------------------------------------- #
+
+
+def test_trait_names_lists_latest_and_excludes_superseded(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, _, imgs = _seed_experiment_scan(cur)
+        _deliver(
+            cur, imgs, "old", traits=[_trait("only_old", 1.0), _trait("shared", 2.0)]
+        )
+        _deliver(
+            cur, imgs, "new", traits=[_trait("shared", 3.0)]
+        )  # latest lacks only_old
+        cur.execute("SELECT name FROM cyl_scan_trait_names")
+        names = {r[0] for r in cur.fetchall()}
+        assert "shared" in names
+        assert "only_old" not in names  # only in a superseded source
+    pg_conn.rollback()
+
+
+def test_trait_names_excludes_null(pg_conn):
+    with pg_conn.cursor() as cur:
+        _, scan_id, _ = _seed_experiment_scan(cur)
+        # latest row with NULL trait_id -> NULL trait_name must not surface
+        cur.execute(
+            "INSERT INTO cyl_scan_traits (scan_id, source_id, trait_id, value) VALUES (%s, NULL, NULL, %s)",
+            (scan_id, 1.0),
+        )
+        cur.execute("SELECT count(*) FROM cyl_scan_trait_names WHERE name IS NULL")
+        assert cur.fetchone()[0] == 0
+    pg_conn.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Requirement: Read path stays open to read roles with no RLS change
+# --------------------------------------------------------------------------- #
+
+_READ_ROLES = ["bloom_agent", "bloom_user", "bloom_admin"]
+
+
+def test_read_roles_are_not_bypassrls(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT rolname, rolbypassrls FROM pg_roles WHERE rolname = ANY(%s)",
+            (_READ_ROLES,),
+        )
+        assert all(b is False for _, b in cur.fetchall())
+    pg_conn.rollback()
+
+
+@pytest.mark.parametrize("role", _READ_ROLES)
+def test_read_roles_can_use_read_surface(pg_conn, role):
+    with pg_conn.cursor() as cur:
+        exp, _, imgs = _seed_experiment_scan(cur)
+        _deliver(cur, imgs, "k", run="r", traits=[_trait("length", 1.0)])
+        cur.execute(f"SET LOCAL ROLE {role}")
+        # joined source_name column must be readable under security_invoker
+        cur.execute("SELECT source_name FROM cyl_scan_traits_source LIMIT 1")
+        cur.fetchone()
+        cur.execute("SELECT count(*) FROM cyl_scan_traits_latest")
+        cur.execute("SELECT count(*) FROM cyl_scan_trait_names")
+        # The call must be PERMITTED (no InsufficientPrivilege). Row count is a function of the
+        # invoker's RLS context on the ancillary join tables (auth.uid()-based; 0 under a raw
+        # SET LOCAL ROLE with no JWT) — unchanged by this read-path change.
+        cur.execute("SELECT count(*) FROM get_scan_traits(%s, %s)", (exp, "length"))
+        assert cur.fetchone()[0] is not None
+        cur.execute("RESET ROLE")
+    pg_conn.rollback()
+
+
+def test_migration_adds_no_write_capability():
+    # The read-path migration is read-only: it grants only SELECT and creates no policy, so it
+    # cannot widen write access to any table (a static property of the migration text).
+    sql = MIGRATION.read_text().lower()
+    assert "create policy" not in sql
+    for verb in ("grant insert", "grant update", "grant delete", "grant all"):
+        assert verb not in sql, f"migration must not {verb}"
+    for clause in ("for insert", "for update", "for delete"):
+        assert clause not in sql, f"migration must not create a {clause} policy"
+
+
+# --------------------------------------------------------------------------- #
+# Requirement: Additive, non-destructive read-path migration
+# --------------------------------------------------------------------------- #
+
+
+def test_migration_body_is_idempotent(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(_sql_body(MIGRATION))  # re-apply on already-applied state
+        for view in (
+            "cyl_scan_traits_source",
+            "cyl_scan_traits_latest",
+            "cyl_scan_trait_names",
+        ):
+            cur.execute("SELECT to_regclass(%s)", (f"public.{view}",))
+            assert cur.fetchone()[0] is not None
+        cur.execute(
+            "SELECT count(*) FROM pg_proc WHERE proname='get_scan_traits' AND pronargs=4"
+        )
+        assert cur.fetchone()[0] == 1
+    pg_conn.rollback()
+
+
+def test_rollback_restores_prior_read_surface(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(_sql_body(ROLLBACK))
+        for view in ("cyl_scan_traits_source", "cyl_scan_traits_latest"):
+            cur.execute("SELECT to_regclass(%s)", (f"public.{view}",))
+            assert cur.fetchone()[0] is None, f"{view} should be dropped by rollback"
+        # exactly one get_scan_traits remains, back to the 2-arg signature (no overload)
+        cur.execute(
+            "SELECT count(*), min(pronargs), max(pronargs) FROM pg_proc WHERE proname='get_scan_traits'"
+        )
+        assert cur.fetchone() == (1, 2, 2)
+        # cyl_scan_trait_names back to the registry passthrough: a registered-but-unmeasured
+        # name (which the latest-only view would exclude) is present again
+        _register_trait(cur, "unmeasured_reg_name")
+        cur.execute(
+            "SELECT count(*) FROM cyl_scan_trait_names WHERE name='unmeasured_reg_name'"
+        )
+        assert cur.fetchone()[0] == 1
+    pg_conn.rollback()
+
+
+def test_recreated_trait_names_readable_by_read_role(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute("SET LOCAL ROLE bloom_agent")
+        cur.execute("SELECT count(*) FROM cyl_scan_trait_names")
+        assert cur.fetchone()[0] is not None
+        cur.execute("RESET ROLE")
+    pg_conn.rollback()

--- a/tests/integration/test_cyl_read_path.py
+++ b/tests/integration/test_cyl_read_path.py
@@ -37,6 +37,14 @@ PINNED_VERSION = "v0.1.0a2"
 _TS = "20260701000000_cyl_trait_read_source_aware"
 MIGRATION = REPO_ROOT / "supabase" / "migrations" / f"{_TS}.sql"
 ROLLBACK = REPO_ROOT / "supabase" / "rollbacks" / f"{_TS}_rollback.sql"
+# The read-path views read cyl_trait_sources.metadata, so change-A's break-glass rollback
+# must CASCADE-drop them (regression guard below).
+A_PROVENANCE_ROLLBACK = (
+    REPO_ROOT
+    / "supabase"
+    / "rollbacks"
+    / "20260609000000_add_cyl_trait_source_provenance_rollback.sql"
+)
 
 # The 10 result columns get_scan_traits has always returned, in order.
 RESULT_COLUMNS = [
@@ -625,4 +633,39 @@ def test_recreated_trait_names_readable_by_read_role(pg_conn):
         cur.execute("SELECT count(*) FROM cyl_scan_trait_names")
         assert cur.fetchone()[0] is not None
         cur.execute("RESET ROLE")
+    pg_conn.rollback()
+
+
+def test_change_a_rollback_cascades_read_views(pg_conn):
+    """Coexistence invariant: the read-path views read cyl_trait_sources.metadata, so change-A's
+    break-glass provenance rollback (DROP COLUMN metadata) must CASCADE-drop them — else it errors
+    with DependentObjectsStillExist. This locks the ripple that broke compose-health-check before
+    the CASCADE fix (a regression here means change-A's rollback lost CASCADE or the dependency
+    changed)."""
+    with pg_conn.cursor() as cur:
+        cur.execute(_sql_body(A_PROVENANCE_ROLLBACK))  # must not raise
+        cur.execute("SELECT to_regclass('public.cyl_scan_traits_source')")
+        assert (
+            cur.fetchone()[0] is None
+        ), "change-A rollback must CASCADE-drop the read-path views"
+    pg_conn.rollback()
+
+
+def test_authenticated_has_select_grant_on_views(pg_conn):
+    """`authenticated` is granted SELECT on all three views (spec + precedent), but a raw
+    `SET LOCAL ROLE authenticated` has no JWT/auth.uid() context, so assert the grant exists
+    rather than exercising a read — a dropped grant would otherwise ship green."""
+    with pg_conn.cursor() as cur:
+        for view in (
+            "cyl_scan_traits_source",
+            "cyl_scan_traits_latest",
+            "cyl_scan_trait_names",
+        ):
+            cur.execute(
+                "SELECT has_table_privilege('authenticated', %s, 'SELECT')",
+                (f"public.{view}",),
+            )
+            assert (
+                cur.fetchone()[0] is True
+            ), f"authenticated should have SELECT on {view}"
     pg_conn.rollback()

--- a/web/lib/database.types.ts
+++ b/web/lib/database.types.ts
@@ -2286,6 +2286,29 @@ export type Database = {
         }
         Relationships: []
       }
+      cyl_scan_traits_latest: {
+        Row: {
+          scan_id: number | null
+          source_id: number | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
+      cyl_scan_traits_source: {
+        Row: {
+          is_latest: boolean | null
+          pipeline_run_id: string | null
+          scan_id: number | null
+          source_id: number | null
+          source_name: string | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
       cyl_scans_extended: {
         Row: {
           accession_id: number | null
@@ -2397,7 +2420,7 @@ export type Database = {
       }
       dblink_is_busy: { Args: { "": string }; Returns: number }
       get_scan_traits: {
-        Args: { experiment_id_: number; trait_name_: string }
+        Args: { experiment_id_: number; run_id_?: string; source_id_?: number; trait_name_: string }
         Returns: {
           accession_name: string
           date_scanned: string

--- a/web/types/database.types.ts
+++ b/web/types/database.types.ts
@@ -1457,6 +1457,29 @@ export interface Database {
         }
         Relationships: []
       }
+      cyl_scan_traits_latest: {
+        Row: {
+          scan_id: number | null
+          source_id: number | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
+      cyl_scan_traits_source: {
+        Row: {
+          is_latest: boolean | null
+          pipeline_run_id: string | null
+          scan_id: number | null
+          source_id: number | null
+          source_name: string | null
+          trait_id: number | null
+          trait_name: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
       cyl_scans_extended: {
         Row: {
           accession_id: number | null
@@ -1536,6 +1559,8 @@ export interface Database {
       get_scan_traits: {
         Args: {
           experiment_id_: number
+          run_id_?: string
+          source_id_?: number
           trait_name_: string
         }
         Returns: {


### PR DESCRIPTION
## Summary

Makes the cyl trait **READ** path source-aware. The write-back RPC (#371) mints a new `cyl_trait_sources` row per pipeline run, so a reprocessed scan now carries **multiple** sources and the source-blind `get_scan_traits` returned duplicate/ambiguous rows. This adds one shared source-aware read surface: latest-source-per-scan by default, with optional source pinning and pipeline-run grouping — backward-compatible for existing callers. Roadmap A2 "read-path" (≡ bloom-mcp data-access; latest = `max(id)`). Bundles the OpenSpec proposal + implementation in one PR.

## Changes

- **`cyl_scan_traits_source`** (substrate view, `security_invoker`): one row per `cyl_scan_traits` row exposing `scan_id, trait_id, trait_name, value, source_id, source_name, pipeline_run_id, is_latest`, where `is_latest = source_id IS NOT DISTINCT FROM max(source_id) OVER (PARTITION BY scan_id)` (window aggregate; legacy `NULL`-source rows count as latest). Single source of truth for the "latest = max(id)" rule.
- **`cyl_scan_traits_latest`** = the `is_latest` rows (canonical latest-per-scan surface, no cross-source mixing).
- **`get_scan_traits(experiment_id_, trait_name_, source_id_ DEFAULT NULL, run_id_ DEFAULT NULL)`**: both NULL ⇒ latest per scan; `source_id_` ⇒ pin a source; `run_id_` ⇒ each scan's values from one pipeline run ("as of run X", deduped to the latest delivery within the run); both set ⇒ error. Legacy 2-arg dropped so exactly one candidate exists (no PostgREST `PGRST203` overload ambiguity); 2-arg callers bind the defaults. plpgsql with table-qualified `ORDER BY` (avoids OUT-variable/column ambiguity).
- **`cyl_scan_trait_names`** now lists distinct non-null trait names present in latest data (column `name` unchanged).
- Forward-only migration `20260701000000_*` + companion manual rollback; hand-edited `database.types.ts` (×5, two new views + optional args); `_WIKI/BLOOMMCP/README.md` steered off the source-blind `cyl_scan_traits` read pattern.
- New capability spec `cyl-trait-read` + design + TDD tasks (`openspec/changes/add-cyl-trait-read-source-aware/`).

## Testing

- [x] Integration tests pass: `tests/integration/test_cyl_read_path.py` — 32 passed, 1 skipped (the PostgREST HTTP no-overload test skips locally without the gateway; runs in CI's `compose-health-check`). Covers latest/pin/run selection, no cross-source mixing, run-dedup, backward-compat (SQL + PostgREST), legacy `NULL`-source rows, non-finite→`NULL`, migration idempotency, and rollback fidelity.
- [x] `cd web && npx tsc --noEmit` — no type errors from this change (the `TraitExplorer` 2-arg call still typechecks; the two new args are optional).
- [x] `openspec validate add-cyl-trait-read-source-aware --strict` passes; migration lint passes; ruff/black/prettier clean.
- [ ] Full `compose-health-check` + web build — deferred to CI (authoritative).

## Database/Supabase Changes

- [x] Migration applied + tested locally against the dev DB (synced to head first).
- [x] No RLS/write-grant change — read-only; new views granted `SELECT` to `bloom_agent`/`bloom_user`/`bloom_admin`/`authenticated`.
- [x] Types regenerated (hand-edited ×5 per the known gen-types drift; #371 precedent).
- [x] Rollback SQL provided under `supabase/rollbacks/`.

## Breaking Changes

None. Backward-compatible: the sole 2-arg caller (`web/app/app/traits/.../TraitExplorer.tsx:194`) is unchanged; single-source scans behave identically, multi-source scans now return the latest instead of duplicates.

## Deferred follow-up (please file as a tracking issue)

Several existing readers still read `cyl_scan_traits` source-blind and should be repointed at the new surface (the substrate view was built to make this trivial):
1. **`cyl_trait_by_experiment_wave`** aggregate view — double-counts across sources; rebuild on `cyl_scan_traits_latest`. Consumers: langchain `cyl_tools.py`, web traits page, `tests/integration/test_phenotyping_supabase_tools.py`.
2. **`langchain/tools/cyl_tools.py` `get_scan_traits_tool`** — source-blind, and already broken (selects `trait_name`, dropped from `cyl_scan_traits` in 20241119). Repoint at `cyl_scan_traits_source`.
3. **`langchain/tools/context_tools.py` `CONTEXT_CYL`** — stale schema (lists dropped `trait_name`, omits `source_id`).

## Related Issues

Closes #298