### PR TITLE
fix(auth): add bloom_workflows branch to custom_access_token_hook

### DIFF
--- a/supabase/migrations/20260703120000_add_bloom_workflows_jwt_hook_branch.sql
+++ b/supabase/migrations/20260703120000_add_bloom_workflows_jwt_hook_branch.sql
@@ -1,0 +1,64 @@
+-- JWT hook: adding a bloom_workflows branch so the workflows service actually runs
+-- least-privilege at runtime.
+--
+-- The workflows API signs in through GoTrue as its own app user. Without this
+-- branch, custom_access_token_hook (20260519140000) forces the JWT role claim to
+-- bloom_admin/bloom_writer/bloom_user, so PostgREST/Storage SET ROLE bloom_user
+-- and the dedicated bloom_workflows role + column-level grants never take effect.
+--
+-- bloom_workflows is a dedicated, non-interactive service identity — orthogonal
+-- to the human admin > writer > user hierarchy — so it is matched first. The flag
+-- lives in raw_app_meta_data (service-role-only, not user-writable from any client
+-- SDK), same trust model as is_admin / is_writer.
+--
+-- Idempotent — safe to re-apply.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  claims       JSONB;
+  is_admin     BOOLEAN;
+  is_writer    BOOLEAN;
+  is_workflows BOOLEAN;
+BEGIN
+  claims := event->'claims';
+
+  SELECT COALESCE(
+    (SELECT (raw_app_meta_data->>'is_admin')::boolean
+     FROM auth.users WHERE id = (claims->>'sub')::uuid),
+    false
+  ) INTO is_admin;
+
+  SELECT COALESCE(
+    (SELECT (raw_app_meta_data->>'is_writer')::boolean
+     FROM auth.users WHERE id = (claims->>'sub')::uuid),
+    false
+  ) INTO is_writer;
+
+  SELECT COALESCE(
+    (SELECT (raw_app_meta_data->>'is_workflows')::boolean
+     FROM auth.users WHERE id = (claims->>'sub')::uuid),
+    false
+  ) INTO is_workflows;
+
+  -- bloom_agent is set out-of-band via static JWT in BLOOM_AGENT_KEY, not here.
+  IF is_workflows THEN
+    claims := jsonb_set(claims, '{role}', '"bloom_workflows"');
+  ELSIF is_admin THEN
+    claims := jsonb_set(claims, '{role}', '"bloom_admin"');
+  ELSIF is_writer THEN
+    claims := jsonb_set(claims, '{role}', '"bloom_writer"');
+  ELSE
+    claims := jsonb_set(claims, '{role}', '"bloom_user"');
+  END IF;
+
+  event := jsonb_set(event, '{claims}', claims);
+  RETURN event;
+END;
+$function$;
+
+COMMIT;

--- a/tests/integration/test_workflows_jwt_hook.py
+++ b/tests/integration/test_workflows_jwt_hook.py
@@ -1,0 +1,46 @@
+"""Integration tests for the custom_access_token_hook role mapping.
+
+Verifies the runtime role a login token receives, against the live compose DB —
+in particular that raw_app_meta_data.is_workflows resolves to bloom_workflows
+(the B2 fix), and that the existing admin/writer/user mappings still hold.
+
+Seeds a temporary auth.users row, calls the hook, asserts, then rolls back so no
+row persists. Uses the `pg_conn` fixture (connects as supabase_admin).
+"""
+
+import json
+import uuid
+
+import pytest
+
+# (raw_app_meta_data flags) -> expected JWT role claim.
+CASES = [
+    ({"is_workflows": True}, "bloom_workflows"),
+    ({"is_admin": True}, "bloom_admin"),
+    ({"is_writer": True}, "bloom_writer"),
+    ({}, "bloom_user"),
+    # A service identity is distinct from the human hierarchy — workflows wins.
+    ({"is_workflows": True, "is_admin": True}, "bloom_workflows"),
+]
+
+
+@pytest.mark.parametrize("app_meta,expected_role", CASES)
+def test_custom_access_token_hook_role_mapping(pg_conn, app_meta, expected_role):
+    uid = str(uuid.uuid4())
+    try:
+        with pg_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO auth.users (id, raw_app_meta_data) VALUES (%s, %s::jsonb)",
+                (uid, json.dumps(app_meta)),
+            )
+            event = {"user_id": uid, "claims": {"sub": uid, "role": "authenticated"}}
+            cur.execute(
+                "SELECT public.custom_access_token_hook(%s::jsonb)",
+                (json.dumps(event),),
+            )
+            result = cur.fetchone()[0]
+    finally:
+        # Never persist the seeded user, pass or fail.
+        pg_conn.rollback()
+
+    assert result["claims"]["role"] == expected_role


### PR DESCRIPTION
## Why

The workflows video endpoint (#391) is built around a dedicated least-privilege DB role, `bloom_workflows`. Adding the bloom_workflow to the `custom_access_token_hook.

So when the service signs in as its own app user, PostgREST/Storage `SET ROLE bloom_user` — the `bloom_workflows` role and its column-level grants are **dead code at runtime**, and the service runs with broader privilege than intended.
## What

`CREATE OR REPLACE` the hook to add an `is_workflows` branch:

- Flag lives in `raw_app_meta_data` (service-role-only, not writable from any client SDK) — same trust model as `is_admin` / `is_writer`.
- `bloom_workflows` is a distinct, non-interactive service identity, so it's matched **before** the `admin > writer > user` hierarchy.
- Idempotent; `CREATE OR REPLACE` preserves the existing GoTrue execute grants.

## Sequencing
Merge **before #391**.