### PR TITLE
fix(security): trivyignore CVE-2026-11940 (python3.13 base package)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -90,3 +90,12 @@ CVE-2026-8376
 # affected code path is unreachable at runtime. No fix available upstream. Reassess on the
 # next python:3.11-slim SHA bump. Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-43185
 CVE-2026-43185
+
+# libpython3.13 / python3.13 (Debian 13 in python:3.11-slim) — affects: langchain-agent / bloommcp
+# tarfile.extractall() 'data'/'tar' filter bypass allowing path traversal on
+# extraction. The container runs python3.11 (not 3.13); python3.13 ships as a
+# base Debian package but is never executed, and no application code extracts
+# untrusted tar archives. Affected code path is unreachable at runtime. No fix
+# available upstream. Reassess on the next python:3.11-slim SHA bump.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-11940
+CVE-2026-11940


### PR DESCRIPTION
## Summary

Trivy's vulnerability DB started flagging **`CVE-2026-11940`** (a `tarfile.extractall()` `data`/`tar` filter bypass, published 2026-07-02) as **CRITICAL** in the `python3.13` Debian base packages (`libpython3.13-*`, `python3.13*`) carried by `python:3.11-slim`.

This fails the `docker-build` **critical-CVE gate** for every service built on that base image (langchain-agent, bloommcp, …). The gate scans images in order, so builds abort on the first affected image (`langchain-agent`). This is unrelated to any application code and will hit all PRs once the DB fully propagates.

## Why suppress rather than fix
- The containers run **python3.11**, not python3.13 — `python3.13` ships only as a base Debian package and is **never executed**.
- No application code extracts untrusted tar archives via the affected module, so the vulnerable code path is **unreachable at runtime**.
- **No fixed base image is available upstream yet** — bumping the pin cannot resolve it today.

This matches the existing family of justified `python:3.11-slim` base-package suppressions already in `.trivyignore` (e.g. `CVE-2026-7210`, `CVE-2026-42496`). 

## Change
- `.trivyignore`: add `CVE-2026-11940`