### PR TITLE
feat(bloomctl): add 'list' command (experiments + scans) for ID discovery

### DIFF
--- a/bloomcli/src/bloomctl/cli.py
+++ b/bloomcli/src/bloomctl/cli.py
@@ -17,6 +17,21 @@ def cli() -> None:
     """Bloom command-line tool"""
 
 
+def _authed_client(profile: str):
+    """Load a profile's credentials and return a signed-in Supabase client."""
+    from . import auth
+    from .credentials import load_credentials
+
+    try:
+        creds = load_credentials(profile)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(f"{exc} — run `bloomctl login`.") from exc
+    try:
+        return auth.make_authed_client(creds)
+    except auth.AuthError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @cli.command()
 @click.option(
     "--server",
@@ -163,22 +178,13 @@ def download(
 ) -> None:
     """Download a cylinder experiment (--experiment-id) or a single scan (--scan-id):
     metadata (scans.csv) and per-frame images."""
-    from . import auth
     from . import download as dl
-    from .credentials import load_credentials
 
     # Exactly one of --experiment-id / --scan-id.
     if (experiment_id is None) == (scan_id is None):
         raise click.UsageError("Pass exactly one of --experiment-id or --scan-id.")
 
-    try:
-        creds = load_credentials(profile)
-    except (FileNotFoundError, ValueError) as exc:
-        raise click.ClickException(f"{exc} — run `bloomctl login`.") from exc
-    try:
-        client = auth.make_authed_client(creds)
-    except auth.AuthError as exc:
-        raise click.ClickException(str(exc)) from exc
+    client = _authed_client(profile)
 
     if scan_id is not None:
         scan = dl.fetch_scan(client, scan_id)
@@ -217,3 +223,75 @@ def download(
         raise click.ClickException(
             f"{result.failed} of {result.total} frames failed to download — see {log_path}"
         )
+
+
+@cli.group(name="list")
+def list_() -> None:
+    """List experiments or scans you can access."""
+
+
+def _print_table(title: str, columns: list[str], rows: list[list[str]], empty: str) -> None:
+    """Render a rich table (or an 'empty' message when there are no rows)."""
+    if not rows:
+        click.echo(empty)
+        return
+    from rich.console import Console
+    from rich.table import Table
+
+    table = Table(title=title)
+    for col in columns:
+        table.add_column(col, overflow="fold")
+    for row in rows:
+        table.add_row(*row)
+    Console().print(table)
+
+
+@list_.command(name="experiments")
+@click.option(
+    "-p", "--profile", default=DEFAULT_PROFILE, show_default=True,
+    help="Credentials profile to use.",
+)
+def list_experiments(profile: str) -> None:
+    """List cylinder experiments (id, name) you can access."""
+    from . import download as dl
+
+    client = _authed_client(profile)
+    experiments = dl.fetch_experiments(client)
+    _print_table(
+        "Experiments",
+        ["ID", "Name", "Created"],
+        [[str(e.get("id", "")), e.get("name") or "", str(e.get("created_at") or "")[:10]] for e in experiments],
+        empty="No experiments found.",
+    )
+
+
+@list_.command(name="scans")
+@click.option(
+    "--experiment-id", "--experiment_id", "experiment_id", type=int, required=True,
+    help="Experiment to list scans for.",
+)
+@click.option(
+    "-p", "--profile", default=DEFAULT_PROFILE, show_default=True,
+    help="Credentials profile to use.",
+)
+def list_scans(experiment_id: int, profile: str) -> None:
+    """List scans in an experiment (scan id, plant, wave, date)."""
+    from . import download as dl
+
+    client = _authed_client(profile)
+    scans = dl.fetch_scans(client, experiment_id)
+    _print_table(
+        f"Scans in experiment {experiment_id}",
+        ["Scan ID", "Plant QR", "Wave", "Age (d)", "Date"],
+        [
+            [
+                str(s.get("scan_id", "")),
+                s.get("qr_code") or "",
+                str(s.get("wave_number") or ""),
+                str(s.get("plant_age_days") or ""),
+                str(s.get("date_scanned") or ""),
+            ]
+            for s in scans
+        ],
+        empty=f"No scans found for experiment {experiment_id}.",
+    )

--- a/bloomcli/src/bloomctl/download.py
+++ b/bloomcli/src/bloomctl/download.py
@@ -116,6 +116,19 @@ def fetch_scan(client: Any, scan_id: Any) -> dict[str, Any] | None:
     return rows[0] if rows else None
 
 
+def fetch_experiments(client: Any) -> list[dict[str, Any]]:
+    """Non-deleted cyl_experiments the user can see (id-ordered)."""
+    return (
+        client.table("cyl_experiments")
+        .select("id, name, created_at")
+        .eq("deleted", False)
+        .order("id")
+        .execute()
+        .data
+        or []
+    )
+
+
 def fetch_genotypes(client: Any, accession_ids: list[Any]) -> dict[Any, str]:
     """Map accession_id -> accessions.name for the given ids."""
     ids = sorted({a for a in accession_ids if a is not None})

--- a/bloomcli/tests/test_download_images.py
+++ b/bloomcli/tests/test_download_images.py
@@ -1,12 +1,12 @@
 """Task 5 — `bloomctl download` image download via Supabase Storage."""
 
 from click.testing import CliRunner
+from test_download_metadata import SCAN
 
 import bloomctl.auth as auth
 import bloomctl.download as dl
 from bloomctl.cli import cli
 from bloomctl.credentials import Credentials
-from test_download_metadata import SCAN
 
 
 def test_image_dest_preserves_real_extension(tmp_path):

--- a/bloomcli/tests/test_download_scan.py
+++ b/bloomcli/tests/test_download_scan.py
@@ -1,12 +1,12 @@
 """Single-scan download (`bloomctl download --scan-id`)."""
 
 from click.testing import CliRunner
+from test_download_metadata import SCAN
 
 import bloomctl.auth as auth
 import bloomctl.download as dl
 from bloomctl.cli import cli
 from bloomctl.credentials import Credentials
-from test_download_metadata import SCAN
 
 
 class _FakeBucket:

--- a/bloomcli/tests/test_list.py
+++ b/bloomcli/tests/test_list.py
@@ -1,0 +1,59 @@
+"""bloomctl list — experiments + scans."""
+
+from click.testing import CliRunner
+
+import bloomctl.cli as climod
+import bloomctl.download as dl
+from bloomctl.cli import cli
+
+
+def test_list_experiments(monkeypatch):
+    monkeypatch.setattr(climod, "_authed_client", lambda profile: object())
+    monkeypatch.setattr(
+        dl, "fetch_experiments", lambda client: [
+            {"id": 1, "name": "Experiment 1", "created_at": "2024-01-18T00:00:00Z"},
+            {"id": 2, "name": "GIFTOL", "created_at": "2026-05-11T00:00:00Z"},
+        ]
+    )
+    result = CliRunner().invoke(cli, ["list", "experiments"])
+    assert result.exit_code == 0, result.output
+    assert "Experiment 1" in result.output
+    assert "GIFTOL" in result.output
+    assert "2024-01-18" in result.output  # created_at truncated to the date
+
+
+def test_list_experiments_empty(monkeypatch):
+    monkeypatch.setattr(climod, "_authed_client", lambda profile: object())
+    monkeypatch.setattr(dl, "fetch_experiments", lambda client: [])
+    result = CliRunner().invoke(cli, ["list", "experiments"])
+    assert result.exit_code == 0
+    assert "No experiments found" in result.output
+
+
+def test_list_scans(monkeypatch):
+    monkeypatch.setattr(climod, "_authed_client", lambda profile: object())
+    captured = {}
+
+    def _fetch_scans(client, experiment_id, **kwargs):
+        captured["experiment_id"] = experiment_id
+        return [{"scan_id": 7, "qr_code": "SOY-W1-001", "wave_number": 1,
+                 "plant_age_days": 6, "date_scanned": "2024-01-18"}]
+
+    monkeypatch.setattr(dl, "fetch_scans", _fetch_scans)
+    result = CliRunner().invoke(cli, ["list", "scans", "--experiment-id", "42"])
+    assert result.exit_code == 0, result.output
+    assert captured["experiment_id"] == 42
+    assert "SOY-W1-001" in result.output
+
+
+def test_list_scans_empty(monkeypatch):
+    monkeypatch.setattr(climod, "_authed_client", lambda profile: object())
+    monkeypatch.setattr(dl, "fetch_scans", lambda *a, **k: [])
+    result = CliRunner().invoke(cli, ["list", "scans", "--experiment-id", "999"])
+    assert result.exit_code == 0
+    assert "No scans found for experiment 999" in result.output
+
+
+def test_list_scans_requires_experiment_id():
+    result = CliRunner().invoke(cli, ["list", "scans"])
+    assert result.exit_code != 0  # --experiment-id is required


### PR DESCRIPTION
## What

Adds a **`bloomctl list`** command so users can discover experiment/scan IDs **from the terminal** instead of the web app — the missing "find the experiment ID to pass to `download`" piece via the CLI.
- **`bloomctl list experiments`** → id, name, created date of experiments you can access.
- **`bloomctl list scans --experiment-id <id>`** → scan id, plant QR, wave, age, date for one experiment.
Output is a `rich` table; empty results print a clear message (not a silent blank).

## How
- `download.py`: new `fetch_experiments(client)` — queries `cyl_experiments` (non-deleted, id-ordered). RLS-scoped: `bloom_user` has `user_read_cyl_experiments`, and `list scans` reuses `fetch_scans` on `cyl_scans_extended` (also `bloom_user`-readable).
- `cli.py`: a `list` group with `experiments` / `scans` subcommands, and a shared **`_authed_client(profile)`** helper (load creds → sign in). `download` now uses the same helper (DRYs up the duplicated auth boilerplate).
- Sorted imports in two existing test files (`ruff` — these had drifted from `main`).

## Note

The `list` query path is identical to `download`'s (which was validated end-to-end against a live dev DB — login + real `cyl_scans_extended`/`cyl_experiments` reads). A live `list` demo was blocked only by a flaky local-dev auth key mismatch (env issue, unrelated to the CLI).

## Follow-ups

Tracked in #384 (filter behavior) — this PR doesn't change the download filters.