### PR TITLE
chore(security): suppress 4 unreachable ffmpeg transitive CVEs (workflows image)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -106,3 +106,42 @@ CVE-2026-53260
 # upstream. Reassess on the next python:3.11-slim SHA bump.
 # Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-11940
 CVE-2026-11940
+
+# Mesa — libgbm1 / libglx-mesa0 / mesa-libgallium 25.0.7-2 (Debian 13 in python:3.11-slim) — affects: workflows
+# Out-of-bounds access in the Mesa GPU/OpenGL userspace driver. The workflows
+# service encodes H.264 in software (libx264) on the CPU, in a container with no
+# GPU and no OpenGL/EGL/GBM/display; ffmpeg never drives a Mesa render path, so
+# the affected code is unreachable at runtime. Mesa is a transitive dependency of
+# the Debian ffmpeg package. Debian marks this will_not_fix — no fixed Debian
+# version available. Reassess on the next python:3.11-slim / ffmpeg SHA bump.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-40393
+CVE-2026-40393
+
+# glib — libglib2.0-0t64 2.84.4-3~deb13u3 (Debian 13 in python:3.11-slim) — affects: workflows
+# Integer underflow in gio/gdbusintrospection.c while parsing D-Bus introspection
+# XML. The workflows service uses no D-Bus (no bus daemon, no GDBus connection);
+# glib is a transitive dependency of the Debian ffmpeg package and this code path
+# is never invoked at runtime. No fixed Debian version available upstream.
+# Reassess on the next python:3.11-slim / ffmpeg SHA bump.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-58016
+CVE-2026-58016
+
+# mbedtls — libmbedcrypto16 3.6.5-0.1~deb13u1 (Debian 13 in python:3.11-slim) — affects: workflows
+# Client impersonation during a TLS 1.3 handshake. mbedtls is only used by ffmpeg
+# for network inputs (https/rtmps/tls URLs); the service hands ffmpeg local file
+# paths and piped raw frames only, and its own HTTP/TLS runs through httpx→OpenSSL,
+# so the mbedtls TLS client path is never exercised. Transitive dependency of the
+# Debian ffmpeg package. No fixed Debian version available upstream. Reassess on the
+# next python:3.11-slim / ffmpeg SHA bump.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-34873
+CVE-2026-34873
+
+# mbedtls — libmbedcrypto16 3.6.5-0.1~deb13u1 (Debian 13 in python:3.11-slim) — affects: workflows
+# Arbitrary code execution in mbedtls / TF-PSA-Crypto, reachable only via the
+# mbedtls TLS/crypto path. ffmpeg uses mbedtls only for network (https/rtmps/tls)
+# inputs; the workflows service only ever encodes local files / piped raw frames
+# and does its own TLS via httpx→OpenSSL, so this path is never exercised.
+# Transitive dependency of the Debian ffmpeg package. No fixed Debian version
+# available upstream. Reassess on the next python:3.11-slim / ffmpeg SHA bump.
+# Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-34875
+CVE-2026-34875


### PR DESCRIPTION
## What

The `workflows` image is the only image that bundles **ffmpeg**. Debian's `ffmpeg` package pulls in Mesa, glib and mbedtls, which carry **4 CRITICAL CVEs with no fixed version available** — so `apt-get upgrade` cannot clear them. This PR suppresses them in `.trivyignore` with a documented reachability analysis for each.

| CVE | Package | What it is | Fix? |
|---|---|---|---|
| `CVE-2026-40393` | Mesa (`libgbm1`/`libglx-mesa0`/`mesa-libgallium`) | OOB in GPU/OpenGL driver | none — `will_not_fix` |
| `CVE-2026-58016` | glib (`libglib2.0-0t64`) | integer underflow in D-Bus introspection XML parsing | none |
| `CVE-2026-34873` | mbedtls (`libmbedcrypto16`) | client impersonation during TLS 1.3 | none |
| `CVE-2026-34875` | mbedtls (`libmbedcrypto16`) | arbitrary code execution | none |

## Why they are unreachable in this service

The workflows service encodes H.264 in **software (`libx264`) on the CPU**:

- **Mesa** — no GPU, no OpenGL/EGL/GBM, no display in the container; ffmpeg never drives a Mesa render path.
- **glib/D-Bus** — the service uses no D-Bus (no bus daemon, no GDBus connection); the vulnerable `gdbusintrospection.c` path is never invoked.
- **mbedtls** — ffmpeg uses mbedtls only for **network** inputs (`https`/`rtmps`/`tls`); the service only ever hands ffmpeg **local file paths and piped raw frames**, and its own HTTP/TLS runs through **httpx → OpenSSL**. The mbedtls TLS path is never exercised.

All four are transitive OS dependencies of the Debian ffmpeg package. Each `.trivyignore` entry records this analysis and links the upstream advisory, with a note to reassess on the next base-image / ffmpeg bump.

## Alternative considered — eliminate instead of suppress

The other option is to **stop installing Debian's `ffmpeg`** (which drags in Mesa/glib/mbedtls) and instead drop a **static `ffmpeg` binary** into the image via a multi-stage build (e.g. `COPY --from=<pinned static-ffmpeg image> /ffmpeg /usr/local/bin/ffmpeg`). A static build has zero apt dependencies, so those packages are **absent from the image entirely** — the 4 CVEs would not be present at all, and this suppression would be unnecessary (smaller image, too). Trade-off: a new pinned external base image to trust, and confirming the static build ships `libx264` (the common builds do).

Since there is **no fix to wait for**, either path is defensible: this PR suppresses with justification (repo's existing pattern for unreachable base-package CVEs); the static-ffmpeg route eliminates them outright. Happy to switch to the static build if that is preferred on review.

## Isolation

Touches **only** `.trivyignore`, per the CVE-change isolation rule.

## Dependency

PR #391 (authenticated on-demand cyl-scan video generation) depends on this — its `workflows` image fails the CRITICAL-CVE gate until these are merged. Once this lands on `staging`, #391 will be rebased so its Trivy gate goes green.