### PR TITLE
feat(storage): scope bloommcp-data uploads to 5 GB

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -383,9 +383,9 @@ services:
       POSTGREST_URL: http://rest:3000
       PGRST_JWT_SECRET: ${JWT_SECRET}
       DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-      # 500 MB cap for GraviScan jpegs (single sensor image). Per-bucket
-      # `storage.buckets.file_size_limit` further constrains where stricter caps are needed.
-      FILE_SIZE_LIMIT: 524288000
+      # 5 GB global ceiling; other buckets pinned to 500 MB.
+      # bloommcp-data gets the full 5 GB.
+      FILE_SIZE_LIMIT: 5368709120
       STORAGE_BACKEND: s3
       STORAGE_S3_BUCKET: bloom-storage
       STORAGE_S3_ENDPOINT: ${MINIO_STORAGE_S3_ENDPOINT}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -502,9 +502,9 @@ services:
       POSTGREST_URL: http://rest:3000
       PGRST_JWT_SECRET: ${JWT_SECRET}
       DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-      # 500 MB cap for GraviScan jpegs (single sensor image). Per-bucket
-      # `storage.buckets.file_size_limit` further constrains where stricter caps are needed.
-      FILE_SIZE_LIMIT: 524288000
+      # 5 GB global ceiling; other buckets pinned to 500 MB.
+      # bloommcp-data gets the full 5 GB.
+      FILE_SIZE_LIMIT: 5368709120
       STORAGE_BACKEND: s3
       STORAGE_S3_BUCKET: bloom-storage
       STORAGE_S3_ENDPOINT: http://supabase-minio:9000

--- a/supabase/migrations/20260707000000_scope_bloommcp_data_5gb_upload.sql
+++ b/supabase/migrations/20260707000000_scope_bloommcp_data_5gb_upload.sql
@@ -1,0 +1,23 @@
+-- Scope a 5 GB upload ceiling to the bloommcp-data bucket; keep every other
+-- bucket at 500 MB.
+--
+-- The storage service's global FILE_SIZE_LIMIT (docker-compose storage env) is
+-- raised to 5 GB in this change so bloommcp can accept GB-scale counts matrices
+-- via the signed upload path. That global is a SHARED ceiling for every bucket,
+-- so this migration pins every other bucket that still inherits it to 500 MB —
+-- preserving today's effective cap rather than letting them inherit 5 GB. A
+-- per-bucket limit can only lower a bucket below the global, never raise it, so
+-- bloommcp-data is set to the full 5 GB.
+--
+-- Safe to re-run: the pin only touches buckets that still inherit the global
+-- (NULL limit); once set, re-running is a no-op.
+
+-- Every other bucket that still inherits the global -> pin to 500 MB.
+UPDATE storage.buckets
+  SET file_size_limit = 524288000  -- 500 MB
+  WHERE file_size_limit IS NULL AND id <> 'bloommcp-data';
+
+-- bloommcp-data -> 5 GB (effective only while the global FILE_SIZE_LIMIT >= 5 GB).
+UPDATE storage.buckets
+  SET file_size_limit = 5368709120  -- 5 GB
+  WHERE id = 'bloommcp-data';


### PR DESCRIPTION
## What

Raises the storage service's global `FILE_SIZE_LIMIT` from **500 MB → 5 GB** so the `bloommcp-data` bucket can accept GB-scale counts matrices via the signed upload path, while keeping every other bucket at its current 500 MB cap.

## Why it's scoped this way

`FILE_SIZE_LIMIT` is a **shared** ceiling for every bucket, and a per-bucket `file_size_limit` can only make a bucket *smaller* than the global — never larger. So to give **only** `bloommcp-data` the headroom:

1. Raise the global ceiling to 5 GB (`docker-compose.dev.yml` + `docker-compose.prod.yml`).
2. Migration pins every other bucket to 500 MB and sets `bloommcp-data` to 5 GB.

Pinning the others to 500 MB **preserves today's behavior** — they were already effectively capped at 500 MB by the previous global, so nothing changes for them.

Resulting bucket limits (verified on dev):

| bucket | limit |
|---|---|
| `bloommcp-data` | 5 GB |
| `images`, `videos`, `scrna`, `species_illustrations`, `tus-files` | 500 MB |

## Merge order

Independent of the bloommcp upload feature — **can merge first**. It just gets storage ready; the upload PR builds on top.

## Deploy note

Both pieces are needed together: the compose env change (redeploy storage) **and** the migration. Until the storage service restarts with the new env, the old global still caps uploads.

## Not covered

GB-scale uploads only work via the **signed / resumable** path; the buffered `/uploads` route stays at 200 MB (it loads the file into memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
