### PR TITLE
feat(#386): add opt-in local-filesystem storage backend for bloommcp

### DIFF
--- a/_WIKI/BLOOMMCP/README.md
+++ b/_WIKI/BLOOMMCP/README.md
@@ -65,6 +65,22 @@ bloommcp-data/
 
 Any new tool that reads or writes a CSV should use this bucket.
 
+### Storage backend (`local` opt-in)
+
+Analysis **outputs** go to Supabase Storage by default — in local dev that means
+MinIO, not files under `./bloommcp/data/ANALYSIS_OUTPUT`. Two env vars control an
+opt-in local-filesystem backend:
+
+- `BLOOM_STORAGE_BACKEND` — `supabase` (default) or `local`. `local` writes outputs
+  as real files laid out by storage key.
+- `BLOOM_STORAGE_LOCAL_ROOT` — the local root when `local`; defaults to
+  `BLOOM_OUTPUT_DIR` when unset.
+
+Note `BLOOM_OUTPUT_DIR` / `BLOOM_USE_LOCAL` do **not** by themselves write local
+CSVs. Do not mix backends for one experiment. Full details:
+[storage-backends.md](../../bloommcp/docs/storage-backends.md). (This is the same
+`supabase_client.py` boundary that #388's user-facing downloads build on.)
+
 ## File reading and writing
 
 Use the helper in `bloommcp/src/bloom_mcp/supabase_client.py` — don't call

--- a/bloommcp/docs/storage-backends.md
+++ b/bloommcp/docs/storage-backends.md
@@ -61,9 +61,15 @@ Resulting on-disk layout (the storage key becomes the path under the root):
   `./bloommcp/data/ANALYSIS_OUTPUT`) — so in dev, `BLOOM_STORAGE_BACKEND=local`
   needs no second variable and finally populates that folder.
 - **Same semantics as Supabase:** manifest/versioning are unchanged; the backend
-  writes atomically (temp file + rename), overwrites in place, copies bytes
-  verbatim (so the recorded `output_sha256` matches the file on disk), and reads
-  resolve back through the same manifest/versioned-cleaned path.
+  overwrites in place, copies bytes verbatim (so the recorded `output_sha256`
+  matches the file on disk), and reads resolve back through the same
+  manifest/versioned-cleaned path.
+- **Atomic writes (POSIX):** on POSIX filesystems the backend writes a temp file,
+  `fsync`s it, then `os.replace`s it into place, so a crash mid-write never leaves
+  a truncated `manifest.json`. **On Windows/NTFS** `os.replace` over an existing
+  file is **not** guaranteed atomic (and can fail if a reader holds the target
+  open) — acceptable for this dev-only backend, but don't rely on crash-atomicity
+  there. (Crash-atomic, not power-loss-durable beyond a best-effort dir `fsync`.)
 - **Read paths work too:** manifest resolution, the versioned-cleaned lookup, and
   the MCP read tools all resolve against the local files.
 
@@ -86,6 +92,16 @@ This backend selection governs **object storage only**. PostgREST/table reads
 (`get_postgrest_client`, `read_input_csv`) and raw-experiment-input reads from the
 local `BLOOM_TRAITS_DIR` are unaffected by `BLOOM_STORAGE_BACKEND`. Production and
 staging stay on Supabase Storage; `local` is opt-in for local/dev.
+
+### `local` is not a fully-offline mode
+
+`local` changes only **where outputs are written**. bloommcp still boots through
+`validate_supabase_env()` and still reads inputs and database tables via Supabase,
+so **`SUPABASE_URL` / `BLOOM_AGENT_KEY` are still required** to start the server and
+to run any tool that reads a table or a `bloommcp_input/` CSV. It gives you real
+output files on disk for inspection — it does not, on its own, make bloommcp run
+without a Supabase stack. (A fully offline mode would also need inputs sourced
+locally — tracked in #395.)
 
 Related: this reshapes the same `supabase_client.py` storage boundary that #388
 (user-facing upload/download of bloommcp files) will build signed-URL downloads

--- a/bloommcp/docs/storage-backends.md
+++ b/bloommcp/docs/storage-backends.md
@@ -1,0 +1,92 @@
+# bloommcp storage backends — where analysis outputs go
+
+bloommcp analysis tools produce versioned artifacts (the cleaned CSV, a
+`cleanup_log.json`, plots, and a `manifest.json` catalog per experiment/tool).
+This doc explains **where those bytes actually land**, why the folder you might
+expect stays empty, and how to opt into writing them as **real files on disk**.
+
+## Default: Supabase Storage (nothing on your local disk)
+
+By default (`BLOOM_STORAGE_BACKEND` unset or `supabase`), every output is uploaded
+to **Supabase Storage**, in the `bloommcp-data` bucket under
+`bloommcp_output/<tool_class>_<stem>/v<N>_<date>/…`. There is **no local-file
+branch** on the default path.
+
+In local dev, Supabase Storage is backed by **MinIO**, so the bytes live inside
+MinIO's object store (under `MINIO_DATA_PATH`, in MinIO's own object format) —
+**not** as files under `./bloommcp/data/ANALYSIS_OUTPUT`. That folder is mounted
+into the container as `BLOOM_OUTPUT_DIR`, but on the default path nothing writes
+new outputs there, which is why it stays empty.
+
+### `BLOOM_OUTPUT_DIR` and `BLOOM_USE_LOCAL` do NOT produce local CSVs
+
+Two env vars look like they'd control this and don't:
+
+- **`BLOOM_OUTPUT_DIR`** — post-migration this only feeds a startup dir-existence
+  check and a *legacy read* fallback for pre-migration cleaned CSVs. Nothing
+  writes new outputs there. (It *is* reused as the default local root — but only
+  when you opt into the `local` backend below.)
+- **`BLOOM_USE_LOCAL`** — dead/commented-out, and it was only ever about CLI login
+  credentials, never about outputs.
+
+### How to reach outputs on the default path (local dev)
+
+- **MinIO console** — `http://localhost:${MINIO_CONSOLE_PORT}` (default `9001`),
+  bucket `bloom-storage` (the underlying MinIO S3 bucket).
+- **Supabase Studio** — `http://localhost:${STUDIO_PORT}` (default `55323`),
+  Storage → bucket `bloommcp-data`.
+- **The bloommcp MCP read tools** (`list_existing_analyses`, `load_experiment_data`, …).
+
+## Opt-in: the `local` backend (real files on disk)
+
+Set `BLOOM_STORAGE_BACKEND=local` to write outputs as real files, laid out by
+storage key under a root directory:
+
+```
+BLOOM_STORAGE_BACKEND=local
+# optional — defaults to BLOOM_OUTPUT_DIR when unset:
+BLOOM_STORAGE_LOCAL_ROOT=/app/data/ANALYSIS_OUTPUT
+```
+
+Resulting on-disk layout (the storage key becomes the path under the root):
+
+```
+<root>/bloommcp_output/qc_<stem>/manifest.json
+<root>/bloommcp_output/qc_<stem>/v1_2026-07-02/_cleaned.csv
+<root>/bloommcp_output/qc_<stem>/v1_2026-07-02/cleanup_log.json
+```
+
+- **Root resolution:** `BLOOM_STORAGE_LOCAL_ROOT` if set, otherwise
+  `BLOOM_OUTPUT_DIR` (already required and, in dev, mounted at
+  `./bloommcp/data/ANALYSIS_OUTPUT`) — so in dev, `BLOOM_STORAGE_BACKEND=local`
+  needs no second variable and finally populates that folder.
+- **Same semantics as Supabase:** manifest/versioning are unchanged; the backend
+  writes atomically (temp file + rename), overwrites in place, copies bytes
+  verbatim (so the recorded `output_sha256` matches the file on disk), and reads
+  resolve back through the same manifest/versioned-cleaned path.
+- **Read paths work too:** manifest resolution, the versioned-cleaned lookup, and
+  the MCP read tools all resolve against the local files.
+
+To enable it in dev, uncomment the two lines in the `bloommcp` service env block
+of `docker-compose.dev.yml` and restart the service.
+
+### ⚠️ Do not mix backends for one experiment
+
+A backend is **not a migration** — the two stores are independent catalogs with
+no cross-store view. If you run some versions of an experiment under `supabase`
+and then flip to `local` (or vice-versa), the second store starts a fresh catalog
+and re-allocates `v1`: version ids collide and each store's `latest` points at a
+different lineage. A later read sees only the store the current backend points at
+and is blind to the other's versions. **Pick one backend per experiment and keep
+it stable** for the life of that experiment's analysis history.
+
+## Scope
+
+This backend selection governs **object storage only**. PostgREST/table reads
+(`get_postgrest_client`, `read_input_csv`) and raw-experiment-input reads from the
+local `BLOOM_TRAITS_DIR` are unaffected by `BLOOM_STORAGE_BACKEND`. Production and
+staging stay on Supabase Storage; `local` is opt-in for local/dev.
+
+Related: this reshapes the same `supabase_client.py` storage boundary that #388
+(user-facing upload/download of bloommcp files) will build signed-URL downloads
+on; the two are independent.

--- a/bloommcp/src/bloom_mcp/experiment_utils.py
+++ b/bloommcp/src/bloom_mcp/experiment_utils.py
@@ -67,6 +67,13 @@ def validate_env() -> None:
         )
     _validate_dirs()
 
+    # Fail fast on a misconfigured storage backend (invalid BLOOM_STORAGE_BACKEND,
+    # or BLOOM_STORAGE_BACKEND=local with an unusable resolved root). Imported here
+    # (not at module top) so importing this module stays side-effect-free.
+    from bloom_mcp.storage_backend import validate_storage_backend
+
+    validate_storage_backend()
+
 
 # metadata columns, matched case-insensitively
 KNOWN_METADATA_COLS = {

--- a/bloommcp/src/bloom_mcp/storage_backend.py
+++ b/bloommcp/src/bloom_mcp/storage_backend.py
@@ -14,7 +14,7 @@ exist:
   the object store's implicit guarantees on a POSIX filesystem: atomic writes
   (temp file on the root's filesystem + ``os.replace``), upsert/overwrite,
   verbatim bytes (so recorded ``output_sha256`` equals the file on disk), and
-  redacted (no host-path) not-found errors.
+  redacted (no host-path) not-found and permission/OS errors.
 
 Selection is driven by ``BLOOM_STORAGE_BACKEND`` (default ``supabase``; ``local``
 opts in). Resolution is **lazy** — this module reads no environment variable and
@@ -41,6 +41,11 @@ logger = logging.getLogger(__name__)
 
 VALID_BACKENDS = ("supabase", "local")
 _DEFAULT_BACKEND = "supabase"
+
+# Prefix for the in-flight atomic-write temp file. Shared by the writer (which
+# creates `<dir>/.tmp-*`) and list_prefix (which filters it out for cross-backend
+# parity), so the two never drift.
+_TMP_PREFIX = ".tmp-"
 
 
 @runtime_checkable
@@ -75,6 +80,35 @@ class StorageKeyNotFound(FileNotFoundError):
     the read path keep working, while carrying only the logical key (never an
     absolute filesystem path) into any agent-facing message.
     """
+
+
+class StorageBackendError(OSError):
+    """A local-backend filesystem failure (permission/OS error), redacted.
+
+    Subclasses ``OSError`` so the read path's broad ``except`` gates keep working,
+    while the agent-facing message names only the logical storage key — never an
+    absolute host path (which would reveal the server's local root layout). The
+    raw error (errno + path) is logged server-side only. See
+    :func:`_redacted_io_error`.
+    """
+
+
+def _redacted_io_error(key: str, exc: OSError) -> StorageBackendError:
+    """Log the raw OSError server-side and return a path-free error for the caller.
+
+    The spec requires local-backend permission/OS errors to surface to agents
+    without leaking an absolute host path, with the detail available only in
+    server logs — mirroring the redaction :class:`StorageKeyNotFound` already
+    gives the not-found case.
+    """
+    logger.warning(
+        "local storage I/O error: key=%s errno=%s",
+        key,
+        getattr(exc, "errno", None),
+        exc_info=True,
+    )
+    kind = "permission denied" if isinstance(exc, PermissionError) else "I/O error"
+    return StorageBackendError(f"storage {kind} for key: {key}")
 
 
 # ─── Supabase backend (deployed default) ──────────────────────────────────────
@@ -168,7 +202,7 @@ class LocalStorageBackend:
             raise ValueError(f"storage key {key!r} escapes the local root")
         return target
 
-    def _atomic_write(self, target: Path, data: bytes) -> None:
+    def _atomic_write(self, target: Path, data: bytes, *, key: str) -> None:
         """Write ``data`` to ``target`` atomically on POSIX.
 
         Writes a temp file in the target's directory (same filesystem), fsyncs
@@ -178,17 +212,26 @@ class LocalStorageBackend:
         best-effort for power-loss durability of the rename. NOTE: ``os.replace``
         is atomic over an existing file on POSIX only; on Windows/NTFS it is not
         guaranteed atomic (see the class docstring).
+
+        ``OSError``\\ s (e.g. a permission-denied root, ENOSPC) are redacted to
+        carry only ``key`` — never the absolute temp/target path.
         """
-        target.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(target.parent), prefix=".tmp-", suffix=target.suffix
-        )
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(
+                dir=str(target.parent), prefix=_TMP_PREFIX, suffix=target.suffix
+            )
+        except OSError as exc:
+            raise _redacted_io_error(key, exc) from None
         try:
             with os.fdopen(fd, "wb") as fh:
                 fh.write(data)
                 fh.flush()
                 os.fsync(fh.fileno())
             os.replace(tmp, target)
+        except OSError as exc:
+            Path(tmp).unlink(missing_ok=True)
+            raise _redacted_io_error(key, exc) from None
         except BaseException:
             Path(tmp).unlink(missing_ok=True)
             raise
@@ -204,28 +247,37 @@ class LocalStorageBackend:
             pass
 
     def upload_file(self, key: str, local_path: Path) -> None:
-        self._atomic_write(self._resolve(key), Path(local_path).read_bytes())
+        self._atomic_write(self._resolve(key), Path(local_path).read_bytes(), key=key)
 
     def write_json(self, key: str, payload: dict) -> None:
-        self._atomic_write(self._resolve(key), _json_bytes(payload))
+        self._atomic_write(self._resolve(key), _json_bytes(payload), key=key)
 
     def download_file(self, key: str, local_path: Path) -> None:
         src = self._resolve(key)
         if not src.is_file():
             logger.debug("local storage miss: key=%s", key)
             raise StorageKeyNotFound(f"storage object not found: {key}")
+        # Read the canonical file, redacting any permission/OS error to the key.
+        try:
+            data = src.read_bytes()
+        except OSError as exc:
+            raise _redacted_io_error(key, exc) from None
         # Copy bytes to the caller-owned destination — never symlink or hand back
         # the canonical file under the root (the caller manages dest's lifetime).
         dest = Path(local_path)
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_bytes(src.read_bytes())
+        dest.write_bytes(data)
 
     def read_json(self, key: str) -> dict:
         src = self._resolve(key)
         if not src.is_file():
             logger.debug("local storage miss: key=%s", key)
             raise StorageKeyNotFound(f"storage object not found: {key}")
-        return json.loads(src.read_bytes().decode("utf-8"))
+        try:
+            raw = src.read_bytes()
+        except OSError as exc:
+            raise _redacted_io_error(key, exc) from None
+        return json.loads(raw.decode("utf-8"))
 
     def list_prefix(self, prefix: str) -> list[str]:
         rel = prefix.strip("/")
@@ -234,10 +286,13 @@ class LocalStorageBackend:
             names = [p.name for p in Path(directory).iterdir()]
         except (FileNotFoundError, NotADirectoryError):
             return []
+        except OSError as exc:
+            # e.g. a permission-denied directory — redact the absolute path.
+            raise _redacted_io_error(prefix, exc) from None
         # Hide in-flight atomic-write temp files: a SIGKILL between mkstemp and
         # os.replace can orphan a `.tmp-*`, which never appears in the Supabase
         # backend — filtering keeps cross-backend list parity.
-        return sorted(n for n in names if not n.startswith(".tmp-"))
+        return sorted(n for n in names if not n.startswith(_TMP_PREFIX))
 
 
 # ─── Selection ────────────────────────────────────────────────────────────────
@@ -275,20 +330,39 @@ def _resolve_local_root() -> Path:
     return Path(fallback)
 
 
+def _unrecognized_backend_error(name: str) -> RuntimeError:
+    """The single 'unrecognized BLOOM_STORAGE_BACKEND' error.
+
+    Shared by lazy selection (:func:`_build_backend`) and boot validation
+    (:func:`validate_storage_backend`) so the message — the offending value + the
+    accepted set — never drifts between the two raise sites.
+    """
+    return RuntimeError(
+        f"BLOOM_STORAGE_BACKEND={name!r} is not recognized; "
+        f"valid values: {', '.join(VALID_BACKENDS)}."
+    )
+
+
 def _build_backend() -> StorageBackend:
     name = _selected_backend_name()
     if name == "supabase":
         return SupabaseStorageBackend()
     if name == "local":
         return LocalStorageBackend(_resolve_local_root())
-    raise RuntimeError(
-        f"BLOOM_STORAGE_BACKEND={name!r} is not recognized; "
-        f"valid values: {', '.join(VALID_BACKENDS)}."
-    )
+    raise _unrecognized_backend_error(name)
 
 
 def active_backend() -> StorageBackend:
-    """The process's active object-storage backend (memoized, resolved on first use)."""
+    """The process's active object-storage backend (memoized, resolved on first use).
+
+    Intentionally lock-free. Under a concurrent first call two threads could each
+    run :func:`_build_backend` and race on the assignment below; that is safe —
+    both backends are cheap and stateless/idempotent to construct
+    (``SupabaseStorageBackend`` holds nothing; ``LocalStorageBackend`` just stores a
+    resolved root), so the two instances are interchangeable and last-write-wins
+    leaves an equivalent object. A lock would only add contention on the hot
+    storage path to prevent a harmless, transient double-build.
+    """
     global _active
     if _active is None:
         _active = _build_backend()
@@ -310,10 +384,7 @@ def validate_storage_backend() -> None:
     """
     name = _selected_backend_name()
     if name not in VALID_BACKENDS:
-        raise RuntimeError(
-            f"BLOOM_STORAGE_BACKEND={name!r} is not recognized; "
-            f"valid values: {', '.join(VALID_BACKENDS)}."
-        )
+        raise _unrecognized_backend_error(name)
     if name == "local":
         root = _resolve_local_root()
         if str(root) in ("", "."):

--- a/bloommcp/src/bloom_mcp/storage_backend.py
+++ b/bloommcp/src/bloom_mcp/storage_backend.py
@@ -1,0 +1,292 @@
+"""Object-storage backend selection for bloommcp.
+
+The five object-storage helpers in :mod:`bloom_mcp.supabase_client`
+(``upload_file`` / ``download_file`` / ``write_json`` / ``read_json`` /
+``list_prefix``) delegate to the *active* backend selected here. Two backends
+exist:
+
+* :class:`SupabaseStorageBackend` — the deployed default (Supabase Storage in the
+  ``bloommcp-data`` bucket). Its method bodies are the pre-backend
+  ``supabase_client`` helpers verbatim, so the default path is byte-for-byte
+  unchanged.
+* :class:`LocalStorageBackend` — opt-in; writes/reads real files under a root
+  dir, mapping each ``/``-separated storage key to ``<root>/<key>``. It preserves
+  the object store's implicit guarantees on a POSIX filesystem: atomic writes
+  (temp file on the root's filesystem + ``os.replace``), upsert/overwrite,
+  verbatim bytes (so recorded ``output_sha256`` equals the file on disk), and
+  redacted (no host-path) not-found errors.
+
+Selection is driven by ``BLOOM_STORAGE_BACKEND`` (default ``supabase``; ``local``
+opts in). Resolution is **lazy** — this module reads no environment variable and
+touches no filesystem at import, so ``import bloom_mcp`` stays side-effect-free.
+:func:`validate_storage_backend` is called at server boot (via
+``experiment_utils.validate_env``) so a misconfigured value or an unusable local
+root fails fast at boot rather than mid-run.
+
+Out of scope: PostgREST/table access (``get_postgrest_client``) and
+``read_input_csv``, which rides that client — neither is one of the five swapped
+helpers, so both are unaffected by the selected backend.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+VALID_BACKENDS = ("supabase", "local")
+_DEFAULT_BACKEND = "supabase"
+
+
+@runtime_checkable
+class StorageBackend(Protocol):
+    """The five object-storage operations bloommcp's write/read paths use."""
+
+    def upload_file(self, key: str, local_path: Path) -> None: ...
+
+    def download_file(self, key: str, local_path: Path) -> None: ...
+
+    def write_json(self, key: str, payload: dict) -> None: ...
+
+    def read_json(self, key: str) -> dict: ...
+
+    def list_prefix(self, prefix: str) -> list[str]: ...
+
+
+def _json_bytes(payload: dict) -> bytes:
+    """Canonical JSON serialization shared by both backends.
+
+    ``sort_keys`` + ``indent=2`` make the manifest bytes deterministic and
+    backend-invariant, so the serialized ``manifest.json`` is byte-identical
+    across the Supabase and local backends for the same payload.
+    """
+    return json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+
+
+class StorageKeyNotFound(FileNotFoundError):
+    """A key has no backing object. The message is redacted — no host path.
+
+    Subclasses ``FileNotFoundError`` so the broad ``except Exception`` gates in
+    the read path keep working, while carrying only the logical key (never an
+    absolute filesystem path) into any agent-facing message.
+    """
+
+
+# ─── Supabase backend (deployed default) ──────────────────────────────────────
+
+
+class SupabaseStorageBackend:
+    """Supabase Storage in the ``bloommcp-data`` bucket — the deployed default.
+
+    Method bodies are the pre-backend ``supabase_client`` helpers verbatim
+    (they re-use ``get_storage_client`` / ``_guess_content_type`` from that
+    module), so selecting ``supabase`` is byte-for-byte the prior behavior.
+    Stateless — each call builds a fresh client via ``get_storage_client``.
+    """
+
+    def upload_file(self, key: str, local_path: Path) -> None:
+        from bloom_mcp.supabase_client import _guess_content_type, get_storage_client
+
+        client = get_storage_client()
+        body = Path(local_path).read_bytes()
+        client.upload(
+            path=key,
+            file=body,
+            file_options={
+                "content-type": _guess_content_type(Path(local_path)),
+                "upsert": "true",
+            },
+        )
+
+    def download_file(self, key: str, local_path: Path) -> None:
+        from bloom_mcp.supabase_client import get_storage_client
+
+        client = get_storage_client()
+        payload = client.download(key)
+        p = Path(local_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(payload)
+
+    def write_json(self, key: str, payload: dict) -> None:
+        from bloom_mcp.supabase_client import get_storage_client
+
+        client = get_storage_client()
+        client.upload(
+            path=key,
+            file=_json_bytes(payload),
+            file_options={"content-type": "application/json", "upsert": "true"},
+        )
+
+    def read_json(self, key: str) -> dict:
+        from bloom_mcp.supabase_client import get_storage_client
+
+        client = get_storage_client()
+        payload = client.download(key)
+        return json.loads(payload.decode("utf-8"))
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        from bloom_mcp.supabase_client import get_storage_client
+
+        client = get_storage_client()
+        items = client.list(prefix)
+        return [item["name"] for item in items]
+
+
+# ─── Local filesystem backend (opt-in) ────────────────────────────────────────
+
+
+class LocalStorageBackend:
+    """Writes/reads the bloommcp object store as real files under ``root``.
+
+    Storage keys are ``/``-separated logical paths; each maps to ``<root>/<key>``.
+    Writes are atomic (temp file on the root's filesystem + ``os.replace``) and
+    overwrite in place; bytes are copied verbatim (binary, no newline/encoding
+    translation) so a recorded ``output_sha256`` equals the file on disk. A
+    resolved-path guard rejects any key that would escape the root.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = Path(root).resolve()
+
+    # key → path, with a resolved-path containment guard
+    def _resolve(self, key: str) -> Path:
+        if not key or key.startswith("/") or "\\" in key:
+            raise ValueError(f"invalid storage key {key!r}")
+        segments = key.split("/")
+        if any(seg in ("", ".", "..") for seg in segments):
+            raise ValueError(f"invalid storage key {key!r}")
+        target = (self._root / Path(*segments)).resolve()
+        if target != self._root and self._root not in target.parents:
+            raise ValueError(f"storage key {key!r} escapes the local root")
+        return target
+
+    # atomic write: temp file in the target's dir (same filesystem) + os.replace
+    def _atomic_write(self, target: Path, data: bytes) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(target.parent), prefix=".tmp-", suffix=target.suffix
+        )
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(data)
+            os.replace(tmp, target)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def upload_file(self, key: str, local_path: Path) -> None:
+        self._atomic_write(self._resolve(key), Path(local_path).read_bytes())
+
+    def write_json(self, key: str, payload: dict) -> None:
+        self._atomic_write(self._resolve(key), _json_bytes(payload))
+
+    def download_file(self, key: str, local_path: Path) -> None:
+        src = self._resolve(key)
+        if not src.is_file():
+            logger.debug("local storage miss: key=%s", key)
+            raise StorageKeyNotFound(f"storage object not found: {key}")
+        # Copy bytes to the caller-owned destination — never symlink or hand back
+        # the canonical file under the root (the caller manages dest's lifetime).
+        dest = Path(local_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(src.read_bytes())
+
+    def read_json(self, key: str) -> dict:
+        src = self._resolve(key)
+        if not src.is_file():
+            logger.debug("local storage miss: key=%s", key)
+            raise StorageKeyNotFound(f"storage object not found: {key}")
+        return json.loads(src.read_bytes().decode("utf-8"))
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        rel = prefix.strip("/")
+        directory = self._root if rel == "" else self._resolve(rel)
+        try:
+            return sorted(os.listdir(directory))
+        except (FileNotFoundError, NotADirectoryError):
+            return []
+
+
+# ─── Selection ────────────────────────────────────────────────────────────────
+
+_active: Optional[StorageBackend] = None
+
+
+def _selected_backend_name() -> str:
+    """The lower-cased ``BLOOM_STORAGE_BACKEND`` value, defaulting to ``supabase``."""
+    return (
+        os.environ.get("BLOOM_STORAGE_BACKEND") or _DEFAULT_BACKEND
+    ).strip().lower() or _DEFAULT_BACKEND
+
+
+def _resolve_local_root() -> Path:
+    """The local root: ``BLOOM_STORAGE_LOCAL_ROOT`` if set, else ``BLOOM_OUTPUT_DIR``."""
+    root = os.environ.get("BLOOM_STORAGE_LOCAL_ROOT") or os.environ.get(
+        "BLOOM_OUTPUT_DIR", ""
+    )
+    return Path(root)
+
+
+def _build_backend() -> StorageBackend:
+    name = _selected_backend_name()
+    if name == "supabase":
+        return SupabaseStorageBackend()
+    if name == "local":
+        return LocalStorageBackend(_resolve_local_root())
+    raise RuntimeError(
+        f"BLOOM_STORAGE_BACKEND={name!r} is not recognized; "
+        f"valid values: {', '.join(VALID_BACKENDS)}."
+    )
+
+
+def active_backend() -> StorageBackend:
+    """The process's active object-storage backend (memoized, resolved on first use)."""
+    global _active
+    if _active is None:
+        _active = _build_backend()
+    return _active
+
+
+def reset_backend_for_tests() -> None:
+    """Clear the memoized backend so tests can re-select from a changed env."""
+    global _active
+    _active = None
+
+
+def validate_storage_backend() -> None:
+    """Fail fast at boot on an invalid backend value or an unusable local root.
+
+    Called from ``experiment_utils.validate_env`` (which ``server.main()`` runs
+    before binding the port). Raising here names the offending value / root, so a
+    misconfigured deploy fails at boot rather than on the first storage call.
+    """
+    name = _selected_backend_name()
+    if name not in VALID_BACKENDS:
+        raise RuntimeError(
+            f"BLOOM_STORAGE_BACKEND={name!r} is not recognized; "
+            f"valid values: {', '.join(VALID_BACKENDS)}."
+        )
+    if name == "local":
+        root = _resolve_local_root()
+        if str(root) in ("", "."):
+            raise RuntimeError(
+                "BLOOM_STORAGE_BACKEND=local but neither BLOOM_STORAGE_LOCAL_ROOT "
+                "nor BLOOM_OUTPUT_DIR is set."
+            )
+        if not root.exists() or not root.is_dir():
+            raise RuntimeError(
+                f"BLOOM_STORAGE_BACKEND=local root {root} does not exist or is not "
+                f"a directory."
+            )
+        if not os.access(root, os.W_OK):
+            raise RuntimeError(
+                f"BLOOM_STORAGE_BACKEND=local root {root} is not writable."
+            )

--- a/bloommcp/src/bloom_mcp/storage_backend.py
+++ b/bloommcp/src/bloom_mcp/storage_backend.py
@@ -144,10 +144,13 @@ class LocalStorageBackend:
     """Writes/reads the bloommcp object store as real files under ``root``.
 
     Storage keys are ``/``-separated logical paths; each maps to ``<root>/<key>``.
-    Writes are atomic (temp file on the root's filesystem + ``os.replace``) and
-    overwrite in place; bytes are copied verbatim (binary, no newline/encoding
-    translation) so a recorded ``output_sha256`` equals the file on disk. A
-    resolved-path guard rejects any key that would escape the root.
+    On **POSIX filesystems** writes are atomic (temp file on the root's
+    filesystem, ``fsync``, then ``os.replace``) and overwrite in place; bytes are
+    copied verbatim (binary, no newline/encoding translation) so a recorded
+    ``output_sha256`` equals the file on disk. A resolved-path guard rejects any
+    key that would escape the root. Windows/NTFS does **not** guarantee atomic
+    replace-over-existing (and may raise if a reader holds the target open) — this
+    is an opt-in dev backend; production stays on Supabase Storage.
     """
 
     def __init__(self, root: Path) -> None:
@@ -165,8 +168,17 @@ class LocalStorageBackend:
             raise ValueError(f"storage key {key!r} escapes the local root")
         return target
 
-    # atomic write: temp file in the target's dir (same filesystem) + os.replace
     def _atomic_write(self, target: Path, data: bytes) -> None:
+        """Write ``data`` to ``target`` atomically on POSIX.
+
+        Writes a temp file in the target's directory (same filesystem), fsyncs
+        it, then ``os.replace``s it into place, so a crash / kill / ENOSPC
+        mid-write leaves either the whole prior file or the whole new file —
+        never a truncated ``manifest.json``. The parent dir is fsynced
+        best-effort for power-loss durability of the rename. NOTE: ``os.replace``
+        is atomic over an existing file on POSIX only; on Windows/NTFS it is not
+        guaranteed atomic (see the class docstring).
+        """
         target.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp = tempfile.mkstemp(
             dir=str(target.parent), prefix=".tmp-", suffix=target.suffix
@@ -174,13 +186,22 @@ class LocalStorageBackend:
         try:
             with os.fdopen(fd, "wb") as fh:
                 fh.write(data)
+                fh.flush()
+                os.fsync(fh.fileno())
             os.replace(tmp, target)
         except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
+            Path(tmp).unlink(missing_ok=True)
             raise
+        # Best-effort durability of the rename itself (POSIX dir fsync; a no-op
+        # / OSError on platforms that can't open a directory fd, e.g. Windows).
+        try:
+            dir_fd = os.open(str(target.parent), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
 
     def upload_file(self, key: str, local_path: Path) -> None:
         self._atomic_write(self._resolve(key), Path(local_path).read_bytes())
@@ -210,9 +231,13 @@ class LocalStorageBackend:
         rel = prefix.strip("/")
         directory = self._root if rel == "" else self._resolve(rel)
         try:
-            return sorted(os.listdir(directory))
+            names = [p.name for p in Path(directory).iterdir()]
         except (FileNotFoundError, NotADirectoryError):
             return []
+        # Hide in-flight atomic-write temp files: a SIGKILL between mkstemp and
+        # os.replace can orphan a `.tmp-*`, which never appears in the Supabase
+        # backend — filtering keeps cross-backend list parity.
+        return sorted(n for n in names if not n.startswith(".tmp-"))
 
 
 # ─── Selection ────────────────────────────────────────────────────────────────
@@ -228,11 +253,26 @@ def _selected_backend_name() -> str:
 
 
 def _resolve_local_root() -> Path:
-    """The local root: ``BLOOM_STORAGE_LOCAL_ROOT`` if set, else ``BLOOM_OUTPUT_DIR``."""
-    root = os.environ.get("BLOOM_STORAGE_LOCAL_ROOT") or os.environ.get(
-        "BLOOM_OUTPUT_DIR", ""
-    )
-    return Path(root)
+    """The local root for the ``local`` backend.
+
+    ``BLOOM_STORAGE_LOCAL_ROOT`` when set. Otherwise falls back to
+    ``BLOOM_OUTPUT_DIR`` — a **bridge-only, deprecated** default that reuses the
+    already-mounted dev dir so ``BLOOM_STORAGE_BACKEND=local`` needs no second var
+    in dev. Prefer setting ``BLOOM_STORAGE_LOCAL_ROOT`` explicitly; the fallback is
+    logged (not silent) so a fourth overlapping use of ``BLOOM_OUTPUT_DIR`` stays
+    observable.
+    """
+    explicit = os.environ.get("BLOOM_STORAGE_LOCAL_ROOT")
+    if explicit:
+        return Path(explicit)
+    fallback = os.environ.get("BLOOM_OUTPUT_DIR", "")
+    if fallback:
+        logger.warning(
+            "BLOOM_STORAGE_BACKEND=local is using BLOOM_OUTPUT_DIR as the local "
+            "storage root because BLOOM_STORAGE_LOCAL_ROOT is unset; this fallback "
+            "is a deprecated dev bridge — set BLOOM_STORAGE_LOCAL_ROOT explicitly."
+        )
+    return Path(fallback)
 
 
 def _build_backend() -> StorageBackend:

--- a/bloommcp/src/bloom_mcp/supabase_client.py
+++ b/bloommcp/src/bloom_mcp/supabase_client.py
@@ -33,7 +33,6 @@ bucket.
 from __future__ import annotations
 
 import io
-import json
 import os
 from pathlib import Path
 
@@ -155,67 +154,61 @@ def get_storage_client():
     return supabase.create_client(url, key).storage.from_(BUCKET)
 
 
+# The five helpers below delegate to the process's active storage backend
+# (`bloom_mcp.storage_backend`), selected by `BLOOM_STORAGE_BACKEND` (default
+# `supabase`). Their names + signatures are unchanged, so every caller and the
+# `fake_supabase_storage` test fixture (which monkeypatches these module-level
+# names) keep working. `active_backend` is imported lazily inside each function
+# so importing this module stays side-effect-free and resolves no backend.
+
+
 def list_prefix(prefix: str) -> list[str]:
-    """List basenames of objects directly under `prefix` in `bloommcp-data`.
-    Lists file inside the folder.
-    list_prefix("") is shows at the root"
-    list_prefix("bloommcp_output/") shows file under the prefix folder
+    """List basenames of objects directly under `prefix`.
+
+    Lists entries inside the folder. `list_prefix("")` lists the root;
+    `list_prefix("bloommcp_output/")` lists entries under that prefix.
     """
-    client = get_storage_client()
-    items = client.list(prefix)
-    return [item["name"] for item in items]
+    from bloom_mcp.storage_backend import active_backend
+
+    return active_backend().list_prefix(prefix)
 
 
 def read_json(key: str) -> dict:
-    """Download `key` from `bloommcp-data` and parse as JSON.
+    """Download `key` and parse as JSON.
 
-    Raises a Supabase storage exception if the key does not exist;
-    callers that treat absence as a normal state should check with
-    `list_prefix()` first (this is what `AnalysisDir.read_manifest`
-    does).
+    Raises if the key does not exist; callers that treat absence as a normal
+    state should check with `list_prefix()` first (this is what
+    `AnalysisDir.read_manifest` does).
     """
-    client = get_storage_client()
-    payload = client.download(key)
-    return json.loads(payload.decode("utf-8"))
+    from bloom_mcp.storage_backend import active_backend
+
+    return active_backend().read_json(key)
 
 
 def write_json(key: str, payload: dict) -> None:
     """Save `payload` as a JSON file at `key`. Overwrites if it exists."""
-    body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
-    client = get_storage_client()
-    client.upload(
-        path=key,
-        file=body,
-        file_options={"content-type": "application/json", "upsert": "true"},
-    )
+    from bloom_mcp.storage_backend import active_backend
+
+    active_backend().write_json(key, payload)
 
 
 def upload_file(key: str, local_path: Path) -> None:
-    """Upload bytes from `local_path` to `key` in `bloommcp-data`.
+    """Upload bytes from `local_path` to `key`.
 
-    Content-type is inferred from the file extension; CSV, JSON, and PNG
-    are the cases AnalysisWriter writes today. Unknown extensions fall
-    back to `application/octet-stream`. Same upsert semantics as
-    `write_json`.
+    On the Supabase backend the content-type is inferred from the file
+    extension (CSV, JSON, PNG; unknown → `application/octet-stream`), with
+    upsert/overwrite semantics; the local backend writes the bytes verbatim.
     """
-    client = get_storage_client()
-    body = local_path.read_bytes()
-    client.upload(
-        path=key,
-        file=body,
-        file_options={
-            "content-type": _guess_content_type(local_path),
-            "upsert": "true",
-        },
-    )
+    from bloom_mcp.storage_backend import active_backend
+
+    active_backend().upload_file(key, local_path)
 
 
 def download_file(key: str, local_path: Path) -> None:
-    """Download `key` from `bloommcp-data` into `local_path`.
+    """Download `key` into `local_path`.
 
     Creates parent directories if needed. Raises on missing key.
     """
-    client = get_storage_client()
-    payload = client.download(key)
-    local_path.parent.mkdir(parents=True, exist_ok=True)
-    local_path.write_bytes(payload)
+    from bloom_mcp.storage_backend import active_backend
+
+    active_backend().download_file(key, local_path)

--- a/bloommcp/tests/test_storage_backend.py
+++ b/bloommcp/tests/test_storage_backend.py
@@ -272,8 +272,51 @@ def test_interrupted_write_leaves_prior_content_intact(tmp_path, monkeypatch):
     # never truncated: the whole prior content survives
     assert target.read_bytes() == original
     # and no orphaned temp files remain
-    leftovers = [p.name for p in target.parent.iterdir() if p.name.startswith(".tmp-")]
+    leftovers = [
+        p.name for p in target.parent.iterdir() if p.name.startswith(sb._TMP_PREFIX)
+    ]
     assert leftovers == []
+
+
+def test_write_permission_error_is_redacted(tmp_path, monkeypatch):
+    """A permission/OS error during the atomic write surfaces to the caller with
+    NO absolute host path — only the logical key (spec: errors do not leak host
+    paths). The raw path is logged server-side, not raised."""
+    b = _local(tmp_path)
+    key = "bloommcp_output/qc_x/manifest.json"
+    leaked = str(tmp_path / "bloommcp_output" / "qc_x" / ".tmp-abc")
+
+    def boom(*a, **k):
+        raise PermissionError(13, "Permission denied", leaked)
+
+    monkeypatch.setattr(sb.tempfile, "mkstemp", boom)
+    with pytest.raises(OSError) as exc:
+        b.write_json(key, {"v": 1})
+    msg = str(exc.value)
+    assert str(tmp_path) not in msg  # no absolute host path leaked
+    assert leaked not in msg
+    assert key in msg  # only the logical storage key
+    assert "permission" in msg.lower()
+
+
+def test_read_permission_error_is_redacted(tmp_path, monkeypatch):
+    """The read path redacts a permission/OS error the same way — logical key
+    only, no host path (distinct from the not-found redaction)."""
+    b = _local(tmp_path)
+    key = "bloommcp_output/x/f.csv"
+    on_disk = tmp_path / "bloommcp_output" / "x" / "f.csv"
+    on_disk.parent.mkdir(parents=True)
+    on_disk.write_bytes(b"data")  # exists, so we pass is_file() and hit read_bytes
+
+    def boom(self, *a, **k):
+        raise PermissionError(13, "Permission denied", str(on_disk))
+
+    monkeypatch.setattr(sb.Path, "read_bytes", boom)
+    with pytest.raises(OSError) as exc:
+        b.download_file(key, tmp_path / "dest")
+    msg = str(exc.value)
+    assert str(tmp_path) not in msg
+    assert key in msg
 
 
 # ─── 3. Root resolution + startup validation ──────────────────────────────────

--- a/bloommcp/tests/test_storage_backend.py
+++ b/bloommcp/tests/test_storage_backend.py
@@ -187,8 +187,30 @@ def test_missing_key_raises_redacted(tmp_path):
     msg = str(exc.value)
     assert str(tmp_path) not in msg  # no absolute host path leaked
     assert "bloommcp_output/x/missing.csv" in msg  # only the logical key
-    with pytest.raises(FileNotFoundError):
+    # read_json arm is redacted the same way as download_file
+    with pytest.raises(FileNotFoundError) as exc2:
         b.read_json("bloommcp_output/x/missing.json")
+    msg2 = str(exc2.value)
+    assert str(tmp_path) not in msg2
+    assert "bloommcp_output/x/missing.json" in msg2
+
+
+def test_empty_file_roundtrip(tmp_path):
+    b = _local(tmp_path)
+    src = _seed_file(tmp_path, b"")
+    b.upload_file("bloommcp_output/x/v1/empty.csv", src)
+    assert (tmp_path / "bloommcp_output/x/v1/empty.csv").read_bytes() == b""
+    dest = tmp_path / "d.csv"
+    b.download_file("bloommcp_output/x/v1/empty.csv", dest)
+    assert dest.read_bytes() == b""
+
+
+def test_unicode_key_and_payload_roundtrip(tmp_path):
+    b = _local(tmp_path)
+    key = "bloommcp_output/qc_café/v1/manifest.json"
+    b.write_json(key, {"trait": "primär-läng"})
+    assert (tmp_path / "bloommcp_output" / "qc_café" / "v1" / "manifest.json").is_file()
+    assert b.read_json(key) == {"trait": "primär-läng"}
 
 
 @pytest.mark.parametrize(
@@ -451,3 +473,99 @@ def test_qc_workflow_local_roundtrip_with_hash_equality(local_workflow_env):
     frame = SupabaseReader().load_experiment("turface.csv", version="latest")
     assert frame.source.startswith("v1")
     assert len(frame.df) > 0
+
+
+# ─── 5. Cross-backend list_prefix parity + read-path fallback ──────────────────
+
+
+def test_list_prefix_parity_fake_vs_local(fake_supabase_storage, tmp_path):
+    """The in-memory fake (Supabase oracle) and the local backend return the same
+    list_prefix results across empty / no-slash / trailing-slash / missing prefixes
+    — the property read_manifest and _resolve_versioned_cleaned depend on."""
+    fake = fake_supabase_storage
+    root = tmp_path / "root"
+    root.mkdir()
+    local = sb.LocalStorageBackend(root)
+    src = tmp_path / "seed.csv"
+    src.write_bytes(b"x")
+
+    keys = [
+        "bloommcp_output/qc_x/manifest.json",
+        "bloommcp_output/qc_x/v1_2026/_cleaned.csv",
+        "bloommcp_output/qc_x/v2_2026/_cleaned.csv",
+        "bloommcp_output/qc_y/manifest.json",
+    ]
+    for k in keys:
+        if k.endswith(".json"):
+            fake.write_json(k, {"k": 1})
+            local.write_json(k, {"k": 1})
+        else:
+            fake.upload_file(k, src)
+            local.upload_file(k, src)
+
+    for prefix in [
+        "",
+        "bloommcp_output",
+        "bloommcp_output/",
+        "bloommcp_output/qc_x",
+        "bloommcp_output/qc_x/",
+        "bloommcp_output/qc_missing/",
+    ]:
+        fake_names = sorted(fake.list_prefix(prefix))
+        local_names = sorted(local.list_prefix(prefix))
+        assert fake_names == local_names, f"list_prefix mismatch for {prefix!r}"
+
+
+def test_resolve_versioned_cleaned_via_local_list_prefix_fallback(
+    monkeypatch, tmp_path
+):
+    """A manifest entry with version_dir='' forces _resolve_versioned_cleaned to
+    locate the version directory via list_prefix — exercising the local backend's
+    list leg end-to-end in the read path (the qc round-trip never hits it because
+    writers always set version_dir)."""
+    from bloom_mcp import experiment_utils as eu
+    from bloom_mcp.storage import (
+        ExperimentBlock,
+        Manifest,
+        VersionEntry,
+        get_code_versions,
+        write_manifest,
+    )
+    from bloom_mcp.supabase_client import upload_file
+
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(root))
+    sb.reset_backend_for_tests()
+
+    stem = "exp"
+    prefix = f"bloommcp_output/qc_{stem}/"
+    cleaned = tmp_path / "cleaned.csv"
+    cleaned.write_bytes(b"trait,value\n1,2\n")
+    upload_file(f"{prefix}v1_2026-07-06/_cleaned.csv", cleaned)
+
+    entry = VersionEntry(
+        id="v1",
+        created_at="2026-07-06T00:00:00Z",
+        tool="run_qc_workflow",
+        params={},
+        based_on_version="raw",
+        code_versions=get_code_versions(),
+        outputs={"_cleaned.csv": "_cleaned.csv"},
+        version_dir="",  # empty → forces the list_prefix sibling lookup
+    )
+    manifest = Manifest(
+        experiment=ExperimentBlock(
+            filename=f"{stem}.csv", source_path="", input_sha256=""
+        ),
+        versions=[entry],
+        latest="v1",
+    )
+    write_manifest(prefix, manifest)
+
+    path, label, err = eu._resolve_versioned_cleaned(eu.OUTPUT_DIR, stem, "latest")
+    assert err is None
+    assert path is not None
+    assert path.read_bytes() == b"trait,value\n1,2\n"
+    assert label == "v1_cleaned"

--- a/bloommcp/tests/test_storage_backend.py
+++ b/bloommcp/tests/test_storage_backend.py
@@ -1,0 +1,453 @@
+"""Tests for the object-storage backend seam (bloommcp-storage-backend).
+
+Covers backend selection (`BLOOM_STORAGE_BACKEND`), the local filesystem backend
+(key→path mapping, listing, escape guard, overwrite, verbatim bytes, atomic
+writes, redacted errors), root resolution + boot-time validation, and
+parity/integrity (byte-identical manifest, hash-equality on disk, a workflow
+round-trip under `local`, the default-writes-no-local-files guard, and
+legacy-fallback disjointness). No live Supabase.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from bloom_mcp import storage_backend as sb
+
+_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "turface_19_final_data.csv"
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    """Isolate the memoized backend so env changes take effect per-test."""
+    sb.reset_backend_for_tests()
+    yield
+    sb.reset_backend_for_tests()
+
+
+def _seed_file(tmp_path: Path, data: bytes = b"x") -> Path:
+    p = tmp_path / "seed.bin"
+    p.write_bytes(data)
+    return p
+
+
+# ─── 1. Backend interface + selection ─────────────────────────────────────────
+
+
+def test_default_selects_supabase(monkeypatch):
+    monkeypatch.delenv("BLOOM_STORAGE_BACKEND", raising=False)
+    sb.reset_backend_for_tests()
+    assert isinstance(sb.active_backend(), sb.SupabaseStorageBackend)
+
+
+def test_explicit_supabase_selects_supabase(monkeypatch):
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "supabase")
+    sb.reset_backend_for_tests()
+    assert isinstance(sb.active_backend(), sb.SupabaseStorageBackend)
+
+
+def test_local_selects_local(monkeypatch, tmp_path):
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path))
+    sb.reset_backend_for_tests()
+    assert isinstance(sb.active_backend(), sb.LocalStorageBackend)
+
+
+def test_invalid_backend_raises_naming_value_and_valid_set(monkeypatch):
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "locel")
+    sb.reset_backend_for_tests()
+    with pytest.raises(RuntimeError) as exc:
+        sb.active_backend()
+    assert "locel" in str(exc.value)
+    assert "supabase" in str(exc.value) and "local" in str(exc.value)
+
+
+def test_selection_reexamines_env_across_values(monkeypatch, tmp_path):
+    """Reset seam lets one session exercise supabase → local without stale memo."""
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "supabase")
+    sb.reset_backend_for_tests()
+    assert isinstance(sb.active_backend(), sb.SupabaseStorageBackend)
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path))
+    sb.reset_backend_for_tests()
+    assert isinstance(sb.active_backend(), sb.LocalStorageBackend)
+
+
+def test_import_does_not_resolve_backend(monkeypatch):
+    """Resolution is lazy: an invalid value does not blow up until first use."""
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "locel")
+    sb.reset_backend_for_tests()
+    assert sb._active is None  # nothing resolved yet
+    with pytest.raises(RuntimeError, match="locel"):
+        sb.active_backend()
+
+
+def test_server_import_is_pure_with_invalid_backend():
+    """A fresh interpreter imports bloom_mcp.server with NO bloom env and an
+    invalid BLOOM_STORAGE_BACKEND — proving selection is never resolved at import."""
+    bloom_vars = (
+        "SUPABASE_URL",
+        "BLOOM_AGENT_KEY",
+        "BLOOM_TRAITS_DIR",
+        "BLOOM_OUTPUT_DIR",
+        "BLOOM_PLOTS_DIR",
+        "BLOOM_PLOTS_URL",
+        "BLOOM_STORAGE_LOCAL_ROOT",
+    )
+    env = {k: v for k, v in os.environ.items() if k not in bloom_vars}
+    env["BLOOM_STORAGE_BACKEND"] = "locel"
+    result = subprocess.run(
+        [sys.executable, "-c", "import bloom_mcp.server"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ─── 2. Local filesystem backend ──────────────────────────────────────────────
+
+
+def _local(tmp_path: Path) -> sb.LocalStorageBackend:
+    return sb.LocalStorageBackend(tmp_path)
+
+
+def test_upload_download_roundtrip_by_key(tmp_path):
+    b = _local(tmp_path)
+    src = _seed_file(tmp_path, b"a,b\n1,2\n")
+    b.upload_file("bloommcp_output/qc_x/v1/_cleaned.csv", src)
+    on_disk = tmp_path / "bloommcp_output" / "qc_x" / "v1" / "_cleaned.csv"
+    assert on_disk.read_bytes() == b"a,b\n1,2\n"
+
+    dest = tmp_path / "out" / "got.csv"
+    b.download_file("bloommcp_output/qc_x/v1/_cleaned.csv", dest)
+    assert dest.read_bytes() == b"a,b\n1,2\n"
+
+
+def test_write_read_json_roundtrip(tmp_path):
+    b = _local(tmp_path)
+    b.write_json("bloommcp_output/qc_x/manifest.json", {"b": 2, "a": 1})
+    assert b.read_json("bloommcp_output/qc_x/manifest.json") == {"a": 1, "b": 2}
+
+
+def test_verbatim_bytes_no_newline_translation(tmp_path):
+    b = _local(tmp_path)
+    payload = b"line1\r\nline2\nline3"  # mixed CRLF/LF must survive intact
+    src = _seed_file(tmp_path, payload)
+    b.upload_file("bloommcp_output/x/v1/f.bin", src)
+    assert (tmp_path / "bloommcp_output/x/v1/f.bin").read_bytes() == payload
+    dest = tmp_path / "d.bin"
+    b.download_file("bloommcp_output/x/v1/f.bin", dest)
+    assert dest.read_bytes() == payload
+
+
+def test_writes_overwrite_in_place(tmp_path):
+    b = _local(tmp_path)
+    b.write_json("k/m.json", {"v": 1})
+    b.write_json("k/m.json", {"v": 2})  # second write wins
+    assert b.read_json("k/m.json") == {"v": 2}
+    # idempotent parent-dir creation: second upload into an existing dir is fine
+    src = _seed_file(tmp_path)
+    b.upload_file("k/a.bin", src)
+    b.upload_file("k/a.bin", src)
+
+
+def test_list_prefix_returns_bare_children(tmp_path):
+    b = _local(tmp_path)
+    (tmp_path / "bloommcp_output" / "qc_x" / "v1_2026").mkdir(parents=True)
+    (tmp_path / "bloommcp_output" / "qc_x" / "manifest.json").write_bytes(b"{}")
+    names = b.list_prefix("bloommcp_output/qc_x/")
+    assert set(names) == {"v1_2026", "manifest.json"}
+    # bare names: no trailing slash, no path prefix — both caller checks work
+    assert all("/" not in n and not n.endswith("/") for n in names)
+    assert "manifest.json" in names  # manifest membership check
+    assert any(n.startswith("v1_") for n in names)  # version-dir startswith check
+
+
+def test_list_prefix_root_and_missing(tmp_path):
+    b = _local(tmp_path)
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b.txt").write_bytes(b"x")
+    assert set(b.list_prefix("")) == {"a", "b.txt"}  # root listing
+    assert b.list_prefix("does/not/exist/") == []  # missing → [], not error
+
+
+def test_missing_key_raises_redacted(tmp_path):
+    b = _local(tmp_path)
+    with pytest.raises(FileNotFoundError) as exc:
+        b.download_file("bloommcp_output/x/missing.csv", tmp_path / "o")
+    msg = str(exc.value)
+    assert str(tmp_path) not in msg  # no absolute host path leaked
+    assert "bloommcp_output/x/missing.csv" in msg  # only the logical key
+    with pytest.raises(FileNotFoundError):
+        b.read_json("bloommcp_output/x/missing.json")
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    ["../../etc/passwd", "/etc/passwd", "a/../../b", "a\\b", "..", "", "a/./b"],
+)
+def test_escape_guard_rejects_bad_keys(tmp_path, bad_key):
+    b = _local(tmp_path)
+    src = _seed_file(tmp_path)
+    before = sorted(p.name for p in tmp_path.iterdir())
+    with pytest.raises(ValueError):
+        b.upload_file(bad_key, src)
+    # the rejected key performs no I/O: nothing new written under the root
+    assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+
+def test_escape_guard_rejects_symlink(tmp_path):
+    b = _local(tmp_path)
+    outside = tmp_path.parent / "sb_outside"
+    outside.mkdir(exist_ok=True)
+    link = tmp_path / "link"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform/privilege")
+    with pytest.raises(ValueError):
+        b.upload_file("link/evil.txt", _seed_file(tmp_path))
+
+
+def test_atomic_write_temp_is_colocated_with_target(tmp_path, monkeypatch):
+    b = _local(tmp_path)
+    captured: dict = {}
+    real_mkstemp = sb.tempfile.mkstemp
+
+    def spy(*a, **k):
+        captured["dir"] = k.get("dir")
+        return real_mkstemp(*a, **k)
+
+    monkeypatch.setattr(sb.tempfile, "mkstemp", spy)
+    b.write_json("bloommcp_output/qc_x/manifest.json", {"v": 1})
+    target = tmp_path / "bloommcp_output" / "qc_x" / "manifest.json"
+    # temp lives in the target's dir → same filesystem → os.replace is atomic
+    assert captured["dir"] == str(target.parent)
+
+
+def test_interrupted_write_leaves_prior_content_intact(tmp_path, monkeypatch):
+    b = _local(tmp_path)
+    key = "bloommcp_output/qc_x/manifest.json"
+    b.write_json(key, {"v": 1})
+    target = tmp_path / "bloommcp_output" / "qc_x" / "manifest.json"
+    original = target.read_bytes()
+
+    def boom(_src, _dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(sb.os, "replace", boom)
+    with pytest.raises(OSError):
+        b.write_json(key, {"v": 2})
+    # never truncated: the whole prior content survives
+    assert target.read_bytes() == original
+    # and no orphaned temp files remain
+    leftovers = [p.name for p in target.parent.iterdir() if p.name.startswith(".tmp-")]
+    assert leftovers == []
+
+
+# ─── 3. Root resolution + startup validation ──────────────────────────────────
+
+
+def test_root_prefers_dedicated_var(monkeypatch, tmp_path):
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path))
+    monkeypatch.setenv("BLOOM_OUTPUT_DIR", str(tmp_path / "other"))
+    assert sb._resolve_local_root() == tmp_path
+
+
+def test_root_falls_back_to_output_dir(monkeypatch, tmp_path):
+    monkeypatch.delenv("BLOOM_STORAGE_LOCAL_ROOT", raising=False)
+    monkeypatch.setenv("BLOOM_OUTPUT_DIR", str(tmp_path))
+    assert sb._resolve_local_root() == tmp_path
+
+
+def test_invalid_backend_fails_via_boot_validator(monkeypatch):
+    """experiment_utils.validate_env (what server.main() calls) fails fast."""
+    import bloom_mcp.experiment_utils as eu
+
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "locel")
+    with pytest.raises(RuntimeError, match="locel"):
+        eu.validate_env()
+
+
+def test_local_unusable_root_fails_via_boot_validator(monkeypatch, tmp_path):
+    import bloom_mcp.experiment_utils as eu
+
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path / "nonexistent"))
+    with pytest.raises(RuntimeError, match="does not exist|not a directory"):
+        eu.validate_env()
+
+
+def test_local_valid_root_passes_boot_validator(monkeypatch, tmp_path):
+    import bloom_mcp.experiment_utils as eu
+
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path))
+    eu.validate_env()  # must not raise
+
+
+# ─── 4. Parity, integrity + workflow round-trip ───────────────────────────────
+
+
+def test_manifest_bytes_identical_fake_vs_local(fake_supabase_storage, tmp_path):
+    """The serialized manifest is byte-identical across backends (the in-memory
+    fake is the Supabase parity oracle)."""
+    payload = {
+        "manifest_schema_version": 3,
+        "versions": [{"id": "v1", "b": 2, "a": 1}],
+        "latest": "v1",
+    }
+    key = "bloommcp_output/qc_x/manifest.json"
+    fake_supabase_storage.write_json(key, payload)
+    fake_bytes = fake_supabase_storage.objects[key]
+
+    sb.LocalStorageBackend(tmp_path).write_json(key, payload)
+    local_bytes = (tmp_path / "bloommcp_output" / "qc_x" / "manifest.json").read_bytes()
+
+    assert local_bytes == fake_bytes
+
+
+def test_local_store_roundtrip_matches_contract(monkeypatch, tmp_path):
+    """SupabaseResultStore on the local backend yields the same observable
+    outcome test_store_parity locks for the fake/Supabase path — plus real files."""
+    from bloom_mcp.contract import Provenance
+    from bloom_mcp.result_store import SupabaseResultStore
+
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path))
+    sb.reset_backend_for_tests()
+
+    store = SupabaseResultStore()
+    run = store.create_run(
+        experiment="exp.csv",
+        tool_class="qc",
+        provenance=Provenance.stamp(tool="t", params={"a": 1}, seed=5),
+    )
+    (run.staging_dir / "_cleaned.csv").write_bytes(b"data")
+    stored = store.commit(run, {"cleaned": "_cleaned.csv"})
+
+    assert stored.run_ref == "v1"
+    assert stored.seed == 5
+    assert stored.output_sha256["cleaned"] == hashlib.sha256(b"data").hexdigest()
+    assert "\\" not in stored.output_keys["cleaned"]
+    assert stored.output_keys["cleaned"].startswith("bloommcp_output/qc_exp/")
+    assert store.get_run("exp.csv", "qc", "latest").run_ref == "v1"
+
+    # real files on disk, laid out by key
+    out = tmp_path / "bloommcp_output" / "qc_exp"
+    assert (out / "manifest.json").is_file()
+    assert (out / stored.version_dir / "_cleaned.csv").read_bytes() == b"data"
+
+
+def test_default_path_writes_no_local_files(
+    fake_supabase_storage, monkeypatch, tmp_path
+):
+    """Opt-in guard: with the default backend, a commit writes NO local files and
+    the (faked) Supabase store receives the bytes."""
+    from bloom_mcp.contract import Provenance
+    from bloom_mcp.result_store import SupabaseResultStore
+
+    monkeypatch.delenv("BLOOM_STORAGE_BACKEND", raising=False)  # default supabase
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path))  # would-be root
+    sb.reset_backend_for_tests()
+
+    store = SupabaseResultStore()
+    run = store.create_run(
+        experiment="exp.csv",
+        tool_class="qc",
+        provenance=Provenance.stamp(tool="t", params={}, seed=1),
+    )
+    (run.staging_dir / "_cleaned.csv").write_bytes(b"data")
+    store.commit(run, {"cleaned": "_cleaned.csv"})
+
+    assert any(k.endswith("_cleaned.csv") for k in fake_supabase_storage.objects)
+    assert list(tmp_path.rglob("*")) == []  # nothing written to the local root
+
+
+def test_local_layout_disjoint_from_legacy_fallback(monkeypatch, tmp_path):
+    """Local outputs live under bloommcp_output/ and never at the legacy
+    <BLOOM_OUTPUT_DIR>/qc_<stem>/<stem>_cleaned.csv fallback path."""
+    from bloom_mcp.contract import Provenance
+    from bloom_mcp.result_store import SupabaseResultStore
+
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(tmp_path))  # == BLOOM_OUTPUT_DIR
+    sb.reset_backend_for_tests()
+
+    store = SupabaseResultStore()
+    run = store.create_run(
+        experiment="exp.csv",
+        tool_class="qc",
+        provenance=Provenance.stamp(tool="t", params={}, seed=1),
+    )
+    (run.staging_dir / "_cleaned.csv").write_bytes(b"data")
+    store.commit(run, {"cleaned": "_cleaned.csv"})
+
+    legacy = tmp_path / "qc_exp" / "exp_cleaned.csv"
+    assert not legacy.exists()
+    assert (tmp_path / "bloommcp_output" / "qc_exp" / "manifest.json").is_file()
+
+
+@pytest.fixture
+def local_workflow_env(monkeypatch, tmp_path):
+    """Real reader/store + local backend + a seeded raw input for a full workflow."""
+    from bloom_mcp import experiment_utils as eu
+    from bloom_mcp.data_access import SupabaseReader
+    from bloom_mcp.result_store import SupabaseResultStore
+    from bloom_mcp.tools import _ports
+
+    root = tmp_path / "store"
+    root.mkdir()
+    monkeypatch.setenv("BLOOM_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("BLOOM_STORAGE_LOCAL_ROOT", str(root))
+    sb.reset_backend_for_tests()
+
+    traits = tmp_path / "traits"
+    traits.mkdir()
+    shutil.copy(_FIXTURE, traits / "turface.csv")
+    monkeypatch.setattr(eu, "TRAITS_DIR", traits)
+
+    _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+    try:
+        yield root
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def test_qc_workflow_local_roundtrip_with_hash_equality(local_workflow_env):
+    """A qc workflow under BLOOM_STORAGE_BACKEND=local writes real files, reads
+    back through _resolve_versioned_cleaned, and each on-disk hash matches the
+    recorded output_sha256."""
+    from bloom_mcp.data_access import SupabaseReader
+    from bloom_mcp.tools.workflows.qc import run_qc_workflow
+
+    root = local_workflow_env
+    resp = run_qc_workflow("turface.csv")
+    assert "error" not in resp, resp
+    assert resp["version_id"] == "v1"
+
+    out = root / "bloommcp_output" / "qc_turface"
+    assert (out / "manifest.json").is_file()
+    manifest = json.loads((out / "manifest.json").read_bytes())
+    entry = manifest["versions"][-1]
+    assert (out / entry["version_dir"] / "_cleaned.csv").is_file()
+
+    # hash-equality: the bytes on disk match the recorded provenance hash
+    for name, sha in entry["output_sha256"].items():
+        key = entry["output_keys"][name]  # logical bloommcp_output/... key
+        on_disk = (root / key).read_bytes()
+        assert hashlib.sha256(on_disk).hexdigest() == sha
+
+    # read-back exercises the download_file local leg via _resolve_versioned_cleaned
+    frame = SupabaseReader().load_experiment("turface.csv", version="latest")
+    assert frame.source.startswith("v1")
+    assert len(frame.df) > 0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -122,6 +122,14 @@ services:
       BLOOM_PLOTS_DIR: /app/data/PLOTS_DIR
       BLOOM_PLOTS_URL: ${BLOOM_PLOTS_URL}
       BLOOMMCP_API_KEY: ${BLOOMMCP_API_KEY}
+      # Storage backend (opt-in, default off). Uncomment to write analysis
+      # outputs as real files on disk instead of Supabase Storage — see
+      # bloommcp/docs/storage-backends.md. The local root defaults to
+      # BLOOM_OUTPUT_DIR (mounted below at ./bloommcp/data/ANALYSIS_OUTPUT), so
+      # `local` needs no extra config in dev. Do NOT mix backends for one
+      # experiment (no cross-store view; version ids can collide).
+      # BLOOM_STORAGE_BACKEND: local
+      # BLOOM_STORAGE_LOCAL_ROOT: /app/data/ANALYSIS_OUTPUT
       # Kept in sync with docker-compose.prod.yml for dev/prod parity, even
       # though dev has a writable root FS. See the prod compose for rationale.
       NUMBA_CACHE_DIR: /tmp/numba

--- a/openspec/changes/add-bloommcp-local-storage-backend/design.md
+++ b/openspec/changes/add-bloommcp-local-storage-backend/design.md
@@ -1,0 +1,165 @@
+## Context
+
+Issue #386. bloommcp's write path and output-read path both funnel through a single
+narrow module, `bloom_mcp.supabase_client`, which exposes five object-storage helpers —
+and the unit suite already substitutes exactly these five behind `fake_supabase_storage`
+(`bloommcp/tests/conftest.py:86-95`):
+
+| Helper | Used by |
+| --- | --- |
+| `upload_file(key, path)` | `AnalysisWriter.commit`, `SupabaseResultStore.commit` |
+| `download_file(key, path)` | `experiment_utils._resolve_versioned_cleaned` (versioned-cleaned read) |
+| `write_json(key, payload)` | `storage.manifest.write_manifest` |
+| `read_json(key)` | `storage.manifest.read_manifest` |
+| `list_prefix(prefix)` | `storage.manifest.read_manifest`, `_resolve_versioned_cleaned` |
+
+Higher layers depend only on the `ResultStore` / `ExperimentReader` ports — never on
+`supabase` directly. So the boundary is proven swappable; this change adds a second
+concrete implementation and a selector.
+
+Three adjacent data paths are deliberately **out of scope**: `get_postgrest_client()`
+(PostgREST/table reads — the database, not object storage); `read_input_csv()`, which —
+despite living in `supabase_client` — rides the **PostgREST client**
+(`supabase_client.py:126`, `get_postgrest_client().storage…`), is **not** one of the five
+faked helpers, and has **no production caller** in `src/`; and raw-experiment-CSV reads
+from the local `BLOOM_TRAITS_DIR` (already local files, read directly in
+`load_experiment_data`, not through the storage boundary). The seam this change swaps is
+exactly the five faked object-storage helpers — no more, no less.
+
+## Goals / Non-Goals
+
+- **Goals**
+  - An opt-in `local` backend that writes/reads bloommcp object storage as real files,
+    preserving the object store's *implicit* integrity guarantees on a POSIX filesystem
+    (atomic manifest, verbatim bytes, hash-truthful, non-leaking errors).
+  - Zero behavior change when the backend is unset or `supabase` (byte-for-byte).
+  - No churn for callers or the existing test fake — the `supabase_client` helper
+    names stay put; only their bodies delegate.
+  - Docs that state the true output destination and de-mystify `BLOOM_OUTPUT_DIR`.
+- **Non-Goals**
+  - Changing the production default, the manifest schema, or versioning semantics.
+  - Swapping PostgREST/table access, `read_input_csv`, or the deprecated `BLOOM_TRAITS_DIR` raw read.
+  - A new higher-level port — selection lives at the object-storage seam, below the
+    `ResultStore` / `ExperimentReader` adapters, so both use the chosen backend transparently.
+  - Cross-store reconciliation or migration. A backend is not a migration; mixing backends
+    for one experiment splits its history (see Risks).
+
+## Decisions
+
+- **Decision: put the seam at `bloom_mcp.supabase_client`, not at the ports.**
+  A new module `bloom_mcp/storage_backend.py` defines a `StorageBackend` protocol with the
+  five operations and two implementations (`SupabaseStorageBackend` wrapping today's client
+  calls; `LocalStorageBackend` mapping keys to paths). `supabase_client` keeps its
+  module-level functions as the public surface — each becomes a thin delegate to the
+  process's active backend. This preserves every import site and the `fake_supabase_storage`
+  monkeypatch (it patches the module-level names, which still exist as wrapper objects).
+  - *Verified:* the `from bloom_mcp.supabase_client import upload_file` callers still route
+    to the newly-selected backend, because the imported wrapper object's identity is stable
+    and only its internal dispatch target changes. The fake still overwrites those wrapper
+    objects wholesale in both `supabase_client` and `manifest`, so it is undisturbed.
+  - *Alternative considered:* add `LocalResultStore` / `LocalReader` adapters at the
+    port layer. Rejected — it duplicates versioning/manifest logic across adapters,
+    and the issue explicitly wants a backend at the storage boundary, not per-writer.
+
+- **Decision: `BLOOM_STORAGE_BACKEND` selects; default `supabase`; unknown → fail fast;
+  resolution is lazy and import-pure.**
+  The active backend is resolved lazily on first use, **never at import**, and the resolver
+  reads no env and touches no filesystem at import time — `import bloom_mcp.server` with no
+  env must stay clean (enforced by `tests/test_package_baseline.py`). The value is validated
+  at boot in `experiment_utils.validate_env` (which `server.main()` already calls at
+  `server.py:123-124`) so a typo like `locel` fails at boot, not mid-run. A small
+  test-only reset seam (e.g. `reset_backend_for_tests()` / `functools.cache` + `cache_clear`)
+  lets the selection tests exercise `supabase` / `local` / invalid within one session without
+  cross-contamination.
+
+- **Decision: local root = `BLOOM_STORAGE_LOCAL_ROOT`, else `BLOOM_OUTPUT_DIR`.**
+  A dedicated var (rather than repurposing `BLOOM_OUTPUT_DIR`) because it names the
+  *storage-backend root* explicitly instead of overloading a var the issue already flags as
+  misleading, and it leaves room for future storage-backed prefixes. Falling back to
+  `BLOOM_OUTPUT_DIR` (a required, dev-mounted dir) means `BLOOM_STORAGE_BACKEND=local` needs
+  no second var in dev and populates the folder people already expect. Because
+  `BLOOM_OUTPUT_DIR` is already required by `validate_env`, the root always resolves under
+  `local`; the only genuinely new startup check is the explicit `BLOOM_STORAGE_LOCAL_ROOT`
+  path when set.
+
+- **Decision: keys are the contract; the local backend maps `key` → `<root>/<key>` with a
+  resolved-path containment guard.**
+  Storage keys use `/` separators and are `..`-free by construction (`AnalysisDir.key`;
+  `validate_outputs` bans `..`). `LocalStorageBackend` joins the key onto the root with
+  `os.sep`; before any I/O it resolves the joined path (`os.path.realpath`) and rejects
+  anything not under `realpath(root)` — this stops absolute-path keys, `..` traversal, and
+  symlink escapes, not just a substring `..` scan. `list_prefix(prefix)` returns the
+  **bare** immediate-child names (files and first-level subdir names, **no trailing slash,
+  no path prefix**) under `<root>/<prefix>/`, matching `os.listdir`, the in-memory fake, and
+  Supabase `.list(prefix)`; a trailing-slash-terminated prefix lists *inside* that dir,
+  `list_prefix("")` lists the root, and a missing prefix returns `[]` (catch
+  `FileNotFoundError`) rather than raising. Both callers depend on this: `manifest.py:46`
+  needs the file `"manifest.json"`, `experiment_utils.py:273` needs the bare dir name for
+  `startswith(f"{entry.id}_")`.
+
+- **Decision: preserve the object store's implicit guarantees explicitly.**
+  - **Atomic writes.** `write_json` / `upload_file` write to a temp file *in the target's
+    directory* (same filesystem as the root — a `/tmp` temp file would degrade `os.replace`
+    to a non-atomic cross-mount copy) then `os.replace` into place. A crash / `kill -9` /
+    `ENOSPC` mid-write leaves either the whole prior file or the whole new file — never a
+    truncated `manifest.json`, which is the single catalog for every version of an experiment.
+  - **Upsert / overwrite.** Writes overwrite an existing key in place (matching the Supabase
+    `upsert:true`), and parent-dir creation is idempotent (`mkdir(parents=True, exist_ok=True)`).
+  - **Verbatim bytes.** `upload_file` / `download_file` are binary copies (`read_bytes` /
+    atomic `write_bytes`) with no newline or encoding translation on any OS, so
+    `sha256(file on disk)` equals the `output_sha256` the manifest records (nothing on the
+    normal read path re-verifies the hash, so a silent divergence would be invisible).
+    `download_file` **copies** bytes to the caller's destination path — it never hands back
+    or symlinks the canonical file under the root, whose lifetime the caller does not own.
+  - **Byte-identical provenance.** Provenance (seed/agent/environment/code_versions/
+    output_sha256/output_keys) is built *above* the seam, so the serialized `manifest.json`
+    is byte-identical across backends for the same run (both use
+    `json.dumps(indent=2, sort_keys=True)`); the parity test asserts this, not merely
+    "equivalent shapes."
+  - **Error redaction.** Local errors must not leak absolute host paths into agent-facing
+    messages (`experiment_utils` interpolates `{e}` into caller-facing strings); the backend
+    surfaces the same non-leaking shape the Supabase path guarantees, with detail logged
+    server-side only.
+  - **Content-type is a no-op for `local`** — extension-driven content typing lives only in
+    the Supabase backend and is not an observable of the local path.
+
+## Risks / Trade-offs
+
+- **Non-atomic manifest on FS → catalog corruption.** → Temp-then-`os.replace` on the root's
+  filesystem (above). This is the single most important durability requirement.
+- **Byte divergence (e.g. Windows newline translation) breaks `output_sha256` silently**,
+  since no read path re-hashes. → Verbatim binary copy + a hash-equality test on disk.
+- **Mixed-backend / backend-flip splits version history.** Run v1/v2 under `supabase`, flip
+  to `local`, and `next_version_id` reads the *absent* local manifest and re-allocates `v1`
+  into a fresh local catalog — two artifacts both claiming "v1", the Supabase lineage
+  invisible to later `local` reads. → Documented non-goal + a docs warning ("do not mix
+  backends for one experiment; there is no cross-store view"); the spec states it so it is
+  not silently relied upon (mirroring how `bloommcp-result-store` documents its single-writer
+  limitation).
+- **Single-writer / no-CAS** is inherited unchanged: the local backend provides the same
+  last-write-wins, no-compare-and-swap semantics as the Supabase path — no stronger, no
+  weaker. Atomicity-against-interruption (above) is distinct from and does not imply
+  concurrent-writer safety.
+- **Legacy-fallback collision.** The legacy read fallback reads
+  `<BLOOM_OUTPUT_DIR>/qc_<stem>/<stem>_cleaned.csv` (`experiment_utils.py:352`), one level
+  shallower than the local backend's `<root>/bloommcp_output/qc_<stem>/…`. They are disjoint
+  *today*, but both are rooted at the same bind mount and the disjointness is load-bearing
+  (a stray `<stem>_cleaned.csv` in the legacy path would be read as an un-versioned,
+  un-hashed "certified" CSV and fed to PCA/UMAP). → The spec asserts disjointness and a test
+  confirms a `local` run produces nothing the legacy branch would pick up.
+- **Cross-platform key mapping** (Windows dev). → Keys stay `/`-joined logical strings; only
+  the local backend converts to OS paths, at the leaf, behind the resolved-path guard.
+- **Env-parity CI.** The new vars are added only as commented dev-compose lines, not
+  `${VAR}` references, so `scripts/validate_env.sh` / `tests/unit/test_env_defaults.py` do
+  not require a `.env.*.defaults` entry.
+
+## Migration Plan
+
+Purely additive and opt-in. No migration: default (`supabase`) is byte-for-byte unchanged,
+no manifest/schema change, production untouched. Rollback = unset `BLOOM_STORAGE_BACKEND`.
+
+## Open Questions
+
+- None. (`read_input_csv` is resolved as **out of scope**: it rides the PostgREST client,
+  is not one of the five faked helpers, and has no production caller — so the seam is the
+  five object-storage helpers only.)

--- a/openspec/changes/add-bloommcp-local-storage-backend/design.md
+++ b/openspec/changes/add-bloommcp-local-storage-backend/design.md
@@ -43,6 +43,9 @@ exactly the five faked object-storage helpers — no more, no less.
     `ResultStore` / `ExperimentReader` adapters, so both use the chosen backend transparently.
   - Cross-store reconciliation or migration. A backend is not a migration; mixing backends
     for one experiment splits its history (see Risks).
+  - Fully-offline operation. `local` changes only where *outputs* go; bloommcp still boots
+    through `validate_supabase_env()` and reads inputs/tables via Supabase, so Supabase env
+    is still required. True offline would also need inputs sourced locally (follow-up #395).
 
 ## Decisions
 

--- a/openspec/changes/add-bloommcp-local-storage-backend/design.md
+++ b/openspec/changes/add-bloommcp-local-storage-backend/design.md
@@ -5,13 +5,13 @@ narrow module, `bloom_mcp.supabase_client`, which exposes five object-storage he
 and the unit suite already substitutes exactly these five behind `fake_supabase_storage`
 (`bloommcp/tests/conftest.py:86-95`):
 
-| Helper | Used by |
-| --- | --- |
-| `upload_file(key, path)` | `AnalysisWriter.commit`, `SupabaseResultStore.commit` |
+| Helper                     | Used by                                                                |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `upload_file(key, path)`   | `AnalysisWriter.commit`, `SupabaseResultStore.commit`                  |
 | `download_file(key, path)` | `experiment_utils._resolve_versioned_cleaned` (versioned-cleaned read) |
-| `write_json(key, payload)` | `storage.manifest.write_manifest` |
-| `read_json(key)` | `storage.manifest.read_manifest` |
-| `list_prefix(prefix)` | `storage.manifest.read_manifest`, `_resolve_versioned_cleaned` |
+| `write_json(key, payload)` | `storage.manifest.write_manifest`                                      |
+| `read_json(key)`           | `storage.manifest.read_manifest`                                       |
+| `list_prefix(prefix)`      | `storage.manifest.read_manifest`, `_resolve_versioned_cleaned`         |
 
 Higher layers depend only on the `ResultStore` / `ExperimentReader` ports — never on
 `supabase` directly. So the boundary is proven swappable; this change adds a second
@@ -30,7 +30,7 @@ exactly the five faked object-storage helpers — no more, no less.
 
 - **Goals**
   - An opt-in `local` backend that writes/reads bloommcp object storage as real files,
-    preserving the object store's *implicit* integrity guarantees on a POSIX filesystem
+    preserving the object store's _implicit_ integrity guarantees on a POSIX filesystem
     (atomic manifest, verbatim bytes, hash-truthful, non-leaking errors).
   - Zero behavior change when the backend is unset or `supabase` (byte-for-byte).
   - No churn for callers or the existing test fake — the `supabase_client` helper
@@ -43,7 +43,7 @@ exactly the five faked object-storage helpers — no more, no less.
     `ResultStore` / `ExperimentReader` adapters, so both use the chosen backend transparently.
   - Cross-store reconciliation or migration. A backend is not a migration; mixing backends
     for one experiment splits its history (see Risks).
-  - Fully-offline operation. `local` changes only where *outputs* go; bloommcp still boots
+  - Fully-offline operation. `local` changes only where _outputs_ go; bloommcp still boots
     through `validate_supabase_env()` and reads inputs/tables via Supabase, so Supabase env
     is still required. True offline would also need inputs sourced locally (follow-up #395).
 
@@ -56,11 +56,12 @@ exactly the five faked object-storage helpers — no more, no less.
   module-level functions as the public surface — each becomes a thin delegate to the
   process's active backend. This preserves every import site and the `fake_supabase_storage`
   monkeypatch (it patches the module-level names, which still exist as wrapper objects).
-  - *Verified:* the `from bloom_mcp.supabase_client import upload_file` callers still route
+
+  - _Verified:_ the `from bloom_mcp.supabase_client import upload_file` callers still route
     to the newly-selected backend, because the imported wrapper object's identity is stable
     and only its internal dispatch target changes. The fake still overwrites those wrapper
     objects wholesale in both `supabase_client` and `manifest`, so it is undisturbed.
-  - *Alternative considered:* add `LocalResultStore` / `LocalReader` adapters at the
+  - _Alternative considered:_ add `LocalResultStore` / `LocalReader` adapters at the
     port layer. Rejected — it duplicates versioning/manifest logic across adapters,
     and the issue explicitly wants a backend at the storage boundary, not per-writer.
 
@@ -77,7 +78,7 @@ exactly the five faked object-storage helpers — no more, no less.
 
 - **Decision: local root = `BLOOM_STORAGE_LOCAL_ROOT`, else `BLOOM_OUTPUT_DIR`.**
   A dedicated var (rather than repurposing `BLOOM_OUTPUT_DIR`) because it names the
-  *storage-backend root* explicitly instead of overloading a var the issue already flags as
+  _storage-backend root_ explicitly instead of overloading a var the issue already flags as
   misleading, and it leaves room for future storage-backed prefixes. Falling back to
   `BLOOM_OUTPUT_DIR` (a required, dev-mounted dir) means `BLOOM_STORAGE_BACKEND=local` needs
   no second var in dev and populates the folder people already expect. Because
@@ -94,15 +95,15 @@ exactly the five faked object-storage helpers — no more, no less.
   symlink escapes, not just a substring `..` scan. `list_prefix(prefix)` returns the
   **bare** immediate-child names (files and first-level subdir names, **no trailing slash,
   no path prefix**) under `<root>/<prefix>/`, matching `os.listdir`, the in-memory fake, and
-  Supabase `.list(prefix)`; a trailing-slash-terminated prefix lists *inside* that dir,
+  Supabase `.list(prefix)`; a trailing-slash-terminated prefix lists _inside_ that dir,
   `list_prefix("")` lists the root, and a missing prefix returns `[]` (catch
   `FileNotFoundError`) rather than raising. Both callers depend on this: `manifest.py:46`
   needs the file `"manifest.json"`, `experiment_utils.py:273` needs the bare dir name for
   `startswith(f"{entry.id}_")`.
 
 - **Decision: preserve the object store's implicit guarantees explicitly.**
-  - **Atomic writes.** `write_json` / `upload_file` write to a temp file *in the target's
-    directory* (same filesystem as the root — a `/tmp` temp file would degrade `os.replace`
+  - **Atomic writes.** `write_json` / `upload_file` write to a temp file _in the target's
+    directory_ (same filesystem as the root — a `/tmp` temp file would degrade `os.replace`
     to a non-atomic cross-mount copy) then `os.replace` into place. A crash / `kill -9` /
     `ENOSPC` mid-write leaves either the whole prior file or the whole new file — never a
     truncated `manifest.json`, which is the single catalog for every version of an experiment.
@@ -114,8 +115,8 @@ exactly the five faked object-storage helpers — no more, no less.
     normal read path re-verifies the hash, so a silent divergence would be invisible).
     `download_file` **copies** bytes to the caller's destination path — it never hands back
     or symlinks the canonical file under the root, whose lifetime the caller does not own.
-  - **Byte-identical provenance.** Provenance (seed/agent/environment/code_versions/
-    output_sha256/output_keys) is built *above* the seam, so the serialized `manifest.json`
+  - **Byte-identical provenance.** Provenance (seed/agent/environment/code*versions/
+    output_sha256/output_keys) is built \_above* the seam, so the serialized `manifest.json`
     is byte-identical across backends for the same run (both use
     `json.dumps(indent=2, sort_keys=True)`); the parity test asserts this, not merely
     "equivalent shapes."
@@ -133,7 +134,7 @@ exactly the five faked object-storage helpers — no more, no less.
 - **Byte divergence (e.g. Windows newline translation) breaks `output_sha256` silently**,
   since no read path re-hashes. → Verbatim binary copy + a hash-equality test on disk.
 - **Mixed-backend / backend-flip splits version history.** Run v1/v2 under `supabase`, flip
-  to `local`, and `next_version_id` reads the *absent* local manifest and re-allocates `v1`
+  to `local`, and `next_version_id` reads the _absent_ local manifest and re-allocates `v1`
   into a fresh local catalog — two artifacts both claiming "v1", the Supabase lineage
   invisible to later `local` reads. → Documented non-goal + a docs warning ("do not mix
   backends for one experiment; there is no cross-store view"); the spec states it so it is
@@ -143,10 +144,19 @@ exactly the five faked object-storage helpers — no more, no less.
   last-write-wins, no-compare-and-swap semantics as the Supabase path — no stronger, no
   weaker. Atomicity-against-interruption (above) is distinct from and does not imply
   concurrent-writer safety.
+- **`list_prefix` parity is against the fake/local interface, not Supabase pagination.** The
+  cross-backend parity test pins fake-vs-local; the deployed
+  `SupabaseStorageBackend.list_prefix` calls `client.list(prefix)`, which inherits the upstream
+  client's default **100-item page cap** and does not paginate — so a prefix with >100 immediate
+  children (e.g. >100 version dirs) could list a truncated set on the `supabase` backend. Low-risk
+  today: callers (`read_manifest`, `_resolve_versioned_cleaned`) use `manifest.json` as the
+  authoritative version list, not `list_prefix` enumeration, and experiments have far fewer than
+  100 versions; the `local` backend is complete (`iterdir`). Paginating the Supabase list is a
+  **follow-up (#396)**, deliberately out of this PR.
 - **Legacy-fallback collision.** The legacy read fallback reads
   `<BLOOM_OUTPUT_DIR>/qc_<stem>/<stem>_cleaned.csv` (`experiment_utils.py:352`), one level
   shallower than the local backend's `<root>/bloommcp_output/qc_<stem>/…`. They are disjoint
-  *today*, but both are rooted at the same bind mount and the disjointness is load-bearing
+  _today_, but both are rooted at the same bind mount and the disjointness is load-bearing
   (a stray `<stem>_cleaned.csv` in the legacy path would be read as an un-versioned,
   un-hashed "certified" CSV and fed to PCA/UMAP). → The spec asserts disjointness and a test
   confirms a `local` run produces nothing the legacy branch would pick up.

--- a/openspec/changes/add-bloommcp-local-storage-backend/proposal.md
+++ b/openspec/changes/add-bloommcp-local-storage-backend/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+bloommcp has **no way to write analysis outputs as local files**. Every output
+(CSV, JSON manifest, PNG) is uploaded to Supabase Storage: `AnalysisWriter.commit`
+/ `SupabaseResultStore.commit` loop over staged files and call `upload_file`
+([writer.py:100-103](../../../bloommcp/src/bloom_mcp/storage/writer.py#L100-L103),
+[supabase_store.py:106-147](../../../bloommcp/src/bloom_mcp/result_store/supabase_store.py#L106-L147)),
+and there is no filesystem branch anywhere in the storage layer. The env vars
+people reach for don't help: `BLOOM_OUTPUT_DIR` post-migration only feeds a
+startup dir-existence check and a legacy read fallback
+([experiment_utils.py:24-52,344-356](../../../bloommcp/src/bloom_mcp/experiment_utils.py#L24-L52)) —
+nothing writes new outputs there — and `BLOOM_USE_LOCAL` is dead/commented-out and
+was only ever about CLI login credentials. In local dev the bytes live inside
+MinIO's object store, not as files under the mounted `./bloommcp/data/ANALYSIS_OUTPUT`,
+so that folder stays empty and the outputs are invisible as files. This blocks
+quick local inspection, offline runs, and confuses anyone reading the env-var names.
+
+The write and output-read paths already funnel through **one narrow seam** — the
+five object-storage helpers in `bloom_mcp.supabase_client` (`upload_file`,
+`download_file`, `write_json`, `read_json`, `list_prefix`). The unit suite already
+substitutes exactly these five with an in-memory fake
+([conftest.py `fake_supabase_storage`](../../../bloommcp/tests/conftest.py)), which
+proves the interface is narrow and swappable. A local-filesystem implementation can
+sit behind the same seam, selected by an env var, with the default path unchanged.
+
+## What Changes
+
+- Introduce a small **storage-backend interface** over the five object-storage
+  helpers, with two implementations: `supabase` (the current behavior) and `local`
+  (real files under a root dir; storage keys → relative paths).
+- Select the backend from **`BLOOM_STORAGE_BACKEND`** (default `supabase`); an
+  unrecognized value fails fast at startup with a clear message. Selection is resolved
+  lazily (never at import — import stays side-effect-free), and the module-level
+  `supabase_client` helper names stay stable, so every caller (`writer`, `manifest`,
+  `supabase_store`, `experiment_utils`) and the existing test fake are unchanged.
+- Add **`BLOOM_STORAGE_LOCAL_ROOT`** for the local root; when unset it falls back to
+  the already-required, already-mounted `BLOOM_OUTPUT_DIR`, so `BLOOM_STORAGE_BACKEND=local`
+  works in dev with no extra config and finally populates `./bloommcp/data/ANALYSIS_OUTPUT`.
+- With `local`, an analysis run writes CSV/JSON/PNG as real files laid out by storage
+  key, and all output-read paths (manifest resolution, versioned-cleaned lookup, MCP
+  read tools) resolve against those files.
+- **Preserve the object-store's implicit integrity guarantees on the filesystem**: the
+  local backend writes the manifest (and every object) atomically (temp-then-rename on
+  the root's filesystem), copies bytes verbatim (no newline/encoding translation), keeps
+  recorded `output_sha256` equal to the bytes on disk, produces a byte-identical
+  provenance manifest across backends, and redacts absolute host paths from agent-facing
+  errors — matching what the Supabase path provides for free.
+- **Docs**: document where outputs actually go by default (Supabase Storage, backed by
+  MinIO in dev) and how to reach them; clarify that `BLOOM_OUTPUT_DIR` / `BLOOM_USE_LOCAL`
+  do **not** produce local CSVs by default; document the opt-in `local` backend,
+  `BLOOM_STORAGE_LOCAL_ROOT`, and the **do-not-mix-backends** caveat.
+- Tests cover the local backend behind the same interface the fake already uses:
+  supabase-fake vs local **parity** (asserting a byte-identical manifest), a workflow
+  run end-to-end under `local` (asserting real files on disk, read-back, and
+  hash-equality), and an explicit guard that the **default path writes no local files**.
+
+## Impact
+
+- **Affected specs:** ADDs a new `bloommcp-storage-backend` capability. No change to
+  `bloommcp-result-store` / `bloommcp-experiment-read` behavior — the local backend is
+  transparent beneath the `ResultStore` / `ExperimentReader` adapters, the default stays
+  `supabase`, and raw-experiment-input reads (local `BLOOM_TRAITS_DIR`) and `read_input_csv`
+  (PostgREST) are deliberately outside the swapped seam, so the reader's input contract is
+  untouched.
+- **Affected code:**
+  - `bloommcp/src/bloom_mcp/supabase_client.py` — the five helpers delegate to the active backend (names + signatures unchanged).
+  - New `bloommcp/src/bloom_mcp/storage_backend.py` — interface + `SupabaseStorageBackend` + `LocalStorageBackend` + lazy selection (import-time pure).
+  - `bloommcp/src/bloom_mcp/experiment_utils.py` (`validate_env`, called by `server.main()`) — validate `BLOOM_STORAGE_BACKEND` and, when `local`, the resolved root, at boot.
+  - `docker-compose.dev.yml` — document the new opt-in vars (commented; default off). These are commented, not `${VAR}` references, so the env-parity CI check (`scripts/validate_env.sh`, `tests/unit/test_env_defaults.py`) is unaffected and needs no `.env.*.defaults` entry.
+  - Docs: new `bloommcp/docs/storage-backends.md`; env-var note in `_WIKI/BLOOMMCP/README.md`.
+  - Tests under `bloommcp/tests/` — backend unit + parity + a `local` workflow round-trip; default-no-local-files guard; startup-validation guard through the boot path.
+
+## Scope / Non-Goals
+
+- **Default is unchanged**: production/staging stay on Supabase Storage (`prod` is
+  `read_only` with `BLOOM_OUTPUT_DIR` on a writable bind mount, but `local` is opt-in and
+  off by default, so prod is untouched). Manifest and versioning semantics are identical —
+  only the bytes' destination changes.
+- **Not** a flag on the writer — it's a backend selection at the object-storage boundary.
+- **Out of scope:** PostgREST/table reads via `get_postgrest_client` (that is the
+  database, not object storage; `read_input_csv` rides this client and is likewise
+  untouched) and the deprecated raw-input reads from local `BLOOM_TRAITS_DIR`. Only the
+  five object-storage helpers are swapped.
+- **Not a migration and not a mixed-mode store:** a backend is not a data migration; the
+  two stores are independent catalogs. Flipping `BLOOM_STORAGE_BACKEND` mid-experiment would
+  split version history across stores (re-allocating `v1`, orphaning the other store's
+  lineage). This is a documented non-goal, warned in the docs — not silently relied upon.
+- **Related but separate:** #388 (user-facing upload/download of bloommcp files) will build
+  signed-URL downloads on this same `supabase_client.py` seam. This change deliberately does
+  **not** add that user-facing surface; it only reshapes the boundary #388 will build on.

--- a/openspec/changes/add-bloommcp-local-storage-backend/specs/bloommcp-storage-backend/spec.md
+++ b/openspec/changes/add-bloommcp-local-storage-backend/specs/bloommcp-storage-backend/spec.md
@@ -136,17 +136,21 @@ filesystem paths; detail SHALL be logged server-side only.
 
 ### Requirement: Local Backend Write Atomicity
 
-The local-filesystem backend SHALL write every object — and especially `manifest.json`, the
-single catalog for all versions of an experiment — atomically against interruption, by
-writing to a temporary file on the same filesystem as the root (in the target's directory)
-and renaming it into place with `os.replace`. A crash, kill, or disk-full condition mid-write
-SHALL leave the on-disk file as either the complete prior content or the complete new content,
-never a truncated or partially-written file, so a reader never observes a corrupt manifest.
+On **POSIX filesystems**, the local-filesystem backend SHALL write every object — and
+especially `manifest.json`, the single catalog for all versions of an experiment —
+atomically against interruption, by writing to a temporary file on the same filesystem as
+the root (in the target's directory), `fsync`-ing it, and renaming it into place with
+`os.replace`. A crash, kill, or disk-full condition mid-write SHALL leave the on-disk file
+as either the complete prior content or the complete new content, never a truncated or
+partially-written file, so a reader never observes a corrupt manifest. This guarantee is
+POSIX-scoped: on Windows/NTFS `os.replace` over an existing file is not guaranteed atomic
+(and may raise if a reader holds the target open); the backend is an opt-in dev feature and
+production stays on Supabase Storage, so the caveat is documented rather than worked around.
 
-#### Scenario: Interrupted manifest write leaves a whole file
+#### Scenario: Interrupted manifest write leaves a whole file (POSIX)
 
-- **WHEN** the local backend writes `manifest.json` (or any object) and the process is
-  interrupted mid-write
+- **WHEN** the local backend writes `manifest.json` (or any object) on a POSIX filesystem and
+  the process is interrupted mid-write
 - **THEN** the on-disk file is either the complete prior content or the complete new content —
   never truncated — because the backend writes a temp file on the root's filesystem and
   `os.replace`s it into place

--- a/openspec/changes/add-bloommcp-local-storage-backend/specs/bloommcp-storage-backend/spec.md
+++ b/openspec/changes/add-bloommcp-local-storage-backend/specs/bloommcp-storage-backend/spec.md
@@ -1,0 +1,303 @@
+## ADDED Requirements
+
+### Requirement: Storage Backend Interface
+
+The system SHALL define a backend-agnostic object-storage interface covering the exact five
+helpers bloommcp's write and output-read paths depend on — `upload_file`, `download_file`,
+`write_json`, `read_json`, and `list_prefix` — with at least two implementations: a Supabase
+Storage backend (the deployed default) and a local-filesystem backend. The public
+`bloom_mcp.supabase_client` helper functions SHALL remain the call surface and delegate to
+the process's active backend, so existing consumers (`storage.writer`, `storage.manifest`,
+`result_store.supabase_store`, `experiment_utils`) and the in-memory test fake keep working
+without modification. This interface SHALL cover object storage only. PostgREST/table access
+via `get_postgrest_client` — including `read_input_csv`, which rides that client — and
+raw-experiment-input reads from the local `BLOOM_TRAITS_DIR` are outside the seam and SHALL
+remain unchanged regardless of the selected storage backend.
+
+#### Scenario: Callers and the test fake are unchanged
+
+- **WHEN** the storage backend abstraction is introduced
+- **THEN** `storage.writer`, `storage.manifest`, `result_store.supabase_store`, and
+  `experiment_utils` still import the same `bloom_mcp.supabase_client` helper names, and
+  the existing `fake_supabase_storage` fixture still substitutes the boundary by
+  monkeypatching those five module-level names in `supabase_client` and `manifest`
+
+#### Scenario: Table reads and input reads are unaffected by the storage backend
+
+- **WHEN** any storage backend is selected
+- **THEN** `get_postgrest_client` and its table reads, `read_input_csv`, and raw-input reads
+  from `BLOOM_TRAITS_DIR` continue to behave exactly as before, because the backend selection
+  governs only the five object-storage helpers
+
+### Requirement: Backend Selection via BLOOM_STORAGE_BACKEND
+
+The system SHALL select the active object-storage backend from the `BLOOM_STORAGE_BACKEND`
+environment variable, defaulting to `supabase` when unset. A value of `local` SHALL select
+the local-filesystem backend. An unrecognized value SHALL fail fast at server startup with a
+clear error naming the offending value and the accepted values, rather than failing mid-run.
+Backend selection SHALL be resolved lazily (never at import) and SHALL read no environment
+variable and touch no filesystem at import time, preserving the package's side-effect-free
+import contract. When the backend is unset or `supabase`, the write and output-read behavior
+SHALL be byte-for-byte identical to the prior Supabase-only behavior, and no local output
+files SHALL be produced.
+
+#### Scenario: Default is Supabase and unchanged
+
+- **WHEN** `BLOOM_STORAGE_BACKEND` is unset or set to `supabase`
+- **THEN** analysis outputs and the manifest are written to and read from Supabase Storage
+  exactly as before, and no files are written to the local root
+
+#### Scenario: Local backend is opt-in
+
+- **WHEN** `BLOOM_STORAGE_BACKEND=local`
+- **THEN** the object-storage boundary is served by the local-filesystem backend for the
+  remainder of the process
+
+#### Scenario: Invalid backend value fails fast at startup
+
+- **WHEN** `BLOOM_STORAGE_BACKEND` is set to an unrecognized value (e.g. `locel`) and the
+  server runs its startup validation
+- **THEN** startup validation raises a clear error naming the offending value and the
+  accepted values, rather than starting and failing on the first storage call
+
+#### Scenario: Import stays side-effect-free
+
+- **WHEN** `import bloom_mcp.server` runs in a fresh interpreter with no bloom environment set
+- **THEN** the import succeeds without reading `BLOOM_STORAGE_BACKEND`, resolving a backend,
+  or touching the filesystem — backend resolution happens only on first use, not at import
+
+### Requirement: Local Filesystem Backend
+
+The local-filesystem backend SHALL implement the object-storage interface by mapping each
+storage key to a path under the configured local root, so that an analysis run produces its
+outputs (CSV, JSON, PNG) and its `manifest.json` as real files laid out by storage key.
+Writes SHALL overwrite an existing key in place (upsert semantics matching the Supabase
+client) with idempotent parent-directory creation. `list_prefix` SHALL return the bare
+immediate-child names directly under a prefix — files and first-level subdirectory names,
+with no trailing slash and no path prefix — matching `os.listdir`, the in-memory fake, and
+the deployed Supabase listing; an empty prefix SHALL list the root and a missing prefix SHALL
+yield an empty list, not an error. Reads of a missing key SHALL raise the same not-found
+condition callers already handle. Storage keys SHALL be treated as `/`-separated logical
+paths regardless of host OS, and the backend SHALL reject — before any I/O — any key whose
+resolved real path is not contained within the resolved real root (covering absolute-path
+keys, `..` traversal, and symlink escapes). Agent-facing errors SHALL NOT leak absolute host
+filesystem paths; detail SHALL be logged server-side only.
+
+#### Scenario: A run under the local backend writes real files by key
+
+- **WHEN** an analysis run commits with `BLOOM_STORAGE_BACKEND=local`
+- **THEN** each staged output and the manifest appear as real files under the local root at
+  paths mirroring their storage keys (e.g. `<root>/bloommcp_output/qc_<stem>/v1_.../_cleaned.csv`
+  and `<root>/bloommcp_output/qc_<stem>/manifest.json`)
+
+#### Scenario: Output-read paths resolve against local files
+
+- **WHEN** manifest resolution, the versioned-cleaned lookup (`_resolve_versioned_cleaned`,
+  which `download_file`s the cleaned CSV), and MCP read tools run with
+  `BLOOM_STORAGE_BACKEND=local` after a committed run
+- **THEN** `read_manifest`, `get_run("latest")`, and the cleaned-CSV download all succeed
+  against the local files and return the committed run's data
+
+#### Scenario: list_prefix returns bare immediate children
+
+- **WHEN** `list_prefix(prefix)` is called against the local backend
+- **THEN** it returns the bare names of entries directly under `<root>/<prefix>/` (files and
+  first-level subdirectory names, no trailing slash, no path prefix) — so a version directory
+  is returned as `v3_2026-…` (matching `startswith(f"{entry.id}_")`) and a sibling file as
+  `manifest.json` (matching the membership check) — lists the root for an empty prefix, and
+  returns an empty list, not an error, for a prefix that does not exist
+
+#### Scenario: Missing key raises not-found
+
+- **WHEN** `download_file` or `read_json` is called for a key with no backing file
+- **THEN** the local backend raises, matching the not-found behavior callers already gate on
+  via `list_prefix`
+
+#### Scenario: Writes overwrite in place
+
+- **WHEN** the same key is written twice (e.g. a manifest rewritten as `latest` advances)
+- **THEN** the second write's content fully replaces the first, and re-creating an existing
+  parent directory does not error
+
+#### Scenario: Keys cannot escape the root
+
+- **WHEN** a key that would resolve outside the configured root is passed to the local backend
+  — for example `../../etc/passwd`, an absolute path such as `/etc/x`, or a path through a
+  symlink under the root pointing elsewhere
+- **THEN** the backend rejects it (raising, performing no I/O), verified by resolving the
+  joined real path against the real root, and logical keys use `/` separators on every host OS
+
+#### Scenario: Errors do not leak host paths
+
+- **WHEN** a missing-key or permission error occurs under the local backend and surfaces to
+  the caller
+- **THEN** the agent-facing message carries no absolute host filesystem path, and the full
+  detail is available only in server-side logs
+
+### Requirement: Local Backend Write Atomicity
+
+The local-filesystem backend SHALL write every object — and especially `manifest.json`, the
+single catalog for all versions of an experiment — atomically against interruption, by
+writing to a temporary file on the same filesystem as the root (in the target's directory)
+and renaming it into place with `os.replace`. A crash, kill, or disk-full condition mid-write
+SHALL leave the on-disk file as either the complete prior content or the complete new content,
+never a truncated or partially-written file, so a reader never observes a corrupt manifest.
+
+#### Scenario: Interrupted manifest write leaves a whole file
+
+- **WHEN** the local backend writes `manifest.json` (or any object) and the process is
+  interrupted mid-write
+- **THEN** the on-disk file is either the complete prior content or the complete new content —
+  never truncated — because the backend writes a temp file on the root's filesystem and
+  `os.replace`s it into place
+
+#### Scenario: Temp file shares the root filesystem
+
+- **WHEN** the local backend prepares an atomic write
+- **THEN** the temporary file is created in the target's directory (or otherwise on the root's
+  filesystem), not in a separate mount such as `/tmp`, so the rename is a true atomic replace
+  rather than a non-atomic cross-mount copy
+
+### Requirement: Local Root Resolution
+
+When `BLOOM_STORAGE_BACKEND=local`, the local root SHALL be `BLOOM_STORAGE_LOCAL_ROOT` when
+set, otherwise `BLOOM_OUTPUT_DIR`. Because `BLOOM_OUTPUT_DIR` is already a required, validated
+directory, the root always resolves under the local backend. The resolved root SHALL be
+validated at startup (exists and is a writable directory) through the same boot-time
+validation the server already runs (`experiment_utils.validate_env`, called by
+`server.main()`), with the same fail-fast discipline as the other required directories.
+
+#### Scenario: Root resolves from the dedicated variable
+
+- **WHEN** `BLOOM_STORAGE_BACKEND=local` and `BLOOM_STORAGE_LOCAL_ROOT` is set to a writable directory
+- **THEN** the local backend roots all files under that directory
+
+#### Scenario: Root falls back to BLOOM_OUTPUT_DIR
+
+- **WHEN** `BLOOM_STORAGE_BACKEND=local` and `BLOOM_STORAGE_LOCAL_ROOT` is unset
+- **THEN** the local backend roots all files under `BLOOM_OUTPUT_DIR` (already required and,
+  in dev, mounted at `./bloommcp/data/ANALYSIS_OUTPUT`)
+
+#### Scenario: Unusable root fails fast at startup
+
+- **WHEN** `BLOOM_STORAGE_BACKEND=local` and the resolved root does not exist or is not a
+  writable directory, and the server runs its boot-time validation
+- **THEN** that validation raises a clear error naming the resolved root, rather than failing
+  on the first write
+
+### Requirement: Backend Parity and Provenance Integrity
+
+Switching backends SHALL NOT change what is recorded for a run. For the same run, the local
+and Supabase backends SHALL produce a byte-identical serialized `manifest.json` (identical
+`seed`, `agent`, `environment`, `code_versions`, `outputs`, `output_keys`, and
+`output_sha256`), because provenance is built above the storage seam. The bytes the local
+backend writes SHALL be verbatim copies of the staged bytes (no newline or encoding
+translation), so the recorded `output_sha256` equals the SHA-256 of the artifact on disk.
+`download_file` SHALL copy bytes to the caller's destination and SHALL NOT expose or mutate
+the canonical file under the root. The local backend SHALL provide the same single-writer,
+last-write-wins, no-compare-and-swap semantics as the Supabase path — no stronger, no weaker.
+A backend is not a migration: the two stores are independent catalogs, and mixing backends for
+one experiment (flipping `BLOOM_STORAGE_BACKEND` mid-history) splits its version history and
+can re-allocate colliding version ids — this SHALL be documented as a non-goal, not silently
+relied upon.
+
+#### Scenario: Manifest and provenance are byte-identical across backends
+
+- **WHEN** the same run is committed through the Supabase-fake boundary and through the local
+  backend
+- **THEN** the serialized `manifest.json` bytes are identical (same provenance fields and
+  per-artifact hash/key maps), and all logical keys use `/` separators regardless of host OS
+
+#### Scenario: Recorded hash equals the bytes on disk
+
+- **WHEN** a run is committed under `BLOOM_STORAGE_BACKEND=local`
+- **THEN** for each artifact, `sha256(<file under the root>)` equals the `output_sha256`
+  recorded in the manifest, because the backend copied the staged bytes verbatim
+
+#### Scenario: download_file does not expose the canonical file
+
+- **WHEN** `download_file(key, dest)` runs under the local backend
+- **THEN** it copies the bytes to `dest` and leaves the backing file under the root unmodified
+  and unlinked-to, so the caller's tmp-file lifetime management cannot delete or mutate the
+  canonical artifact
+
+#### Scenario: Mixed-backend history split is a documented non-goal
+
+- **WHEN** an experiment has versions committed under `supabase` and `BLOOM_STORAGE_BACKEND`
+  is then flipped to `local` (or vice versa)
+- **THEN** the behavior is documented as unsupported — the local read sees only the local
+  catalog, `next_version_id` may re-allocate a colliding `v<N>`, and the docs warn against
+  mixing backends for one experiment — rather than the split being silent
+
+#### Scenario: Local layout is disjoint from the legacy cleaned-CSV fallback
+
+- **WHEN** a run commits under `BLOOM_STORAGE_BACKEND=local` with the root at `BLOOM_OUTPUT_DIR`
+- **THEN** its files land under the `bloommcp_output/` prefix
+  (`<root>/bloommcp_output/qc_<stem>/…`) and never at the legacy fallback path
+  `<BLOOM_OUTPUT_DIR>/qc_<stem>/<stem>_cleaned.csv`, so the legacy `load_experiment_data`
+  fallback cannot misread a local-backend artifact as an un-versioned cleaned CSV
+
+### Requirement: Documentation of Output Destinations
+
+Documentation SHALL describe where bloommcp analysis outputs actually go by default (Supabase
+Storage, backed by MinIO in local dev) and how to reach them (MinIO console, Supabase Studio,
+the MCP read tools), and SHALL clarify that `BLOOM_OUTPUT_DIR` and `BLOOM_USE_LOCAL` do **not**
+produce local CSVs by default. Documentation SHALL describe the opt-in
+`BLOOM_STORAGE_BACKEND=local` backend, the `BLOOM_STORAGE_LOCAL_ROOT` root variable (and its
+fallback to `BLOOM_OUTPUT_DIR`), the resulting on-disk layout keyed by storage key, and the
+warning that backends MUST NOT be mixed for one experiment.
+
+#### Scenario: Default destination is documented
+
+- **WHEN** a developer reads the storage docs
+- **THEN** they learn outputs go to Supabase Storage by default (MinIO-backed in dev), how to
+  reach them, and that `BLOOM_OUTPUT_DIR` / `BLOOM_USE_LOCAL` do not by themselves write local CSVs
+
+#### Scenario: Opt-in local backend and its caveats are documented
+
+- **WHEN** a developer wants real CSV/JSON/PNG files on disk
+- **THEN** the docs show setting `BLOOM_STORAGE_BACKEND=local` (and optionally
+  `BLOOM_STORAGE_LOCAL_ROOT`), describe the on-disk layout keyed by storage key, and warn not
+  to mix backends for one experiment (no cross-store view; version ids can collide)
+
+### Requirement: Local Backend Test Coverage
+
+The local-filesystem backend SHALL be covered by tests exercising the same object-storage
+interface the in-memory fake already uses, with no live Supabase. Coverage SHALL include: a
+parity check that the same write → read → list → manifest round-trip produces a byte-identical
+manifest across the Supabase-fake boundary and the local backend (the in-memory fake is the
+parity oracle); at least one workflow run end-to-end under `BLOOM_STORAGE_BACKEND=local`
+asserting real files on disk, successful read-back through `_resolve_versioned_cleaned`, and
+`sha256(on-disk) == output_sha256`; and an explicit guard that the default (unset) path writes
+no local files while still using the faked Supabase boundary. The existing fixture-based suites
+SHALL remain green after the helper bodies are re-pointed to the backend.
+
+#### Scenario: Backend parity yields a byte-identical manifest
+
+- **WHEN** the same round-trip (write outputs, write and read the manifest, list a prefix,
+  resolve `get_run("latest")`) runs against the in-memory Supabase fake and against the local
+  backend on a temp root
+- **THEN** both produce equivalent observable results and a byte-identical serialized manifest,
+  with logical keys using `/` separators regardless of host OS
+
+#### Scenario: Workflow round-trips through real local files with hash-equality
+
+- **WHEN** a workflow runs end-to-end with `BLOOM_STORAGE_BACKEND=local` against a temp root
+- **THEN** its outputs and manifest exist as real files under the root laid out by storage key,
+  the read path reads the committed run back through `_resolve_versioned_cleaned`, and each
+  artifact's on-disk SHA-256 equals the manifest's `output_sha256` — with no network or
+  Supabase access
+
+#### Scenario: Default path writes no local files
+
+- **WHEN** a commit runs with `BLOOM_STORAGE_BACKEND` unset and the `fake_supabase_storage`
+  boundary active
+- **THEN** the faked Supabase store receives the bytes and the temp local root contains no
+  output files, guarding the opt-in default
+
+#### Scenario: Existing fixture-based suites stay green
+
+- **WHEN** the `supabase_client` helper bodies are re-pointed to delegate to the active backend
+- **THEN** the fixture-based suites (`test_store_parity`, `test_supabase_result_store`,
+  `test_supabase_reader`, `test_workflow_persistence`) still pass unchanged, because the fake
+  monkeypatches the same module-level helper names

--- a/openspec/changes/add-bloommcp-local-storage-backend/tasks.md
+++ b/openspec/changes/add-bloommcp-local-storage-backend/tasks.md
@@ -1,0 +1,43 @@
+## 1. Backend interface + selection (TDD)
+
+- [x] 1.1 (red) Add `bloommcp/tests/test_storage_backend.py`: (a) `BLOOM_STORAGE_BACKEND` unset/`supabase` selects the Supabase backend, `local` selects the local backend, and an unrecognized value raises a clear error naming the bad value + accepted values; (b) selection re-reads the env across the three values in one session via the reset seam (no memoized cross-contamination); (c) a fresh-interpreter `import bloom_mcp.server` with no env reads no env / touches no FS (import purity, mirroring `tests/test_package_baseline.py`).
+- [x] 1.2 Add `bloom_mcp/storage_backend.py`: a `StorageBackend` protocol with the **five** ops (`upload_file`, `download_file`, `write_json`, `read_json`, `list_prefix`), a `SupabaseStorageBackend` wrapping today's `supabase.create_client(...).storage` calls, a lazy `active_backend()` selector driven by `BLOOM_STORAGE_BACKEND`, and a test-only `reset_backend_for_tests()`. No env read / no FS touch at import.
+- [x] 1.3 Repoint the five `bloom_mcp/supabase_client.py` helper bodies to delegate to `active_backend()`, keeping the module-level names and signatures identical (callers + `fake_supabase_storage` unchanged). Leave `read_input_csv` / `get_postgrest_client` untouched (out of the seam).
+- [x] 1.4 (green) Confirm 1.1 passes and the fixture-based suites stay green untouched: run the full `bloommcp/tests/` suite and explicitly `test_store_parity`, `test_supabase_result_store`, `test_supabase_reader`, `test_workflow_persistence`, `test_package_baseline`.
+
+## 2. Local filesystem backend (TDD)
+
+- [x] 2.1 (red) Extend `test_storage_backend.py` for `LocalStorageBackend`: key → `<root>/<key>` mapping; round-trip `upload_file`/`download_file` and `write_json`/`read_json`; `list_prefix` returns bare immediate children (files + first-level dir names, **no trailing slash**), root listing for `""`, and `[]` for a missing prefix (not raise); missing-key read raises; **overwrite** re-write replaces content and `mkdir` is idempotent; **escape guard** rejects `../../etc/passwd`, an absolute-path key, and a symlink-escape via resolved-path (`realpath`) containment with no I/O; **verbatim bytes** (write then read yields identical bytes incl. `\n`, no newline translation); `download_file` copies to dest and leaves/does-not-symlink the backing file; surfaced errors carry no absolute host path.
+- [x] 2.2 (red) Add atomicity tests: `write_json`/`upload_file` write via a temp file on the root's filesystem + `os.replace`; assert the temp file is co-located with the target (same dir/filesystem, not `/tmp`); assert an interrupted/partial write never leaves a truncated file (e.g. monkeypatch to fail between write and replace and assert the prior content survives intact).
+- [x] 2.3 Implement `LocalStorageBackend` in `storage_backend.py`: join `/`-keys onto the root, resolved-path containment guard, idempotent `mkdir(parents=True, exist_ok=True)`, temp-then-`os.replace` atomic binary writes, `os.listdir`-based `list_prefix` (catch `FileNotFoundError` → `[]`), verbatim `read_bytes`/`write_bytes`, copy-out `download_file`, and non-leaking error surface.
+- [x] 2.4 (green) Confirm 2.1–2.2 pass.
+
+## 3. Root resolution + startup validation (TDD)
+
+- [x] 3.1 (red) Add tests: with `local`, root = `BLOOM_STORAGE_LOCAL_ROOT` when set else `BLOOM_OUTPUT_DIR`; a missing/non-writable resolved root and an invalid `BLOOM_STORAGE_BACKEND` both fail fast **through the boot-time validation path** (assert via the validator `server.main()` actually calls, not a standalone helper).
+- [x] 3.2 Resolve the local root (`BLOOM_STORAGE_LOCAL_ROOT` → `BLOOM_OUTPUT_DIR`) in `storage_backend.py`; extend **`experiment_utils.validate_env`** (already invoked by `server.main()` at `server.py:123-124`, and it owns the dir existence/writability checks) to validate the `BLOOM_STORAGE_BACKEND` value and, when `local`, the resolved root.
+- [x] 3.3 (green) Confirm 3.1 passes.
+
+## 4. Parity, integrity + workflow round-trip (TDD)
+
+- [x] 4.1 (red) Add a parity test (mirroring `result_store/test_store_parity.py`, whose oracle is the in-memory fake): the same write → manifest write/read → `list_prefix` → `get_run("latest")` round-trip yields equivalent observable results **and a byte-identical serialized manifest** across the fake and the local backend on a temp root; assert `/`-separated logical keys on every OS.
+- [x] 4.2 (red) Add a workflow round-trip test: run one workflow (e.g. qc) end-to-end with `BLOOM_STORAGE_BACKEND=local` against a temp root; assert real files exist under the root by storage key (outputs + `manifest.json`), the read path reads the run back **through `_resolve_versioned_cleaned`** (the `download_file` cleaned-CSV leg), and `sha256(<on-disk artifact>) == output_sha256` recorded in the manifest.
+- [x] 4.3 (red) Add guards: (a) default (unset) commit writes **no** files under a temp local root while the faked Supabase boundary receives the bytes; (b) a `local` run produces nothing at the legacy fallback path `<BLOOM_OUTPUT_DIR>/qc_<stem>/<stem>_cleaned.csv` (disjoint from `<root>/bloommcp_output/…`).
+- [x] 4.4 (green) Make 4.1–4.3 pass.
+
+## 5. Config wiring
+
+- [x] 5.1 Add commented `BLOOM_STORAGE_BACKEND` / `BLOOM_STORAGE_LOCAL_ROOT` to the `bloommcp` service env in `docker-compose.dev.yml` (default off; note the root falls back to the already-mounted `BLOOM_OUTPUT_DIR`). Keep them commented (not `${VAR}` references) so `scripts/validate_env.sh` / `tests/unit/test_env_defaults.py` need no `.env.*.defaults` entry.
+- [x] 5.2 Confirm `docker-compose.prod.yml` needs no change (default `supabase`; `local` is opt-in even though the prod `BLOOM_OUTPUT_DIR` bind mount is writable under `read_only`); add a one-line comment only if it aids parity review.
+
+## 6. Documentation
+
+- [x] 6.1 Add `bloommcp/docs/storage-backends.md`: default destination (Supabase Storage / MinIO in dev) + how to reach outputs (MinIO console, Supabase Studio, MCP read tools); explicit note that `BLOOM_OUTPUT_DIR` / `BLOOM_USE_LOCAL` do not produce local CSVs by default; the opt-in `local` backend, `BLOOM_STORAGE_LOCAL_ROOT` + fallback, the on-disk layout keyed by storage key, and a **do-not-mix-backends** warning (no cross-store view; version ids can collide).
+- [x] 6.2 Add the two new env vars to the bloommcp env-var reference in `_WIKI/BLOOMMCP/README.md` (and cross-link the new doc). Note the sibling relationship to #388 (user-facing upload/download builds on this same seam).
+
+## 7. Validate
+
+- [x] 7.1 `openspec validate add-bloommcp-local-storage-backend --strict`.
+- [x] 7.2 Run the full bloommcp unit suite (`uv run pytest` in `bloommcp/`) — all green, no live Supabase.
+- [x] 7.3 Run lint/format (ruff + black) on new/changed Python.
+- [x] 7.4 Verified the dev behavior via automated equivalents (stronger than a one-off manual docker run): `test_qc_workflow_local_roundtrip_with_hash_equality` drives a real workflow under `BLOOM_STORAGE_BACKEND=local` and asserts real files on disk by key + read-back; `test_default_path_writes_no_local_files` asserts the default path writes none. (A live `make dev-up` container check was not run.)


### PR DESCRIPTION
## Summary

Closes #386. bloommcp analysis outputs always went to Supabase Storage — there was **no way to write them as local files**, and the env vars people reach for (`BLOOM_OUTPUT_DIR`, `BLOOM_USE_LOCAL`) don't do what their names suggest, so `./bloommcp/data/ANALYSIS_OUTPUT` stays empty and outputs are invisible as files.

This adds an **opt-in local-filesystem storage backend**, selected by `BLOOM_STORAGE_BACKEND=local`, at the narrow object-storage seam in `bloom_mcp.supabase_client`. The default (`supabase`) path is byte-for-byte unchanged.

## What changed

- **New `bloom_mcp/storage_backend.py`** — a `StorageBackend` interface over the **five** object-storage helpers (`upload_file` / `download_file` / `write_json` / `read_json` / `list_prefix`), with `SupabaseStorageBackend` (deployed default) and `LocalStorageBackend` (opt-in). Selection via `BLOOM_STORAGE_BACKEND` (default `supabase`); resolution is lazy and import-pure.
- **`supabase_client.py`** — the five helpers now delegate to the active backend; names/signatures unchanged, so every caller and the `fake_supabase_storage` fixture keep working (verified — repointing was a no-op for callers).
- **`experiment_utils.validate_env`** — validates `BLOOM_STORAGE_BACKEND` and (when `local`) the resolved root at boot, via the validator `server.main()` already calls. An invalid value / unusable root fails fast.
- **Local root** = `BLOOM_STORAGE_LOCAL_ROOT`, falling back to `BLOOM_OUTPUT_DIR` — so `=local` needs no extra config in dev and finally populates `./bloommcp/data/ANALYSIS_OUTPUT`.
- **Docs** — new `bloommcp/docs/storage-backends.md` (where outputs really go, how to reach them, the opt-in backend, do-not-mix caveat) + a `_WIKI` env-var note. Clarifies `BLOOM_OUTPUT_DIR` / `BLOOM_USE_LOCAL` do **not** produce local CSVs.
- **`docker-compose.dev.yml`** — commented opt-in vars (default off; not `${VAR}` refs, so env-parity CI is unaffected).

## Object-store guarantees preserved on the filesystem

The local backend is not a dumb path-mapper — it reproduces the guarantees the object store gives for free:

- **Atomic writes** — temp file on the root's filesystem + `os.replace`, so a crash mid-write never corrupts `manifest.json` (the single catalog for all versions).
- **Verbatim bytes** — binary copy, no newline translation, so the recorded `output_sha256` equals the file on disk (nothing on the read path re-hashes).
- **Byte-identical provenance** manifest across backends; **upsert/overwrite**; **resolved-path escape guard** (absolute/`..`/symlink); **redacted errors** (no host paths).
- **Documented non-goal**: don't mix backends for one experiment (independent catalogs; version ids collide).

## Testing

New `tests/test_storage_backend.py` (34 tests) — selection + import-purity, local mechanics (mapping, `list_prefix` contract, escape guard, overwrite, verbatim bytes, atomicity), root resolution + boot-time fail-fast, parity (byte-identical manifest), a **full qc-workflow round-trip under `local`** asserting real files on disk + read-back through `_resolve_versioned_cleaned` + `sha256(on-disk) == output_sha256`, a default-writes-no-local-files guard, and legacy-fallback disjointness.

- **176** bloommcp unit tests pass (no live Supabase).
- **22** repo-root `tests/unit/test_supabase_client.py` pass (delegate repoint is backward-compatible).
- Lint/format clean (ruff 0.9.9 + black 26.3.1).

## Scope / non-goals

- Default `supabase` path is byte-for-byte unchanged; production/staging untouched (`local` is opt-in, off by default).
- **Out of scope:** PostgREST/table reads (`get_postgrest_client`), `read_input_csv` (rides that client), and raw-input reads from `BLOOM_TRAITS_DIR`. Only the five object-storage helpers are swapped.
- Related but separate: #388 (user-facing upload/download) will build signed-URL downloads on this same seam.

## OpenSpec

Implements `openspec/changes/add-bloommcp-local-storage-backend/` (proposal + design + tasks + `bloommcp-storage-backend` spec delta). Reviewed via the `openspec-review` 5-subagent pass and revised before implementation; `openspec validate --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
