### PR TITLE
chore(security): trivyignore python3.13 tarfile CVE-2026-11940 (unreachable)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -98,3 +98,11 @@ CVE-2026-43185
 # path is unreachable at runtime. No fixed Debian version available upstream. Reassess on the
 # next python:3.11-slim SHA bump. Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-53260
 CVE-2026-53260
+
+# libpython3.13-* / python3.13-* (Debian 13.4 in python:3.11-slim) — affects: langchain-agent / bloommcp
+# tarfile.extractall() filter bypass (data/tar filters). The services run python3.11 (not 3.13);
+# python3.13 ships as a transitive Debian base package but is never executed, and the app does not
+# extract untrusted tar archives via python3.13 at runtime. No fixed Debian version available
+# upstream. Reassess on the next python:3.11-slim SHA bump.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-11940
+CVE-2026-11940


### PR DESCRIPTION
## What

Adds `CVE-2026-11940` to `.trivyignore` so the **Build Docker Images & Scan for CVEs** check passes again.

## Why

Trivy's DB just flagged **CVE-2026-11940 (CRITICAL)** across four `python3.13` packages (`libpython3.13-minimal`, `libpython3.13-stdlib`, `python3.13`, `python3.13-minimal`), failing the CVE scan on every branch (a base-image scan against a freshly-published advisory — no code change involved).

- **Not exploitable here:** our services run **Python 3.11**; `python3.13` ships only as a transitive Debian base package and is never executed, and the app extracts no untrusted tar via python3.13 at runtime.
- **No fix available:** Trivy reports an empty *Fixed Version* — a base-image bump can't resolve it today.

## Change

- `.trivyignore` — one entry for `CVE-2026-11940` with a justification comment, matching the existing `python3.13` / `linux-libc-dev` suppressions. Reassess on the next `python:3.11-slim` SHA bump.

## Impact / safety

- CI-only. No application, image, or dependency changes. Unblocks the Docker CVE scan on all open branches (the `bloomctl` CLI PRs #350/#351/#353 are currently red on this same advisory check).