### PR TITLE
feat(bloommcp): upload input files to the bloommcp-data bucket

### DIFF
--- a/bloommcp/pyproject.toml
+++ b/bloommcp/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     "numpy>=2.3.2",
     "scipy>=1.10.0",
     "scikit-learn>=1.3.0",
+    # Uploaded-input formats (bloom_mcp.input_formats): pyarrow powers
+    "pyarrow>=17.0.0",
+    "openpyxl>=3.1.0",
     # Visualization
     "matplotlib>=3.7.0",
     "seaborn>=0.12.0",

--- a/bloommcp/src/bloom_mcp/data_access/fake_reader.py
+++ b/bloommcp/src/bloom_mcp/data_access/fake_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 import pandas as pd
@@ -34,6 +35,8 @@ class FakeReader:
         self._latest: dict[str, str] = {}
         # name -> experiment_name label
         self._exp_name: dict[str, str] = {}
+        # name -> uploaded input frame (bloommcp_input/ analogue)
+        self._uploaded: dict[str, pd.DataFrame] = {}
 
     # --- seeding -----------------------------------------------------------
 
@@ -47,6 +50,18 @@ class FakeReader:
         """Register a raw experiment frame under ``name``."""
         self._raw[name] = df.copy()
         self._exp_name[name] = experiment_name or _stem(name)
+
+    def add_uploaded_input(
+        self,
+        name: str,
+        df: pd.DataFrame,
+        *,
+        experiment_name: Optional[str] = None,
+    ) -> None:
+        """Register an uploaded input frame under ``name`` (the ``bloommcp_input/``
+        analogue). Resolves with source ``"uploaded"`` when no raw/cleaned exists."""
+        self._uploaded[name] = df.copy()
+        self._exp_name.setdefault(name, experiment_name or _stem(name))
 
     def add_cleaned_version(
         self,
@@ -89,31 +104,41 @@ class FakeReader:
             )
 
         raw = self._raw.get(name)
-        if raw is None:
-            raise ExperimentNotFoundError(f"Experiment {name!r} not found.")
-        return _frame(raw, "raw")
+        if raw is not None:
+            return _frame(raw, "raw")
+
+        uploaded = self._uploaded.get(name)
+        if uploaded is not None:
+            return _frame(uploaded, "uploaded")
+
+        raise ExperimentNotFoundError(f"Experiment {name!r} not found.")
 
     def list_experiments(self) -> list[ExperimentSummary]:
         summaries: list[ExperimentSummary] = []
+        # Raw first, then uploaded inputs not shadowed by a raw of the same name.
         for name, df in sorted(self._raw.items()):
-            detected = detect_columns(df)
-            summaries.append(
-                ExperimentSummary(
-                    filename=name,
-                    stem=_stem(name),
-                    rows=len(df),
-                    total_columns=len(df.columns),
-                    trait_columns=len(detected["trait_cols"]),
-                    experiment_name=self._exp_name.get(name, _stem(name)),
-                    genotype_col=detected["genotype_col"],
-                    sample_id_col=detected["sample_id_col"],
-                )
-            )
+            summaries.append(self._summary(name, df))
+        for name, df in sorted(self._uploaded.items()):
+            if name not in self._raw:
+                summaries.append(self._summary(name, df))
         return summaries
+
+    def _summary(self, name: str, df: pd.DataFrame) -> ExperimentSummary:
+        detected = detect_columns(df)
+        return ExperimentSummary(
+            filename=name,
+            stem=_stem(name),
+            rows=len(df),
+            total_columns=len(df.columns),
+            trait_columns=len(detected["trait_cols"]),
+            experiment_name=self._exp_name.get(name, _stem(name)),
+            genotype_col=detected["genotype_col"],
+            sample_id_col=detected["sample_id_col"],
+        )
 
 
 def _stem(name: str) -> str:
-    return name[:-4] if name.endswith(".csv") else name
+    return Path(name).stem
 
 
 def _frame(df: pd.DataFrame, source: str) -> ExperimentFrame:

--- a/bloommcp/src/bloom_mcp/data_access/supabase_reader.py
+++ b/bloommcp/src/bloom_mcp/data_access/supabase_reader.py
@@ -1,22 +1,32 @@
 """Supabase-backed :class:`ExperimentReader` — wraps the deployed read path.
 
 This adapter relocates ``experiment_utils.load_experiment_data`` behind the
-port: versioned-cleaned outputs from Supabase Storage, then the legacy
-un-versioned cleaned CSV, then the raw input. The raw-input read still comes
-from the local ``BLOOM_TRAITS_DIR`` and is **deprecated** — it emits a
-:class:`DeprecationWarning` so the follow-up that migrates inputs into
-``bloommcp_input/`` can remove it.
+port. Resolution order for a name:
+
+1. versioned-cleaned output from Supabase Storage (the QC manifest's latest),
+2. the legacy un-versioned cleaned CSV,
+3. the raw input from the local ``BLOOM_TRAITS_DIR`` — **deprecated**; it emits a
+   :class:`DeprecationWarning` and is removed once inputs fully move to
+   ``bloommcp_input/``,
+4. an **uploaded input** in ``bloommcp_input/`` (Supabase Storage), loaded via
+   the format registry so any registered format works, not just CSV.
+
+``list_experiments`` returns the local experiments plus any uploaded inputs.
 """
 
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
+from typing import Optional
 
+from bloom_mcp import input_formats
 from bloom_mcp.experiment_utils import (
     detect_columns,
     list_experiments as _list_experiments,
     load_experiment_data as _load_experiment_data,
 )
+from bloom_mcp.supabase_client import download_input, list_input_names
 
 from .ports import (
     CleanedVersionRequiredError,
@@ -29,6 +39,65 @@ _LOCAL_RAW_DEPRECATION = (
     "Reading raw experiment inputs from the local BLOOM_TRAITS_DIR is "
     "deprecated; inputs will move to Supabase Storage (bloommcp_input/)."
 )
+
+
+def _frame_from(df, config, source: str) -> ExperimentFrame:
+    return ExperimentFrame(
+        df=df,
+        trait_cols=config["trait_cols"],
+        metadata_cols=config["metadata_cols"],
+        genotype_col=config["genotype_col"],
+        replicate_col=config["replicate_col"],
+        sample_id_col=config["sample_id_col"],
+        source=source,
+    )
+
+
+def _load_uploaded(name: str) -> Optional[ExperimentFrame]:
+    """Resolve an uploaded input in `bloommcp_input/` via the format registry.
+
+    Returns ``None`` when the name is not a registered format, the object is
+    missing, or it does not parse — the caller then signals not-found. Storage
+    errors are swallowed so no bucket/path detail leaks to the caller.
+    """
+    if input_formats.get_format_by_filename(name) is None:
+        return None
+    try:
+        data = download_input(name)
+    except Exception:  # noqa: BLE001 - missing/unreadable object → fall through
+        return None
+    try:
+        df = input_formats.load_frame(name, data)
+    except input_formats.FormatError:
+        return None
+    return _frame_from(df, detect_columns(df), "uploaded")
+
+
+def _list_uploaded_summaries() -> list[ExperimentSummary]:
+    """List uploaded inputs (names only — not downloaded), skipping unregistered
+    formats. Numeric fields are 0/None until the file is actually loaded."""
+    try:
+        names = list_input_names()
+    except Exception:  # noqa: BLE001 - listing failure is not fatal to discovery
+        return []
+    summaries: list[ExperimentSummary] = []
+    for name in names:
+        if input_formats.get_format_by_filename(name) is None:
+            continue
+        stem = Path(name).stem
+        summaries.append(
+            ExperimentSummary(
+                filename=name,
+                stem=stem,
+                rows=0,
+                total_columns=0,
+                trait_columns=0,
+                experiment_name=stem,
+                genotype_col=None,
+                sample_id_col=None,
+            )
+        )
+    return summaries
 
 
 class SupabaseReader:
@@ -44,33 +113,31 @@ class SupabaseReader:
         df, _trait_cols, config, source_label = _load_experiment_data(
             name, require_clean=require_clean, version=version
         )
-        if df is None:
-            # `source_label` here is the raw error string from the deployed
-            # loader (may name a path); do NOT surface it. Raise a caller-safe
-            # message instead.
-            if require_clean:
-                raise CleanedVersionRequiredError(
-                    f"No cleaned dataset found for {name!r}; run the QC workflow first."
-                )
-            raise ExperimentNotFoundError(
-                f"Experiment {name!r} (version={version!r}) could not be resolved."
+        if df is not None:
+            if source_label == "raw":
+                warnings.warn(_LOCAL_RAW_DEPRECATION, DeprecationWarning, stacklevel=2)
+            return _frame_from(df, config, source_label)
+
+        # The deployed tiers (versioned/legacy cleaned, local raw) all missed.
+        # Try an uploaded input in bloommcp_input/ (multi-format) before
+        # signalling not-found. Uploaded inputs are raw, so only for latest/raw.
+        if not require_clean and version in ("latest", "raw"):
+            uploaded = _load_uploaded(name)
+            if uploaded is not None:
+                return uploaded
+
+        # `source_label` here may be the loader's raw error string (may name a
+        # path); do NOT surface it — raise a caller-safe message instead.
+        if require_clean:
+            raise CleanedVersionRequiredError(
+                f"No cleaned dataset found for {name!r}; run the QC workflow first."
             )
-
-        if source_label == "raw":
-            warnings.warn(_LOCAL_RAW_DEPRECATION, DeprecationWarning, stacklevel=2)
-
-        return ExperimentFrame(
-            df=df,
-            trait_cols=config["trait_cols"],
-            metadata_cols=config["metadata_cols"],
-            genotype_col=config["genotype_col"],
-            replicate_col=config["replicate_col"],
-            sample_id_col=config["sample_id_col"],
-            source=source_label,
+        raise ExperimentNotFoundError(
+            f"Experiment {name!r} (version={version!r}) could not be resolved."
         )
 
     def list_experiments(self) -> list[ExperimentSummary]:
-        return [
+        summaries = [
             ExperimentSummary(
                 filename=exp["filename"],
                 stem=exp["stem"],
@@ -83,6 +150,12 @@ class SupabaseReader:
             )
             for exp in _list_experiments()
         ]
+        seen = {s.filename for s in summaries}
+        for extra in _list_uploaded_summaries():
+            if extra.filename not in seen:
+                summaries.append(extra)
+                seen.add(extra.filename)
+        return summaries
 
 
 # Re-exported so consumers that need ad-hoc role detection use the same source

--- a/bloommcp/src/bloom_mcp/input_formats.py
+++ b/bloommcp/src/bloom_mcp/input_formats.py
@@ -1,0 +1,242 @@
+"""Registry of accepted input file formats for uploaded analysis inputs.
+
+Each registered format declares how to load its bytes into a DataFrame and how to
+validate a **bounded** prefix/schema without a full parse, so a multi-GB upload is
+never fully read just to confirm its type. Row-oriented formats (CSV/TSV/Excel/JSON)
+peek the first ``PEEK_ROWS`` rows; columnar formats (Parquet/Feather) validate via the
+footer schema and read no data rows.
+
+Pickle is deliberately absent — unpickling untrusted bytes executes arbitrary code, so
+it is not a registered (accepted) format.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Callable, Optional
+
+import pandas as pd
+
+# Rows read by the bounded validators for row-oriented formats.
+PEEK_ROWS = 50
+
+_MB = 1024 * 1024
+_GB = 1024 * _MB
+# Counts matrices reach ~1-2 GB; the default cap targets them. Row-oriented,
+# non-columnar formats (Excel/JSON) are never that large, so they cap lower.
+DEFAULT_MAX_SIZE = 2 * _GB
+DOCUMENT_MAX_SIZE = 200 * _MB
+
+# Size limit for the simple ``/uploads`` endpoint, which loads the whole file into
+# the server's memory before saving it. Files larger than this must use
+# ``/uploads/sign`` instead, where the client uploads straight to Storage and the
+# file never passes through the server's memory.
+MAX_BUFFERED_UPLOAD_SIZE = DOCUMENT_MAX_SIZE
+
+
+class FormatError(Exception):
+    """Base for input-format failures, carrying a caller-safe message.
+
+    Messages include only the caller-supplied filename and the format id — never a
+    bucket key, object path, or storage traceback.
+    """
+
+
+class UnsupportedFormatError(FormatError):
+    """The filename's extension is not a registered input format."""
+
+
+class FileTooLargeError(FormatError):
+    """The upload exceeds the registered format's maximum size."""
+
+
+class InvalidFormatError(FormatError):
+    """The bytes do not parse as the declared format."""
+
+
+@dataclass(frozen=True)
+class FormatSpec:
+    """One accepted input format: how to load it and how to peek it.
+
+    ``load`` returns the full DataFrame; ``peek`` returns a bounded validation frame
+    (first rows for row-oriented formats, an empty schema frame for columnar ones) and
+    raises when the bytes are not valid for the format.
+    """
+
+    id: str
+    extensions: tuple[str, ...]
+    mime: tuple[str, ...]
+    max_size: int
+    load: Callable[[bytes], pd.DataFrame]
+    peek: Callable[[bytes], pd.DataFrame]
+
+
+# ─── Loaders / bounded validators ─────────────────────────────────────────────
+
+
+def _load_csv(data: bytes) -> pd.DataFrame:
+    return pd.read_csv(io.BytesIO(data))
+
+
+def _peek_csv(data: bytes) -> pd.DataFrame:
+    return pd.read_csv(io.BytesIO(data), nrows=PEEK_ROWS)
+
+
+def _load_tsv(data: bytes) -> pd.DataFrame:
+    return pd.read_csv(io.BytesIO(data), sep="\t")
+
+
+def _peek_tsv(data: bytes) -> pd.DataFrame:
+    return pd.read_csv(io.BytesIO(data), sep="\t", nrows=PEEK_ROWS)
+
+
+def _load_excel(data: bytes) -> pd.DataFrame:
+    return pd.read_excel(io.BytesIO(data))
+
+
+def _peek_excel(data: bytes) -> pd.DataFrame:
+    return pd.read_excel(io.BytesIO(data), nrows=PEEK_ROWS)
+
+
+def _load_parquet(data: bytes) -> pd.DataFrame:
+    return pd.read_parquet(io.BytesIO(data))
+
+
+def _peek_parquet(data: bytes) -> pd.DataFrame:
+    """Read only the Parquet footer schema — no data rows."""
+    import pyarrow.parquet as pq
+
+    schema = pq.read_schema(io.BytesIO(data))
+    return pd.DataFrame(columns=list(schema.names))
+
+
+def _load_feather(data: bytes) -> pd.DataFrame:
+    return pd.read_feather(io.BytesIO(data))
+
+
+def _peek_feather(data: bytes) -> pd.DataFrame:
+    """Read only the Feather (Arrow IPC) schema — no data rows."""
+    import pyarrow.ipc as ipc
+
+    reader = ipc.open_file(io.BytesIO(data))
+    return pd.DataFrame(columns=list(reader.schema.names))
+
+
+def _load_json(data: bytes) -> pd.DataFrame:
+    return pd.read_json(io.BytesIO(data), orient="records")
+
+
+def _peek_json(data: bytes) -> pd.DataFrame:
+    # JSON-records is not a GB-scale target format; peek the head after parse.
+    return pd.read_json(io.BytesIO(data), orient="records").head(PEEK_ROWS)
+
+
+# ─── Registry ─────────────────────────────────────────────────────────────────
+
+_FORMATS: tuple[FormatSpec, ...] = (
+    FormatSpec("csv", (".csv",), ("text/csv",), DEFAULT_MAX_SIZE, _load_csv, _peek_csv),
+    FormatSpec(
+        "tsv",
+        (".tsv",),
+        ("text/tab-separated-values",),
+        DEFAULT_MAX_SIZE,
+        _load_tsv,
+        _peek_tsv,
+    ),
+    FormatSpec(
+        "excel",
+        (".xlsx",),
+        ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",),
+        DOCUMENT_MAX_SIZE,
+        _load_excel,
+        _peek_excel,
+    ),
+    FormatSpec(
+        "parquet",
+        (".parquet",),
+        ("application/vnd.apache.parquet", "application/octet-stream"),
+        DEFAULT_MAX_SIZE,
+        _load_parquet,
+        _peek_parquet,
+    ),
+    FormatSpec(
+        "feather",
+        (".feather",),
+        ("application/vnd.apache.arrow.file", "application/octet-stream"),
+        DEFAULT_MAX_SIZE,
+        _load_feather,
+        _peek_feather,
+    ),
+    FormatSpec(
+        "json",
+        (".json",),
+        ("application/json",),
+        DOCUMENT_MAX_SIZE,
+        _load_json,
+        _peek_json,
+    ),
+)
+
+_BY_EXT: dict[str, FormatSpec] = {ext: spec for spec in _FORMATS for ext in spec.extensions}
+_BY_ID: dict[str, FormatSpec] = {spec.id: spec for spec in _FORMATS}
+
+
+def registered_extensions() -> list[str]:
+    """Sorted list of accepted file extensions (e.g. ``[".csv", ".parquet", ...]``)."""
+    return sorted(_BY_EXT)
+
+
+def get_format_by_filename(filename: str) -> Optional[FormatSpec]:
+    """Return the :class:`FormatSpec` matching ``filename``'s extension, or ``None``."""
+    ext = PurePosixPath(filename).suffix.lower()
+    return _BY_EXT.get(ext)
+
+
+def get_format(format_id: str) -> Optional[FormatSpec]:
+    """Return the :class:`FormatSpec` with ``id == format_id``, or ``None``."""
+    return _BY_ID.get(format_id)
+
+
+def _resolve(filename: str) -> FormatSpec:
+    spec = get_format_by_filename(filename)
+    if spec is None:
+        raise UnsupportedFormatError(
+            f"unsupported input format for {filename!r}; accepted extensions: "
+            f"{', '.join(registered_extensions())}"
+        )
+    return spec
+
+
+def validate_upload(filename: str, data: bytes) -> pd.DataFrame:
+    """Bounded validation of ``data`` against ``filename``'s registered format.
+
+    Returns the peeked frame (first rows for row-oriented formats, an empty
+    schema-only frame for columnar ones). Raises:
+
+    - :class:`UnsupportedFormatError` if the extension is not registered,
+    - :class:`FileTooLargeError` if ``data`` exceeds the format's max size,
+    - :class:`InvalidFormatError` if the bytes do not parse as the format.
+    """
+    spec = _resolve(filename)
+    if len(data) > spec.max_size:
+        raise FileTooLargeError(f"upload exceeds the {spec.id} size limit")
+    try:
+        return spec.peek(data)
+    except FormatError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - map any parse failure to a caller-safe error
+        raise InvalidFormatError(f"bytes do not parse as {spec.id}") from exc
+
+
+def load_frame(filename: str, data: bytes) -> pd.DataFrame:
+    """Fully load ``data`` into a DataFrame using ``filename``'s registered loader.
+
+    Raises :class:`UnsupportedFormatError` / :class:`InvalidFormatError` on failure.
+    """
+    spec = _resolve(filename)
+    try:
+        return spec.load(data)
+    except Exception as exc:  # noqa: BLE001 - map any parse failure to a caller-safe error
+        raise InvalidFormatError(f"bytes do not parse as {spec.id}") from exc

--- a/bloommcp/src/bloom_mcp/input_formats.py
+++ b/bloommcp/src/bloom_mcp/input_formats.py
@@ -24,9 +24,11 @@ PEEK_ROWS = 50
 
 _MB = 1024 * 1024
 _GB = 1024 * _MB
-# Counts matrices reach ~1-2 GB; the default cap targets them. Row-oriented,
-# non-columnar formats (Excel/JSON) are never that large, so they cap lower.
-DEFAULT_MAX_SIZE = 2 * _GB
+# Counts matrices (CSV/TSV/Parquet/Feather) can be GB-scale, so those cap at
+# 5 GB — matching the bloommcp-data bucket's storage ceiling. Excel and JSON
+# aren't used for bulk matrices (Excel tops out near ~1M rows, JSON is too
+# verbose at that scale), so they cap lower.
+DEFAULT_MAX_SIZE = 5 * _GB
 DOCUMENT_MAX_SIZE = 200 * _MB
 
 # Size limit for the simple ``/uploads`` endpoint, which loads the whole file into

--- a/bloommcp/src/bloom_mcp/server.py
+++ b/bloommcp/src/bloom_mcp/server.py
@@ -34,14 +34,17 @@ Sections (per-package sub-servers, see bloom_mcp/sections/):
   - phenotyping_segmentation: Lin's segmentation tools (empty scaffold today)
 """
 
+import hmac
 import logging
 
 from fastmcp import FastMCP
 from fastmcp.utilities.lifespan import combine_lifespans
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse
+from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Mount
+
+from bloom_mcp import input_formats, uploads
 
 # Env validation is lazy (see supabase_client / experiment_utils validate_env):
 # importing this module no longer requires Supabase or the BLOOM_*_DIR env, so
@@ -131,6 +134,85 @@ def build_app() -> Starlette:
 
     lifespans = [combined_app.lifespan, *(a.lifespan for a in section_apps.values())]
     return Starlette(routes=routes, lifespan=combine_lifespans(*lifespans))
+
+
+# --- File upload surface ---
+# Plain HTTP routes (not MCP tools — tool calls can't carry file bytes), gated by
+# the same BLOOMMCP_API_KEY bearer as the MCP transport. Files land flat in
+# bloommcp_input/ under bloom_agent; per-user identity/namespacing is deferred (#406).
+
+
+def _authorized(request: Request) -> bool:
+    """Constant-time Bearer check against BLOOMMCP_API_KEY.
+
+    Mirrors the MCP transport's ApiKeyVerifier. When no API key is configured
+    (dev mode) the routes are open, matching the server's existing dev behavior.
+    """
+    if not API_KEY:
+        return True
+    header = request.headers.get("authorization", "")
+    prefix = "bearer "
+    token = header[len(prefix):] if header.lower().startswith(prefix) else ""
+    return bool(token) and hmac.compare_digest(token, API_KEY)
+
+
+@mcp.custom_route("/uploads", methods=["POST"])
+async def upload_input(request: Request) -> JSONResponse:
+    """Receive a small/moderate input file (multipart `file`), validate it, and
+    store it in bloommcp_input/. Large files should use `/uploads/sign` instead."""
+    if not _authorized(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    # Reject an oversized upload from its Content-Length before buffering the body
+    # into memory; direct it to the signed direct-to-Storage route instead.
+    oversized = uploads.buffered_limit_exceeded(request.headers.get("content-length"))
+    if oversized is not None:
+        return JSONResponse(
+            {
+                "error": (
+                    f"upload of {oversized} bytes exceeds the "
+                    f"{input_formats.MAX_BUFFERED_UPLOAD_SIZE}-byte limit for this "
+                    f"endpoint; use POST /uploads/sign for large files"
+                ),
+                "use": "/uploads/sign",
+            },
+            status_code=413,
+        )
+    form = await request.form()
+    upload = form.get("file")
+    if upload is None or not hasattr(upload, "filename"):
+        return JSONResponse({"error": "missing file"}, status_code=400)
+    data = await upload.read()
+    try:
+        result = uploads.receive_upload(upload.filename, data)
+    except input_formats.FileTooLargeError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=413)
+    except input_formats.FormatError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except Exception:  # noqa: BLE001 - never leak internals to the caller
+        logger.exception("input upload failed")
+        return JSONResponse({"error": "internal error"}, status_code=500)
+    return JSONResponse(result, status_code=201)
+
+
+@mcp.custom_route("/uploads/sign", methods=["POST"])
+async def sign_input_upload(request: Request) -> JSONResponse:
+    """Mint a scoped signed upload URL for a large input so the client streams
+    directly to Storage. Body: `{"filename": "<name.ext>"}`."""
+    if not _authorized(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001 - malformed body
+        body = {}
+    filename = (body or {}).get("filename", "")
+    try:
+        result = uploads.signed_input_upload(filename)
+    except input_formats.FormatError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except Exception:  # noqa: BLE001 - never leak internals to the caller
+        logger.exception("signed upload url failed")
+        return JSONResponse({"error": "internal error"}, status_code=500)
+    return JSONResponse(result, status_code=200)
 
 
 # --- Entry Point ---

--- a/bloommcp/src/bloom_mcp/supabase_client.py
+++ b/bloommcp/src/bloom_mcp/supabase_client.py
@@ -6,16 +6,26 @@ prefix decisions in one place means future tools cannot accidentally
 upload to the wrong bucket, hit Supabase as service_role, or skip the
 required input/output prefix.
 
-Public surface (exactly three functions):
+Input read/write surface (all take a bare basename — the `bloommcp_input/`
+prefix is added here; a `name` containing `/` raises ValueError so a tool
+cannot cross prefixes or escape the bucket):
+
+    download_input(name)             → raw bytes of `bloommcp_input/{name}`,
+                                       ANY registered format. This is the
+                                       multi-format read the reader uses; the
+                                       bytes are turned into a DataFrame by
+                                       `bloom_mcp.input_formats.load_frame`
+                                       (CSV/TSV/Parquet/Feather/Excel/JSON).
+    read_input_csv(name)             → DataFrame from `bloommcp_input/{name}`,
+                                       CSV ONLY. Legacy convenience, superseded
+                                       by `download_input` + the format registry.
+    write_input(name, data)          → upload small input bytes (backend path).
+    create_signed_upload_url(name)   → scoped signed URL for a large, direct-to-
+                                       Storage upload (no backend buffering).
+    list_input_names()               → basenames under `bloommcp_input/`.
 
     get_postgrest_client()           → supabase.Client authenticated as
-                                       bloom_agent. Use for table reads
-                                       via PostgREST. Construct fresh per
-                                       call; do not cache.
-
-    read_input_csv(name)             → pd.DataFrame loaded from object
-                                       `bloommcp_input/{name}` in the
-                                       `bloommcp-data` bucket.
+                                       bloom_agent, for table reads via PostgREST.
 
 For tool outputs, use `AnalysisWriter` instead — it routes through the
 versioned `bloommcp_output/<tool_class>_<stem>/v<N>_<date>_<slug>/`
@@ -23,17 +33,13 @@ prefix and updates `manifest.json`. The generic storage helpers below
 (`upload_file`, `write_json`, etc.) take a fully-qualified `key` and are
 called by `AnalysisWriter.commit()`; they are not meant for direct use
 by tools.
-
-`name` for `read_input_csv` is always a basename (no slashes). The
-helper prepends the input prefix. Passing a key that contains `/` raises
-ValueError so a tool cannot accidentally cross prefixes or escape the
-bucket.
 """
 
 from __future__ import annotations
 
 import io
 import os
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -160,6 +166,28 @@ def create_signed_upload_url(name: str) -> dict:
     _validate_name(name)
     client = get_storage_client()
     return client.create_signed_upload_url(f"{INPUT_PREFIX}{name}")
+
+
+def download_input(name: str) -> bytes:
+    """Return the raw bytes of `bloommcp_input/{name}` (any registered format).
+
+    The multi-format read companion to `read_input_csv` / `write_input`, used by
+    the reader to resolve an uploaded input. Routes through the active storage
+    backend (so the `fake_supabase_storage` fixture covers it). Raises if the
+    object is missing.
+    """
+    _validate_name(name)
+    tmp = Path(tempfile.NamedTemporaryFile(delete=False).name)
+    try:
+        download_file(f"{INPUT_PREFIX}{name}", tmp)
+        return tmp.read_bytes()
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def list_input_names() -> list[str]:
+    """List basenames of objects directly under `bloommcp_input/`."""
+    return list_prefix(INPUT_PREFIX)
 
 
 # ─── Generic storage helpers ──────────────────────────────────────────────────

--- a/bloommcp/src/bloom_mcp/supabase_client.py
+++ b/bloommcp/src/bloom_mcp/supabase_client.py
@@ -127,6 +127,41 @@ def read_input_csv(name: str) -> pd.DataFrame:
     return pd.read_csv(io.BytesIO(payload))
 
 
+def write_input(name: str, data: bytes) -> str:
+    """Upload input `data` to `bloommcp_input/{name}` in `bloommcp-data`.
+
+    The write twin of `read_input_csv`, used by the upload surface for small
+    files that pass through the backend. `name` is a bare basename (no slashes);
+    the input prefix is added here. Overwrites if it exists (flat, shared
+    namespace — per-user isolation is deferred). Returns `name` as the input
+    reference the analysis tools use.
+    """
+    _validate_name(name)
+    client = get_storage_client()
+    client.upload(
+        path=f"{INPUT_PREFIX}{name}",
+        file=data,
+        file_options={
+            "content-type": _guess_content_type(Path(name)),
+            "upsert": "true",
+        },
+    )
+    return name
+
+
+def create_signed_upload_url(name: str) -> dict:
+    """Mint a scoped signed upload URL for `bloommcp_input/{name}`.
+
+    Lets a client upload bytes **directly to Storage** (no backend buffering) to
+    exactly this one key, without holding the `bloom_agent` credential. `name` is
+    a bare basename (no slashes). Returns the storage client's response (the
+    signed URL, its token, and the path).
+    """
+    _validate_name(name)
+    client = get_storage_client()
+    return client.create_signed_upload_url(f"{INPUT_PREFIX}{name}")
+
+
 # ─── Generic storage helpers ──────────────────────────────────────────────────
 #
 # These six helpers are the storage primitives AnalysisWriter uses to store

--- a/bloommcp/src/bloom_mcp/uploads.py
+++ b/bloommcp/src/bloom_mcp/uploads.py
@@ -1,0 +1,76 @@
+"""Receive and register uploaded analysis inputs (auth-deferred, flat namespace).
+
+Files land at ``bloommcp_input/<name>`` under ``bloom_agent``. Small files pass
+through the backend and are validated in memory (:func:`receive_upload`); large
+files use a scoped signed upload URL so the client streams **directly to Storage**
+(:func:`signed_input_upload`), with content validated lazily when the reader loads
+the object. Per-user identity/namespacing is deferred (#406) — the namespace is flat
+and shared, so a same-named upload overwrites.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from bloom_mcp import input_formats, supabase_client
+
+
+def buffered_limit_exceeded(content_length: str | None) -> int | None:
+    """Return the declared upload size if it exceeds the buffered-route cap, else
+    ``None`` — so the ``/uploads`` route can reject an oversized file from its
+    ``Content-Length`` **before** reading the body into memory.
+
+    ``None`` when the header is absent or unparseable (nothing to pre-check): the
+    per-format cap still applies after buffering, and large files should use the
+    signed-URL path regardless.
+    """
+    if content_length is None:
+        return None
+    try:
+        size = int(content_length)
+    except ValueError:
+        return None
+    return size if size > input_formats.MAX_BUFFERED_UPLOAD_SIZE else None
+
+
+def _basename(filename: str) -> str:
+    """Strip any directory components so an upload cannot target a sub-path."""
+    name = PurePosixPath(filename or "").name
+    if not name:
+        raise input_formats.UnsupportedFormatError("upload filename is empty")
+    return name
+
+
+def receive_upload(filename: str, data: bytes) -> dict:
+    """Validate an uploaded input (bounded peek) and store it flat in
+    ``bloommcp_input/``.
+
+    Returns ``{"input_ref", "format", "columns"}``. Raises
+    :class:`input_formats.FormatError` subclasses on an unsupported, oversize, or
+    unparseable upload — the caller maps these to structured HTTP errors.
+    """
+    name = _basename(filename)
+    peek = input_formats.validate_upload(name, data)
+    spec = input_formats.get_format_by_filename(name)
+    ref = supabase_client.write_input(name, data)
+    return {"input_ref": ref, "format": spec.id, "columns": list(peek.columns)}
+
+
+def signed_input_upload(filename: str) -> dict:
+    """Validate the format is registered and mint a scoped signed upload URL.
+
+    The client uploads bytes directly to ``bloommcp_input/<name>``; content is
+    validated lazily when the reader loads the object (the large-file path avoids
+    buffering GB through the backend). Returns
+    ``{"input_ref", "format", "upload"}``. Raises
+    :class:`input_formats.UnsupportedFormatError` for an unregistered format.
+    """
+    name = _basename(filename)
+    spec = input_formats.get_format_by_filename(name)
+    if spec is None:
+        raise input_formats.UnsupportedFormatError(
+            f"unsupported input format for {name!r}; accepted extensions: "
+            f"{', '.join(input_formats.registered_extensions())}"
+        )
+    signed = supabase_client.create_signed_upload_url(name)
+    return {"input_ref": name, "format": spec.id, "upload": signed}

--- a/bloommcp/tests/data_access/test_fake_reader.py
+++ b/bloommcp/tests/data_access/test_fake_reader.py
@@ -84,3 +84,36 @@ def test_list_experiments_empty_then_populated():
     assert summaries[0].experiment_name == "My Exp"
     assert summaries[0].trait_columns == 2
     assert summaries[0].genotype_col == "Genotype"
+
+
+# --- uploaded inputs (bloommcp_input/ analogue) --------------------------------
+
+
+def test_uploaded_input_loads_with_declared_roles():
+    reader = FakeReader()
+    reader.add_uploaded_input("counts.parquet", _raw())
+
+    frame = reader.load_experiment("counts.parquet")
+    assert frame.source == "uploaded"
+    assert set(frame.trait_cols) == {"trait_x", "trait_y"}
+    assert frame.genotype_col == "Genotype"
+
+
+def test_raw_shadows_uploaded_of_same_name():
+    reader = FakeReader()
+    reader.add_uploaded_input("exp.csv", _raw().iloc[:1])
+    reader.add_experiment("exp.csv", _raw())
+    assert reader.load_experiment("exp.csv").source == "raw"
+
+
+def test_uploaded_input_appears_in_list():
+    reader = FakeReader()
+    reader.add_uploaded_input("counts.parquet", _raw())
+    names = [s.filename for s in reader.list_experiments()]
+    assert "counts.parquet" in names
+
+
+def test_missing_uploaded_is_not_found():
+    reader = FakeReader()
+    with pytest.raises(ExperimentNotFoundError):
+        reader.load_experiment("counts.parquet")

--- a/bloommcp/tests/data_access/test_supabase_reader.py
+++ b/bloommcp/tests/data_access/test_supabase_reader.py
@@ -50,3 +50,40 @@ def test_unknown_experiment_raises_not_found(
     reader = SupabaseReader()
     with pytest.raises(ExperimentNotFoundError):
         reader.load_experiment("nope.csv")
+
+
+def _seed_uploaded_parquet(store, name: str, df: pd.DataFrame) -> None:
+    import io
+
+    buf = io.BytesIO()
+    df.to_parquet(buf)
+    store.objects[f"bloommcp_input/{name}"] = buf.getvalue()
+
+
+def test_resolves_uploaded_input_multi_format(
+    fake_supabase_storage, tmp_path, monkeypatch
+):
+    import bloom_mcp.experiment_utils as eu
+
+    monkeypatch.setattr(eu, "TRAITS_DIR", tmp_path)  # empty local raw
+    df = pd.DataFrame({"Genotype": ["g0", "g1"], "trait_x": [1.0, 2.0]})
+    _seed_uploaded_parquet(fake_supabase_storage, "counts.parquet", df)
+
+    frame = SupabaseReader().load_experiment("counts.parquet")
+    assert frame.source == "uploaded"
+    assert "trait_x" in frame.trait_cols
+    assert list(frame.df.columns) == ["Genotype", "trait_x"]
+
+
+def test_lists_uploaded_inputs(fake_supabase_storage, tmp_path, monkeypatch):
+    import bloom_mcp.experiment_utils as eu
+
+    monkeypatch.setattr(eu, "TRAITS_DIR", tmp_path)
+    _seed_uploaded_parquet(
+        fake_supabase_storage,
+        "counts.parquet",
+        pd.DataFrame({"Genotype": ["g"], "trait": [1.0]}),
+    )
+
+    names = [s.filename for s in SupabaseReader().list_experiments()]
+    assert "counts.parquet" in names

--- a/bloommcp/tests/test_input_formats.py
+++ b/bloommcp/tests/test_input_formats.py
@@ -1,0 +1,117 @@
+"""Format-registry oracle + edge cases (bloom_mcp.input_formats)."""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+
+import pandas as pd
+import pytest
+
+from bloom_mcp import input_formats as fmt
+
+
+def _frame(rows: int = 3) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "genotype": [f"g{i % 2}" for i in range(rows)],
+            "trait_x": [float(i) for i in range(rows)],
+            "trait_y": [float(i) * 2 for i in range(rows)],
+        }
+    )
+
+
+def _to_bytes(df: pd.DataFrame, fmt_id: str) -> bytes:
+    buf = io.BytesIO()
+    if fmt_id == "csv":
+        return df.to_csv(index=False).encode()
+    if fmt_id == "tsv":
+        return df.to_csv(sep="\t", index=False).encode()
+    if fmt_id == "excel":
+        df.to_excel(buf, index=False)
+    elif fmt_id == "parquet":
+        df.to_parquet(buf)
+    elif fmt_id == "feather":
+        df.to_feather(buf)
+    elif fmt_id == "json":
+        return df.to_json(orient="records").encode()
+    else:  # pragma: no cover - guard
+        raise AssertionError(fmt_id)
+    return buf.getvalue()
+
+
+ALL_FORMATS = ["csv", "tsv", "excel", "parquet", "feather", "json"]
+ROW_ORIENTED = ["csv", "tsv", "excel", "json"]
+COLUMNAR = ["parquet", "feather"]
+
+
+# ─── Registry membership ──────────────────────────────────────────────────────
+
+
+def test_registered_extensions_cover_the_set_and_exclude_pickle():
+    exts = fmt.registered_extensions()
+    for ext in (".csv", ".tsv", ".xlsx", ".parquet", ".feather", ".json"):
+        assert ext in exts
+    assert ".pkl" not in exts and ".pickle" not in exts
+
+
+@pytest.mark.parametrize("ext", [".pkl", ".pickle", ".txt", ".h5", ""])
+def test_unregistered_extension_is_rejected(ext):
+    with pytest.raises(fmt.UnsupportedFormatError):
+        fmt.validate_upload(f"data{ext}", b"anything")
+    with pytest.raises(fmt.UnsupportedFormatError):
+        fmt.load_frame(f"data{ext}", b"anything")
+
+
+# ─── Load round-trips ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("fmt_id", ALL_FORMATS)
+def test_load_frame_round_trips(fmt_id):
+    df = _frame(3)
+    loaded = fmt.load_frame(f"exp.{'xlsx' if fmt_id == 'excel' else fmt_id}", _to_bytes(df, fmt_id))
+    assert list(loaded.columns) == list(df.columns)
+    assert len(loaded) == len(df)
+    assert loaded["genotype"].tolist() == df["genotype"].tolist()
+
+
+# ─── Bounded validation ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("fmt_id", ROW_ORIENTED)
+def test_row_oriented_peek_is_bounded(fmt_id):
+    df = _frame(fmt.PEEK_ROWS * 4)
+    peek = fmt.validate_upload(
+        f"big.{'xlsx' if fmt_id == 'excel' else fmt_id}", _to_bytes(df, fmt_id)
+    )
+    assert list(peek.columns) == list(df.columns)
+    assert len(peek) <= fmt.PEEK_ROWS
+
+
+@pytest.mark.parametrize("fmt_id", COLUMNAR)
+def test_columnar_peek_reads_schema_only(fmt_id):
+    df = _frame(500)
+    peek = fmt.validate_upload(f"big.{fmt_id}", _to_bytes(df, fmt_id))
+    # schema-only: correct columns, zero data rows read
+    assert list(peek.columns) == list(df.columns)
+    assert len(peek) == 0
+
+
+@pytest.mark.parametrize("fmt_id", COLUMNAR)
+def test_invalid_bytes_raise_invalid_format(fmt_id):
+    with pytest.raises(fmt.InvalidFormatError):
+        fmt.validate_upload(f"corrupt.{fmt_id}", b"this is not a valid columnar file")
+
+
+def test_oversize_upload_is_rejected(monkeypatch):
+    tiny = dataclasses.replace(fmt.get_format("csv"), max_size=10)
+    monkeypatch.setitem(fmt._BY_EXT, ".csv", tiny)
+    with pytest.raises(fmt.FileTooLargeError):
+        fmt.validate_upload("big.csv", b"genotype,trait_x\n" + b"a,1\n" * 100)
+
+
+def test_within_size_limit_passes(monkeypatch):
+    tiny = dataclasses.replace(fmt.get_format("csv"), max_size=10_000)
+    monkeypatch.setitem(fmt._BY_EXT, ".csv", tiny)
+    peek = fmt.validate_upload("ok.csv", _to_bytes(_frame(3), "csv"))
+    assert len(peek) == 3

--- a/bloommcp/tests/test_uploads.py
+++ b/bloommcp/tests/test_uploads.py
@@ -1,0 +1,136 @@
+"""Upload surface: receive_upload / signed_input_upload core + supabase_client
+write helpers, against a monkeypatched storage boundary (no live Supabase)."""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+
+import pandas as pd
+import pytest
+
+from bloom_mcp import input_formats, supabase_client, uploads
+
+
+def _csv_bytes(rows: int = 3) -> bytes:
+    df = pd.DataFrame({"genotype": ["g"] * rows, "trait_x": list(range(rows))})
+    return df.to_csv(index=False).encode()
+
+
+class _FakeStorage:
+    """Records uploads and returns a canned signed-upload response."""
+
+    def __init__(self):
+        self.uploaded: list[tuple[str, bytes]] = []
+        self.signed: list[str] = []
+
+    def upload(self, *, path, file, file_options):
+        self.uploaded.append((path, file))
+
+    def create_signed_upload_url(self, path):
+        self.signed.append(path)
+        return {"signed_url": f"https://storage/signed/{path}", "token": "tok", "path": path}
+
+
+@pytest.fixture
+def storage(monkeypatch):
+    fake = _FakeStorage()
+    monkeypatch.setattr(supabase_client, "get_storage_client", lambda: fake)
+    return fake
+
+
+# ─── receive_upload (small-file path) ─────────────────────────────────────────
+
+
+def test_receive_upload_stores_and_returns_reference(storage):
+    result = uploads.receive_upload("accessions.csv", _csv_bytes(3))
+    assert result["input_ref"] == "accessions.csv"
+    assert result["format"] == "csv"
+    assert result["columns"] == ["genotype", "trait_x"]
+    # landed under the input prefix, flat
+    assert storage.uploaded == [("bloommcp_input/accessions.csv", _csv_bytes(3))]
+
+
+def test_receive_upload_strips_directory_to_basename(storage):
+    uploads.receive_upload("sub/dir/exp.csv", _csv_bytes(2))
+    assert storage.uploaded[0][0] == "bloommcp_input/exp.csv"
+
+
+def test_receive_upload_rejects_unregistered_format(storage):
+    with pytest.raises(input_formats.UnsupportedFormatError):
+        uploads.receive_upload("model.pkl", b"anything")
+    assert storage.uploaded == []
+
+
+def test_receive_upload_rejects_oversize(monkeypatch, storage):
+    tiny = dataclasses.replace(input_formats.get_format("csv"), max_size=5)
+    monkeypatch.setitem(input_formats._BY_EXT, ".csv", tiny)
+    with pytest.raises(input_formats.FileTooLargeError):
+        uploads.receive_upload("big.csv", _csv_bytes(50))
+    assert storage.uploaded == []
+
+
+def test_receive_upload_rejects_invalid_bytes(storage):
+    with pytest.raises(input_formats.InvalidFormatError):
+        uploads.receive_upload("corrupt.parquet", b"not a parquet file")
+    assert storage.uploaded == []
+
+
+# ─── signed_input_upload (large-file path) ────────────────────────────────────
+
+
+def test_signed_input_upload_mints_scoped_url(storage):
+    result = uploads.signed_input_upload("counts.parquet")
+    assert result["input_ref"] == "counts.parquet"
+    assert result["format"] == "parquet"
+    assert result["upload"]["path"] == "bloommcp_input/counts.parquet"
+    assert storage.signed == ["bloommcp_input/counts.parquet"]
+
+
+def test_signed_input_upload_rejects_unregistered(storage):
+    with pytest.raises(input_formats.UnsupportedFormatError):
+        uploads.signed_input_upload("weights.pkl")
+    assert storage.signed == []
+
+
+# ─── Content-Length guard (reject before buffering) ──────────────────────────
+
+
+def test_buffered_limit_exceeded_flags_oversize():
+    over = input_formats.MAX_BUFFERED_UPLOAD_SIZE + 1
+    assert uploads.buffered_limit_exceeded(str(over)) == over
+
+
+def test_buffered_limit_allows_within_cap():
+    assert uploads.buffered_limit_exceeded(str(input_formats.MAX_BUFFERED_UPLOAD_SIZE)) is None
+    assert uploads.buffered_limit_exceeded("1024") is None
+
+
+def test_buffered_limit_ignores_absent_or_unparseable_header():
+    assert uploads.buffered_limit_exceeded(None) is None
+    assert uploads.buffered_limit_exceeded("not-a-number") is None
+
+
+# ─── supabase_client write helpers ────────────────────────────────────────────
+
+
+def test_write_input_uses_input_prefix(storage):
+    ref = supabase_client.write_input("exp.csv", b"a,b\n1,2\n")
+    assert ref == "exp.csv"
+    assert storage.uploaded[0][0] == "bloommcp_input/exp.csv"
+
+
+def test_write_input_rejects_slash():
+    with pytest.raises(ValueError):
+        supabase_client.write_input("a/b.csv", b"x")
+
+
+def test_create_signed_upload_url_scopes_to_key(storage):
+    out = supabase_client.create_signed_upload_url("counts.parquet")
+    assert out["path"] == "bloommcp_input/counts.parquet"
+    assert storage.signed == ["bloommcp_input/counts.parquet"]
+
+
+def test_create_signed_upload_url_rejects_slash():
+    with pytest.raises(ValueError):
+        supabase_client.create_signed_upload_url("a/b.parquet")

--- a/bloommcp/uv.lock
+++ b/bloommcp/uv.lock
@@ -114,7 +114,9 @@ dependencies = [
     { name = "httpx" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "pandas" },
+    { name = "pyarrow" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -142,7 +144,9 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=2.3.2" },
+    { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -1772,6 +1776,56 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds the ability for a client to **upload input data files to bloommcp storage** (the `bloommcp-data` bucket, `bloommcp_input/` prefix) and lets the analysis tools read those uploaded files back. This is the input half of the bloommcp file-exchange workflow.

## The two upload routes

Both are **plain HTTP routes** (`@mcp.custom_route`, *not* MCP tools) hit **directly by the client** — not by the LLM or by other tools, because MCP tool calls (JSON-RPC) can't carry raw file bytes. Both land the file at `bloommcp_input/<name>` via the **Supabase Storage API**, gated by the `BLOOMMCP_API_KEY` bearer (open in dev when no key is set). They differ by file size:

**`POST /uploads` — small/moderate files (≤ 200 MB), server-mediated**
- Client POSTs the file bytes (multipart `file`).
- Server buffers them, validates with a **bounded peek** (confirms the file parses as its format and extracts its columns), then writes to Storage via `client.upload(...)`.
- Returns `{input_ref, format, columns}` — schema is known immediately.
- Bytes pass **through** the server, so it's capped at 200 MB. A `Content-Length` pre-check bounces bigger files to `/uploads/sign` *before* buffering the body.
- Advantages: fail-fast validation, immediate schema feedback, single round-trip.

**`POST /uploads/sign` — large files (up to 5 GB), direct-to-Storage**
- Client POSTs just `{"filename": "<name.ext>"}`.
- Server validates the extension is a registered format and mints a **scoped signed upload URL** (`create_signed_upload_url` — a JWT-signed URL to the Storage API, scoped to that one object key, short-lived).
- Returns `{input_ref, format, upload}`; the client then makes a **second request** — a direct `PUT` of the bytes to the signed URL.
- Bytes go **client → Storage API directly**; the server never buffers them (no memory pressure, no GB streamed through the container). The client never holds the `bloom_agent` credential.
- Content validation is **deferred** to read-time, since the server never sees the bytes.

| | `/uploads` | `/uploads/sign` |
|---|---|---|
| Client sends | file bytes | filename |
| Who carries bytes to the Storage API | the **server** | the **client** (direct PUT) |
| Validation | at upload (fail-fast) | deferred to read-time |
| Returns | `format` + `columns` | signed upload ticket |
| Round-trips | 1 | 2 |
| Size | ≤ 200 MB | up to 5 GB |

Both write through the Supabase **Storage API**; MinIO/S3 is the Storage service's backend, invisible to the client.

## Included (2 commits + a follow-up)

**1. Input upload surface + format registry** — the two routes above, `input_formats.py` (registry + bounded-peek validation) and `uploads.py` helpers; `supabase_client` gains `write_input`, `create_signed_upload_url`, `list_input_names`.

**2. Resolve uploaded inputs for analysis** — `SupabaseReader` / `FakeReader` resolve an uploaded input by name across the supported formats, so an uploaded file can be consumed by the analysis tools.

**Follow-up commit** — corrected the input size-cap comment and aligned `DEFAULT_MAX_SIZE` to 5 GB (the `bloommcp-data` ceiling).

## Dependencies

- Bucket + `bloom_agent` write policies (`bloommcp-data`, INSERT/UPDATE scoped to that bucket) — already in `staging` (migration `20260605000000`). No new migration here.
- The **5 GB** ceiling in the table above depends on the storage-limit PR (#417). Until that lands, the effective cap is the current global (500 MB).

## Not included

The output/result download half (signed result URLs + result-discovery tool) is intentionally deferred to a follow-up. This PR is scoped to input upload + resolution.

## Tests

- 50 targeted tests: format registry, upload routes incl. the `Content-Length` guard, and multi-format uploaded-input resolution.
- Full bloommcp suite green (289 passed) on this branch.

## Notes

- Files land flat in `bloommcp_input/` under the shared `bloom_agent` role; per-user identity/namespacing is deferred (#406).
- `server.py` was merged against the current section-scaffold `build_app()`: the upload routes and `build_app()` coexist (routes registered on the combined surface via `@mcp.custom_route`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
