### PR TITLE
feat(#308): granular pca_analysis MCP tool (bloom-mcp Phase 2 Tier 4)

### DIFF
--- a/bloommcp/src/bloom_mcp/server.py
+++ b/bloommcp/src/bloom_mcp/server.py
@@ -19,6 +19,8 @@ Discovery tools (always-on):
 Direct tools (granular, available for ad-hoc use):
   - qc_clean:          clean a raw trait table for analysis (delegates to
                        sleap_roots_analyze.clean_traits_for_analysis)
+  - pca_analysis:      PCA on a cleaned experiment (require_clean; delegates to
+                       sleap_roots_analyze.perform_pca_analysis)
   - correlation_tools: 8 cross-experiment correlation tools
   - viz_tools:         7 plotting tools
 """
@@ -44,6 +46,7 @@ from bloom_mcp.tools import (
     correlation_tools,
     storage_tools,
     qc_clean_tool,
+    pca_analysis_tool,
 )
 from bloom_mcp.tools.workflows import (
     clustering as clustering_workflow,
@@ -94,6 +97,7 @@ clustering_workflow.register(mcp)
 
 # Direct tools (granular)
 qc_clean_tool.register(mcp)
+pca_analysis_tool.register(mcp)
 correlation_tools.register(mcp)
 viz_tools.register(mcp)
 

--- a/bloommcp/src/bloom_mcp/tools/pca_analysis_tool.py
+++ b/bloommcp/src/bloom_mcp/tools/pca_analysis_tool.py
@@ -1,0 +1,261 @@
+"""pca_analysis — PCA on a cleaned experiment, delegating to sleap-roots-analyze.
+
+The first granular **consumer** (Tier 4 / #308): it reads a *cleaned* experiment
+through the :class:`ExperimentReader` port with ``require_clean=True`` and delegates
+**all** PCA to ``sleap_roots_analyze.perform_pca_analysis``, wrapping the result into
+the upstream typed :class:`PCAResult` via ``PCAResult.from_pca_dict``. The MCP owns no
+PCA math — no standardization, eigendecomposition, component selection, or loadings
+computation of its own, and it never touches the vendored ``bloom_mcp.pca``.
+
+**Consume, don't re-clean.** ``perform_pca_analysis`` silently ``dropna()``s, so running
+it on raw data is uncontrolled sample loss. Requiring a cleaned version is necessary but
+not sufficient: the reader's cleaned frame guarantees no-NaN only in its *surviving* trait
+columns (``frame.trait_cols``). So the tool restricts the selection to that certified set —
+a requested column outside it (or one that still carries NaN) is rejected with
+``invalid_input`` rather than silently row-dropped — making the delegate's internal
+``dropna()`` a genuine no-op over the sample set ``qc_clean`` certified.
+
+**Deterministic.** PCA here fits via sklearn's deterministic solver, so the tool declares
+no ``random_state`` and records ``seed = None`` (matching ``qc_clean``). It persists a
+versioned run under tool class ``pca`` — the loadings + component scores as CSVs and the
+serialized ``PCAResult`` — recording ``based_on_version`` = the consumed cleaned version so
+the ``qc_clean`` → ``pca_analysis`` lineage is recoverable, and returns a variance summary +
+links (never the score/loadings matrices inline).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+from pydantic import BaseModel, Field
+from sleap_roots_analyze import PCAResult, perform_pca_analysis
+
+from bloom_mcp.contract import BloomMCPError, Provenance, as_mcp_tool
+from bloom_mcp.contract import register as _contract_register
+from bloom_mcp.data_access import (
+    CleanedVersionRequiredError,
+    ExperimentFrame,
+    ExperimentReadError,
+)
+from bloom_mcp.tools import _ports
+
+_TOOL_CLASS = "pca"
+_LOADINGS_NAME = "loadings.csv"
+_SCORES_NAME = "scores.csv"
+_RESULT_NAME = "pca_result.json"
+
+
+class PCAAnalysisParams(BaseModel):
+    """Inputs for ``pca_analysis``. No ``seed`` — PCA here is deterministic."""
+
+    experiment: str = Field(
+        ...,
+        description="Experiment (CSV filename) to analyze. Must have a cleaned version "
+        "produced by qc_clean; pca_analysis consumes it (require_clean).",
+    )
+    trait_columns: Optional[list[str]] = Field(
+        default=None,
+        description="Subset of cleaned trait columns to analyze; omit to use all "
+        "certified-clean traits. Each must be a cleaned trait column of the experiment.",
+    )
+    standardize: bool = Field(
+        default=True,
+        description="Z-score each trait before PCA (matches the recorded golden).",
+    )
+    explained_variance_threshold: float = Field(
+        default=0.95,
+        ge=0.0,
+        le=1.0,
+        description="Cumulative-variance threshold for automatic component selection; "
+        "used only when n_components is omitted.",
+    )
+    n_components: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Fixed number of components; overrides the variance threshold. "
+        "Clamped to the number of selected features (never raises if larger).",
+    )
+    user_label: Optional[str] = Field(
+        default=None,
+        description="Optional slug appended to the version directory name.",
+    )
+
+
+class PCAAnalysisResult(BaseModel):
+    """A small variance summary + links to the persisted PCA run (no matrices inline)."""
+
+    experiment: str
+    source: str
+    n_samples: int
+    n_features: int
+    n_components: int
+    feature_names: list[str]
+    explained_variance_ratio: list[float]
+    cumulative_variance_ratio: list[float]
+    eigenvalues: list[float]
+    run_ref: str
+    version_dir: str
+    manifest_path: str
+    outputs: dict[str, str]
+
+
+def _validate_trait_subset(
+    frame: ExperimentFrame, requested: list[str], experiment: str
+) -> None:
+    """Require every selected column to be in the certified-clean trait set.
+
+    ``require_clean`` guarantees no-NaN only within ``frame.trait_cols``; the frame may
+    still carry other numeric columns holding NaNs. Restricting the selection to the
+    certified set (not merely "exists + numeric" over the whole frame) is what forecloses
+    the silent-``dropna()`` path — a NaN-bearing numeric column ``qc_clean`` did not adopt
+    as a surviving trait cannot be selected. Unknown, metadata, and non-certified columns
+    all surface here as a fixable ``invalid_input`` naming the offenders.
+    """
+    certified = set(frame.trait_cols)
+    outside = [c for c in requested if c not in certified]
+    if outside:
+        raise BloomMCPError(
+            code="invalid_input",
+            message=(
+                f"trait_columns includes columns that are not certified-clean traits of "
+                f"{experiment!r}: {outside}."
+            ),
+            remedy=(
+                "Pass only cleaned trait columns (see load_experiment_data on the cleaned "
+                "version), or omit trait_columns to use all of them."
+            ),
+        )
+    non_numeric = [
+        c for c in requested if not pd.api.types.is_numeric_dtype(frame.df[c])
+    ]
+    if non_numeric:
+        raise BloomMCPError(
+            code="invalid_input",
+            message=f"trait_columns includes non-numeric columns: {non_numeric}.",
+            remedy="Pass only numeric trait columns; identifiers/metadata cannot be analyzed.",
+        )
+
+
+def _loadings_frame(pca: PCAResult) -> pd.DataFrame:
+    """Component loadings as features (rows) × components (columns)."""
+    cols = [f"PC{i + 1}" for i in range(pca.n_components)]
+    return pd.DataFrame(pca.loadings, index=pca.feature_names, columns=cols)
+
+
+def _scores_frame(pca: PCAResult) -> pd.DataFrame:
+    """Sample scores as samples (rows) × components (columns)."""
+    cols = [f"PC{i + 1}" for i in range(pca.n_components)]
+    return pd.DataFrame(pca.scores, columns=cols)
+
+
+@as_mcp_tool(
+    input_model=PCAAnalysisParams,
+    output_model=PCAAnalysisResult,
+    errors=(ExperimentReadError,),
+)
+def pca_analysis(
+    params: PCAAnalysisParams, *, provenance: Provenance
+) -> PCAAnalysisResult:
+    """Run PCA on a cleaned ``experiment`` via ``perform_pca_analysis`` and persist it."""
+    reader = _ports.reader()
+    store = _ports.store()
+
+    # Consumer: require a cleaned version. A missing one is a precondition failure with a
+    # concrete remedy — caught here so it carries "run qc_clean first" rather than the
+    # contract's generic tool_error message for the declared read error.
+    try:
+        frame = reader.load_experiment(params.experiment, require_clean=True)
+    except CleanedVersionRequiredError:
+        raise BloomMCPError(
+            code="tool_error",
+            message=(
+                f"No cleaned version of {params.experiment!r} exists; pca_analysis "
+                f"requires a cleaned input."
+            ),
+            remedy=f"Run qc_clean on {params.experiment!r} first, then retry pca_analysis.",
+        ) from None
+
+    if params.trait_columns is not None:
+        _validate_trait_subset(frame, params.trait_columns, params.experiment)
+    trait_cols = (
+        list(params.trait_columns) if params.trait_columns else list(frame.trait_cols)
+    )
+    selected = frame.df[trait_cols]
+
+    # Defense-in-depth: the certified-clean set must be NaN-free, so the delegate's
+    # internal dropna() never silently loses a certified sample. A mis-reporting reader
+    # is the only way this fires.
+    if int(selected.isna().sum().sum()) > 0:
+        raise BloomMCPError(
+            code="assumption_violated",
+            message="The cleaned experiment carries NaNs in its certified trait columns.",
+            remedy="Re-run qc_clean to produce a NaN-free cleaned version, then retry.",
+        )
+
+    # Delegate ALL PCA. The delegate *raises* ValueError on degenerate input (< 2 samples,
+    # no non-constant trait) — map it to a self-correctable error rather than letting it
+    # fall through to the contract's opaque internal_error.
+    try:
+        result_dict = perform_pca_analysis(
+            selected,
+            standardize=params.standardize,
+            explained_variance_threshold=params.explained_variance_threshold,
+            n_components=params.n_components,
+        )
+    except ValueError:
+        # The delegate's ValueError reasons (< 2 samples / no non-constant trait) collapse
+        # to one remedy; give a fixed, actionable message rather than echoing the raw
+        # exception text into the user-facing envelope.
+        raise BloomMCPError(
+            code="assumption_violated",
+            message="PCA could not fit the selected traits (too few samples, or no trait with non-zero variance).",
+            remedy=(
+                "Select a broader set of numeric trait columns (at least two samples and "
+                "a non-constant trait), then retry."
+            ),
+        ) from None
+
+    pca = PCAResult.from_pca_dict(result_dict)
+
+    # Persist a versioned run, recording the cleaned-source lineage on the manifest so the
+    # qc_clean run that produced this PCA's input is recoverable.
+    prov = provenance.model_copy(update={"based_on_version": frame.source})
+    run = store.create_run(
+        experiment=params.experiment,
+        tool_class=_TOOL_CLASS,
+        provenance=prov,
+        user_label=params.user_label,
+    )
+    _loadings_frame(pca).to_csv(run.staging_dir / _LOADINGS_NAME, index=True)
+    _scores_frame(pca).to_csv(run.staging_dir / _SCORES_NAME, index=False)
+    (run.staging_dir / _RESULT_NAME).write_text(pca.to_json())
+    stored = store.commit(
+        run,
+        {
+            _LOADINGS_NAME: _LOADINGS_NAME,
+            _SCORES_NAME: _SCORES_NAME,
+            _RESULT_NAME: _RESULT_NAME,
+        },
+    )
+
+    return PCAAnalysisResult(
+        experiment=params.experiment,
+        source=frame.source,
+        n_samples=len(selected),
+        n_features=len(trait_cols),
+        n_components=pca.n_components,
+        feature_names=list(pca.feature_names),
+        explained_variance_ratio=list(pca.explained_variance_ratio),
+        cumulative_variance_ratio=list(pca.cumulative_variance_ratio),
+        eigenvalues=list(pca.eigenvalues),
+        run_ref=stored.run_ref,
+        version_dir=stored.version_dir,
+        manifest_path=stored.manifest_path,
+        outputs=dict(stored.output_keys),
+    )
+
+
+def register(mcp):
+    """Register pca_analysis with the MCP server."""
+    return _contract_register(mcp, pca_analysis)

--- a/bloommcp/src/bloom_mcp/tools/pca_analysis_tool.py
+++ b/bloommcp/src/bloom_mcp/tools/pca_analysis_tool.py
@@ -11,22 +11,31 @@ computation of its own, and it never touches the vendored ``bloom_mcp.pca``.
 it on raw data is uncontrolled sample loss. Requiring a cleaned version is necessary but
 not sufficient: the reader's cleaned frame guarantees no-NaN only in its *surviving* trait
 columns (``frame.trait_cols``). So the tool restricts the selection to that certified set —
-a requested column outside it (or one that still carries NaN) is rejected with
-``invalid_input`` rather than silently row-dropped — making the delegate's internal
-``dropna()`` a genuine no-op over the sample set ``qc_clean`` certified.
+a requested column outside it (or one that still carries a non-finite value) is rejected
+with ``invalid_input`` / ``assumption_violated`` rather than silently row-dropped — making
+the delegate's internal ``dropna()`` a genuine no-op over the sample set ``qc_clean``
+certified.
 
-**Deterministic.** PCA here fits via sklearn's deterministic solver, so the tool declares
-no ``random_state`` and records ``seed = None`` (matching ``qc_clean``). It persists a
-versioned run under tool class ``pca`` — the loadings + component scores as CSVs and the
-serialized ``PCAResult`` — recording ``based_on_version`` = the consumed cleaned version so
+**Deterministic in this tool's regime.** PCA here fits via sklearn's ``svd_solver="auto"``,
+which selects the deterministic ``covariance_eigh`` path for the tabular-phenotyping regime
+this tool serves (few trait columns, many samples). There ``random_state`` is inert, so the
+tool declares no ``random_state`` and records ``seed = None`` (matching ``qc_clean``). The
+delegate still hard-codes an internal seed, so a fit that fell into sklearn's randomized
+path (a very wide selection — see the design doc's Risks) would remain *reproducible*, but
+``seed = None`` would then under-describe it; that boundary is documented rather than
+silently assumed. It persists a versioned run under tool class ``pca`` — the loadings +
+component scores as CSVs and the serialized ``PCAResult`` — recording ``based_on_version`` =
+the consumed cleaned version and content-addressing the consumed frame via ``source_csv`` so
 the ``qc_clean`` → ``pca_analysis`` lineage is recoverable, and returns a variance summary +
 links (never the score/loadings matrices inline).
 """
 
 from __future__ import annotations
 
-from typing import Optional
+import tempfile
+from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from pydantic import BaseModel, Field
 from sleap_roots_analyze import PCAResult, perform_pca_analysis
@@ -44,6 +53,7 @@ _TOOL_CLASS = "pca"
 _LOADINGS_NAME = "loadings.csv"
 _SCORES_NAME = "scores.csv"
 _RESULT_NAME = "pca_result.json"
+_INPUT_SNAPSHOT_NAME = "input.csv"
 
 
 class PCAAnalysisParams(BaseModel):
@@ -54,10 +64,11 @@ class PCAAnalysisParams(BaseModel):
         description="Experiment (CSV filename) to analyze. Must have a cleaned version "
         "produced by qc_clean; pca_analysis consumes it (require_clean).",
     )
-    trait_columns: Optional[list[str]] = Field(
+    trait_columns: list[str] | None = Field(
         default=None,
         description="Subset of cleaned trait columns to analyze; omit to use all "
-        "certified-clean traits. Each must be a cleaned trait column of the experiment.",
+        "certified-clean traits. Each must be a cleaned trait column of the experiment. "
+        "Pass at least one column with no duplicates (an empty list is rejected).",
     )
     standardize: bool = Field(
         default=True,
@@ -70,13 +81,13 @@ class PCAAnalysisParams(BaseModel):
         description="Cumulative-variance threshold for automatic component selection; "
         "used only when n_components is omitted.",
     )
-    n_components: Optional[int] = Field(
+    n_components: int | None = Field(
         default=None,
         ge=1,
         description="Fixed number of components; overrides the variance threshold. "
         "Clamped to the number of selected features (never raises if larger).",
     )
-    user_label: Optional[str] = Field(
+    user_label: str | None = Field(
         default=None,
         description="Optional slug appended to the version directory name.",
     )
@@ -103,7 +114,7 @@ class PCAAnalysisResult(BaseModel):
 def _validate_trait_subset(
     frame: ExperimentFrame, requested: list[str], experiment: str
 ) -> None:
-    """Require every selected column to be in the certified-clean trait set.
+    """Require the selection to be a duplicate-free set of certified-clean trait columns.
 
     ``require_clean`` guarantees no-NaN only within ``frame.trait_cols``; the frame may
     still carry other numeric columns holding NaNs. Restricting the selection to the
@@ -111,7 +122,29 @@ def _validate_trait_subset(
     the silent-``dropna()`` path — a NaN-bearing numeric column ``qc_clean`` did not adopt
     as a surviving trait cannot be selected. Unknown, metadata, and non-certified columns
     all surface here as a fixable ``invalid_input`` naming the offenders.
+
+    An **empty** list and **duplicate** names are rejected too: ``[]`` would otherwise fall
+    through to "all certified traits" (a full-frame PCA the caller did not ask for), and a
+    duplicate name would be re-selected by the delegate's ``standardize_data``, inflating the
+    feature set (e.g. ``["Holes", "Holes"]`` → four features) while ``n_features`` still
+    reported two.
     """
+    if not requested:
+        raise BloomMCPError(
+            code="invalid_input",
+            message="trait_columns was given as an empty list.",
+            remedy=(
+                "Omit trait_columns to analyze all certified-clean traits, or name at "
+                "least one certified trait column."
+            ),
+        )
+    duplicates = sorted({c for c in requested if requested.count(c) > 1})
+    if duplicates:
+        raise BloomMCPError(
+            code="invalid_input",
+            message=f"trait_columns contains duplicate columns: {duplicates}.",
+            remedy="List each trait column at most once.",
+        )
     certified = set(frame.trait_cols)
     outside = [c for c in requested if c not in certified]
     if outside:
@@ -143,10 +176,22 @@ def _loadings_frame(pca: PCAResult) -> pd.DataFrame:
     return pd.DataFrame(pca.loadings, index=pca.feature_names, columns=cols)
 
 
-def _scores_frame(pca: PCAResult) -> pd.DataFrame:
-    """Sample scores as samples (rows) × components (columns)."""
+def _scores_frame(pca: PCAResult, frame: ExperimentFrame) -> pd.DataFrame:
+    """Sample scores as samples (rows) × components (columns), carrying sample identity.
+
+    Prepends the frame's ``metadata_cols`` (e.g. Barcode/Genotype/Replicate) so each score
+    row maps back to its plant by a shared key rather than fragile positional alignment —
+    mirroring how the upstream ``run_pca_and_export_artifacts`` stitches ``metadata_cols``
+    onto its exported scores. This is sound *because* the tool certifies the selection
+    finite before fitting: the delegate's internal ``dropna()`` is then a no-op, so
+    ``pca.scores`` is row-aligned (in order) with ``frame.df``.
+    """
     cols = [f"PC{i + 1}" for i in range(pca.n_components)]
-    return pd.DataFrame(pca.scores, columns=cols)
+    scores = pd.DataFrame(pca.scores, columns=cols)
+    if not frame.metadata_cols:
+        return scores
+    identity = frame.df[frame.metadata_cols].reset_index(drop=True)
+    return pd.concat([identity, scores], axis=1)
 
 
 @as_mcp_tool(
@@ -176,26 +221,30 @@ def pca_analysis(
             remedy=f"Run qc_clean on {params.experiment!r} first, then retry pca_analysis.",
         ) from None
 
-    if params.trait_columns is not None:
+    if params.trait_columns is None:
+        trait_cols = list(frame.trait_cols)
+    else:
         _validate_trait_subset(frame, params.trait_columns, params.experiment)
-    trait_cols = (
-        list(params.trait_columns) if params.trait_columns else list(frame.trait_cols)
-    )
+        trait_cols = list(params.trait_columns)
     selected = frame.df[trait_cols]
 
-    # Defense-in-depth: the certified-clean set must be NaN-free, so the delegate's
-    # internal dropna() never silently loses a certified sample. A mis-reporting reader
-    # is the only way this fires.
-    if int(selected.isna().sum().sum()) > 0:
+    # Defense-in-depth: the certified-clean set must be finite, so the delegate's internal
+    # dropna() never silently loses a certified sample. isna() alone misses ±inf (which
+    # dropna() also keeps), so it would poison standardization/eigendecomposition — check
+    # full finiteness. A mis-reporting reader is the only way this fires.
+    if not np.isfinite(selected.to_numpy(dtype=float)).all():
         raise BloomMCPError(
             code="assumption_violated",
-            message="The cleaned experiment carries NaNs in its certified trait columns.",
-            remedy="Re-run qc_clean to produce a NaN-free cleaned version, then retry.",
+            message=(
+                "The cleaned experiment carries non-finite values (NaN or ±inf) in its "
+                "certified trait columns."
+            ),
+            remedy="Re-run qc_clean to produce a finite-valued cleaned version, then retry.",
         )
 
     # Delegate ALL PCA. The delegate *raises* ValueError on degenerate input (< 2 samples,
-    # no non-constant trait) — map it to a self-correctable error rather than letting it
-    # fall through to the contract's opaque internal_error.
+    # empty, no non-constant trait) — map it to a self-correctable error rather than letting
+    # it fall through to the contract's opaque internal_error.
     try:
         result_dict = perform_pca_analysis(
             selected,
@@ -204,46 +253,84 @@ def pca_analysis(
             n_components=params.n_components,
         )
     except ValueError:
-        # The delegate's ValueError reasons (< 2 samples / no non-constant trait) collapse
-        # to one remedy; give a fixed, actionable message rather than echoing the raw
-        # exception text into the user-facing envelope.
+        # The delegate's ValueError reasons collapse to one remedy; give a fixed, actionable
+        # message rather than echoing the raw exception text into the user-facing envelope
+        # (it may carry backend internals — see the no-leak test).
         raise BloomMCPError(
             code="assumption_violated",
-            message="PCA could not fit the selected traits (too few samples, or no trait with non-zero variance).",
+            message=(
+                "PCA could not fit the selected traits — the cleaned selection is degenerate "
+                "(empty, fewer than two samples, or no trait with non-zero variance)."
+            ),
             remedy=(
                 "Select a broader set of numeric trait columns (at least two samples and "
                 "a non-constant trait), then retry."
             ),
         ) from None
 
-    pca = PCAResult.from_pca_dict(result_dict)
+    # Stamp the threshold that produced the fit so the serialized PCAResult self-describes
+    # its selection rule (random_state stays None — consistent with seed=None; the delegate's
+    # deterministic path does not consume one).
+    pca = PCAResult.from_pca_dict(
+        result_dict,
+        explained_variance_threshold=params.explained_variance_threshold,
+    )
+
+    # The delegate silently drops zero-variance (constant) columns before fitting, so
+    # feature_names can be shorter than the requested set — which would make the reported
+    # n_features disagree with the persisted (n-1)-row loadings. Surface that rather than
+    # emit an internally inconsistent artifact. (Duplicate names are already rejected, so a
+    # shrink here means a constant certified trait, not a re-selected duplicate.)
+    fitted = set(pca.feature_names)
+    dropped = [c for c in trait_cols if str(c) not in fitted]
+    if dropped:
+        raise BloomMCPError(
+            code="assumption_violated",
+            message=(
+                "PCA dropped constant (zero-variance) trait column(s) from the certified "
+                f"selection: {dropped}. Fitting the remainder would report a feature count "
+                "that disagrees with the persisted loadings."
+            ),
+            remedy=(
+                "Exclude the constant column(s) from trait_columns (or re-run qc_clean to "
+                "drop them), then retry."
+            ),
+        )
 
     # Persist a versioned run, recording the cleaned-source lineage on the manifest so the
-    # qc_clean run that produced this PCA's input is recoverable.
+    # qc_clean run that produced this PCA's input is recoverable. The consumed cleaned frame
+    # lives in the backend, not at a known local path, so snapshot it to a temp CSV and pass
+    # it as source_csv — the manifest then content-addresses the exact input (input_sha256),
+    # not just the mutable v<N>_cleaned label. The snapshot must outlive commit(), which is
+    # where the store hashes it.
     prov = provenance.model_copy(update={"based_on_version": frame.source})
-    run = store.create_run(
-        experiment=params.experiment,
-        tool_class=_TOOL_CLASS,
-        provenance=prov,
-        user_label=params.user_label,
-    )
-    _loadings_frame(pca).to_csv(run.staging_dir / _LOADINGS_NAME, index=True)
-    _scores_frame(pca).to_csv(run.staging_dir / _SCORES_NAME, index=False)
-    (run.staging_dir / _RESULT_NAME).write_text(pca.to_json())
-    stored = store.commit(
-        run,
-        {
-            _LOADINGS_NAME: _LOADINGS_NAME,
-            _SCORES_NAME: _SCORES_NAME,
-            _RESULT_NAME: _RESULT_NAME,
-        },
-    )
+    with tempfile.TemporaryDirectory(prefix="pca_input_") as _tmp:
+        source_snapshot = Path(_tmp) / _INPUT_SNAPSHOT_NAME
+        frame.df.to_csv(source_snapshot, index=False)
+        run = store.create_run(
+            experiment=params.experiment,
+            tool_class=_TOOL_CLASS,
+            provenance=prov,
+            user_label=params.user_label,
+            source_csv=source_snapshot,
+        )
+        _loadings_frame(pca).to_csv(run.staging_dir / _LOADINGS_NAME, index=True)
+        _scores_frame(pca, frame).to_csv(run.staging_dir / _SCORES_NAME, index=False)
+        (run.staging_dir / _RESULT_NAME).write_text(pca.to_json())
+        stored = store.commit(
+            run,
+            {
+                _LOADINGS_NAME: _LOADINGS_NAME,
+                _SCORES_NAME: _SCORES_NAME,
+                _RESULT_NAME: _RESULT_NAME,
+            },
+        )
 
     return PCAAnalysisResult(
         experiment=params.experiment,
         source=frame.source,
         n_samples=len(selected),
-        n_features=len(trait_cols),
+        n_features=len(pca.feature_names),
         n_components=pca.n_components,
         feature_names=list(pca.feature_names),
         explained_variance_ratio=list(pca.explained_variance_ratio),

--- a/bloommcp/tests/fixtures/README.md
+++ b/bloommcp/tests/fixtures/README.md
@@ -26,19 +26,25 @@ code under test — so the oracle is a genuine cross-tier regression check.
   recorded in the `_reproduced_by_sleap_roots_analyze_version` key.
 - `turface_19_pca_golden.json` — recorded golden + drift snapshots for that table.
   The keys carry **distinct provenance** (see the `_*_source` fields):
+
   - **PCA** (`pca_explained_variance` ≈0.95991, `n_pca_components` = 3) is an
-    *independently recorded* golden from #120's `viz_pca_metadata.json`. The recorded
+    _independently recorded_ golden from #120's `viz_pca_metadata.json`. The recorded
     `top_features` field was **omitted**: it comes from a viz-specific ranking
     heuristic in #120 that `perform_pca_analysis` does not expose, so it cannot be
-    asserted as a faithful oracle.
+    asserted as a faithful oracle. The per-PC `pca_explained_variance_ratio`
+    (`[0.8613, 0.0582, 0.0404]`, added for Tier 4 / #308) is a **characterization
+    snapshot** re-derived from `perform_pca_analysis==0.1.0a3` (see `_pca_evr_source`):
+    the upstream viz metadata records only the _cumulative_ value, so this per-PC split
+    is a drift gate, **not** an independent oracle — its three entries sum to the
+    independent cumulative `pca_explained_variance` above.
   - **Heritability** (`heritability_mean` = 0.7650…, `heritability_method`,
-    `heritability_n_above_0.5`) is a *characterization snapshot* of
+    `heritability_n_above_0.5`) is a _characterization snapshot_ of
     `sleap-roots-analyze==0.1.0a2` on this fixture — **not** an independently validated
     value (the PCA-metadata source above does not contain a heritability mean). It gates
     future drift only; reconciling it to the R/lme4 reference the library docstring
     claims to match is tracked by **#315**.
   - **UMAP** (`umap_trustworthiness` ≈0.95, `umap_trustworthiness_floor` = 0.88) is a
-    *structural* snapshot: UMAP coordinates are not cross-OS bit-stable, so the gate
+    _structural_ snapshot: UMAP coordinates are not cross-OS bit-stable, so the gate
     asserts neighbor-preservation (trustworthiness) of the embedding w.r.t. the
     standardized input — a wrong `n_neighbors`/`min_dist`/`init` delegation drops it
     below the floor (verified by a companion negative test).

--- a/bloommcp/tests/fixtures/turface_19_pca_golden.json
+++ b/bloommcp/tests/fixtures/turface_19_pca_golden.json
@@ -1,23 +1,25 @@
 {
- "_pca_source": "talmolab/sleap-roots-analyze#120 / PR #146 — tests/fixtures/real/wheat_edpie/expected/viz/turface_19/viz_pca_metadata.json. Independently recorded golden (NOT re-derived from the code under test).",
- "_heritability_source": "Characterization snapshot of sleap-roots-analyze==0.1.0a2 on this fixture (re-verified unchanged through 0.1.0a3, #327) — NOT an independently validated scientific value. It gates future drift only. The viz_pca_metadata.json above does NOT contain a heritability mean. TODO(#315): reconcile heritability_mean against the R/lme4 reference calculate_heritability_estimates' docstring claims to match, then promote this to an independent golden.",
- "_umap_source": "Characterization snapshot of sleap-roots-analyze==0.1.0a2 on this fixture (re-verified unchanged through 0.1.0a3, #327). UMAP coordinates are not cross-OS bit-stable, so the recorded value is the STRUCTURAL trustworthiness (neighbor-preservation) of the embedding w.r.t. the standardized input — a wrong n_neighbors/min_dist/init delegation drops it well below the floor.",
- "_reproduced_by_sleap_roots_analyze_version": "0.1.0a2 (re-verified unchanged through 0.1.0a3, #327)",
- "trait_cols": [
-  "Holes",
-  "Network Area (mm²)",
-  "Perimeter (mm)",
-  "Root Biomass (mg)",
-  "Shoot Biomass (mg)",
-  "Surface Area (mm²)",
-  "Total Root Length (mm)",
-  "Volume (mm³)"
- ],
- "pca_explained_variance": 0.9599095965599803,
- "n_pca_components": 3,
- "heritability_mean": 0.7650052743157678,
- "heritability_method": "mixed_model",
- "heritability_n_above_0.5": 8,
- "umap_trustworthiness": 0.9524,
- "umap_trustworthiness_floor": 0.88
+  "_pca_source": "talmolab/sleap-roots-analyze#120 / PR #146 — tests/fixtures/real/wheat_edpie/expected/viz/turface_19/viz_pca_metadata.json. Independently recorded golden (NOT re-derived from the code under test).",
+  "_heritability_source": "Characterization snapshot of sleap-roots-analyze==0.1.0a2 on this fixture (re-verified unchanged through 0.1.0a3, #327) — NOT an independently validated scientific value. It gates future drift only. The viz_pca_metadata.json above does NOT contain a heritability mean. TODO(#315): reconcile heritability_mean against the R/lme4 reference calculate_heritability_estimates' docstring claims to match, then promote this to an independent golden.",
+  "_umap_source": "Characterization snapshot of sleap-roots-analyze==0.1.0a2 on this fixture (re-verified unchanged through 0.1.0a3, #327). UMAP coordinates are not cross-OS bit-stable, so the recorded value is the STRUCTURAL trustworthiness (neighbor-preservation) of the embedding w.r.t. the standardized input — a wrong n_neighbors/min_dist/init delegation drops it well below the floor.",
+  "_reproduced_by_sleap_roots_analyze_version": "0.1.0a2 (re-verified unchanged through 0.1.0a3, #327)",
+  "trait_cols": [
+    "Holes",
+    "Network Area (mm²)",
+    "Perimeter (mm)",
+    "Root Biomass (mg)",
+    "Shoot Biomass (mg)",
+    "Surface Area (mm²)",
+    "Total Root Length (mm)",
+    "Volume (mm³)"
+  ],
+  "pca_explained_variance": 0.9599095965599803,
+  "n_pca_components": 3,
+  "pca_explained_variance_ratio": [0.8612933510667774, 0.05820169635401897, 0.040414549139183936],
+  "_pca_evr_source": "Characterization snapshot of perform_pca_analysis==0.1.0a3 on this fixture's 8 trait_cols — a per-PC DRIFT GATE, NOT an independent oracle. The upstream viz_pca_metadata.json records only the cumulative pca_explained_variance (0.9599…) + n_pca_components; the per-PC split is not published there, so it is re-derived from the code under test (its three values sum to the independent cumulative above). Same honesty caveat as heritability_mean / umap_trustworthiness. TODO(#308): promote to an independent oracle if a non-test reference (e.g. R prcomp) records the per-PC split.",
+  "heritability_mean": 0.7650052743157678,
+  "heritability_method": "mixed_model",
+  "heritability_n_above_0.5": 8,
+  "umap_trustworthiness": 0.9524,
+  "umap_trustworthiness_floor": 0.88
 }

--- a/bloommcp/tests/tools/test_pca_analysis_tool.py
+++ b/bloommcp/tests/tools/test_pca_analysis_tool.py
@@ -1,0 +1,315 @@
+"""Contract + oracle tests for the granular ``pca_analysis`` tool (Tier 4 / #308).
+
+Five contract patterns + the #120 turface_19 golden PCA reproduced **through the MCP
+tool**, plus the consumer guarantees the tool exists to provide: it reads a *cleaned*
+experiment (``require_clean=True``), selects only certified-clean traits (so the delegate
+never silently ``dropna()``s), delegates ALL PCA to
+``sleap_roots_analyze.perform_pca_analysis`` (typed via ``PCAResult.from_pca_dict``), is
+deterministic (``seed = None``), and persists a versioned ``pca`` run — returning a variance
+summary + links, never the matrices inline.
+
+The unit oracle seeds a cleaned version directly via ``FakeReader.add_cleaned_version`` (the
+reader/store fakes are disjoint), so these tests do not depend on a live ``qc_clean`` run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bloom_mcp.contract import BloomMCPError
+from bloom_mcp.data_access import FakeReader, SupabaseReader
+from bloom_mcp.result_store import FakeResultStore, SupabaseResultStore
+from bloom_mcp.tools import _ports
+from bloom_mcp.tools import pca_analysis_tool
+from bloom_mcp.tools.pca_analysis_tool import (
+    PCAAnalysisParams,
+    PCAAnalysisResult,
+    pca_analysis,
+)
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_FINAL = _FIXTURES / "turface_19_final_data.csv"
+_GOLDEN = json.loads((_FIXTURES / "turface_19_pca_golden.json").read_text())
+
+_EXPERIMENT = "turface_19.csv"
+_TRAITS = _GOLDEN["trait_cols"]  # the recorded 8-trait PCA selection
+_VAR_TOL = (
+    1e-6  # matches tests/test_oracle.py — safe: deterministic solver, no randomness
+)
+
+
+def _final_df() -> pd.DataFrame:
+    return pd.read_csv(_FINAL)
+
+
+@pytest.fixture
+def injected_ports():
+    """FakeReader serving the cleaned fixture as a cleaned version + FakeResultStore."""
+    reader = FakeReader()
+    store = FakeResultStore()
+    # Seed the post-QC fixture as a *cleaned* version so require_clean=True resolves it.
+    reader.add_cleaned_version(_EXPERIMENT, "v1", _final_df(), make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        yield reader, store
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def _run(**overrides) -> PCAAnalysisResult:
+    params = {"experiment": _EXPERIMENT, "trait_columns": _TRAITS, **overrides}
+    return pca_analysis(PCAAnalysisParams(**params))
+
+
+# ── 2. Golden PCA through the tool (north star) ─────────────────────────────
+
+
+def test_golden_pca_through_the_tool(injected_ports):
+    """2.2 — reproduce the #120 turface_19 golden through the MCP boundary."""
+    result = _run()
+
+    # Independent oracle: n=3 + cumulative variance (from #120 viz_pca_metadata.json).
+    assert result.n_components == 3 == _GOLDEN["n_pca_components"]
+    assert result.cumulative_variance_ratio[2] == pytest.approx(
+        _GOLDEN["pca_explained_variance"], abs=_VAR_TOL
+    )
+    # Per-PC drift snapshot (characterization; read the key, don't hard-code literals).
+    assert result.explained_variance_ratio == pytest.approx(
+        _GOLDEN["pca_explained_variance_ratio"], abs=_VAR_TOL
+    )
+    assert result.feature_names == _TRAITS
+
+
+def test_no_silent_sample_loss(injected_ports):
+    """2.3 — PCA runs on the full certified sample set; no silent dropna()."""
+    result = _run()
+    assert result.n_samples == len(_final_df()) == 153
+    assert result.n_features == len(_TRAITS) == 8
+
+
+# ── 3.1 tools/list presence ─────────────────────────────────────────────────
+
+
+def test_pca_analysis_in_tools_list_and_workflow_preserved():
+    """3.1 — pca_analysis is discoverable; the dimred workflow is still registered."""
+    from fastmcp import Client
+
+    from bloom_mcp import server
+
+    async def _list():
+        async with Client(server.mcp) as client:
+            return await client.list_tools()
+
+    tools = {t.name: t for t in asyncio.run(_list())}
+    assert "pca_analysis" in tools
+    assert tools["pca_analysis"].inputSchema is not None
+    assert "run_dimensionality_reduction_workflow" in tools  # additive — not removed
+
+
+# ── 3.2 delegation pinning (spy) ────────────────────────────────────────────
+
+
+def test_delegates_once_and_never_calls_vendored_pca(injected_ports, monkeypatch):
+    captured = {}
+    real = pca_analysis_tool.perform_pca_analysis
+
+    def _spy(data, **kwargs):
+        captured["n_calls"] = captured.get("n_calls", 0) + 1
+        captured["columns"] = list(data.columns)
+        captured["kwargs"] = kwargs
+        return real(data, **kwargs)
+
+    monkeypatch.setattr(pca_analysis_tool, "perform_pca_analysis", _spy)
+
+    import bloom_mcp.pca as vendored
+
+    def _boom(*a, **k):  # pragma: no cover
+        raise AssertionError("pca_analysis called the vendored bloom_mcp.pca")
+
+    monkeypatch.setattr(vendored, "perform_pca_analysis", _boom)
+
+    _run()
+
+    assert captured["n_calls"] == 1
+    assert captured["columns"] == _TRAITS  # the validated certified subset, in order
+
+
+# ── 3.3 n_components override vs threshold + clamp ──────────────────────────
+
+
+def test_n_components_override_and_clamp(injected_ports):
+    # Explicit n_components overrides the variance threshold.
+    assert _run(n_components=2).n_components == 2
+    # Omitted → threshold-based selection (the golden's 3).
+    assert _run(n_components=None).n_components == 3
+    # Larger than the feature count → the delegate clamps, never raises.
+    assert _run(n_components=99).n_components == len(_TRAITS) == 8
+
+
+# ── 3.4 schema round-trip ───────────────────────────────────────────────────
+
+
+def test_valid_input_output_round_trip(injected_ports):
+    result = _run()
+    again = PCAAnalysisResult.model_validate(json.loads(result.model_dump_json()))
+    assert again.explained_variance_ratio == result.explained_variance_ratio
+
+
+# ── 3.5 invalid input — out of range ────────────────────────────────────────
+
+
+def test_threshold_out_of_range_is_invalid_input(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        pca_analysis({"experiment": _EXPERIMENT, "explained_variance_threshold": 1.5})
+    assert exc.value.code == "invalid_input"
+
+
+def test_n_components_below_one_is_invalid_input(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        pca_analysis({"experiment": _EXPERIMENT, "n_components": 0})
+    assert exc.value.code == "invalid_input"
+
+
+# ── 3.6 trait-column validation (closes the require_clean NaN hole) ─────────
+
+
+def test_unknown_trait_column_is_invalid_input_naming_it(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        _run(trait_columns=["NoSuchTrait"])
+    assert exc.value.code == "invalid_input"
+    assert "NoSuchTrait" in exc.value.message
+
+
+def test_non_certified_numeric_column_is_rejected_not_dropped(
+    injected_ports, monkeypatch
+):
+    """A numeric column present in the frame but OUTSIDE the certified-clean trait set
+    (here ``Replicate``, a metadata column) must be rejected up front — never passed to
+    the delegate where it could silently drop rows."""
+    called = {"n": 0}
+
+    def _spy(*a, **k):  # pragma: no cover - must not run
+        called["n"] += 1
+        raise AssertionError("delegate called with a non-certified column")
+
+    monkeypatch.setattr(pca_analysis_tool, "perform_pca_analysis", _spy)
+
+    with pytest.raises(BloomMCPError) as exc:
+        _run(trait_columns=["Replicate"])
+    assert exc.value.code == "invalid_input"
+    assert "Replicate" in exc.value.message
+    assert called["n"] == 0
+
+
+# ── 3.7 degenerate fit → structured, not internal; no leak; no run ──────────
+
+
+def test_degenerate_fit_is_structured_without_leaking(injected_ports, monkeypatch):
+    _reader, store = injected_ports
+
+    def _boom(*a, **k):
+        raise ValueError("secret path /var/secrets/key and host db.internal")
+
+    monkeypatch.setattr(pca_analysis_tool, "perform_pca_analysis", _boom)
+    with pytest.raises(BloomMCPError) as exc:
+        _run()
+    assert exc.value.code == "assumption_violated"
+    msg = f"{exc.value.message} {exc.value.remedy}"
+    assert "/var" not in msg and "db.internal" not in msg
+    assert store.list_runs(_EXPERIMENT, "pca") == []  # nothing persisted
+
+
+def test_real_delegate_degenerate_selection_is_assumption_violated(injected_ports):
+    """The REAL delegate raises ValueError on a constant/degenerate selection; it must
+    surface as a self-correctable assumption_violated, not the contract's internal_error.
+    """
+    reader, store = injected_ports
+    # A cleaned frame whose only traits are constant → no non-zero-variance column.
+    const = pd.DataFrame({"tA": [5.0] * 6, "tB": [5.0] * 6})
+    reader.add_cleaned_version("const.csv", "v1", const, make_latest=True)
+    with pytest.raises(BloomMCPError) as exc:
+        pca_analysis(PCAAnalysisParams(experiment="const.csv"))
+    assert exc.value.code == "assumption_violated"
+    assert store.list_runs("const.csv", "pca") == []
+
+
+# ── 3.8 require_clean consumption (property / invariant) ────────────────────
+
+
+def test_raw_only_experiment_is_rejected_with_qc_clean_remedy():
+    reader = FakeReader()
+    store = FakeResultStore()
+    reader.add_experiment("rawonly.csv", _final_df())  # raw only, no cleaned version
+    _ports.configure(reader=reader, store=store)
+    try:
+        with pytest.raises(BloomMCPError) as exc:
+            pca_analysis(PCAAnalysisParams(experiment="rawonly.csv"))
+        assert "qc_clean" in exc.value.remedy.lower()
+        assert store.list_runs("rawonly.csv", "pca") == []
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def test_consumes_cleaned_version_source(injected_ports):
+    result = _run()
+    assert result.source == "v1_cleaned"
+    assert result.source != "raw"
+
+
+# ── 3.9 provenance: deterministic, seed None ────────────────────────────────
+
+
+def test_provenance_seed_none(injected_ports):
+    _reader, store = injected_ports
+    _run()
+    stored = store.get_run(_EXPERIMENT, "pca", "latest")
+    assert stored.tool == "pca_analysis"
+    assert stored.seed is None  # PCA here is deterministic — no random_state
+
+
+# ── 3.10 determinism ────────────────────────────────────────────────────────
+
+
+def test_repeated_runs_are_identical(injected_ports):
+    a = _run()
+    b = _run()
+    assert a.explained_variance_ratio == pytest.approx(
+        b.explained_variance_ratio, abs=_VAR_TOL
+    )
+    assert a.cumulative_variance_ratio == pytest.approx(
+        b.cumulative_variance_ratio, abs=_VAR_TOL
+    )
+
+
+# ── 5.2 persist: links (not blobs) + outputs set + version increments ───────
+
+
+def test_persists_artifacts_and_returns_links_not_matrices(injected_ports):
+    _reader, store = injected_ports
+    result = _run()
+
+    stored = store.get_run(_EXPERIMENT, "pca", "latest")
+    assert set(stored.output_keys) == {"loadings.csv", "scores.csv", "pca_result.json"}
+    assert set(result.outputs) == {"loadings.csv", "scores.csv", "pca_result.json"}
+    assert result.run_ref == stored.run_ref
+    assert result.manifest_path == stored.manifest_path
+
+    # Links, not blobs: no field carries the N×k score / loadings matrices inline.
+    assert not hasattr(result, "scores") and not hasattr(result, "loadings")
+    dumped = result.model_dump()
+    assert not any(
+        isinstance(v, (list, dict)) and len(str(v)) > 5000 for v in dumped.values()
+    )
+
+
+def test_second_run_increments_version(injected_ports):
+    _reader, store = injected_ports
+    _run()
+    _run()
+    assert [r.run_ref for r in store.list_runs(_EXPERIMENT, "pca")] == ["v1", "v2"]
+    assert store.get_run(_EXPERIMENT, "pca", "latest").run_ref == "v2"

--- a/bloommcp/tests/tools/test_pca_analysis_tool.py
+++ b/bloommcp/tests/tools/test_pca_analysis_tool.py
@@ -15,6 +15,7 @@ reader/store fakes are disjoint), so these tests do not depend on a live ``qc_cl
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 from pathlib import Path
 
@@ -313,3 +314,161 @@ def test_second_run_increments_version(injected_ports):
     _run()
     assert [r.run_ref for r in store.list_runs(_EXPERIMENT, "pca")] == ["v1", "v2"]
     assert store.get_run(_EXPERIMENT, "pca", "latest").run_ref == "v2"
+
+
+# ── 9. Review hardening — silent-inconsistency + provenance gaps (PR #377) ───
+
+
+def _capture_staged_outputs(store, monkeypatch) -> dict[str, str]:
+    """Read each staged artifact's text at commit time (before the fake store rmtree's it)."""
+    captured: dict[str, str] = {}
+    real_commit = store.commit
+
+    def _commit(run, outputs):
+        for name in outputs:
+            captured[name] = (run.staging_dir / name).read_text()
+        return real_commit(run, outputs)
+
+    monkeypatch.setattr(store, "commit", _commit)
+    return captured
+
+
+# 9.2 — an explicitly empty selection is rejected, not treated as "all traits"
+
+
+def test_empty_trait_columns_is_invalid_input(injected_ports, monkeypatch):
+    _reader, store = injected_ports
+
+    def _spy(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("delegate called on an empty selection")
+
+    monkeypatch.setattr(pca_analysis_tool, "perform_pca_analysis", _spy)
+
+    with pytest.raises(BloomMCPError) as exc:
+        _run(trait_columns=[])
+    assert exc.value.code == "invalid_input"
+    assert store.list_runs(_EXPERIMENT, "pca") == []
+
+
+# 9.3 — duplicate names are rejected before they inflate the feature set
+
+
+def test_duplicate_trait_columns_is_invalid_input_naming_them(
+    injected_ports, monkeypatch
+):
+    _reader, store = injected_ports
+
+    def _spy(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("delegate called with duplicate columns")
+
+    monkeypatch.setattr(pca_analysis_tool, "perform_pca_analysis", _spy)
+
+    with pytest.raises(BloomMCPError) as exc:
+        _run(trait_columns=[_TRAITS[0], _TRAITS[0]])
+    assert exc.value.code == "invalid_input"
+    assert _TRAITS[0] in exc.value.message
+    assert store.list_runs(_EXPERIMENT, "pca") == []
+
+
+# 9.4 — a constant certified trait the delegate would silently drop is surfaced
+
+
+def test_constant_certified_trait_is_assumption_violated(injected_ports):
+    reader, store = injected_ports
+    # Two varying traits (a real fit is reachable) + one constant trait the delegate drops.
+    mixed = pd.DataFrame(
+        {
+            "tA": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "tB": [2.0, 1.0, 5.0, 3.0, 8.0, 4.0],
+            "tConst": [7.0] * 6,
+        }
+    )
+    reader.add_cleaned_version("mixed.csv", "v1", mixed, make_latest=True)
+    with pytest.raises(BloomMCPError) as exc:
+        pca_analysis(PCAAnalysisParams(experiment="mixed.csv"))
+    assert exc.value.code == "assumption_violated"
+    assert "tConst" in exc.value.message
+    # The internally inconsistent artifact is never persisted.
+    assert store.list_runs("mixed.csv", "pca") == []
+
+
+def test_n_features_equals_fitted_feature_count(injected_ports):
+    """The reported n_features is the count actually fit, never the requested count."""
+    result = _run()
+    assert result.n_features == len(result.feature_names) == 8
+
+
+# 9.6 — a non-finite value that dropna() would keep is rejected, not fit
+
+
+def test_non_finite_certified_trait_is_rejected(injected_ports, monkeypatch):
+    reader, store = injected_ports
+    inf_df = pd.DataFrame(
+        {
+            "tA": [1.0, 2.0, 3.0, 4.0],
+            "tB": [4.0, float("inf"), 2.0, 1.0],
+        }
+    )
+    reader.add_cleaned_version("inf.csv", "v1", inf_df, make_latest=True)
+
+    def _spy(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("delegate called with a non-finite value")
+
+    monkeypatch.setattr(pca_analysis_tool, "perform_pca_analysis", _spy)
+
+    with pytest.raises(BloomMCPError) as exc:
+        pca_analysis(PCAAnalysisParams(experiment="inf.csv"))
+    assert exc.value.code == "assumption_violated"
+    assert store.list_runs("inf.csv", "pca") == []
+
+
+# 9.1 — persisted scores carry sample identity (traceability, not positional alignment)
+
+
+def test_scores_csv_carries_sample_identity(injected_ports, monkeypatch):
+    _reader, store = injected_ports
+    captured = _capture_staged_outputs(store, monkeypatch)
+    _run()
+
+    scores = pd.read_csv(io.StringIO(captured["scores.csv"]))
+    # Identity columns (Barcode/Genotype/Replicate) prefix the PC columns.
+    assert list(scores.columns[:3]) == ["Barcode", "Genotype", "Replicate"]
+    assert scores.columns[3].startswith("PC")
+    # Row-aligned with the cleaned frame's samples (same Barcodes, same order).
+    final = _final_df()
+    assert scores["Barcode"].tolist() == final["Barcode"].tolist()
+    assert len(scores) == len(final) == 153
+
+
+# 9.5 — the serialized PCAResult stamps the threshold that produced it (random_state None)
+
+
+def test_persisted_result_records_threshold(injected_ports, monkeypatch):
+    _reader, store = injected_ports
+    captured = _capture_staged_outputs(store, monkeypatch)
+    _run(explained_variance_threshold=0.8)
+
+    payload = json.loads(captured["pca_result.json"])
+    assert payload["explained_variance_threshold"] == pytest.approx(0.8)
+    assert payload["random_state"] is None  # consistent with seed=None
+
+
+# 9.8 — the consumed cleaned frame is content-addressed via source_csv
+
+
+def test_passes_source_csv_for_input_lineage(injected_ports, monkeypatch):
+    _reader, store = injected_ports
+    captured: dict[str, object] = {}
+    real_create = store.create_run
+
+    def _spy(**kwargs):
+        src = kwargs.get("source_csv")
+        captured["source_csv"] = src
+        captured["exists"] = src is not None and Path(src).exists()
+        return real_create(**kwargs)
+
+    monkeypatch.setattr(store, "create_run", _spy)
+    _run()
+
+    assert captured["source_csv"] is not None
+    assert captured["exists"]  # the snapshot exists when the store hashes it

--- a/bloommcp/tests/tools/test_qc_clean_tool.py
+++ b/bloommcp/tests/tools/test_qc_clean_tool.py
@@ -337,6 +337,167 @@ def test_qc_clean_run_composes_into_require_clean_read(fake_supabase_storage, tm
     assert len(resolved.trait_cols) == _GOLDEN["cleaned_traits"] == 18
 
 
+# ── parity: qc_clean output == direct pipeline cleanup step on same fixture ──
+
+
+def test_qc_clean_matches_pipeline_cleanup_on_same_fixture(
+    fake_supabase_storage, tmp_path
+):
+    """Parity oracle: the table qc_clean persists is exactly the table the QC
+    pipeline cleanup step (``clean_traits_for_analysis``) produces on the same raw
+    fixture, called with the same params + adapter-detected role columns.
+
+    The other tests pin *delegation happens* (the spy in
+    ``test_delegates_once_...``) and *output matches a frozen golden shape*
+    (``test_cleaned_table_has_no_nans_and_matches_golden_shape``) — but none
+    re-derive the delegate's actual output and compare it, cell-for-cell, to what
+    the tool shipped. This closes that gap end-to-end: run the cleanup step
+    directly, run qc_clean, reload the persisted cleaned frame, assert equal.
+
+    Both sides share ONE ``QCCleanParams`` instance, so thresholds cannot drift
+    between the direct call and the tool call. Driven through the Supabase adapters
+    (like ``test_qc_clean_run_composes_into_require_clean_read``) because that is
+    the only path that can reload the persisted cleaned frame for comparison.
+    """
+    from sleap_roots_analyze import clean_traits_for_analysis
+
+    from bloom_mcp.tools.qc_clean_tool import _role_kwargs
+
+    reader = FakeReader()
+    reader.add_experiment(_EXPERIMENT, _raw_df())
+    store = SupabaseResultStore()  # writes to the patched object store
+    _ports.configure(reader=reader, store=store)
+
+    # One params object feeds BOTH sides — the exact inputs the tool forwards.
+    params = QCCleanParams(experiment=_EXPERIMENT, max_nans_per_trait=_MNT)
+    try:
+        frame = reader.load_experiment(_EXPERIMENT, version="raw")
+        # The pipeline cleanup step, called directly with the tool's own params.
+        expected_df, expected_kept, _log = clean_traits_for_analysis(
+            frame.df,
+            trait_cols=frame.trait_cols,
+            max_zeros_per_trait=params.max_zeros_per_trait,
+            max_nans_per_trait=params.max_nans_per_trait,
+            max_nans_per_sample=params.max_nans_per_sample,
+            min_samples_per_trait=params.min_samples_per_trait,
+            **_role_kwargs(frame),
+        )
+
+        result = qc_clean(params)
+        # Reload the cleaned frame the tool actually persisted.
+        resolved = SupabaseReader().load_experiment(_EXPERIMENT, require_clean=True)
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+    expected_kept = list(expected_kept)
+    # The summary the tool reported matches the direct cleanup step.
+    assert result.kept_trait_columns == expected_kept
+    assert result.n_samples_out == len(expected_df)
+    assert result.n_traits_out == len(expected_kept)
+
+    # The persisted cleaned trait table equals the direct pipeline output.
+    pd.testing.assert_frame_equal(
+        resolved.df[expected_kept].reset_index(drop=True),
+        expected_df[expected_kept].reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+# ── parity: qc_clean persisted output == the FULL QC pipeline's cleanup step ──
+
+
+def test_qc_clean_matches_full_pipeline_cleanup_step(fake_supabase_storage, tmp_path):
+    """Strong parity oracle: what ``qc_clean`` persists equals what the **full QC
+    pipeline's cleanup step** (``CleanupTraitsStep``, QC step 02) produces on the
+    same raw fixture — the guarantee ``qc_clean``'s "reproduces the canonical
+    pipeline clean" claim rests on.
+
+    ``test_qc_clean_matches_pipeline_cleanup_on_same_fixture`` above compares
+    against ``clean_traits_for_analysis`` — the *same* function ``qc_clean`` calls,
+    so it can't catch a divergence between that minimal entry point and the real
+    pipeline. This test drives the genuine pipeline **step object** instead, with
+    the real ``QCPipelineConfig`` / canonical ``CleanupConfig``, and asserts the
+    tool's persisted cleaned table makes the *same cleaning decisions* cell-for-cell.
+
+    The step sanitizes/abbreviates trait names (``Total.Root.Length.mm`` →
+    ``Total Root Length (mm)``) and reorders columns; ``qc_clean`` does neither
+    (analyze#164 minimal entry point). Byte-equivalence is explicitly a non-goal —
+    so we compare *decisions*: same surviving samples, same surviving trait
+    identities (mapped through the step's own name map), same values aligned on
+    ``Barcode``. Both sides run at the canonical config with no threshold override,
+    so a drift in either path's defaults breaks this.
+    """
+    from sleap_roots_analyze.pipeline.config import get_default_qc_config
+    from sleap_roots_analyze.pipeline.core import StepResult
+    from sleap_roots_analyze.pipeline.steps.cleanup_traits import CleanupTraitsStep
+
+    raw = _raw_df()
+    meta_cols = ["Barcode", "geno", "rep"]
+    trait_cols = [c for c in raw.columns if c not in meta_cols]
+
+    # ── Full pipeline cleanup step (step 02), driven with the REAL pipeline config.
+    # Only config.cleanup / config.columns are consulted by the step; the canonical
+    # CleanupConfig is the default, asserted here so a config-default drift is loud.
+    config = get_default_qc_config(pipeline_name="qc_clean_parity")
+    config.columns.barcode = "Barcode"
+    config.columns.genotype = "geno"
+    config.columns.replicate = "rep"
+    assert (
+        config.cleanup.max_zeros_per_trait,
+        config.cleanup.max_nans_per_trait,
+        config.cleanup.max_nan_fraction,
+        config.cleanup.min_samples_per_trait,
+    ) == (0.5, 0.2, 0.0, 10)
+
+    prev = StepResult(
+        data=raw,
+        metadata={
+            "trait_column_names": trait_cols,
+            "metadata_column_names": meta_cols,
+        },
+    )
+    pipe = CleanupTraitsStep().execute(
+        data=raw, config=config, run_dir=tmp_path, prev_result=prev
+    )
+    pipe_clean = pipe.data
+    # raw → sanitized name map the step applied (only *changed* names are keyed).
+    name_map = pipe.metadata["trait_name_mapping"]
+    pipe_meta = {"Barcode", "Genotype", "Replicate"}
+    pipe_kept_sanitized = sorted(c for c in pipe_clean.columns if c not in pipe_meta)
+
+    # ── qc_clean at canonical defaults (no override), through the persistence path,
+    # then reload the frame the tool actually shipped.
+    reader = FakeReader()
+    reader.add_experiment(_EXPERIMENT, raw)
+    _ports.configure(reader=reader, store=SupabaseResultStore())
+    try:
+        result = qc_clean(QCCleanParams(experiment=_EXPERIMENT))  # canonical defaults
+        resolved = SupabaseReader().load_experiment(_EXPERIMENT, require_clean=True)
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+    tool_clean = resolved.df
+
+    # 1. Same cleaning decisions: surviving sample + trait counts.
+    assert result.n_samples_out == len(pipe_clean) == 158
+    assert result.n_traits_out == pipe.metadata["traits_final"]
+
+    # 2. Same surviving trait identities (map the tool's raw names through the
+    #    step's own sanitizer; unchanged names are absent from the map).
+    tool_kept_raw = list(result.kept_trait_columns)
+    tool_kept_sanitized = sorted(name_map.get(c, c) for c in tool_kept_raw)
+    assert tool_kept_sanitized == pipe_kept_sanitized
+
+    # 3. Same values, cell-for-cell — align on Barcode, rename the tool's traits to
+    #    the step's sanitized names, put both in the same column order.
+    tool_vals = (
+        tool_clean.set_index("Barcode")[tool_kept_raw]
+        .rename(columns=name_map)
+        .sort_index()[tool_kept_sanitized]
+    )
+    pipe_vals = pipe_clean.set_index("Barcode")[tool_kept_sanitized].sort_index()
+    pd.testing.assert_frame_equal(tool_vals, pipe_vals, check_dtype=False)
+
+
 # ── trait_columns validation (blocking #3) ──────────────────────────────────
 
 

--- a/openspec/changes/add-bloommcp-pca-analysis-tool/design.md
+++ b/openspec/changes/add-bloommcp-pca-analysis-tool/design.md
@@ -1,0 +1,168 @@
+## Context
+
+Phase 2 Tiers 1–3 shipped the reusable seams (contract + ports) and the QC **producer**
+(`qc_clean`). This tier is the first **consumer** that binds them into an analysis tool. The
+constraints are fixed by the existing code:
+
+- `@as_mcp_tool(input_model=, output_model=, errors=)` validates Pydantic I/O, maps exceptions to
+  `BloomMCPError`, and stamps one `Provenance`. It reads a requested seed from the input model's
+  `seed` field and injects `random_state` / `provenance` **only** into parameters the tool
+  function declares. A tool that declares **no** `random_state` records `seed = None`; a tool that
+  declares it gets the resolved seed injected and recorded. A `BloomMCPError` raised _inside_ the
+  tool is passed through verbatim (`wrap.py:127-128`); a **declared** exception (the `errors=`
+  tuple) is mapped to a **fixed** `code="tool_error"` with a generic remedy — it does **not**
+  carry a custom code or remedy. So to surface a specific code/remedy the tool must raise the
+  `BloomMCPError` itself. `contract/wrap.py:80-130`, `contract/errors.py:90-95`
+- `ExperimentReader.load_experiment(name, *, version="latest", require_clean=False)` returns an
+  `ExperimentFrame` exposing `df`, `trait_cols`, `metadata_cols`, the detected role columns, and a
+  `source` label (`"raw"`, `"legacy_cleaned"`, or `"v<N>_cleaned"`). `require_clean=True` raises
+  `CleanedVersionRequiredError` when no cleaned version exists. For a cleaned source, `trait_cols`
+  is the set `qc_clean` certified no-NaN. `data_access/ports.py:36-86`, `fake_reader.py`
+- `ResultStore.create_run(*, experiment, tool_class, provenance, user_label, source_csv) ->
+RunHandle` then `commit(run, outputs) -> StoredRun`; `RunHandle` exposes `staging_dir` /
+  `version_id` / `manifest_path`, and `StoredRun` exposes `run_ref`, `version_dir`,
+  `manifest_path`, `outputs`, `output_keys`, `output_sha256`, `seed`, `code_versions`. `params`
+  and `based_on_version` flow via the stamped `Provenance`. `result_store/ports.py:38-121`
+- Tools reach the ports through `bloom_mcp.tools._ports` (`reader()`, `store()`, `configure()`);
+  the composition root injects Supabase adapters at boot and fakes in tests. `FakeReader` exposes
+  `add_cleaned_version(name, version_id, df, *, make_latest=True)` — no `trait_cols` argument; the
+  cleaned frame's `trait_cols` are auto-derived by `detect_columns(df)`. `FakeReader` and
+  `FakeResultStore` are **disjoint** in-memory stores (a commit to the store is not visible to the
+  reader), so a cleaned version consumed by `require_clean=True` must be seeded **into the reader**
+  directly. `data_access/fake_reader.py:51`, `result_store/fake_store.py`
+- The delegate: `perform_pca_analysis(data, standardize=True, explained_variance_threshold=0.95,
+n_components=None, random_state=42, include_feature_metrics=True, ddof_feature_var=None) ->
+Dict`. It `dropna()`s internally and **raises `ValueError`** on degenerate input (not 2D, empty,
+  no samples after NaN-drop, no non-zero-variance numeric column, < 2 samples), and **clamps**
+  `n_components` to the feature count (verified: it does not raise on `n_components > n_features`).
+  On the pinned **sklearn 1.8.0**, `PCA` is constructed with `svd_solver="auto"`, which selects the
+  deterministic `covariance_eigh` path for this tool's data regime (n_samples ≫ few features); the
+  randomized/arpack path is not taken, and `covariance_eigh` ignores `random_state`. So the fit is
+  deterministic and `random_state` is inert here. The typed bridge is
+  `PCAResult.from_pca_dict(result_dict) -> PCAResult`, whose fields are `n_components`,
+  `feature_names`, `explained_variance_ratio` (per-PC), `cumulative_variance_ratio`, `eigenvalues`,
+  `loadings`, `scores`, `standardized`, `random_state`, `explained_variance_threshold`,
+  `feature_contributions`; it offers `to_dict`, `to_json`, `cumulative_variance`. Released in
+  `0.1.0a3`, already pinned. (`sleap_roots_analyze.pca`)
+- The golden: on the post-QC `turface_19_final_data.csv` restricted to the 8 recorded `trait_cols`,
+  the delegate yields `n_components_selected == 3`, per-PC `explained_variance_ratio ==
+[0.8612933510667774, 0.05820169635401897, 0.040414549139183936]` and
+  `cumulative_variance_ratio[2] == 0.9599095965599803`. The **cumulative** value + `n=3` are the
+  independent #120 / PR #146 oracle (recorded in upstream `viz_pca_metadata.json`); the **per-PC
+  split is not in the upstream metadata** — it is only reproducible by running the delegate, so it
+  is a characterization snapshot, not an independent oracle (see Decisions).
+
+## Goals / Non-Goals
+
+- **Goals:** one contract-wrapped `pca_analysis` tool, registered + discoverable, delegating all
+  PCA to `perform_pca_analysis` (typed via `PCAResult.from_pca_dict`), consuming a **cleaned**
+  input through `require_clean=True` and selecting only certified-clean traits, **deterministic
+  with `seed = None`**, reproducing the #120 cumulative-variance oracle through the MCP boundary,
+  persisting a versioned `pca` run whose manifest records the cleaned-source lineage, with the 5
+  contract patterns under test.
+- **Non-Goals:** any PCA math in the MCP; re-cleaning or running PCA on raw data; a stochastic seed
+  (PCA here is deterministic); removing `bloom_mcp.pca` or `run_dimensionality_reduction_workflow`
+  (deferred to after Stage 1); heritability / UMAP / clustering (separate tiers); inline
+  score/loadings matrices; a `v1/` tool namespace; the DB-direct reader or per-user-identity writer
+  (deferred adapters).
+
+## Decisions
+
+- **Decision: delegate everything to `perform_pca_analysis`; the MCP owns no PCA.** The tool reads,
+  calls the one upstream entry point, wraps the dict into the upstream `PCAResult` via
+  `PCAResult.from_pca_dict` (analyze's own adapter — so the dict→typed mapping is tested upstream,
+  not re-implemented here), persists, and returns links. It does **not** call the vendored
+  `bloom_mcp.pca` and does **not** standardize / decompose / select components itself. A
+  delegation-pinning test (spy the delegate is called once; assert `bloom_mcp.pca` is never called)
+  guards this.
+- **Decision: require a cleaned input (`require_clean=True`) AND restrict selection to
+  `frame.trait_cols`.** `pca_analysis` is the _consumer_. Requiring a cleaned version is necessary
+  but **not sufficient** — the reader's cleaned frame guarantees no-NaN only in its _surviving_
+  trait columns, and the frame still carries other numeric columns that may hold NaNs. If the tool
+  validated `trait_columns` by mere existence + numeric dtype (as `qc_clean` does over a raw frame),
+  a caller could select a NaN-bearing numeric non-surviving column and `perform_pca_analysis` would
+  silently `dropna()` those rows — the exact uncontrolled loss `require_clean` is meant to prevent.
+  So the tool requires each requested column to be in `frame.trait_cols` (the certified set) and
+  numeric, raising `invalid_input` otherwise, and asserts the selected subset is NaN-free before
+  fitting (defense-in-depth against a mis-reporting reader → `assumption_violated`). This makes
+  "PCA runs only on a certified no-NaN table" literally true, not assumed.
+- **Decision: deterministic; declare no `random_state`; record `seed = None`.** Verified: on the
+  pinned sklearn the delegate fits via the deterministic `covariance_eigh` solver and the golden is
+  bit-identical across seeds 42 / 7 / 999999. Recording a resolved seed for a computation that does
+  not consume one would be reproducibility theater — and the codebase's own convention (`qc_clean`,
+  deterministic) is to record `seed = None` and declare no `random_state`. `pca_analysis` follows
+  it. The genuinely stochastic tools (KMeans / GMM / UMAP) arrive in the clustering tier (#309),
+  where `random_state` is consequential; that is where the contract's seed-resolution path is
+  exercised for real.
+- **Decision: catch-and-remap errors in-tool for specific codes/remedies.** The contract's
+  `errors=` declared-exception path yields a generic `tool_error`, so the tool raises its own
+  `BloomMCPError`: `CleanedVersionRequiredError` → `code="tool_error"`-is-not-enough, so catch it
+  and raise `BloomMCPError(code=..., remedy="run qc_clean first ...")`; the delegate's `ValueError`
+  (degenerate fit) → `BloomMCPError(code="assumption_violated", remedy=pick-a-broader-subset)`;
+  unknown/out-of-set/non-numeric `trait_columns` → `BloomMCPError(code="invalid_input", ...)` naming
+  the columns. The `errors=` tuple is therefore **not** relied on to produce these codes.
+- **Decision: forward `standardize` / `explained_variance_threshold` / `n_components` with
+  validated ranges.** `explained_variance_threshold` is `[0,1]`; `n_components` is `>= 1` and, when
+  given, overrides threshold-based selection (delegate precedence). The delegate **clamps**
+  `n_components` to the feature count rather than raising, and the tool surfaces the clamped value in
+  `n_components` — a scenario pins this. `standardize` defaults `True` (the golden was computed with
+  standardization on).
+- **Decision: return the variance summary inline, persist the matrices as links.** `n_components`,
+  per-PC `explained_variance_ratio`, `cumulative_variance_ratio`, `eigenvalues`, `feature_names`,
+  and the certified `n_samples` / `n_features` go inline; `loadings.csv`, `scores.csv`, and the
+  serialized `PCAResult` (`pca_result.json`) go to `ResultStore` and come back as `resource_link`s.
+  The N×k score matrix is **never** inlined. (Resolves the earlier open question on the artifact
+  set: three artifacts — `loadings.csv`, `scores.csv`, `pca_result.json`.)
+- **Decision: persist under tool class `pca` and record the cleaned-source lineage.** A new analysis
+  class, distinct from the legacy `dimred` workflow and from `qc`. The stamped `Provenance` sets
+  `based_on_version = frame.source` (the `v<N>_cleaned` label) so the manifest answers "which
+  `qc_clean` run produced the input this PCA consumed"; `input_sha256` / `source_csv` capture input
+  _content_, `based_on_version` captures the _version lineage_. Versioning is single-writer.
+
+## Risks / Trade-offs
+
+- **Composition needs `qc_clean` (#356) merged** → only the _live-smoke_ leg exercises
+  `require_clean` against a real `qc_clean` run. The unit oracle and the `require_clean` property
+  test seed a cleaned version directly through `FakeReader.add_cleaned_version` (serving the post-QC
+  `turface_19_final_data.csv`), so they assert the consumer contract without a live Tier 3.
+  Implementation rebases onto `staging` once #356 lands; the smoke leg is gated on it. Because the
+  fakes' reader and store are disjoint, the cleaned version must be seeded into the **reader**, not
+  produced by a store commit.
+- **The golden fixture is NaN-free in every column** → the oracle test alone cannot expose a silent
+  `dropna()`. So the NaN-safety is pinned by a _separate_ test that seeds a cleaned version whose
+  selected subset is clean but a sibling numeric column carries NaN, and asserts (a) selecting the
+  NaN column is rejected (`invalid_input`) and (b) `result.n_samples` equals the certified row count
+  — making silent sample loss a test failure.
+- **The per-PC golden split is a characterization snapshot, not an independent oracle** → the
+  independent, externally recorded values are the cumulative `0.9599…` + `n=3` (from upstream
+  `viz_pca_metadata.json`). The added per-PC `pca_explained_variance_ratio` is honestly labeled as a
+  drift gate re-derived from `perform_pca_analysis==0.1.0a3` (its own `_pca_evr_source` field),
+  matching how the fixture already frames heritability/UMAP. It guards drift; it does not
+  independently corroborate the split.
+- **`from_pca_dict` coupling to the result-dict shape** → `from_pca_dict` is upstream's own,
+  version-pinned adapter; the tool relies on it rather than mapping keys itself, so a breaking
+  upstream change surfaces as an upstream test failure, not silent corruption here.
+- **Rank-deficient selection** → a rank-deficient-but-not-constant selection (e.g. two perfectly
+  collinear traits, or `n_components > rank`) yields a near-zero-variance trailing PC without a
+  warning (constant/all-zero/<2-sample inputs correctly raise `ValueError → assumption_violated`).
+  Documented as a known limitation for now; a low-variance-component warning is a possible follow-up.
+- **Cleaned frame has 12 detected traits, golden uses 8** → `detect_columns(turface_19_final_data)`
+  finds 12 numeric traits (15 columns − Barcode/Genotype/Replicate); the golden oracle is over a
+  specific 8 (`golden["trait_cols"]`). All 8 are within the 12, so the certified-set restriction
+  keeps them; the oracle test passes `trait_columns=golden["trait_cols"]`.
+
+## Migration Plan
+
+Additive only — a new tool + one registration line (+ one docstring entry), reusing an existing
+fixture (with an added, clearly-labeled per-PC drift key). No schema or data migration; old
+manifests are unaffected; no dependency pin moves. Rollback = unregister the tool.
+
+## Open Questions
+
+- Whether to inline a compact `feature_contributions` summary (top-loading traits per PC) alongside
+  the variance ratios, or link only the full `pca_result.json` — settle during RED against the
+  small-model agent surface (the small surface favors a terse summary; upstream `viz_pca_metadata`
+  records a `top_features` list that could seed this).
+- Whether to extract the `trait_columns` subset validator now (shared with `qc_clean`) or after both
+  tools are on `staging` — deferred to a follow-up refactor, since `qc_clean_tool.py` is not on
+  `staging` until #356 merges.

--- a/openspec/changes/add-bloommcp-pca-analysis-tool/design.md
+++ b/openspec/changes/add-bloommcp-pca-analysis-tool/design.md
@@ -112,12 +112,21 @@ Dict`. It `dropna()`s internally and **raises `ValueError`** on degenerate input
   and the certified `n_samples` / `n_features` go inline; `loadings.csv`, `scores.csv`, and the
   serialized `PCAResult` (`pca_result.json`) go to `ResultStore` and come back as `resource_link`s.
   The N×k score matrix is **never** inlined. (Resolves the earlier open question on the artifact
-  set: three artifacts — `loadings.csv`, `scores.csv`, `pca_result.json`.)
+  set: three artifacts — `loadings.csv`, `scores.csv`, `pca_result.json`.) `scores.csv` prepends the
+  frame's `metadata_cols` (Barcode/Genotype/Replicate, mirroring upstream's
+  `run_pca_and_export_artifacts` stitch) so a score row is traceable to its plant by a shared key,
+  not by fragile positional alignment — sound because the finite-guard makes the delegate's `dropna()`
+  a no-op, keeping `pca.scores` row-aligned with `frame.df`. `loadings.csv` keeps its
+  feature-name index.
 - **Decision: persist under tool class `pca` and record the cleaned-source lineage.** A new analysis
   class, distinct from the legacy `dimred` workflow and from `qc`. The stamped `Provenance` sets
   `based_on_version = frame.source` (the `v<N>_cleaned` label) so the manifest answers "which
   `qc_clean` run produced the input this PCA consumed"; `input_sha256` / `source_csv` capture input
-  _content_, `based_on_version` captures the _version lineage_. Versioning is single-writer.
+  _content_, `based_on_version` captures the _version lineage_. Because the consumed cleaned frame
+  lives in the backend (not at a known local path), the tool snapshots `frame.df` to a temp CSV and
+  passes it as `source_csv`, so `input_sha256` content-addresses the exact bytes fed to the fit — the
+  same parity `qc_clean` gives its raw input, closing the "bytes changed under an unchanged
+  `v<N>_cleaned` label" gap. Versioning is single-writer.
 
 ## Risks / Trade-offs
 
@@ -146,6 +155,25 @@ Dict`. It `dropna()`s internally and **raises `ValueError`** on degenerate input
   collinear traits, or `n_components > rank`) yields a near-zero-variance trailing PC without a
   warning (constant/all-zero/<2-sample inputs correctly raise `ValueError → assumption_violated`).
   Documented as a known limitation for now; a low-variance-component warning is a possible follow-up.
+  Note that duplicate **column names** (`["Holes", "Holes"]`) are a distinct hazard — the delegate's
+  `standardize_data` re-selects each, inflating the feature set while `n_features` under-reports — so
+  the tool rejects duplicates up front (`invalid_input`) rather than fitting collinear copies.
+- **`seed = None` is regime-scoped, not universal** → the determinism claim rests on sklearn's
+  `svd_solver="auto"` choosing the deterministic `covariance_eigh` path, which holds only while
+  `n_features <= 1000` **and** `n_samples >= 10 * n_features`. That is comfortably true for this
+  tool's tabular-phenotyping regime (a handful to a few dozen traits over hundreds–thousands of
+  samples), and every shipped test exercises it. A pathologically **wide** selection (e.g. ~150
+  traits × ~1300 samples fails the `10×` guard) could route `auto` to the randomized solver, which
+  consumes the delegate's hard-coded `random_state=42`. The fit stays *reproducible* (fixed internal
+  seed), but `seed = None` would then under-describe the computation. This is a documented boundary,
+  not a silent assumption; if wide selections become in-scope, the tool should either assert the
+  `covariance_eigh` precondition (reject/branch otherwise) or record the effective seed.
+- **`n_features` mismatch from a constant certified trait** → the delegate silently drops
+  zero-variance columns before fitting, which would leave `n_features` (requested count) disagreeing
+  with the shorter `loadings`/`feature_names` it actually fit. The tool detects the drop after the
+  fit and raises `assumption_violated` naming the constant column(s) rather than persisting an
+  internally inconsistent artifact, so the reported `n_features` always equals the fitted feature
+  count.
 - **Cleaned frame has 12 detected traits, golden uses 8** → `detect_columns(turface_19_final_data)`
   finds 12 numeric traits (15 columns − Barcode/Genotype/Replicate); the golden oracle is over a
   specific 8 (`golden["trait_cols"]`). All 8 are within the 12, so the certified-set restriction

--- a/openspec/changes/add-bloommcp-pca-analysis-tool/proposal.md
+++ b/openspec/changes/add-bloommcp-pca-analysis-tool/proposal.md
@@ -1,0 +1,125 @@
+## Why
+
+bloom-mcp Phase 2 has landed the contract layer (`@as_mcp_tool`, Tier 1 / #306), the
+persistence ports (`ExperimentReader` + `ResultStore`, Tier 2 / #307), and the **QC producer**
+`qc_clean` (Tier 3 / #338): a tool that turns a raw trait table into a versioned, no-NaN
+**cleaned** run the reader resolves via `require_clean=True`. But **nothing consumes a cleaned
+run yet**. The current PCA surface is the bespoke `run_dimensionality_reduction_workflow` over
+the **vendored** `bloom_mcp.pca` copy, which the MCP should not own.
+
+Tier 4 (#308) adds `pca_analysis`: the **first granular consumer**. It performs PCA on a
+_cleaned_ experiment by delegating to `sleap-roots-analyze`'s tested `perform_pca_analysis` →
+typed `PCAResult` (`PCAResult.from_pca_dict`) — re-orchestrating nothing. This closes the
+composition the tier sequence is built to prove: `qc_clean` → cleaned versioned run →
+`pca_analysis` consumes it.
+
+## Why require a cleaned input (consume, don't re-clean)
+
+`perform_pca_analysis` does not reject NaNs — it silently `dropna()`s, dropping _every row with
+any NaN_ before fitting (an uncontrolled sample loss; the function's own docstring lists "no
+valid samples remain after dropping NaN values" as a raise condition). The whole point of Tier 3
+was to clean **first**, with analyze's tested `clean_traits_for_analysis`, dropping bad _traits_
+before dropping samples. So `pca_analysis` **must not** re-clean and **must not** run PCA on raw
+data: it loads with `require_clean=True`, which the reader satisfies only from a committed
+cleaned version, **and it selects only from that version's certified-clean trait set**
+(`frame.trait_cols`). Because the reader's cleaned frame guarantees no-NaN _only_ in its surviving
+trait columns, restricting the selection to those columns is what makes PCA's internal `dropna()`
+a genuine no-op — so the sample set PCA sees is exactly the one `qc_clean` certified. The
+composition guarantee `qc_clean` was designed to provide is the guarantee `pca_analysis` relies
+on, made explicit rather than assumed.
+
+## What Changes
+
+- **ADD** a granular `pca_analysis` MCP tool: Pydantic input/output models, a tool function
+  wrapped by `@as_mcp_tool`, that
+  - reads the experiment frame through the injected `ExperimentReader` port with
+    **`require_clean=True`** (this tool is the _consumer_ of cleaned data). An experiment with no
+    committed cleaned version raises `CleanedVersionRequiredError`, which the tool **catches and
+    re-raises** as a structured `BloomMCPError` whose remedy is "run `qc_clean` first" — never a
+    raw backend message and never a silent PCA over raw, NaN-bearing data;
+  - is **deterministic** and records `seed = None`. The tool declares **no** `random_state`
+    parameter — like `qc_clean`, and per the Tier-1 contract the resolved seed is recorded only
+    when a `random_state` is actually applied. PCA here fits via sklearn's deterministic
+    `covariance_eigh`/full-SVD solver (no randomized path in this data regime), so there is no
+    stochastic input to record; the determinism-governing `params` (standardize, threshold,
+    `n_components`, trait selection) are captured in provenance instead;
+  - delegates **all** PCA to `sleap_roots_analyze.perform_pca_analysis` and wraps its result into
+    the upstream typed `PCAResult` via `PCAResult.from_pca_dict`. The MCP contains **no PCA
+    math** — no standardization, eigendecomposition, component selection, or loadings computation
+    of its own. It does **not** call the vendored `bloom_mcp.pca`;
+  - validates a caller-supplied `trait_columns` subset up front: each requested column MUST be a
+    member of the reader's **certified-clean trait set** (`frame.trait_cols`) and numeric →
+    otherwise `invalid_input` naming the offending columns. Restricting to the certified set (not
+    merely "exists + numeric" over the whole frame) is what forecloses the silent-row-drop path —
+    a NaN-bearing numeric column that `qc_clean` did not adopt as a surviving trait cannot be
+    selected. As defense-in-depth the tool also asserts the selected subset is NaN-free before
+    fitting;
+  - forwards `standardize`, `explained_variance_threshold`, and an optional `n_components`
+    (overrides threshold-based selection; the delegate clamps it to the feature count, never
+    raising on `n_components > n_features`) to the delegate, with validated ranges;
+  - **persists a versioned run via the `ResultStore` port** under tool class `pca` — the loadings
+    and component scores as CSV artifacts + the serialized `PCAResult` (`pca_result.json`, via
+    `to_json`) + provenance — and records **`based_on_version` = the cleaned source version**
+    (`frame.source`, e.g. `v3_cleaned`) so the `qc_clean` → `pca_analysis` lineage (which cleaned
+    run produced this PCA's input) is recoverable from the manifest. It returns the small variance
+    summary inline with `resource_link`s to those artifacts, **never** the N×k score matrix
+    inline;
+  - carries the contract-stamped `Provenance` (`seed = None`) into the persisted manifest.
+- **REGISTER** the tool in `src/bloom_mcp/server.py` so it appears in MCP `tools/list`, and add
+  it to the module docstring's "Direct tools" list.
+- **NO pin bump required** — `perform_pca_analysis` has been public since `0.1.0a2`, and the typed
+  `PCAResult` + `PCAResult.from_pca_dict` ship in `0.1.0a3`, which `bloommcp/pyproject.toml`
+  already pins (bloom #327 / #354, merged). Unlike `qc_clean`, this tier adds no dependency.
+- **LEAVE** the existing `run_dimensionality_reduction_workflow` and the vendored `bloom_mcp.pca`
+  in place — this **adds granularity alongside**; retirement of `source/*` + the bespoke workflow
+  tools is **deferred to after Stage 1** (deleting `pca.py` now breaks the booting server, whose
+  `tools/workflows/dimred.py` module-level-imports `run_pca_and_export_artifacts`).
+- Tests cover the **5 contract patterns + the golden-PCA oracle through the tool**: oracle
+  reproduction, `tools/list` presence, schema round-trip, provenance presence (seed **recorded as
+  `None`**; two runs identical), property/invariant (`require_clean` consumption + certified-set
+  restriction), and the structured error envelope.
+- **EXTEND** the live persistence smoke (`make bloommcp-smoke`) with a **Tier-4 `pca_analysis`
+  leg** that runs PCA over a committed `qc_clean` cleaned version through the **real**
+  `SupabaseReader` / `SupabaseResultStore`, proving the cross-tier composition end-to-end. This
+  leg builds on the qc_clean smoke leg and lands once #356 is merged.
+
+## Impact
+
+- **Affected specs:** `bloommcp-pca-analysis-tool` (new capability). Builds on (does not modify)
+  the existing `bloommcp-tool-contract`, `bloommcp-experiment-read`, `bloommcp-result-store`
+  (Tiers 1–2) and `bloommcp-qc-clean-tool` (Tier 3, #338) capabilities — it **consumes** the
+  cleaned version `qc_clean` produces.
+- **Affected code:**
+  - new `bloommcp/src/bloom_mcp/tools/pca_analysis_tool.py` (tool + I/O models + `register`);
+  - `bloommcp/src/bloom_mcp/server.py` (register the tool; update the module docstring);
+  - new `bloommcp/tests/tools/test_pca_analysis_tool.py` (5 patterns) + the oracle through the
+    tool;
+  - **reuses** the already-vendored `bloommcp/tests/fixtures/turface_19_pca_golden.json` and the
+    post-QC `turface_19_final_data.csv` (both on `staging`). The existing `pca_explained_variance`
+    (cumulative `0.9599…`) + `n_pca_components: 3` are the **independent** #120 / PR #146 oracle
+    (from `viz_pca_metadata.json`). This change **adds** a per-PC `pca_explained_variance_ratio`
+    key **honestly labeled as a characterization snapshot** of `perform_pca_analysis==0.1.0a3`
+    (its own `_pca_evr_source` provenance note, matching how the fixture already frames its
+    `heritability_mean` / `umap_trustworthiness` keys) — a per-PC drift gate, **not** an
+    independently recorded oracle. The upstream viz metadata records only the cumulative value;
+    the per-PC split is not independently sourced, so it is not claimed to be;
+  - `bloommcp/scripts/live_persistence_smoke.py` + `tests/scripts/` — extend the live smoke with
+    the `pca_analysis` composition leg + its pure-helper unit tests (lands after #356);
+  - possibly extract the shared `trait_columns` subset validator (shared with `qc_clean_tool.py`)
+    into a small helper — a refactor deferred to a follow-up after both tools are on `staging`
+    (`qc_clean_tool.py` is not on `staging` until #356 merges);
+  - no change to `bloom_mcp.pca`'s logic, `run_dimensionality_reduction_workflow`, or the
+    discovery tools; **no** edit to `bloommcp/docs/roadmap.md` (its tier-number reshape —
+    qc_clean=Tier 3, pca→4, clustering→5 — is owned by #339).
+- **Dependencies:** `sleap_roots_analyze.perform_pca_analysis` + `PCAResult.from_pca_dict`
+  (analyze#149's typed result, released in `0.1.0a3`, already pinned). No new pin.
+- **Composition dependency & merge order:** exercising `require_clean=True` against a real
+  `qc_clean` run needs Tier 3 (#356) merged. The proposal, spec, and the **fakes-backed** unit
+  oracle (which seeds a cleaned version directly via `FakeReader.add_cleaned_version`) do **not**
+  block on #356. This PR **can merge into `staging` independently of #356** on the strength of the
+  fakes oracle proving the consumer contract; only the live-smoke composition leg is a follow-up
+  gated on #356 (rebase onto `staging` after it lands). Note: until #356 ships, no production path
+  produces a cleaned version, so `pca_analysis` correctly returns the "run `qc_clean` first"
+  remedy end-to-end — expected behavior, not a defect.
+- **Branch/PR:** branches off `origin/staging` (`egao28/bloommcp-tier4-pca`); PR targets
+  `staging`.

--- a/openspec/changes/add-bloommcp-pca-analysis-tool/specs/bloommcp-pca-analysis-tool/spec.md
+++ b/openspec/changes/add-bloommcp-pca-analysis-tool/specs/bloommcp-pca-analysis-tool/spec.md
@@ -1,0 +1,204 @@
+## ADDED Requirements
+
+### Requirement: PCA Analysis Tool Registration and Discovery
+
+The system SHALL expose a `pca_analysis` MCP tool registered on the FastMCP server so it is
+discoverable via the MCP `tools/list` operation. The tool name SHALL be stable (`pca_analysis`,
+never versioned in the name) and its registration SHALL NOT remove or rename the existing
+`run_dimensionality_reduction_workflow` tool or the vendored `bloom_mcp.pca` module.
+
+#### Scenario: Tool appears in tools/list
+
+- **WHEN** a FastMCP `Client` connects to the server and calls `tools/list`
+- **THEN** a tool named `pca_analysis` is present with a description and an input schema derived
+  from its Pydantic input model
+
+#### Scenario: Existing dimensionality-reduction workflow is preserved
+
+- **WHEN** the server registers `pca_analysis`
+- **THEN** `run_dimensionality_reduction_workflow` remains registered and `bloom_mcp.pca` remains
+  importable, so server boot is unaffected
+
+### Requirement: PCA Analysis Delegates All Computation to the Tested Upstream Entry Point
+
+The `pca_analysis` tool SHALL delegate the PCA computation to
+`sleap_roots_analyze.perform_pca_analysis` and SHALL wrap its result into the upstream typed
+`PCAResult` via `PCAResult.from_pca_dict`. It SHALL contain no PCA math of its own — no
+standardization, eigendecomposition, component selection, or loadings/scores computation — and
+SHALL NOT call the vendored `bloom_mcp.pca`.
+
+#### Scenario: PCA is delegated, not re-implemented
+
+- **WHEN** `pca_analysis` runs on a cleaned experiment frame
+- **THEN** `sleap_roots_analyze.perform_pca_analysis` is invoked exactly once and the component
+  count, explained-variance ratios, loadings, and scores are taken from its result via
+  `PCAResult.from_pca_dict`
+- **AND** the vendored `bloom_mcp.pca` is never called and the tool performs no standardization or
+  decomposition itself
+
+#### Scenario: Tunable parameters are forwarded to the delegate
+
+- **WHEN** a caller sets `standardize`, `explained_variance_threshold`, or `n_components`
+- **THEN** the tool forwards them to `perform_pca_analysis`, and an explicit `n_components`
+  overrides threshold-based component selection
+
+#### Scenario: A component count above the feature count is clamped, not rejected
+
+- **WHEN** `n_components` exceeds the number of selected trait features
+- **THEN** the delegate clamps the component count to the feature count without raising, and the
+  result's reported `n_components` reflects the clamped value
+
+### Requirement: PCA Analysis Requires a Cleaned Input and Selects Only Certified-Clean Traits
+
+The `pca_analysis` tool SHALL load its experiment frame through the injected `ExperimentReader`
+port with `require_clean=True`, as the **consumer** of cleaned data, and SHALL restrict the PCA to
+columns within the resolved frame's certified-clean trait set (`frame.trait_cols`). It SHALL NOT
+run PCA on a raw input and SHALL NOT perform its own cleaning. When no committed cleaned version
+exists for the experiment, the tool SHALL surface a structured `BloomMCPError` whose remedy directs
+the caller to run `qc_clean` first. A requested trait column outside the certified-clean set (or a
+NaN that survives into the selected subset) SHALL be rejected rather than silently row-dropped by
+the delegate.
+
+#### Scenario: A cleaned experiment is consumed
+
+- **WHEN** `pca_analysis` is invoked on an experiment that has a committed cleaned version (a
+  `qc_clean` run)
+- **THEN** the reader resolves the cleaned version (source `v<N>_cleaned`, not `raw`), and the tool
+  runs PCA on it
+
+#### Scenario: An experiment with no cleaned version is rejected with a remedy
+
+- **WHEN** `pca_analysis` is invoked on an experiment that has only a raw input and no committed
+  cleaned version
+- **THEN** the tool returns a `BloomMCPError` whose remedy is to run `qc_clean` first, and no PCA
+  run is produced
+
+#### Scenario: A trait column outside the certified-clean set is rejected, not silently dropped
+
+- **WHEN** `trait_columns` names a numeric column that is present in the frame but not in the
+  certified-clean trait set (`frame.trait_cols`), including one that still carries NaN values
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` naming the column, and does
+  not fit PCA on it — so the delegate never silently `dropna()`s the affected samples
+- **AND** on a valid selection the result's `n_samples` equals the certified cleaned row count (no
+  samples are silently lost)
+
+### Requirement: PCA Analysis Reproduces the #120 turface_19 Golden Through the Tool
+
+The `pca_analysis` tool SHALL, when invoked through the MCP boundary on the cleaned #120 turface_19
+fixture restricted to the recorded golden trait columns, reproduce the independently recorded PCA
+oracle within tolerance: three selected components and the recorded **cumulative** explained
+variance. It SHALL additionally reproduce the recorded per-PC explained-variance split (a
+characterization drift gate, not an independent oracle) within tolerance.
+
+#### Scenario: Golden component count and cumulative explained variance match (independent oracle)
+
+- **WHEN** `pca_analysis` runs on the cleaned turface_19 experiment with `trait_columns` set to the
+  8 recorded `turface_19_pca_golden.json` trait columns, `standardize = true`, and
+  `explained_variance_threshold = 0.95`
+- **THEN** the result reports `n_components == 3`
+- **AND** the `cumulative_variance_ratio` at the third component equals `0.9599095965599803` within
+  `abs = 1e-6` — the independently recorded #120 / PR #146 value
+
+#### Scenario: Per-PC explained-variance split matches the recorded characterization snapshot
+
+- **WHEN** the same call completes
+- **THEN** the per-PC `explained_variance_ratio` equals the recorded
+  `pca_explained_variance_ratio` `[0.8612933510667774, 0.05820169635401897, 0.040414549139183936]`
+  within `abs = 1e-6` — a drift gate re-derived from `perform_pca_analysis==0.1.0a3`, whose sum
+  equals the independent cumulative oracle above
+
+### Requirement: PCA Analysis Is Deterministic and Records No Seed
+
+The `pca_analysis` tool SHALL be deterministic: it SHALL declare no `random_state` parameter, and
+the stamped `Provenance` SHALL record `seed = None` (matching the codebase convention for
+non-stochastic tools such as `qc_clean`). Two runs with identical inputs SHALL produce identical
+results.
+
+#### Scenario: Seed is recorded as None
+
+- **WHEN** `pca_analysis` completes
+- **THEN** the stamped `Provenance` records `seed = None`, together with the tool name and the PCA
+  params (standardize, threshold, `n_components`, trait selection)
+
+#### Scenario: Repeated runs are identical
+
+- **WHEN** `pca_analysis` is invoked twice on the same cleaned experiment with the same parameters
+- **THEN** the two results' `explained_variance_ratio` and `cumulative_variance_ratio` are equal
+  within `abs = 1e-6`
+
+### Requirement: PCA Analysis Honors the Contract Envelope
+
+The `pca_analysis` tool SHALL be wrapped by `@as_mcp_tool` so that inputs and outputs are validated
+against declared Pydantic models, every declared/undeclared failure is mapped to a structured
+`BloomMCPError` (never a raw traceback or leaked backend internals), and a single `Provenance` is
+stamped per call.
+
+#### Scenario: Input/output schema round-trip
+
+- **WHEN** a valid request is serialized to the tool's input schema and the result is validated
+  against the output schema
+- **THEN** both validate without loss
+
+#### Scenario: Out-of-range parameters are rejected
+
+- **WHEN** a request sets `explained_variance_threshold` outside `[0,1]` or `n_components < 1`
+- **THEN** the tool returns a `BloomMCPError` with an input/validation code, and no run is persisted
+
+#### Scenario: A caller-supplied trait column that is unknown or non-numeric is rejected
+
+- **WHEN** `trait_columns` names a column absent from the experiment, or a non-numeric
+  (metadata/identifier) column
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` whose message names the
+  offending column(s), rather than an opaque internal error or a silently mis-selected fit
+
+#### Scenario: A degenerate fit surfaces as a self-correctable error
+
+- **WHEN** the delegate `perform_pca_analysis` raises `ValueError` (e.g. a `trait_columns` subset
+  leaving fewer than two samples or no non-zero-variance column)
+- **THEN** the tool returns a `BloomMCPError` with code `assumption_violated` and a remedy (not
+  `internal_error`), and no run is persisted
+
+### Requirement: PCA Analysis Persists a Versioned Run With Lineage and Returns Links
+
+The `pca_analysis` tool SHALL persist its outputs as a versioned run via the `ResultStore` port
+under tool class `pca`, carrying the contract-stamped `Provenance` into the manifest, recording the
+cleaned-source version it consumed as `based_on_version`, writing the component loadings and scores
+and the serialized `PCAResult`, and SHALL return the small variance summary inline together with
+**links** to the persisted artifacts — never the loadings or score matrices inline.
+
+#### Scenario: Run is committed with provenance and cleaned-source lineage
+
+- **WHEN** `pca_analysis` completes successfully
+- **THEN** a `StoredRun` is recorded for `(experiment, "pca")` with a `run_ref`, a manifest path,
+  the same `Provenance` (including `seed = None`) the contract stamped, and `based_on_version` equal
+  to the consumed cleaned source version (e.g. `v3_cleaned`)
+- **AND** the committed outputs include the loadings CSV, the component scores CSV, and the
+  serialized `PCAResult` (`pca_result.json`)
+
+#### Scenario: Result returns a summary and links, not the matrices
+
+- **WHEN** the tool returns its result
+- **THEN** `n_components`, the per-PC `explained_variance_ratio`, the `cumulative_variance_ratio`,
+  the `eigenvalues`, `feature_names`, and the certified `n_samples` / `n_features` are inline
+- **AND** the loadings and component-score matrices are referenced via links (object keys +
+  manifest path) to the persisted run rather than embedded inline
+
+### Requirement: PCA Analysis Is Exercised End-to-End by the Live Persistence Smoke
+
+The `pca_analysis` tool SHALL be validated against a running dev stack through the **real**
+`SupabaseReader` and `SupabaseResultStore` adapters (not the in-memory fakes) by the
+`make bloommcp-smoke` driver, consuming a cleaned version committed by a prior `qc_clean` run —
+proving the `qc_clean` → `pca_analysis` composition resolves and persists end-to-end. The smoke
+driver's pure decision logic SHALL remain factored into importable helpers that are unit-testable
+with no live stack.
+
+#### Scenario: pca_analysis consumes a committed cleaned run through the real ports
+
+- **WHEN** the live persistence smoke, after a `qc_clean` run has committed a cleaned version, calls
+  `pca_analysis(experiment=…, trait_columns=…)` through the real `SupabaseReader` /
+  `SupabaseResultStore`
+- **THEN** the reader resolves the cleaned version (`require_clean=True` succeeds, source
+  `v<N>_cleaned`, not `raw`)
+- **AND** the committed PCA run's manifest reports `manifest_schema_version == 3`, records
+  `based_on_version` equal to the consumed cleaned version, and each recorded `output_sha256` equals
+  the SHA-256 of the bytes actually stored for its artifact

--- a/openspec/changes/add-bloommcp-pca-analysis-tool/specs/bloommcp-pca-analysis-tool/spec.md
+++ b/openspec/changes/add-bloommcp-pca-analysis-tool/specs/bloommcp-pca-analysis-tool/spec.md
@@ -151,6 +151,19 @@ stamped per call.
 - **THEN** the tool returns a `BloomMCPError` with code `invalid_input` whose message names the
   offending column(s), rather than an opaque internal error or a silently mis-selected fit
 
+#### Scenario: An explicitly empty trait selection is rejected, not treated as "all traits"
+
+- **WHEN** `trait_columns` is supplied as an empty list `[]`
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input`, rather than falling through
+  to a full-frame PCA over every certified trait the caller did not select
+
+#### Scenario: A trait selection with duplicate column names is rejected
+
+- **WHEN** `trait_columns` names the same column more than once (e.g. `["Holes", "Holes"]`)
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` naming the duplicate(s),
+  rather than fitting collinear copies the delegate would re-select — which would inflate the fitted
+  feature set while `n_features` under-reported it
+
 #### Scenario: A degenerate fit surfaces as a self-correctable error
 
 - **WHEN** the delegate `perform_pca_analysis` raises `ValueError` (e.g. a `trait_columns` subset
@@ -158,13 +171,30 @@ stamped per call.
 - **THEN** the tool returns a `BloomMCPError` with code `assumption_violated` and a remedy (not
   `internal_error`), and no run is persisted
 
+#### Scenario: A constant certified trait is surfaced rather than silently dropped
+
+- **WHEN** the selection includes a certified-clean trait that is constant (zero variance), so the
+  delegate would silently drop it and fit fewer features than requested
+- **THEN** the tool returns a `BloomMCPError` with code `assumption_violated` naming the dropped
+  column(s), and no run is persisted — rather than persisting an artifact whose reported
+  `n_features` disagrees with the shorter `loadings`/`feature_names` actually fit
+
+#### Scenario: A non-finite value in a certified trait is rejected
+
+- **WHEN** a selected certified-clean trait carries a non-finite value (`NaN`, `+inf`, or `-inf`)
+  that would survive the delegate's `dropna()`
+- **THEN** the tool returns a `BloomMCPError` with code `assumption_violated` and no run is
+  persisted, rather than poisoning standardization/eigendecomposition with the non-finite value
+
 ### Requirement: PCA Analysis Persists a Versioned Run With Lineage and Returns Links
 
 The `pca_analysis` tool SHALL persist its outputs as a versioned run via the `ResultStore` port
 under tool class `pca`, carrying the contract-stamped `Provenance` into the manifest, recording the
-cleaned-source version it consumed as `based_on_version`, writing the component loadings and scores
-and the serialized `PCAResult`, and SHALL return the small variance summary inline together with
-**links** to the persisted artifacts — never the loadings or score matrices inline.
+cleaned-source version it consumed as `based_on_version` and content-addressing the consumed frame
+via `source_csv` (so the manifest's `input_sha256` pins the exact input bytes, not just the mutable
+`v<N>_cleaned` label), writing the component loadings and the component scores **with sample
+identity** and the serialized `PCAResult`, and SHALL return the small variance summary inline
+together with **links** to the persisted artifacts — never the loadings or score matrices inline.
 
 #### Scenario: Run is committed with provenance and cleaned-source lineage
 
@@ -174,6 +204,15 @@ and the serialized `PCAResult`, and SHALL return the small variance summary inli
   to the consumed cleaned source version (e.g. `v3_cleaned`)
 - **AND** the committed outputs include the loadings CSV, the component scores CSV, and the
   serialized `PCAResult` (`pca_result.json`)
+- **AND** the tool passes the consumed cleaned frame as `source_csv`, so the manifest's
+  `input_sha256` content-addresses the exact input rather than resting on the mutable version label
+
+#### Scenario: Persisted scores carry sample identity for traceability
+
+- **WHEN** the tool writes the component-scores CSV
+- **THEN** each score row is prefixed with the frame's `metadata_cols` (e.g. Barcode/Genotype/
+  Replicate), so a PC-score row maps back to its plant by a shared key rather than by fragile
+  positional alignment against the cleaned version
 
 #### Scenario: Result returns a summary and links, not the matrices
 

--- a/openspec/changes/add-bloommcp-pca-analysis-tool/tasks.md
+++ b/openspec/changes/add-bloommcp-pca-analysis-tool/tasks.md
@@ -1,0 +1,171 @@
+> **TDD note:** the RED steps below (§2–§3) are a _local_ working-tree rhythm — write each test,
+> confirm it fails, then make it pass. Do **not** push a RED-only commit: CI gates the PR head, and
+> a committed failing/uncollectable test is red. Commit RED+GREEN together. Suggested commits
+> (each green after it): `test(#308)` golden per-PC drift key + README provenance → `feat(#308)`
+> tool + tests (RED+GREEN in one commit) → optional follow-up `test(#308)` live-smoke leg (after
+> #356 merges). The OpenSpec proposal files may ride in the first commit or a `docs(#308)` commit.
+>
+> **Staging guardrail:** the working tree carries unrelated noise — a stray empty file `n`, a
+> mode-bit-only change to `scripts/render_plate_videos.py`, and an **untracked, non-gitignored** > `bloommcp/data/` runtime-output dir. **Stage by explicit path only** (never `git add -A` / `git
+add .` / `git add bloommcp/`); run `git status` before each commit and confirm those three are
+> absent from the index.
+>
+> **Composition note:** the unit oracle and `require_clean` tests seed a cleaned version directly
+> via `FakeReader.add_cleaned_version` (the reader and store fakes are disjoint — a store commit is
+> not visible to the reader), so they do **not** depend on #356. Only the live-smoke leg (§7) needs
+> Tier 3 (#356) merged; rebase onto `staging` before adding it. This PR may merge into `staging`
+> independently of #356 on the strength of the fakes oracle.
+
+## 1. Pre-work — fixtures + honest golden extension (prerequisite, no new dependency)
+
+- [x] 1.1 Confirm the analyze pin already satisfies the delegate: `bloommcp/pyproject.toml` pins
+      `sleap-roots-analyze>=0.1.0a3` (on `staging`), and `wsl -d Ubuntu -- bash -lc 'cd
+  ~/repos/bloom/bloommcp && uv run --frozen python -c "from sleap_roots_analyze import
+  perform_pca_analysis, PCAResult; PCAResult.from_pca_dict"'` imports clean. **No pin bump or
+      `uv.lock` change is part of this tier.**
+- [x] 1.2 Reuse the vendored `bloommcp/tests/fixtures/turface_19_pca_golden.json` and the post-QC
+      `turface_19_final_data.csv` (both on `staging`). The existing `pca_explained_variance`
+      (cumulative `0.9599…`) + `n_pca_components: 3` are the **independent** #120 / PR #146 oracle
+      (upstream `viz_pca_metadata.json`). **Add** a per-PC key `"pca_explained_variance_ratio":
+  [0.8612933510667774, 0.05820169635401897, 0.040414549139183936]` **honestly labeled as a
+      characterization snapshot** — add a sibling `"_pca_evr_source"` string stating it is
+      re-derived from `perform_pca_analysis==0.1.0a3` (a per-PC drift gate, NOT independently
+      recorded; the upstream viz metadata records only the cumulative value). Document the addition
+      in `tests/fixtures/README.md` using the SAME honest framing the file already uses for
+      `heritability_mean` / `umap_trustworthiness` (characterization snapshot, not an independent
+      oracle). Edit the JSON **preserving LF** (`.gitattributes` pins `*.json text eol=lf`).
+
+## 2. RED — golden PCA through the tool (north star, write first)
+
+- [x] 2.1 Add `bloommcp/tests/tools/test_pca_analysis_tool.py`. Wire the ports through a fixture
+      that calls `bloom_mcp.tools._ports.configure(reader=FakeReader(...), store=FakeResultStore())`
+      and **restores the Supabase adapters in a `finally:`** (mirror qc_clean's `injected_ports`
+      fixture — `_ports` is global module state; leaking a fake into later test modules is a bug).
+      Seed the cleaned version into the **reader** with the real signature
+      `reader.add_cleaned_version("turface_19.csv", "v1", final_data, make_latest=True)` (there is
+      **no** `trait_cols=` kwarg; the frame's `trait_cols` are auto-derived via `detect_columns`).
+- [x] 2.2 Write the **golden-through-the-tool** test FIRST: invoke `pca_analysis(experiment=…,
+  trait_columns=golden["trait_cols"], standardize=True, explained_variance_threshold=0.95)`;
+      assert `n_components == 3` and `cumulative_variance_ratio[2] ==
+  pytest.approx(golden["pca_explained_variance"], abs=1e-6)` (the independent oracle), **and**
+      `explained_variance_ratio == pytest.approx(golden["pca_explained_variance_ratio"], abs=1e-6)`
+      (read the key added in §1.2 — do not hard-code the literals). Confirm it fails (no tool yet).
+      **Do not loosen the tolerance to pass** — debug to green. (`abs=1e-6` matches
+      `test_oracle.py`'s `_VAR_TOL`; safe because the solver is deterministic — no randomized path.)
+- [x] 2.3 Assert **no silent sample loss**: `result.n_samples` equals the cleaned fixture's row
+      count (the certified set), so a future regression that let PCA `dropna()` rows fails here.
+
+## 3. RED — the other four contract patterns (one discrete confirm-RED test each)
+
+- [x] 3.1 **tools/list presence:** a FastMCP `Client` over the server lists `pca_analysis` with a
+      schema-bearing input model; assert `run_dimensionality_reduction_workflow` is still listed.
+- [x] 3.2 **Delegation pinning:** spy `pca_analysis_tool.perform_pca_analysis`; assert it is called
+      **exactly once** with the validated `trait_columns` subset, and monkeypatch
+      `bloom_mcp.pca.perform_pca_analysis` to raise — assert it is **never** called. (Covers spec
+      "PCA is delegated, not re-implemented".)
+- [x] 3.3 **`n_components` override vs threshold:** with `n_components=2` on the golden fixture
+      assert `result.n_components == 2` (overrides the threshold's 3) and the spy captured
+      `n_components=2`; with `n_components=None` + `explained_variance_threshold=0.95` assert
+      `n_components == 3`. Add a boundary case: `n_components=99` (> feature count) → assert the
+      delegate clamps and `result.n_components == n_features` (no raise).
+- [x] 3.4 **Schema round-trip:** valid request ↔ input schema and result ↔ output schema round-trip
+      without loss.
+- [x] 3.5 **Invalid input — out-of-range (split):** one assertion each — `explained_variance_
+  threshold` out of `[0,1]` → `BloomMCPError` validation code; `n_components < 1` → validation
+      code. No run persisted.
+- [x] 3.6 **Invalid input — trait columns (split):** (a) a column absent from the frame →
+      `invalid_input` whose message contains the column name; (b) a non-numeric metadata column →
+      `invalid_input`; (c) a numeric column present in the frame but **outside the certified-clean
+      set** (`frame.trait_cols`), including one carrying NaN → `invalid_input`, and assert the
+      delegate spy was **not** called (no silent `dropna()`). (Covers the require_clean NaN-safety
+      hole.)
+- [x] 3.7 **Degenerate fit → structured, not internal:** using the **real** delegate (no mock) on a
+      degenerate valid selection (e.g. a single certified trait that is constant), assert the tool
+      returns `code == "assumption_violated"` (not `internal_error`), the message does not leak a
+      traceback/backend path, and `store.list_runs(...)` is empty.
+- [x] 3.8 **Require-clean consumption (property):** with only a **raw** version registered (no
+      cleaned) → `BloomMCPError` whose remedy names `qc_clean`, and no run committed; with a cleaned
+      version seeded into the reader → the tool resolves it and asserts `frame.source` starts with
+      `v` and ends `_cleaned` (the fake emits `v<N>_cleaned`; `legacy_cleaned` is a live-only path).
+- [x] 3.9 **Provenance (deterministic):** after a successful call the stamped `Provenance` records
+      `seed is None`, the tool name, and the PCA params; and the committed `StoredRun.seed is None`.
+- [x] 3.10 **Determinism:** invoke `pca_analysis` twice with identical inputs; assert the two
+      results' `explained_variance_ratio` and `cumulative_variance_ratio` are equal within `abs=1e-6`.
+
+## 4. GREEN — implement the tool
+
+- [x] 4.1 Add `bloommcp/src/bloom_mcp/tools/pca_analysis_tool.py`: `PCAAnalysisParams`
+      (`experiment`, `trait_columns?`, `standardize=True`, `explained_variance_threshold=0.95` with
+      `ge=0, le=1`, `n_components?` with `ge=1`, `user_label?` — **no `seed` field**) and
+      `PCAAnalysisResult` (experiment, source, `n_samples`, `n_features`, `n_components`,
+      `feature_names`, `explained_variance_ratio`, `cumulative_variance_ratio`, `eigenvalues`,
+      `run_ref`, `version_dir`, `manifest_path`, `outputs`).
+- [x] 4.2 Tool fn `pca_analysis(params, *, provenance: Provenance) -> PCAAnalysisResult` wrapped by
+      `@as_mcp_tool(input_model=…, output_model=…)` (**no `random_state` param** → contract records
+      `seed=None`): read via `reader().load_experiment(params.experiment, require_clean=True)`;
+      validate that each `trait_columns` entry is in `frame.trait_cols` **and** numeric →
+      `invalid_input` naming offenders (default to all of `frame.trait_cols` when omitted); assert
+      `frame.df[selected].isna().sum().sum() == 0` (else `assumption_violated`); call
+      `perform_pca_analysis(frame.df[selected], standardize=…, explained_variance_threshold=…,
+  n_components=…)` (let the delegate use its default `random_state`); wrap via
+      `PCAResult.from_pca_dict`.
+- [x] 4.3 **Catch-and-remap for specific codes/remedies** (the `errors=` declared path only yields a
+      generic `tool_error`): catch `CleanedVersionRequiredError` → `raise BloomMCPError(code=…,
+  remedy="run qc_clean first …")`; catch the delegate's `ValueError` → `raise
+  BloomMCPError(code="assumption_violated", remedy="select a broader trait subset …")`. Do
+      **not** rely on the `errors=` tuple to carry these codes.
+- [x] 4.4 `register(mcp)` via `bloom_mcp.contract.register`; register in
+      `bloommcp/src/bloom_mcp/server.py` (import + `pca_analysis_tool.register(mcp)`) and add a
+      `pca_analysis` entry under the module docstring's "Direct tools (granular)" list.
+
+## 5. GREEN — persist the run with lineage + return links
+
+- [x] 5.1 Persist via `store().create_run(experiment=…, tool_class="pca", provenance=provenance,
+  user_label=…)`; set the stamped provenance's `based_on_version = frame.source` (the
+      `v<N>_cleaned` label) so the manifest records the cleaned-source lineage. Write `loadings.csv`,
+      `scores.csv`, and `pca_result.json` (`PCAResult.to_json`) into `run.staging_dir`, then
+      `store().commit(run, {...})`.
+- [x] 5.2 Return the variance summary inline + `run_ref` / `version_dir` / `manifest_path` /
+      `outputs` (object keys). Add tests: `set(stored.output_keys) ==
+  {"loadings.csv","scores.csv","pca_result.json"}`; `stored` records `based_on_version ==
+  frame.source`; the result carries **no** score/loadings matrix inline
+      (`assert not any(isinstance(v,(list,dict)) and len(str(v))>5000 for v in
+  result.model_dump().values())`); a second `pca_analysis` run increments the version (`v1`→`v2`,
+      `latest`→`v2`).
+
+## 6. Refactor (optional, deferred — behavior-preserving)
+
+- [ ] 6.1 The `trait_columns` subset validator overlaps with `qc_clean_tool.py` (which is not on
+      `staging` until #356). **Do not** extract it in this PR (it would couple this change to #356's
+      file and there is nothing to share with on `staging`). File a follow-up after both tools land.
+
+## 7. Live persistence smoke — composition leg (after #356 merges)
+
+- [ ] 7.1 Rebase onto `staging` once Tier 3 (#356) is merged. Extend
+      `bloommcp/scripts/live_persistence_smoke.py` with a `pca_analysis` leg: after the existing
+      `qc_clean` leg commits a cleaned version, run `pca_analysis` through the real `SupabaseReader`
+      / `SupabaseResultStore`, assert `require_clean=True` resolves the `v<N>_cleaned` source, the
+      PCA manifest is `manifest_schema_version == 3`, records `based_on_version` = the consumed
+      cleaned version, and each `output_sha256` matches the stored bytes.
+- [ ] 7.2 Factor the leg's pure decision logic into importable helpers and unit-test them in
+      `tests/scripts/` with no live stack. Add the pca note to `bloommcp/docs/local-validation.md`
+      (created by #356; edit it only after the rebase).
+
+## 8. Agent-surface validation, docs + verification
+
+- [ ] 8.1 **Validate on Claude Desktop (capable model) and sanity-check Qwen3.5-9B** (a #308
+      acceptance criterion — kept as its own checkbox, not folded into pre-merge): confirm
+      `pca_analysis` is discoverable, the schema is legible to a small model, a happy-path call on a
+      cleaned experiment returns the variance summary + links, and the "run qc_clean first" remedy
+      renders sensibly when no cleaned version exists.
+- [x] 8.2 Update the `server.py` module docstring (done in 4.4). Do **not** edit
+      `bloommcp/docs/roadmap.md` (its tier-number reshape is owned by #339) or `bloommcp/README.md`
+      (it lists tools by category — "dimensionality reduction" already covers PCA).
+- [x] 8.3 `wsl -d Ubuntu -- bash -lc 'cd ~/repos/bloom && npx --yes -p @fission-ai/openspec openspec
+  validate add-bloommcp-pca-analysis-tool --strict'` is clean.
+- [x] 8.4 Tests + lint green: `cd bloommcp && uv run --frozen --extra test pytest
+  tests/tools/test_pca_analysis_tool.py tests/test_oracle.py` and the full bloommcp suite;
+      `uv run black --check .`, `uv run ruff check .`, and `pre-commit run --all-files` (or `/lint`).
+- [ ] 8.5 `/pre-merge` → `/pr-description` → PR to `staging` linking #308 (stage by explicit path;
+      confirm `n`, `render_plate_videos.py`, `bloommcp/data/` are not staged). Merge order relative
+      to #356: this PR may merge first (fakes oracle); the §7 live-smoke leg follows post-#356.

--- a/openspec/changes/add-bloommcp-pca-analysis-tool/tasks.md
+++ b/openspec/changes/add-bloommcp-pca-analysis-tool/tasks.md
@@ -169,3 +169,40 @@ add .` / `git add bloommcp/`); run `git status` before each commit and confirm t
 - [ ] 8.5 `/pre-merge` → `/pr-description` → PR to `staging` linking #308 (stage by explicit path;
       confirm `n`, `render_plate_videos.py`, `bloommcp/data/` are not staged). Merge order relative
       to #356: this PR may merge first (fakes oracle); the §7 live-smoke leg follows post-#356.
+
+## 9. Review hardening (PR #377 re-review — silent-inconsistency + provenance gaps)
+
+- [x] 9.1 **Scores traceability (blocking #1):** `scores.csv` prepends the frame's `metadata_cols`
+      (mirroring upstream's `run_pca_and_export_artifacts` metadata stitch) so a PC-score row maps
+      back to its plant by a shared key, not fragile positional alignment. Sound because the
+      finite-guard keeps `pca.scores` row-aligned with `frame.df`. Test: scores CSV carries the
+      identity columns in row-aligned order.
+- [x] 9.2 **Empty selection (blocking #2):** an explicitly empty `trait_columns=[]` is rejected with
+      `invalid_input` instead of silently meaning "all certified traits". Selection no longer uses a
+      truthiness fall-through. Test added.
+- [x] 9.3 **Duplicate columns (blocking #3):** duplicate names in `trait_columns` are rejected with
+      `invalid_input` naming them, rather than the delegate re-selecting each and inflating the
+      feature set. Test added.
+- [x] 9.4 **`n_features` consistency (blocking #4):** after the fit, if the delegate dropped a
+      constant (zero-variance) certified trait, the tool raises `assumption_violated` naming it
+      (no run persisted) rather than reporting a count that disagrees with the shorter loadings;
+      `n_features` is reported from `pca.feature_names`. Test added.
+- [x] 9.5 **Threshold provenance (#5):** `PCAResult.from_pca_dict` is called with
+      `explained_variance_threshold=params.explained_variance_threshold` so the serialized result
+      self-describes its selection rule; `random_state` stays `None` (consistent with `seed=None`).
+      Test asserts the persisted `pca_result.json` records the threshold.
+- [x] 9.6 **Non-finite guard (#6):** the NaN check is replaced by `np.isfinite(...).all()` so a
+      certified trait carrying `±inf` (which `dropna()` keeps) is rejected as `assumption_violated`
+      rather than poisoning the fit. Test added.
+- [x] 9.7 **Seed regime boundary (#7):** the design's Risks now own the `covariance_eigh`
+      precondition (`n_features <= 1000` and `n_samples >= 10 * n_features`) under which `seed = None`
+      is honest, and the module docstring scopes the determinism claim to this tool's regime rather
+      than asserting `random_state` is universally inert.
+- [x] 9.8 **Input content-addressing (#8):** the consumed cleaned frame is snapshotted to a temp CSV
+      and passed as `source_csv`, so the manifest's `input_sha256` pins the exact input bytes (parity
+      with `qc_clean`), honoring the design's `input_sha256`/`source_csv` claim.
+- [x] 9.9 **ValueError message (#9):** the single degenerate-fit remedy message is reworded to be
+      accurate across the delegate's collapsed `ValueError` causes (empty / <2 samples / no
+      non-constant trait); raw exception text is still never echoed (no-leak test unchanged).
+- [x] 9.10 **Style:** `Optional[...]` → `X | None` (the file has `from __future__ import
+      annotations`), matching the `qc_clean` sibling.


### PR DESCRIPTION
## Summary

Adds  — the first **granular consumer** tool in bloom-mcp Phase 2 (**Tier 4**, #308). It performs PCA on a **cleaned** experiment by thin-delegating to  → typed , closing the  →  composition that Tier 3 (#338) set up.

Part of #308 (implementation; the live-persistence-smoke leg and Claude-Desktop/Qwen validation are tracked follow-ups, so this does not auto-close the issue).

## What changed
- **New tool** , registered in :
  - Reads  (consumer); a missing cleaned version → structured  with a **"run qc_clean first"** remedy.
  - **Restricts the selection to the certified-clean trait set** () so the delegate’s internal  is a genuine no-op — closes a silent-sample-loss hole found in review (a NaN-bearing numeric non-surviving column can no longer be selected).
  - Delegates **all** PCA to  → ; no PCA math in the MCP, never touches the vendored .
  - **Deterministic → records ** (declares no ; PCA fits via sklearn’s deterministic solver, so the seed is inert here).
  - Persists a versioned  run ( /  / ) with  lineage; returns a variance summary + links, never the matrices inline.
  - Delegate  →  (fixed, non-leaking message).
- **Golden fixture**  gains a per-PC , honestly labeled as a **characterization snapshot** () — NOT an independent oracle (upstream  records only the cumulative). Documented in .
- **OpenSpec change**  (proposal / design / tasks / spec).

Legacy  + vendored  are **left in place** (additive; retirement deferred). No dependency/lockfile change.

## Testing
- **18 new tests** in : the #120 golden **through the tool** (n=3, per-PC , cumulative  @ ), tools/list presence, delegation-pinning (never calls vendored ),  override/clamp, schema round-trip, invalid-input, **certified-set rejection** (closes the NaN hole), degenerate-fit → structured error, require_clean remedy, deterministic , determinism across runs, persisted-links-not-blobs, version increment.
- **140/140** bloommcp unit tests pass; pre-commit clean (black / ruff / prettier / gitleaks);  valid.

## Review
Scaffolded via OpenSpec, run through  (5 adversarial agents), and reconciled — including two substantive fixes: the fabricated-oracle framing (now honest) and the  NaN hole (now closed by the certified-set restriction). Seed handling was changed from an initial "first stochastic tool" framing to  after review proved PCA is deterministic in this regime.

## Deferred (tracked follow-ups)
- Live persistence smoke leg ( through the real Supabase adapters).
- Shared  validator extraction with .
- Claude-Desktop (capable model) + Qwen small-model agent-surface validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
