### PR TITLE
hotfix(bloomctl): CLI package + release pipeline to main (enable first PyPI release)

### DIFF
--- a/.claude/commands/prepare-release-bloomctl.md
+++ b/.claude/commands/prepare-release-bloomctl.md
@@ -1,0 +1,53 @@
+---
+name: Prepare bloomctl Release
+description: Drive a bloomctl PyPI release (version bump, changelog, GitHub Release) per RELEASE_PROCESS.md
+category: Release
+tags: [bloomctl, release, pypi, changelog]
+---
+
+# Prepare bloomctl Release
+
+Guide a `bloomctl` release end to end, following
+[`bloomcli/RELEASE_PROCESS.md`](../../bloomcli/RELEASE_PROCESS.md). The pipeline
+publishes to real PyPI via trusted publishing on a **published GitHub Release**
+only.
+
+## Steps
+
+1. **Decide the version.** Ask which bump is intended (`patch`/`minor`/`major`,
+   or a pre-release `alpha`/`beta`/`rc`/`stable`). Confirm the resulting PEP 440
+   version.
+
+2. **Bump it.** Prefer the CI path (Actions → **version-bloomcli** → Run
+   workflow), or locally:
+
+   ```bash
+   cd bloomcli && uv version --bump <type>
+   ```
+
+   Merge the resulting bump PR before continuing.
+
+3. **Update the changelog.** Add a `## [X.Y.Z] - YYYY-MM-DD` section to
+   `bloomcli/CHANGELOG.md` under `[Unreleased]`, summarizing Added/Changed/Fixed.
+   (`validate-release` blocks publishing if this entry is missing.)
+
+4. **Dry-run (optional but recommended).** Trigger `release-bloomcli.yml` via
+   `workflow_dispatch` — it validates, builds, and smoke-tests the wheel
+   (`import bloomctl` + `bloomctl --version`) without publishing.
+
+5. **Cut the Release.** Create a GitHub Release whose tag matches the version
+   (`bloomctl-vX.Y.Z`). Tick **"Set as a pre-release"** for `aN`/`bN`/`rcN`.
+   Publishing it runs `release-bloomcli.yml` → validate → build → publish to PyPI.
+
+6. **Verify.** `uvx bloomctl --version` (stable) or
+   `uvx --prerelease=allow bloomctl --version` (pre-release).
+
+## Guardrails
+
+- Never publish by pushing to a branch or a raw tag — only a published Release
+  (or a non-publishing dispatch dry run) is valid.
+- The tag MUST equal the `pyproject.toml` version, and the changelog MUST have a
+  matching entry, or `validate-release` fails.
+- If publishing fails on trusted publishing, the pending publisher / `pypi`
+  environment setup is incomplete — see RELEASE_PROCESS.md "Setup requirements".
+  Nothing is uploaded on failure, so it's safe to fix and re-run.

--- a/.github/workflows/release-bloomcli.yml
+++ b/.github/workflows/release-bloomcli.yml
@@ -1,0 +1,116 @@
+name: release-bloomcli
+
+# Builds and publishes the bloomctl package to PyPI.
+#
+# Trigger: a *published* GitHub Release (the developer-gated entry point, with a
+# home for release notes and a pre-release flag) or a manual workflow_dispatch.
+#
+# A dispatch run validates + builds + smoke-tests but NEVER publishes — use it
+# as a dry run. There is intentionally no push/tag publish trigger.
+#
+# The validate-release job gates build-and-publish (`needs:`), so an immutable
+# PyPI upload can only happen after tag/version/changelog/lint/test checks pass
+# and the freshly built wheel has been imported and run (`bloomctl --version`).
+#
+# Auth is PyPI trusted publishing (OIDC) — no API token is stored. The publisher
+# is bound to this repo + this workflow filename + the `pypi` environment; that
+# pending publisher must be registered on PyPI before the first release.
+#
+# Pre-releases (aN/bN/rcN) publish to real PyPI and are marked "pre-release" on
+# the GitHub Release; `uvx bloomctl` ignores them unless `--prerelease=allow`.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-bloomcli
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: bloomcli
+
+jobs:
+  validate-release:
+    name: Validate release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+
+      - name: Read version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(uv version | awk '{print $NF}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "bloomctl version: $VERSION"
+
+      # Release tag must equal the package version. Accepts `bloomctl-vX`, `vX`,
+      # or a bare `X` tag by stripping the known prefixes.
+      # Untrusted inputs (the release tag) go through env, never interpolated
+      # into the script text, so a crafted tag can't break out of the command.
+      - name: Validate tag matches version
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG_VERSION="${TAG#bloomctl-v}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          if [ "$TAG_VERSION" != "$VERSION" ]; then
+            echo "::error::Release tag ($TAG -> $TAG_VERSION) does not match bloomcli/pyproject.toml version ($VERSION)"
+            exit 1
+          fi
+          echo "Tag $TAG matches version $VERSION"
+
+      - name: Validate changelog entry exists
+        if: github.event_name == 'release'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::No changelog entry '## [$VERSION]' found in bloomcli/CHANGELOG.md"
+            exit 1
+          fi
+          echo "Changelog entry found for $VERSION"
+
+      # Lint via uvx (pinned to the repo's .pre-commit-config.yaml ruff version)
+      # so ruff is not a project dependency.
+      - name: Lint (ruff)
+        run: uvx ruff@0.9.9 check .
+
+      - name: Run tests
+        run: uv run --extra test pytest -q
+
+  build-and-publish:
+    name: Build and publish
+    needs: validate-release
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write # OIDC token for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      # Immutable-upload insurance: prove the built wheel imports and the CLI
+      # entry point runs from an isolated install BEFORE publishing.
+      - name: Verify wheel imports
+        run: uv run --isolated --no-project --with dist/*.whl python -c "import bloomctl; print('bloomctl', bloomctl.__version__)"
+
+      - name: Verify CLI entry point
+        run: uv run --isolated --no-project --with dist/*.whl bloomctl --version
+
+      # Publishes only on a real Release; a workflow_dispatch dry run stops here.
+      - name: Publish to PyPI (trusted publishing)
+        if: github.event_name == 'release'
+        run: uv publish --trusted-publishing always

--- a/.github/workflows/version-bloomcli.yml
+++ b/.github/workflows/version-bloomcli.yml
@@ -1,0 +1,86 @@
+name: version-bloomcli
+
+# Manually bump the bloomctl version and open a PR with the change.
+#
+# Modeled on talmolab/sleap-roots-analyze's version.yml. Replaces the old
+# bloomctl-version-bump-check.yml guard: instead of a CI check asserting a human
+# remembered to bump, the bump itself is a reviewable PR. Run it from the Actions
+# tab, pick a bump type (or a custom version), and merge the PR it opens. Then
+# update bloomcli/CHANGELOG.md and cut a GitHub Release to publish.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - alpha
+          - beta
+          - rc
+          - stable
+      custom_version:
+        description: "Custom version (optional, overrides bump_type)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    working-directory: bloomcli
+
+jobs:
+  bump-version:
+    name: Bump bloomctl version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+
+      - name: Read current version
+        id: current
+        run: echo "version=$(uv version | awk '{print $NF}')" >> "$GITHUB_OUTPUT"
+
+      # Free-text inputs go through env, never interpolated into the script text,
+      # so a crafted custom_version can't break out of the command.
+      - name: Bump version
+        id: bump
+        env:
+          CUSTOM_VERSION: ${{ inputs.custom_version }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: |
+          if [ -n "$CUSTOM_VERSION" ]; then
+            uv version "$CUSTOM_VERSION"
+          else
+            uv version --bump "$BUMP_TYPE"
+          fi
+          echo "new_version=$(uv version | awk '{print $NF}')" >> "$GITHUB_OUTPUT"
+
+      - name: Open version-bump PR
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          # bloomctl commits no uv.lock (not in scripts/check-uv-locks.py), so the
+          # bump PR only touches pyproject.toml.
+          add-paths: |
+            bloomcli/pyproject.toml
+          commit-message: "chore(bloomctl): bump version to ${{ steps.bump.outputs.new_version }}"
+          title: "chore(bloomctl): bump version to ${{ steps.bump.outputs.new_version }}"
+          body: |
+            Automated `bloomctl` version bump.
+
+            - Previous: `${{ steps.current.outputs.version }}`
+            - New: `${{ steps.bump.outputs.new_version }}`
+
+            Before releasing: add a `## [${{ steps.bump.outputs.new_version }}]`
+            entry to `bloomcli/CHANGELOG.md`, then publish a GitHub Release tagged
+            to this version to trigger `release-bloomcli.yml`.
+          branch: bloomctl-version-bump-${{ steps.bump.outputs.new_version }}
+          delete-branch: true
+          labels: version

--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to `bloomctl` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
+(pre-releases are published to PyPI as `aN`/`bN`/`rcN`).
+
+## [Unreleased]
+
+## [0.1.0a1] - 2026-06-30
+
+### Added
+
+- Initial pre-release of the Python `bloomctl`, successor to the Node
+  `@salk-hpi/bloom-cli` (#347).
+- `bloomctl login` — bootstraps client config from the Bloom server
+  `/api/client-info` endpoint and authenticates, storing credentials per profile.
+- Credential management (`--profile`, `--server`, `--api-url`, `--anon-key`).

--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -1,0 +1,7 @@
+# bloomctl
+
+Python command-line tool for the Bloom server — download cylinder experiments
+(metadata + images) and manage credentials. Successor to the Node
+`@salk-hpi/bloom-cli`. Tracked by issue #347.
+
+Full install + usage docs land with the `download` command.

--- a/bloomcli/RELEASE_PROCESS.md
+++ b/bloomcli/RELEASE_PROCESS.md
@@ -1,0 +1,92 @@
+# bloomctl Release Process
+
+How to cut a `bloomctl` release to PyPI. The pipeline is a single workflow,
+`.github/workflows/release-bloomcli.yml`, that publishes to **real PyPI** via
+trusted publishing (OIDC) — there is no TestPyPI lane and no stored token.
+
+## Overview
+
+- **Publish** — `uv publish` with [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/)
+  (OIDC). No API token in CI.
+- **Trigger** — publishing runs only when a **GitHub Release is published**. A
+  manual `workflow_dispatch` run validates + builds + smoke-tests but does NOT
+  publish (a safe dry run).
+- **Pre-releases** — publish to real PyPI as PEP 440 `aN`/`bN`/`rcN`, marked
+  "pre-release" on the GitHub Release. `uvx bloomctl` ignores them unless the
+  caller passes `--prerelease=allow`.
+
+## Version management
+
+The version lives in `bloomcli/pyproject.toml` (single source of truth;
+`bloomcli/src/bloomctl/__init__.py` reads it from installed metadata).
+
+- **In CI:** run the **version-bloomcli** workflow (Actions tab → Run workflow),
+  pick a bump type, and it opens a PR with the bump.
+- **Locally:**
+
+  ```bash
+  cd bloomcli
+  uv version --bump patch    # 0.1.0  -> 0.1.1
+  uv version --bump minor    # 0.1.0  -> 0.2.0
+  uv version --bump alpha    # 0.2.0  -> 0.2.0a1
+  uv version --bump stable   # 0.2.0a1 -> 0.2.0
+  ```
+
+### Pre-release progression
+
+`0.2.0a1 → 0.2.0a2 → 0.2.0b1 → 0.2.0rc1 → 0.2.0`. Pre-releases go to real PyPI
+and are marked as a pre-release on GitHub.
+
+## Cutting a release
+
+1. Bump the version (workflow or `uv version`), merge the bump PR.
+2. Add a `## [X.Y.Z] - YYYY-MM-DD` entry to `bloomcli/CHANGELOG.md`.
+3. Create a **GitHub Release** whose tag matches the version (`bloomctl-vX.Y.Z`,
+   `vX.Y.Z`, or `X.Y.Z`). Tick **"Set as a pre-release"** for `aN`/`bN`/`rcN`.
+4. Publishing the Release runs `release-bloomcli.yml`:
+   - `validate-release`: tag ↔ version match, changelog entry exists, lint + tests.
+   - `build-and-publish`: `uv build`, import the wheel + run `bloomctl --version`,
+     then `uv publish`.
+5. Verify on PyPI: `uvx bloomctl --version` (stable) or
+   `uvx --prerelease=allow bloomctl --version` (pre-release).
+
+## Setup requirements (one-time, before the first release)
+
+### PyPI trusted publishing
+
+Register a **pending trusted publisher** on PyPI (the package need not exist yet)
+bound to exactly these values — they must match the workflow or publishing fails:
+
+| Field | Value |
+|---|---|
+| PyPI Project Name | `bloomctl` |
+| Owner | `Salk-Harnessing-Plants-Initiative` |
+| Repository name | `bloom` |
+| Workflow name | `release-bloomcli.yml` |
+| Environment name | `pypi` |
+
+Salk-HPI has no PyPI organization, so the project is registered under **Talmo's
+PyPI org**. The GitHub owner (Salk-HPI) and the PyPI org (Talmo) are independent;
+trusted publishing binds the GitHub repo to the PyPI project.
+
+### GitHub Environment
+
+Create a repo Environment named **`pypi`** (Settings → Environments). Add
+protections (required reviewers, wait timer) here if a human gate on publishing
+is wanted.
+
+## Troubleshooting
+
+- **`uv publish` fails with a trusted-publishing error** — the pending publisher
+  or the `pypi` environment is missing or the names don't match exactly. PyPI
+  uploads nothing, so it's safe to fix and re-run the job.
+- **`validate-release` fails on tag/version** — the Release tag doesn't equal the
+  `pyproject.toml` version. Retag the Release or bump the version.
+- **`validate-release` fails on changelog** — add the `## [X.Y.Z]` entry to
+  `bloomcli/CHANGELOG.md`.
+
+## References
+
+- [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+- [PEP 440 versioning](https://peps.python.org/pep-0440/)
+- [Keep a Changelog](https://keepachangelog.com/)

--- a/bloomcli/pyproject.toml
+++ b/bloomcli/pyproject.toml
@@ -1,0 +1,61 @@
+[project]
+name = "bloomctl"
+version = "0.1.0a1"
+description = "Bloom command-line tool for Bloom Database"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "BSD-2-Clause"
+authors = [{ name = "Salk Harnessing Plants Initiative" }]
+keywords = ["bloom", "cli", "plant-phenotyping","cylinder"]
+classifiers = [
+    "Programming Language :: Python :: 3.11",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "click>=8.1",
+    "rich>=13.0",
+    # /client-info bootstrap fetch (login).
+    "httpx>=0.27",
+    # Supabase PostgREST + Storage client (auth, metadata query, image signing).
+    "supabase>=2.0.0",
+    "python-dotenv>=1.0.0",
+    # Security floor for the supabase auth/JWT transitive dep, per repo convention
+    # (open floor past the upstream CVE fix; see bloommcp/pyproject.toml).
+    "cryptography>=48.0.1",
+]
+
+[project.scripts]
+bloomctl = "bloomctl.cli:cli"
+
+# Test stack lives in the `test` extra (not a dev dependency-group) so CI invokes
+# it as `uv run --extra test pytest` — the repo-wide convention enforced by
+# tests/unit/test_ci_workflow_uv_conventions.py.
+[project.optional-dependencies]
+test = [
+    "pytest>=8.3",
+]
+
+[build-system]
+requires = ["uv_build>=0.11.0,<0.12.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = "bloomctl"
+module-root = "src"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+
+# Lint config lives here (matching bloommcp); CI runs ruff via `uvx ruff`
+# pinned to the repo's .pre-commit-config.yaml version, so ruff is not a
+# project dependency.
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+# Line length is owned by the formatter (black), per ruff's guidance for
+# formatter-managed projects — so E501 is not linted here.
+ignore = ["E501"]

--- a/bloomcli/src/bloomctl/__init__.py
+++ b/bloomcli/src/bloomctl/__init__.py
@@ -1,0 +1,11 @@
+"""bloomctl — the Bloom command-line tool (Python successor to @salk-hpi/bloom-cli)."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    # Single source of truth: the version comes from the installed package
+    # metadata (built from pyproject.toml), so `uv version --bump` can't drift
+    # from what `bloomctl --version` prints.
+    __version__ = version("bloomctl")
+except PackageNotFoundError:  # running from a source tree that isn't installed
+    __version__ = "0.0.0+unknown"

--- a/bloomcli/src/bloomctl/auth.py
+++ b/bloomcli/src/bloomctl/auth.py
@@ -1,0 +1,68 @@
+"""Auth helpers for bloomctl: anon-key bootstrap + login verification.
+
+Heavy imports (httpx, supabase) are deferred into the functions that use them so
+importing this module (e.g. for ``bloomctl --help``) stays fast.
+"""
+
+from __future__ import annotations
+
+DEFAULT_SERVER = "https://bloom.salk.edu"
+
+
+class AuthError(Exception):
+    """Login bootstrap or authentication failed."""
+
+
+def fetch_anon_credentials(
+    server: str = DEFAULT_SERVER, *, timeout: float = 10.0
+) -> tuple[str, str]:
+    """Fetch ``(api_url, anon_key)`` from ``<server>/api/client-info``.
+
+    Mirrors the legacy CLI bootstrap. Raises :class:`AuthError` if the endpoint
+    is unreachable (e.g. a 401 while the Kong basic-auth gate still covers it),
+    pointing the user at the ``--api-url`` / ``--anon-key`` overrides.
+    """
+    import httpx
+
+    url = f"{server.rstrip('/')}/api/client-info"
+    try:
+        resp = httpx.get(url, timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["api_url"], data["anon_key"]
+    except (httpx.HTTPError, KeyError, ValueError) as exc:
+        raise AuthError(
+            f"could not fetch client config from {url}: {exc}. "
+            "Pass --api-url and --anon-key to skip this fetch."
+        ) from exc
+
+
+def verify_credentials(api_url: str, anon_key: str, email: str, password: str) -> None:
+    """Authenticate against Supabase; raise :class:`AuthError` on failure."""
+    from supabase import create_client
+
+    client = create_client(api_url, anon_key)
+    try:
+        res = client.auth.sign_in_with_password({"email": email, "password": password})
+    except Exception as exc:  # supabase raises various AuthApiError subtypes
+        raise AuthError(f"sign-in failed: {exc}") from exc
+    if not getattr(res, "session", None):
+        raise AuthError("sign-in failed — check email/password")
+
+
+def make_authed_client(creds):
+    """Create a Supabase client signed in as ``creds`` (for authenticated queries)."""
+    from supabase import create_client
+
+    client = create_client(creds.api_url, creds.anon_key)
+    try:
+        res = client.auth.sign_in_with_password(
+            {"email": creds.email, "password": creds.password}
+        )
+    except Exception as exc:
+        raise AuthError(f"sign-in failed: {exc}") from exc
+    if not getattr(res, "session", None):
+        raise AuthError(
+            "sign-in failed — check stored credentials (try `bloomctl login`)"
+        )
+    return client

--- a/bloomcli/src/bloomctl/cli.py
+++ b/bloomcli/src/bloomctl/cli.py
@@ -1,0 +1,219 @@
+"""bloomctl command group (entry point ``bloomctl = bloomctl.cli:cli``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from . import __version__
+from .auth import DEFAULT_SERVER
+from .credentials import DEFAULT_PROFILE
+
+
+@click.group()
+@click.version_option(version=__version__, prog_name="bloomctl")
+def cli() -> None:
+    """Bloom command-line tool"""
+
+
+@cli.command()
+@click.option(
+    "--server",
+    default=DEFAULT_SERVER,
+    show_default=True,
+    help="Which Bloom server to log in to — prod by default; pass a staging/local URL to switch.",
+)
+@click.option(
+    "--api-url",
+    default=None,
+    help="Supabase API URL (e.g. https://bloom.salk.edu/api). Pair with --anon-key to skip the /client-info fetch.",
+)
+@click.option(
+    "--anon-key",
+    default=None,
+    help="Public anon key — pair with --api-url to supply credentials manually when /client-info can't be fetched (interim / local / offline).",
+)
+@click.option(
+    "-p",
+    "--profile",
+    default=DEFAULT_PROFILE,
+    show_default=True,
+    help="Credentials profile to write (credentials.txt for prod).",
+)
+@click.option("--email", default=None, help="Login email (prompted if omitted).")
+@click.option("--password", default=None, help="Login password (prompted if omitted).")
+def login(
+    server: str,
+    api_url: str | None,
+    anon_key: str | None,
+    profile: str,
+    email: str | None,
+    password: str | None,
+) -> None:
+    """Log in to Bloom and save credentials to ~/.bloom/credentials.txt."""
+    from . import auth
+    from .credentials import Credentials, save_credentials
+
+    if not email:
+        email = click.prompt("Email")
+    if not password:
+        password = click.prompt("Password", hide_input=True)
+
+    # api_url + anon_key come from --api-url/--anon-key, else from /client-info.
+    if api_url and anon_key:
+        resolved_api_url, resolved_anon_key = api_url, anon_key
+    else:
+        try:
+            resolved_api_url, resolved_anon_key = auth.fetch_anon_credentials(server)
+        except auth.AuthError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    try:
+        auth.verify_credentials(resolved_api_url, resolved_anon_key, email, password)
+    except auth.AuthError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    path = save_credentials(
+        Credentials(
+            api_url=resolved_api_url,
+            anon_key=resolved_anon_key,
+            email=email,
+            password=password,
+        ),
+        profile=profile,
+    )
+    click.echo(f"Logged in as {email}. Credentials saved to {path}.")
+
+
+@cli.command()
+@click.argument("out_dir", type=click.Path(file_okay=False, path_type=Path))
+@click.option(
+    "--experiment-id",
+    "--experiment_id",
+    "experiment_id",
+    type=int,
+    default=None,
+    help="Download a whole experiment by ID (mutually exclusive with --scan-id).",
+)
+@click.option(
+    "--scan-id",
+    "--scan_id",
+    "scan_id",
+    type=int,
+    default=None,
+    help="Download a single scan by ID (mutually exclusive with --experiment-id).",
+)
+@click.option(
+    "-p",
+    "--profile",
+    default=DEFAULT_PROFILE,
+    show_default=True,
+    help="Credentials profile to use.",
+)
+@click.option(
+    "--meta-only",
+    "--meta_only",
+    "meta_only",
+    is_flag=True,
+    help="Write scans.csv only; skip image download.",
+)
+@click.option(
+    "--plant-qr-code",
+    "--plant_qr_code",
+    "plant_qr_code",
+    default=None,
+    help="Restrict to a single plant QR code.",
+)
+@click.option(
+    "--plant-age-min",
+    "--plant_age_min",
+    "plant_age_min",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Minimum plant age in days.",
+)
+@click.option(
+    "--plant-age-max",
+    "--plant_age_max",
+    "plant_age_max",
+    type=int,
+    default=1000,
+    show_default=True,
+    help="Maximum plant age in days.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=100000,
+    show_default=True,
+    help="Maximum number of scans to fetch.",
+)
+def download(
+    out_dir: Path,
+    experiment_id: int | None,
+    scan_id: int | None,
+    profile: str,
+    meta_only: bool,
+    plant_qr_code: str | None,
+    plant_age_min: int,
+    plant_age_max: int,
+    limit: int,
+) -> None:
+    """Download a cylinder experiment (--experiment-id) or a single scan (--scan-id):
+    metadata (scans.csv) and per-frame images."""
+    from . import auth
+    from . import download as dl
+    from .credentials import load_credentials
+
+    # Exactly one of --experiment-id / --scan-id.
+    if (experiment_id is None) == (scan_id is None):
+        raise click.UsageError("Pass exactly one of --experiment-id or --scan-id.")
+
+    try:
+        creds = load_credentials(profile)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(f"{exc} — run `bloomctl login`.") from exc
+    try:
+        client = auth.make_authed_client(creds)
+    except auth.AuthError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if scan_id is not None:
+        scan = dl.fetch_scan(client, scan_id)
+        if scan is None:
+            raise click.ClickException(f"Scan {scan_id} not found.")
+        scans = [scan]
+    else:
+        scans = dl.fetch_scans(
+            client,
+            experiment_id,
+            plant_qr_code=plant_qr_code,
+            plant_age_min=plant_age_min,
+            plant_age_max=plant_age_max,
+            limit=limit,
+        )
+    genotypes = dl.fetch_genotypes(client, [s.get("accession_id") for s in scans])
+    rows = [dl.build_scan_row(s, genotypes.get(s.get("accession_id"))) for s in scans]
+
+    out = Path(out_dir)
+    csv_path = out / "scans.csv"
+    dl.write_scans_csv(rows, csv_path)
+    click.echo(f"Wrote {len(rows)} scans -> {csv_path}")
+
+    if meta_only:
+        return
+
+    result = dl.download_images(client, scans, out)
+    log_path = out / "download_log.txt"
+    dl.write_download_log(result, log_path)
+    click.echo(
+        f"Downloaded {result.ok}/{result.total} image frames -> {out / 'images'}  (log: {log_path})"
+    )
+    if result.failed:
+        # Partial download: surface it and exit non-zero so a pipeline knows the
+        # output is incomplete (the log lists every failed frame).
+        raise click.ClickException(
+            f"{result.failed} of {result.total} frames failed to download — see {log_path}"
+        )

--- a/bloomcli/src/bloomctl/credentials.py
+++ b/bloomcli/src/bloomctl/credentials.py
@@ -1,0 +1,104 @@
+"""Profile-based credential storage for bloomctl.
+
+Mirrors the legacy ``packages/bloom-fs`` format: a dotenv file at
+``~/.bloom/credentials.txt`` (profile ``prod``) or ``~/.bloom/credentials.<name>.txt``
+(profile ``<name>``), with keys BLOOM_EMAIL / BLOOM_PASSWORD / BLOOM_API_URL /
+BLOOM_ANON_KEY.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+DEFAULT_PROFILE = "prod"
+_REQUIRED_KEYS = ("BLOOM_API_URL", "BLOOM_ANON_KEY", "BLOOM_EMAIL", "BLOOM_PASSWORD")
+# credentials.txt -> profile "prod"; credentials.<name>.txt -> profile "<name>"
+_CRED_RE = re.compile(r"^credentials(?:\.(.+))?\.txt$")
+
+
+@dataclass(frozen=True)
+class Credentials:
+    api_url: str
+    anon_key: str
+    email: str
+    password: str
+
+
+def default_config_dir() -> Path:
+    """The Bloom config directory (``~/.bloom``)."""
+    return Path.home() / ".bloom"
+
+
+def filename_for_profile(profile: str) -> str:
+    """Filename a profile is *written* to (`prod` -> credentials.txt)."""
+    return "credentials.txt" if profile == DEFAULT_PROFILE else f"credentials.{profile}.txt"
+
+
+def available_profiles(config_dir: Path) -> dict[str, Path]:
+    """Map profile name -> credentials file found in ``config_dir``.
+
+    Both ``credentials.txt`` and ``credentials.prod.txt`` resolve to ``prod`` —
+    having both is ambiguous and raises.
+    """
+    profiles: dict[str, Path] = {}
+    for path in sorted(config_dir.glob("credentials*.txt")):
+        match = _CRED_RE.match(path.name)
+        if not match:
+            continue
+        name = match.group(1) or DEFAULT_PROFILE
+        if name in profiles:
+            raise ValueError(
+                f"Conflicting credential files for profile '{name}': "
+                f"{profiles[name].name} and {path.name}. Keep only one."
+            )
+        profiles[name] = path
+    return profiles
+
+
+def resolve_profile_path(profile: str, config_dir: Path | None = None) -> Path:
+    """Path to the credentials file for ``profile``, or raise with a login hint."""
+    config_dir = config_dir or default_config_dir()
+    profiles = available_profiles(config_dir)
+    if profile not in profiles:
+        hint = "bloomctl login" + ("" if profile == DEFAULT_PROFILE else f" --profile {profile}")
+        raise FileNotFoundError(
+            f"No credentials for profile '{profile}'. Run `{hint}` "
+            f"(expected {config_dir / filename_for_profile(profile)})."
+        )
+    return profiles[profile]
+
+
+def load_credentials(profile: str = DEFAULT_PROFILE, config_dir: Path | None = None) -> Credentials:
+    """Load and validate the four credential keys for ``profile``."""
+    path = resolve_profile_path(profile, config_dir)
+    values = dotenv_values(path)
+    missing = [k for k in _REQUIRED_KEYS if not values.get(k)]
+    if missing:
+        raise ValueError(f"{path} is missing required keys: {', '.join(missing)}")
+    return Credentials(
+        api_url=values["BLOOM_API_URL"],
+        anon_key=values["BLOOM_ANON_KEY"],
+        email=values["BLOOM_EMAIL"],
+        password=values["BLOOM_PASSWORD"],
+    )
+
+
+def save_credentials(
+    creds: Credentials, profile: str = DEFAULT_PROFILE, config_dir: Path | None = None
+) -> Path:
+    """Write ``creds`` to the profile's dotenv file (creating ``config_dir``)."""
+    config_dir = config_dir or default_config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = config_dir / filename_for_profile(profile)
+    path.write_text(
+        f"BLOOM_EMAIL={creds.email}\n"
+        f"BLOOM_PASSWORD={creds.password}\n"
+        f"BLOOM_API_URL={creds.api_url}\n"
+        f"BLOOM_ANON_KEY={creds.anon_key}\n"
+    )
+    path.chmod(0o600)
+    return path

--- a/bloomcli/src/bloomctl/download.py
+++ b/bloomcli/src/bloomctl/download.py
@@ -1,0 +1,211 @@
+"""Cylinder experiment download: metadata (scans.csv) + per-frame images.
+
+Pure helpers (column mapping, paths) are separated from the supabase/storage I/O
+so the contract is unit-testable without a live server.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# scans.csv schema: (output column, source key in a cyl_scans_extended row).
+# Order matches the legacy CLI's predict-container contract; `genotype` is
+# inserted after `accession_id`, and `scan_path` is derived (relative).
+_COLUMNS: list[tuple[str, str | None]] = [
+    ("scan_id", "scan_id"),
+    ("plant_qr_code", "qr_code"),
+    ("scan_path", None),  # derived
+    ("scanner_id", "scanner_id"),
+    ("species_id", "species_id"),
+    ("species_name", "species_name"),
+    ("species_genus", "species_genus"),
+    ("species_species", "species_species"),
+    ("uploaded_at", "uploaded_at"),
+    ("wave_id", "wave_id"),
+    ("wave_number", "wave_number"),
+    ("wave_name", "wave_name"),
+    ("accession_id", "accession_id"),
+    ("genotype", None),  # derived (accessions.name)
+    ("date_scanned", "date_scanned"),
+    ("experiment_id", "experiment_id"),
+    ("experiment_name", "experiment_name"),
+    ("germ_day", "germ_day"),
+    ("germ_day_color", "germ_day_color"),
+    ("phenotyper_id", "phenotyper_id"),
+    ("plant_age_days", "plant_age_days"),
+    ("plant_id", "plant_id"),
+]
+CSV_COLUMNS: list[str] = [name for name, _ in _COLUMNS]
+
+
+def scan_relative_dir(scan: dict[str, Any]) -> str:
+    """Per-scan image dir, relative to the output dir (where scans.csv lives)."""
+    wave = scan.get("wave_number") or 0
+    return f"images/Wave{wave}/Day{scan.get('plant_age_days')}_{scan.get('date_scanned')}/{scan.get('qr_code')}"
+
+
+def build_scan_row(scan: dict[str, Any], genotype: str | None) -> dict[str, Any]:
+    """Map a cyl_scans_extended row to the ordered scans.csv row."""
+    row: dict[str, Any] = {}
+    for name, key in _COLUMNS:
+        if name == "scan_path":
+            row[name] = scan_relative_dir(scan)
+        elif name == "genotype":
+            row[name] = genotype if genotype is not None else ""
+        else:
+            row[name] = scan.get(key, "")
+    return row
+
+
+def write_scans_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    """Write rows to scans.csv with the fixed column order."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def image_dest(out_dir: Path, scan: dict[str, Any], image: dict[str, Any]) -> Path:
+    """Absolute destination for one frame, preserving its real extension."""
+    ext = Path(image["object_path"]).suffix or ".png"
+    return Path(out_dir) / scan_relative_dir(scan) / f"{image['frame_number']}{ext}"
+
+
+# --- supabase / storage I/O -------------------------------------------------
+
+
+def fetch_scans(
+    client: Any,
+    experiment_id: int,
+    *,
+    plant_qr_code: str | None = None,
+    plant_age_min: int = 0,
+    plant_age_max: int = 1000,
+    limit: int = 100000,
+) -> list[dict[str, Any]]:
+    """Query cyl_scans_extended for an experiment (legacy filter semantics)."""
+    query = (
+        client.table("cyl_scans_extended")
+        .select("*")
+        .eq("experiment_id", experiment_id)
+    )
+    if plant_qr_code:
+        query = query.eq("qr_code", plant_qr_code)
+    else:
+        query = query.gte("plant_age_days", plant_age_min).lte(
+            "plant_age_days", plant_age_max
+        )
+    return query.limit(limit).execute().data or []
+
+
+def fetch_scan(client: Any, scan_id: Any) -> dict[str, Any] | None:
+    """Single cyl_scans_extended row for one scan_id, or None if not found."""
+    rows = (
+        client.table("cyl_scans_extended")
+        .select("*")
+        .eq("scan_id", scan_id)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    return rows[0] if rows else None
+
+
+def fetch_genotypes(client: Any, accession_ids: list[Any]) -> dict[Any, str]:
+    """Map accession_id -> accessions.name for the given ids."""
+    ids = sorted({a for a in accession_ids if a is not None})
+    if not ids:
+        return {}
+    rows = (
+        client.table("accessions").select("id, name").in_("id", ids).execute().data
+        or []
+    )
+    return {row["id"]: row["name"] for row in rows}
+
+
+def fetch_images(client: Any, scan_id: Any) -> list[dict[str, Any]]:
+    """Frames for a scan, ordered by frame_number."""
+    return (
+        client.table("cyl_images")
+        .select("*")
+        .eq("scan_id", scan_id)
+        .order("frame_number")
+        .execute()
+        .data
+        or []
+    )
+
+
+@dataclass
+class FrameResult:
+    """Outcome of one frame download."""
+
+    scan_id: Any
+    frame_number: Any
+    object_path: str
+    ok: bool
+    error: str = ""
+
+
+@dataclass
+class DownloadResult:
+    """Aggregate outcome of a `download_images` run."""
+
+    frames: list[FrameResult]
+
+    @property
+    def ok(self) -> int:
+        return sum(1 for f in self.frames if f.ok)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for f in self.frames if not f.ok)
+
+    @property
+    def total(self) -> int:
+        return len(self.frames)
+
+
+def download_images(client: Any, scans: list[dict[str, Any]], out_dir: Path) -> DownloadResult:
+    """Download every frame for every scan from Storage bucket `images`.
+
+    Each frame is downloaded independently: a failure is recorded, not raised, so
+    one bad frame (missing object, transient 5xx) can't abort the whole run.
+    Signs server-side via Supabase Storage (no MinIO secrets, no legacy Lambda).
+    """
+    bucket = client.storage.from_("images")
+    frames: list[FrameResult] = []
+    for scan in scans:
+        for image in fetch_images(client, scan["scan_id"]):
+            object_path = image.get("object_path", "")
+            result = FrameResult(scan.get("scan_id"), image.get("frame_number"), object_path, ok=False)
+            try:
+                data = bucket.download(object_path)
+                if data is None:
+                    raise ValueError("empty response from storage")
+                dest = image_dest(out_dir, scan, image)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(data)
+                result.ok = True
+            except Exception as exc:  # per-frame: record and continue
+                result.error = str(exc)
+            frames.append(result)
+    return DownloadResult(frames)
+
+
+def write_download_log(result: DownloadResult, path: Path) -> None:
+    """Write a per-frame download log (one line per frame) with a summary footer."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for f in result.frames:
+        line = f"{'OK  ' if f.ok else 'FAIL'} scan={f.scan_id} frame={f.frame_number} {f.object_path}"
+        if not f.ok:
+            line += f"  error={f.error}"
+        lines.append(line)
+    lines.append(f"\nSummary: {result.ok} downloaded, {result.failed} failed, {result.total} total")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/bloomcli/tests/test_cli.py
+++ b/bloomcli/tests/test_cli.py
@@ -1,0 +1,16 @@
+"""Task 1.2 — the CLI exposes its commands."""
+
+from click.testing import CliRunner
+
+from bloomctl.cli import cli
+
+
+def test_root_help_lists_commands():
+    result = CliRunner().invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "login" in result.output
+
+
+def test_login_help_exits_zero():
+    result = CliRunner().invoke(cli, ["login", "--help"])
+    assert result.exit_code == 0

--- a/bloomcli/tests/test_credentials.py
+++ b/bloomcli/tests/test_credentials.py
@@ -1,0 +1,79 @@
+"""Task 2.1 — profile-based dotenv credentials (mirrors packages/bloom-fs)."""
+
+import pytest
+
+from bloomctl.credentials import (
+    Credentials,
+    available_profiles,
+    filename_for_profile,
+    load_credentials,
+    resolve_profile_path,
+    save_credentials,
+)
+
+CREDS = Credentials(
+    api_url="https://bloom.salk.edu/api",
+    anon_key="anon-xyz",
+    email="user@salk.edu",
+    password="hunter2",
+)
+
+
+def test_filename_for_profile():
+    assert filename_for_profile("prod") == "credentials.txt"
+    assert filename_for_profile("staging") == "credentials.staging.txt"
+
+
+def test_save_then_load_default_prod_profile(tmp_path):
+    path = save_credentials(CREDS, config_dir=tmp_path)
+    assert path.name == "credentials.txt"
+    assert load_credentials("prod", config_dir=tmp_path) == CREDS
+
+
+def test_save_then_load_named_profile(tmp_path):
+    path = save_credentials(CREDS, profile="staging", config_dir=tmp_path)
+    assert path.name == "credentials.staging.txt"
+    assert load_credentials("staging", config_dir=tmp_path) == CREDS
+
+
+def test_saved_file_is_dotenv_with_four_keys(tmp_path):
+    path = save_credentials(CREDS, config_dir=tmp_path)
+    text = path.read_text()
+    for line in (
+        "BLOOM_EMAIL=user@salk.edu",
+        "BLOOM_PASSWORD=hunter2",
+        "BLOOM_API_URL=https://bloom.salk.edu/api",
+        "BLOOM_ANON_KEY=anon-xyz",
+    ):
+        assert line in text
+
+
+def test_saved_file_is_owner_only(tmp_path):
+    # The file holds a plaintext password — it must not be readable by group/other.
+    path = save_credentials(CREDS, config_dir=tmp_path)
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_available_profiles_maps_filenames(tmp_path):
+    (tmp_path / "credentials.txt").write_text("BLOOM_EMAIL=a\n")
+    (tmp_path / "credentials.staging.txt").write_text("BLOOM_EMAIL=b\n")
+    profiles = available_profiles(tmp_path)
+    assert set(profiles) == {"prod", "staging"}
+
+
+def test_conflicting_prod_files_raise(tmp_path):
+    (tmp_path / "credentials.txt").write_text("BLOOM_EMAIL=a\n")
+    (tmp_path / "credentials.prod.txt").write_text("BLOOM_EMAIL=b\n")
+    with pytest.raises(ValueError, match="profile 'prod'"):
+        available_profiles(tmp_path)
+
+
+def test_missing_profile_raises_with_login_hint(tmp_path):
+    with pytest.raises(FileNotFoundError, match="bloomctl login"):
+        resolve_profile_path("prod", config_dir=tmp_path)
+
+
+def test_file_missing_required_key_raises(tmp_path):
+    (tmp_path / "credentials.txt").write_text("BLOOM_EMAIL=a\nBLOOM_PASSWORD=b\n")  # no url/anon
+    with pytest.raises(ValueError, match="missing required keys"):
+        load_credentials("prod", config_dir=tmp_path)

--- a/bloomcli/tests/test_download_images.py
+++ b/bloomcli/tests/test_download_images.py
@@ -1,0 +1,134 @@
+"""Task 5 — `bloomctl download` image download via Supabase Storage."""
+
+from click.testing import CliRunner
+from test_download_metadata import SCAN
+
+import bloomctl.auth as auth
+import bloomctl.download as dl
+from bloomctl.cli import cli
+from bloomctl.credentials import Credentials
+
+
+def test_image_dest_preserves_real_extension(tmp_path):
+    image = {"frame_number": 0, "object_path": "cyl-images/cyl-image_1_abc.png"}
+    dest = dl.image_dest(tmp_path, SCAN, image)
+    assert dest == tmp_path / "images/Wave2/Day14_2026-05-11/QR-1/0.png"
+
+
+def test_image_dest_defaults_png_when_no_extension(tmp_path):
+    image = {"frame_number": 2, "object_path": "cyl-images/no-ext"}
+    assert dl.image_dest(tmp_path, SCAN, image).suffix == ".png"
+
+
+class _FakeBucket:
+    def download(self, object_path):
+        return f"bytes::{object_path}".encode()
+
+
+class _FakeStorage:
+    def from_(self, bucket):
+        assert bucket == "images"
+        return _FakeBucket()
+
+
+class _FakeClient:
+    storage = _FakeStorage()
+
+
+def test_download_images_writes_frames(tmp_path, monkeypatch):
+    images = [
+        {"frame_number": 0, "object_path": "cyl-images/a.png"},
+        {"frame_number": 1, "object_path": "cyl-images/b.png"},
+    ]
+    monkeypatch.setattr(dl, "fetch_images", lambda client, scan_id: images)
+
+    result = dl.download_images(_FakeClient(), [SCAN], tmp_path)
+
+    assert result.ok == 2 and result.failed == 0 and result.total == 2
+    frame = tmp_path / "images/Wave2/Day14_2026-05-11/QR-1/0.png"
+    assert frame.read_bytes() == b"bytes::cyl-images/a.png"
+
+
+class _FlakyBucket:
+    """Downloads succeed except for object paths containing 'boom'."""
+
+    def download(self, object_path):
+        if "boom" in object_path:
+            raise RuntimeError("500 storage error")
+        return f"bytes::{object_path}".encode()
+
+
+class _FlakyClient:
+    storage = type("S", (), {"from_": lambda self, b: _FlakyBucket()})()
+
+
+def test_download_images_records_failures_and_keeps_going(tmp_path, monkeypatch):
+    images = [
+        {"frame_number": 0, "object_path": "cyl-images/a.png"},
+        {"frame_number": 1, "object_path": "cyl-images/boom.png"},  # fails
+        {"frame_number": 2, "object_path": "cyl-images/c.png"},
+    ]
+    monkeypatch.setattr(dl, "fetch_images", lambda client, scan_id: images)
+
+    result = dl.download_images(_FlakyClient(), [SCAN], tmp_path)
+
+    # One bad frame does not abort the run: the other two still download.
+    assert result.ok == 2 and result.failed == 1 and result.total == 3
+    assert (tmp_path / "images/Wave2/Day14_2026-05-11/QR-1/0.png").exists()
+    assert (tmp_path / "images/Wave2/Day14_2026-05-11/QR-1/2.png").exists()
+    assert not (tmp_path / "images/Wave2/Day14_2026-05-11/QR-1/1.png").exists()
+
+    log = tmp_path / "download_log.txt"
+    dl.write_download_log(result, log)
+    text = log.read_text()
+    assert "FAIL scan=1 frame=1" in text
+    assert "500 storage error" in text
+    assert "Summary: 2 downloaded, 1 failed, 3 total" in text
+
+
+def test_partial_download_exits_nonzero(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FlakyClient())
+    monkeypatch.setattr(dl, "fetch_scans", lambda *a, **k: [SCAN])
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {42: "Spring-32"})
+    monkeypatch.setattr(
+        dl, "fetch_images", lambda client, scan_id: [
+            {"frame_number": 0, "object_path": "cyl-images/boom.png"}
+        ]
+    )
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(cli, ["download", str(out), "--experiment-id", "17957"])
+
+    # Partial download -> non-zero exit, but scans.csv + log are still written.
+    assert result.exit_code != 0
+    assert "frames failed" in result.output
+    assert (out / "scans.csv").exists()
+    assert (out / "download_log.txt").exists()
+
+
+def test_full_download_writes_csv_and_images(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FakeClient())
+    monkeypatch.setattr(dl, "fetch_scans", lambda *a, **k: [SCAN])
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {42: "Spring-32"})
+    monkeypatch.setattr(
+        dl,
+        "fetch_images",
+        lambda client, scan_id: [
+            {"frame_number": 0, "object_path": "cyl-images/a.png"}
+        ],
+    )
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(cli, ["download", str(out), "--experiment-id", "17957"])
+
+    assert result.exit_code == 0, result.output
+    assert (out / "scans.csv").exists()
+    assert (out / "images/Wave2/Day14_2026-05-11/QR-1/0.png").exists()

--- a/bloomcli/tests/test_download_metadata.py
+++ b/bloomcli/tests/test_download_metadata.py
@@ -1,0 +1,86 @@
+"""Task 4 — `bloomctl download` metadata (scans.csv) contract."""
+
+import csv
+
+from click.testing import CliRunner
+
+import bloomctl.auth as auth
+import bloomctl.download as dl
+from bloomctl.cli import cli
+from bloomctl.credentials import Credentials
+
+SCAN = {
+    "scan_id": 1,
+    "qr_code": "QR-1",
+    "scanner_id": 7,
+    "species_id": 3,
+    "species_name": "Pennycress",
+    "species_genus": "Thlaspi",
+    "species_species": "arvense",
+    "uploaded_at": "2026-05-11T00:00:00Z",
+    "wave_id": 11,
+    "wave_number": 2,
+    "wave_name": "Wave 2",
+    "accession_id": 42,
+    "date_scanned": "2026-05-11",
+    "experiment_id": 17957,
+    "experiment_name": "2026-05-11 GIFTOL",
+    "germ_day": 1,
+    "germ_day_color": "green",
+    "phenotyper_id": 5,
+    "plant_age_days": 14,
+    "plant_id": 100,
+}
+
+
+def test_genotype_column_follows_accession_id():
+    cols = dl.CSV_COLUMNS
+    assert cols[cols.index("accession_id") + 1] == "genotype"
+
+
+def test_build_scan_row_fills_genotype_and_relative_scan_path():
+    row = dl.build_scan_row(SCAN, "Spring-32")
+    assert row["genotype"] == "Spring-32"
+    assert row["scan_path"] == "images/Wave2/Day14_2026-05-11/QR-1"
+    assert row["scan_id"] == 1
+
+
+def test_build_scan_row_blank_genotype_when_missing():
+    assert dl.build_scan_row(SCAN, None)["genotype"] == ""
+
+
+def test_write_scans_csv_roundtrip(tmp_path):
+    path = tmp_path / "scans.csv"
+    dl.write_scans_csv([dl.build_scan_row(SCAN, "Spring-32")], path)
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        assert reader.fieldnames == dl.CSV_COLUMNS
+        rows = list(reader)
+    assert len(rows) == 1
+    assert rows[0]["genotype"] == "Spring-32"
+
+
+def test_meta_only_writes_csv_and_skips_images(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: object())
+    monkeypatch.setattr(dl, "fetch_scans", lambda *a, **k: [SCAN])
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {42: "Spring-32"})
+
+    def _no_images(*a, **k):
+        raise AssertionError("images must not download under --meta-only")
+
+    monkeypatch.setattr(dl, "download_images", _no_images)
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(
+        cli, ["download", str(out), "--experiment_id", "17957", "--meta_only"]
+    )
+
+    assert result.exit_code == 0, result.output
+    with (out / "scans.csv").open() as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 1
+    assert rows[0]["genotype"] == "Spring-32"

--- a/bloomcli/tests/test_download_scan.py
+++ b/bloomcli/tests/test_download_scan.py
@@ -1,0 +1,132 @@
+"""Single-scan download (`bloomctl download --scan-id`)."""
+
+from click.testing import CliRunner
+from test_download_metadata import SCAN
+
+import bloomctl.auth as auth
+import bloomctl.download as dl
+from bloomctl.cli import cli
+from bloomctl.credentials import Credentials
+
+
+class _FakeBucket:
+    def download(self, object_path):
+        return f"bytes::{object_path}".encode()
+
+
+class _FakeStorage:
+    def from_(self, bucket):
+        assert bucket == "images"
+        return _FakeBucket()
+
+
+class _FakeClient:
+    storage = _FakeStorage()
+
+
+def test_fetch_scan_returns_single_row():
+    captured = {}
+
+    class _Q:
+        def select(self, *a):
+            return self
+
+        def eq(self, col, val):
+            captured["col"], captured["val"] = col, val
+            return self
+
+        def limit(self, n):
+            return self
+
+        def execute(self):
+            return type("R", (), {"data": [SCAN]})()
+
+    class _Client:
+        def table(self, name):
+            captured["table"] = name
+            return _Q()
+
+    scan = dl.fetch_scan(_Client(), 1)
+    assert scan == SCAN
+    assert captured == {"table": "cyl_scans_extended", "col": "scan_id", "val": 1}
+
+
+def test_fetch_scan_missing_returns_none():
+    class _Client:
+        def table(self, name):
+            class _Q:
+                def select(self, *a):
+                    return self
+
+                def eq(self, *a):
+                    return self
+
+                def limit(self, n):
+                    return self
+
+                def execute(self):
+                    return type("R", (), {"data": []})()
+
+            return _Q()
+
+    assert dl.fetch_scan(_Client(), 999) is None
+
+
+def test_download_scan_writes_that_scan_only(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FakeClient())
+    monkeypatch.setattr(dl, "fetch_scan", lambda client, scan_id: SCAN)
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {42: "Spring-32"})
+    monkeypatch.setattr(
+        dl, "fetch_images", lambda client, scan_id: [
+            {"frame_number": 0, "object_path": "cyl-images/a.png"}
+        ]
+    )
+    # fetch_scans must NOT be called in scan mode.
+    monkeypatch.setattr(
+        dl, "fetch_scans", lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("fetch_scans must not run for --scan-id")
+        ),
+    )
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(cli, ["download", str(out), "--scan-id", "1"])
+
+    assert result.exit_code == 0, result.output
+    with (out / "scans.csv").open() as fh:
+        import csv
+
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 1
+    assert rows[0]["scan_id"] == "1"
+    assert (out / "images/Wave2/Day14_2026-05-11/QR-1/0.png").exists()
+
+
+def test_scan_not_found_errors(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FakeClient())
+    monkeypatch.setattr(dl, "fetch_scan", lambda client, scan_id: None)
+
+    result = CliRunner().invoke(cli, ["download", str(tmp_path / "out"), "--scan-id", "999"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_scan_id_and_experiment_id_are_mutually_exclusive(tmp_path):
+    result = CliRunner().invoke(
+        cli, ["download", str(tmp_path / "out"), "--scan-id", "1", "--experiment-id", "17957"]
+    )
+    assert result.exit_code != 0
+    assert "exactly one" in result.output.lower()
+
+
+def test_scan_id_or_experiment_id_is_required(tmp_path):
+    result = CliRunner().invoke(cli, ["download", str(tmp_path / "out")])
+    assert result.exit_code != 0
+    assert "exactly one" in result.output.lower()

--- a/bloomcli/tests/test_login.py
+++ b/bloomcli/tests/test_login.py
@@ -1,0 +1,67 @@
+"""Task 3.1 — `bloomctl login` (supabase + /client-info fetch mocked)."""
+
+import pytest
+from click.testing import CliRunner
+
+import bloomctl.auth as auth
+import bloomctl.credentials as credentials
+from bloomctl.cli import cli
+from bloomctl.credentials import load_credentials
+
+
+@pytest.fixture
+def cfg(tmp_path, monkeypatch):
+    """Redirect credential writes to a tmp config dir."""
+    monkeypatch.setattr(credentials, "default_config_dir", lambda: tmp_path / ".bloom")
+    return tmp_path / ".bloom"
+
+
+def test_login_fetches_config_and_writes_creds(cfg, monkeypatch):
+    monkeypatch.setattr(
+        auth, "fetch_anon_credentials",
+        lambda server=auth.DEFAULT_SERVER: ("https://bloom.salk.edu/api", "ANON123"),
+    )
+    monkeypatch.setattr(auth, "verify_credentials", lambda *a, **k: None)
+
+    result = CliRunner().invoke(cli, ["login"], input="user@salk.edu\nsecret\n")
+
+    assert result.exit_code == 0, result.output
+    creds = load_credentials("prod", config_dir=cfg)
+    assert creds.email == "user@salk.edu"
+    assert creds.password == "secret"
+    assert creds.api_url == "https://bloom.salk.edu/api"
+    assert creds.anon_key == "ANON123"
+
+
+def test_login_override_skips_client_info_fetch(cfg, monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("fetch_anon_credentials must not run when overridden")
+
+    monkeypatch.setattr(auth, "fetch_anon_credentials", _boom)
+    monkeypatch.setattr(auth, "verify_credentials", lambda *a, **k: None)
+
+    result = CliRunner().invoke(cli, [
+        "login", "--api-url", "https://x/api", "--anon-key", "KEY",
+        "--email", "a@b.co", "--password", "pw", "--profile", "staging",
+    ])
+
+    assert result.exit_code == 0, result.output
+    creds = load_credentials("staging", config_dir=cfg)
+    assert (creds.api_url, creds.anon_key) == ("https://x/api", "KEY")
+
+
+def test_login_invalid_credentials_writes_no_file(cfg, monkeypatch):
+    monkeypatch.setattr(
+        auth, "fetch_anon_credentials",
+        lambda server=auth.DEFAULT_SERVER: ("https://x/api", "KEY"),
+    )
+
+    def _fail(*a, **k):
+        raise auth.AuthError("sign-in failed — check email/password")
+
+    monkeypatch.setattr(auth, "verify_credentials", _fail)
+
+    result = CliRunner().invoke(cli, ["login"], input="user@salk.edu\nbad\n")
+
+    assert result.exit_code != 0
+    assert not (cfg / "credentials.txt").exists()

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -63,6 +63,14 @@
 	# -------------------
 	@main host {$DOMAIN_MAIN}
 	handle @main {
+		# CLI bootstrap config: the public {api_url, anon_key}. EXACT path only
+		# (no wildcard) so every other /api/* still routes to Kong unchanged.
+		# Served by bloom-web's Next.js route; must NOT fall through to Kong's
+		# basic-auth dashboard catch-all, which 401s it (issue #347).
+		handle /api/client-info {
+			reverse_proxy bloom-web:{$BLOOM_WEB_PORT}
+		}
+
 		# Supabase API — strip /api prefix, proxy to Kong
 		handle_path /api/* {
 			reverse_proxy kong:{$KONG_PORT}

--- a/tests/unit/test_caddy_client_info_route.py
+++ b/tests/unit/test_caddy_client_info_route.py
@@ -1,0 +1,101 @@
+"""Config-shape test for the /api/client-info edge route (issue #347).
+
+Caddy must route the EXACT path /api/client-info to bloom-web (the Next.js
+route that serves {api_url, anon_key}), NOT to Kong — otherwise it falls
+through to Kong's basic-auth dashboard catch-all and returns 401. The match
+must be exact so no other /api/* traffic (frontend, graviscan, plate scanners,
+auth/rest/storage/realtime) is diverted from Kong.
+
+Assertions are scoped to the `handle @main { ... }` host block via brace
+matching, so the route can't false-pass by living in a non-functional block
+(e.g. @minio). For the live 200 + non-null-body regression guard, see
+tests/integration/test_api_endpoints.py::test_client_info_returns_200.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CADDYFILE = REPO_ROOT / "caddy" / "Caddyfile"
+
+
+def _text() -> str:
+    return CADDYFILE.read_text(encoding="utf-8")
+
+
+def _block_after(text: str, header_pattern: str) -> str | None:
+    """Body of the first `<header> {` directive, sliced by matching braces."""
+    header = re.search(header_pattern, text)
+    if not header:
+        return None
+    open_brace = text.find("{", header.end())
+    if open_brace == -1:
+        return None
+    depth = 0
+    for i in range(open_brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace + 1 : i]
+    return None
+
+
+def _main_block(text: str) -> str | None:
+    """The body of the `handle @main { ... }` host block."""
+    return _block_after(text, r"handle\s+@main\b")
+
+
+def _client_info_block(text: str) -> str | None:
+    """The body of the `handle /api/client-info { ... }` directive within @main."""
+    main = _main_block(text)
+    if main is None:
+        return None
+    return _block_after(main, r"handle\s+/api/client-info\b")
+
+
+def test_client_info_routed_to_bloom_web_not_kong():
+    block = _client_info_block(_text())
+    assert block is not None, (
+        "missing `handle /api/client-info` inside `handle @main` in caddy/Caddyfile"
+    )
+    # Assert the exact upstream — a dropped `:{$BLOOM_WEB_PORT}` would break the
+    # proxy, and a substring check like `"reverse_proxy bloom-web" in block`
+    # would not catch it.
+    assert re.search(
+        r"reverse_proxy\s+bloom-web:\{\$BLOOM_WEB_PORT\}", block
+    ), "/api/client-info must proxy to bloom-web:{$BLOOM_WEB_PORT}"
+    assert "kong" not in block.lower(), "/api/client-info must NOT proxy to kong"
+
+
+def test_client_info_match_is_exact_not_wildcard():
+    main = _main_block(_text())
+    assert main is not None, "missing `handle @main` block in caddy/Caddyfile"
+    # exact path only — no prefix/wildcard, and no handle_path (which would strip
+    # the prefix and break the Next.js route match).
+    assert "handle /api/client-info*" not in main
+    assert "handle_path /api/client-info" not in main
+
+
+def test_client_info_precedes_api_wildcard():
+    """The exact route must sit ahead of the /api/* -> kong catch-all (documents
+    intent; Caddy specificity makes ordering cosmetic, but the source order is
+    the contract a reviewer reads)."""
+    main = _main_block(_text())
+    assert main is not None, "missing `handle @main` block in caddy/Caddyfile"
+    ci = re.search(r"handle\s+/api/client-info\b", main)
+    wildcard = re.search(r"handle_path\s+/api/\*", main)
+    assert ci and wildcard, "both /api/client-info and /api/* handlers must exist in @main"
+    assert ci.start() < wildcard.start(), (
+        "/api/client-info must be declared before the /api/* -> kong handler"
+    )
+
+
+def test_other_api_traffic_still_goes_to_kong():
+    main = _main_block(_text())
+    assert main is not None, "missing `handle @main` block in caddy/Caddyfile"
+    m = re.search(r"handle_path\s+/api/\*\s*\{(.*?)reverse_proxy\s+kong", main, re.DOTALL)
+    assert m, "the /api/* -> kong handler must remain unchanged"

--- a/tests/unit/test_release_bloomcli_workflow_shape.py
+++ b/tests/unit/test_release_bloomcli_workflow_shape.py
@@ -1,0 +1,132 @@
+"""Regression guard for the bloomctl release + version workflows.
+
+These workflows can never be exercised by PR CI before they land
+(`release-bloomcli.yml` fires only on a published Release or manual dispatch;
+`version-bloomcli.yml` is dispatch-only), so this unit test is the only
+pre-merge gate on their shape.
+
+It locks the safety-critical properties the design signed off on:
+  - the publish workflow triggers ONLY on a Release (`published`) or
+    workflow_dispatch — never on a push or tag;
+  - `build-and-publish` is gated by `needs: validate-release`;
+  - `build-and-publish` requests the OIDC token (`id-token: write`) and pins the
+    `pypi` environment so trusted publishing works, and stores no API token;
+  - the actual `uv publish` runs only on a real Release event;
+  - the built wheel is smoke-tested (import + `bloomctl --version`) before upload;
+  - there is no TestPyPI lane;
+  - the version workflow bumps via `uv version` and opens a PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+RELEASE = WORKFLOWS / "release-bloomcli.yml"
+VERSION = WORKFLOWS / "version-bloomcli.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _on(wf: dict) -> dict:
+    # PyYAML parses the bare key `on` as boolean True (YAML 1.1).
+    return wf.get("on") or wf.get(True)
+
+
+def _steps_text(job: dict) -> str:
+    parts = []
+    for s in job["steps"]:
+        parts.append(str(s.get("run", "")))
+        parts.append(str(s.get("uses", "")))
+        parts.append(str(s.get("env", "")))  # untrusted inputs are passed via env:
+    return "\n".join(parts)
+
+
+def _raw(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# --- publish workflow: triggers --------------------------------------------
+
+def test_release_triggers_only_on_release_and_dispatch():
+    on = _on(_load(RELEASE))
+    assert set(on) == {"release", "workflow_dispatch"}
+    assert on["release"]["types"] == ["published"]
+    # Never publish on a push or a raw tag.
+    assert "push" not in on
+
+
+# --- publish workflow: validate gates publish ------------------------------
+
+def test_publish_needs_validate_release():
+    jobs = _load(RELEASE)["jobs"]
+    assert "validate-release" in jobs
+    assert "build-and-publish" in jobs
+    assert jobs["build-and-publish"]["needs"] == "validate-release"
+
+
+def test_validate_checks_tag_changelog_lint_tests():
+    text = _steps_text(_load(RELEASE)["jobs"]["validate-release"])
+    assert "github.event.release.tag_name" in text  # tag ↔ version match
+    assert "CHANGELOG.md" in text                    # changelog entry check
+    assert "ruff" in text                            # lint
+    assert "pytest" in text                          # tests
+
+
+# --- publish workflow: trusted publishing + immutability guard -------------
+
+def test_publish_uses_oidc_pypi_env_and_no_token():
+    wf = _load(RELEASE)
+    job = wf["jobs"]["build-and-publish"]
+    assert job["permissions"]["id-token"] == "write"
+    assert job["environment"] == "pypi"
+    text = _steps_text(job)
+    assert "uv publish --trusted-publishing always" in text
+    # No stored PyPI token anywhere in the workflow.
+    raw = _raw(RELEASE)
+    assert "PYPI_API_TOKEN" not in raw
+    assert "test.pypi.org" not in raw  # no TestPyPI lane
+
+
+def test_publish_step_gated_on_real_release():
+    job = _load(RELEASE)["jobs"]["build-and-publish"]
+    publish = [s for s in job["steps"] if "uv publish" in str(s.get("run", ""))]
+    assert len(publish) == 1
+    assert publish[0]["if"] == "github.event_name == 'release'"
+
+
+def test_built_wheel_is_smoke_tested_before_publish():
+    text = _steps_text(_load(RELEASE)["jobs"]["build-and-publish"])
+    assert "uv build" in text
+    assert "import bloomctl" in text            # wheel imports
+    assert "bloomctl --version" in text         # CLI entry point runs
+    assert "dist/*.whl" in text                 # from the freshly built wheel
+
+
+# --- version workflow -------------------------------------------------------
+
+def test_version_workflow_is_dispatch_only_with_bump_input():
+    on = _on(_load(VERSION))
+    assert set(on) == {"workflow_dispatch"}
+    inputs = on["workflow_dispatch"]["inputs"]
+    assert "bump_type" in inputs
+    assert {"patch", "minor", "major"}.issubset(set(inputs["bump_type"]["options"]))
+
+
+def test_version_workflow_bumps_and_opens_pr():
+    wf = _load(VERSION)
+    assert wf["permissions"]["contents"] == "write"
+    assert wf["permissions"]["pull-requests"] == "write"
+    text = _steps_text(wf["jobs"]["bump-version"])
+    assert "uv version" in text
+    assert "peter-evans/create-pull-request" in text
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What

Brings the **`bloomctl` CLI**, its **single-index PyPI release pipeline**, and the **`/api/client-info` edge route** to `main` — so the first release can be cut *and* the installed CLI can actually reach prod.

Contents (already reviewed + merged to `staging` via #349 / #350 / #351 / #353):
- `bloomcli/` — the CLI package: `login`, `download` (`--experiment-id` / `--scan-id`), resilient per-frame download + log, credential storage (`0600`). 31 tests. **(new)**
- `.github/workflows/release-bloomcli.yml` — Release-gated publish pipeline (validate → build → smoke-test → trusted-publish to PyPI). **(new)**
- `.github/workflows/version-bloomcli.yml` — version-bump → auto-PR. **(new)**
- `tests/unit/test_release_bloomcli_workflow_shape.py` — workflow-shape guard. **(new)**
- `.claude/commands/prepare-release-bloomctl.md` — release runbook command. **(new)**
- `caddy/Caddyfile` — adds the exact-match `handle /api/client-info` route → `bloom-web` (from #349), plus its config-shape test. **(one-block edit + new test)** — so the deployed prod server serves the public `{api_url, anon_key}` that `bloomctl login` fetches, instead of 401ing through Kong's dashboard catch-all.

Everything except the one Caddyfile route block is a **new file** — no changes to any existing `main` code.

## Why a hotfix to `main` (not a full staging→main promotion)

GitHub runs `release`-triggered workflows **from the default branch**, so `release-bloomcli.yml` must be on `main` to publish. `staging` is ~184 commits ahead of `main` and has other **unfinished work not ready for prod**, so a full promotion isn't appropriate. This hotfix brings **only** the CLI + its release pipeline + the `/client-info` route so the CLI can be released and reach prod, without shipping the rest of staging.

## After merge (to release)

1. Confirm the PyPI trusted publisher is registered (project `bloomctl`, workflow `release-bloomcli.yml`, env `pypi`).
2. Ensure `main` deploys (so the `/api/client-info` route reaches prod) — verify `https://bloom.salk.edu/api/client-info` returns a real `api_url`.
3. Cut a GitHub Release tagged `bloomctl-v0.1.0a1`, marked **pre-release** → the pipeline publishes to PyPI.
4. Verify: `uvx --prerelease=allow bloomctl --version`.
