### PR TITLE
feat(db): enable pgmq for Postgres-native durable queues

### DIFF
--- a/supabase/migrations/20260715000000_enable_pgmq.sql
+++ b/supabase/migrations/20260715000000_enable_pgmq.sql
@@ -1,0 +1,13 @@
+-- Enable pgmq (Postgres Message Queue) — the queue engine behind Supabase Queues.
+-- Gives SQS-style durable queues natively in Postgres: send/read with a
+-- visibility timeout, retries, and archival, consumed pull-style by a worker.
+--
+-- Enabling the extension only creates the `pgmq` schema and its management
+-- functions; it does NOT create any queues. A follow-up PR adds the queued
+-- video-generation route and will create its queue + grant the workflows role
+-- the pgmq functions it needs.
+--
+-- Available since supabase/postgres 15.6.1.143 (dev 15.8.1.060, prod 15.14.1.104
+-- both qualify). Idempotent — safe to re-apply.
+
+CREATE EXTENSION IF NOT EXISTS pgmq;


### PR DESCRIPTION
## What

Enables the **`pgmq`** extension — the queue engine behind [Supabase Queues](https://supabase.com/docs/guides/queues) — so upcoming workflow routes can use **SQS-style durable queues** natively in Postgres (send/read with a visibility timeout, retries, archival), with no external queue service.

This only creates the `pgmq` schema + its management functions. **No queues are created here**, and no role grants are added yet.

## Why a draft / why separate

This is the infrastructure step. The **follow-up PR** adds the queued video-generation route (the async counterpart to the on-demand route in #391) — it will create its queue (`pgmq.create(...)`), grant the workflows role the pgmq functions it needs, and wire up the consumer/worker. Splitting the extension-enable from the feature keeps this reviewable on its own.

refer : https://github.com/pgmq/pgmq#visibility-timeout-vt for building queue

## Verification

Applied against the live dev stack and smoke-tested the queue API:

- `CREATE EXTENSION` → `pgmq v1.4.4` installed
- `pgmq.create()` → `pgmq.send()` (msg_id) → `pgmq.read()` returned the message
- visibility-timeout semantics behave correctly (a `pop` right after a `read` finds nothing while the message is still invisible)
- test queue dropped — no residue

## Context

Follows the queue discussion in #404 (A4 pipeline / run tracking). `pgmq` is the durable-queue option there; the alternative for simple cases is the `SELECT … FOR UPDATE SKIP LOCKED` table pattern (what `video_jobs` already uses).