### PR TITLE
feat(orthovec): Arabidopsis accession ESM3 comparison

### DIFF
--- a/supabase/migrations/20260708000000_register_esm3_and_accessions.sql
+++ b/supabase/migrations/20260708000000_register_esm3_and_accessions.sql
@@ -1,0 +1,218 @@
+-- =============================================================================
+-- 20260708000000_register_esm3_and_accessions.sql
+--
+-- Adds the single-species Arabidopsis-accession embedding layer on top of the
+-- existing multi-model protein-embedding registry (20260610000000). This is
+-- the ESM-3 model the original schema's registry was designed to accept, plus
+-- a new within-species dimension the original schema did not anticipate:
+-- accession identity (Col-0, Ler-0, Cvi-0, … — natural variants of A. thaliana).
+--
+-- Layout added here:
+--   protein_embedding_runs      provenance for each embedding batch (checkpoint,
+--                               pooling, layer, sequence source) so a stored
+--                               vector is always reproducible/traceable
+--   arabidopsis_accessions      accession registry (common_name + external_id +
+--                               id_source natural key; one is_reference baseline)
+--   proteins.accession_id       nullable FK — cross-species rows stay NULL,
+--                               accession rows point at an accession. One locus
+--                               per accession enforced by a partial unique index.
+--   protein_embeddings_esm3     per-model vector(1536) embeddings (ESM-3),
+--                               HNSW cosine-indexed, linked to a run
+--
+-- The comparison RPCs (knn_search_esm3, compare_gene_across_accessions,
+-- search_accession_genes) and the search_genes scoping change live in the
+-- sibling migration 20260708000100.
+--
+-- HNSW (not IVFFLAT) to match protein_embeddings_esm2: IVFFLAT degenerates on
+-- the empty table this migration ships (K-means has no vectors to train on) and
+-- on tiny test fixtures (each row in its own partition, probes=1 returns only
+-- the query). HNSW needs no training step.
+--
+-- RLS pattern (matching 20260610000000 + 20260622180000):
+--   admin_all_<table>   FOR ALL    TO bloom_admin  USING true WITH CHECK true
+--   agent_read_<table>  FOR SELECT TO bloom_agent   USING true
+--   user_read_<table>   FOR SELECT TO bloom_user    USING true
+--   writer_read_<table> FOR SELECT TO bloom_writer  USING true
+--   writer_insert_<t>   FOR INSERT TO bloom_writer  WITH CHECK true
+--   writer_update_<t>   FOR UPDATE TO bloom_writer  USING true WITH CHECK true
+-- Ingest runs as bloom_writer.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS, ADD COLUMN IF NOT EXISTS,
+-- CREATE INDEX IF NOT EXISTS, DROP POLICY IF EXISTS, ON CONFLICT DO NOTHING.
+-- =============================================================================
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ─── register the ESM-3 model in the existing registry ────────────────────
+INSERT INTO public.protein_embedding_models
+  (model_id,               display_name,             dimension, table_suffix, description)
+VALUES
+  ('esm3_open_small_1p4B', 'ESM3-open small (1.4B)',  1536,      'esm3',
+   'ESM3-open small protein language model (1.4B params), model dim 1536. Used for single-species Arabidopsis accession comparison.')
+ON CONFLICT (model_id) DO NOTHING;
+
+-- ─── protein_embedding_runs (embedding provenance) ────────────────────────
+CREATE TABLE IF NOT EXISTS public.protein_embedding_runs (
+  id               bigserial   PRIMARY KEY,
+  model_id         text        NOT NULL REFERENCES public.protein_embedding_models(model_id),
+  checkpoint_hash  text        NOT NULL,
+  pooling          text        NOT NULL,
+  layer            int,
+  sequence_source  text        NOT NULL,
+  software_version text,
+  computed_at      timestamptz NOT NULL DEFAULT now(),
+  notes            text
+);
+
+CREATE INDEX IF NOT EXISTS protein_embedding_runs_model_id_idx
+  ON public.protein_embedding_runs (model_id);
+
+COMMENT ON TABLE public.protein_embedding_runs IS
+  'Provenance for a batch of protein embeddings: exact model checkpoint_hash, pooling (e.g. mean/bos), layer, sequence_source (e.g. Araport11 primary transcript), software_version. A vector(N) is not reproducible or citable without this. Mirrors the versioned orthogroup_runs pattern; every protein_embeddings_<suffix> row references a run.';
+
+-- ─── arabidopsis_accessions (accession registry) ──────────────────────────
+CREATE TABLE IF NOT EXISTS public.arabidopsis_accessions (
+  id           bigserial   PRIMARY KEY,
+  common_name  text        NOT NULL,
+  external_id  text        NOT NULL,
+  id_source    text        NOT NULL,
+  is_reference boolean     NOT NULL DEFAULT false,
+  notes        text,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (id_source, external_id)
+);
+
+-- At most one designated reference accession (expected: Col-0), the biological
+-- baseline compare_gene_across_accessions ranks against by default.
+CREATE UNIQUE INDEX IF NOT EXISTS arabidopsis_accessions_one_reference_idx
+  ON public.arabidopsis_accessions (is_reference)
+  WHERE is_reference = true;
+
+COMMENT ON TABLE public.arabidopsis_accessions IS
+  'Registry of Arabidopsis thaliana accessions (natural variants/ecotypes). Natural key (id_source, external_id) — the same numeric ID from two sources stays distinct. common_name is the display label. At most one row may be is_reference=true (the baseline, expected Col-0).';
+
+-- ─── proteins.accession_id (nullable accession dimension) ──────────────────
+ALTER TABLE public.proteins
+  ADD COLUMN IF NOT EXISTS accession_id bigint REFERENCES public.arabidopsis_accessions(id);
+
+CREATE INDEX IF NOT EXISTS proteins_accession_id_idx
+  ON public.proteins (accession_id);
+
+-- One embedding per locus per accession (primary transcript). Cross-species
+-- rows (accession_id IS NULL) are exempt and may repeat a gene_id.
+CREATE UNIQUE INDEX IF NOT EXISTS proteins_accession_gene_uidx
+  ON public.proteins (accession_id, gene_id)
+  WHERE accession_id IS NOT NULL;
+
+COMMENT ON COLUMN public.proteins.accession_id IS
+  'Nullable FK to arabidopsis_accessions(id). NULL = cross-species protein (ESM-2 surface); NOT NULL = per-accession protein (ESM-3 surface). uid is opaque, keyed on the numeric accession_id (<accession_id>:<gene_id>) and never parsed by application code.';
+
+-- ─── protein_embeddings_esm3 (per-model, provenance-linked) ───────────────
+CREATE TABLE IF NOT EXISTS public.protein_embeddings_esm3 (
+  uid        text         PRIMARY KEY REFERENCES public.proteins(uid) ON DELETE CASCADE,
+  embedding  vector(1536) NOT NULL,
+  run_id     bigint       NOT NULL REFERENCES public.protein_embedding_runs(id),
+  created_at timestamptz  NOT NULL DEFAULT now(),
+  -- Reject the zero vector: NOT NULL does not stop an all-zeros embedding from
+  -- a failed inference, which yields an undefined (NaN) cosine distance and
+  -- silently corrupts KNN ordering. vector_norm() is the L2 norm for the
+  -- `vector` type (l2_norm() covers only halfvec/sparsevec and is ambiguous here).
+  CONSTRAINT protein_embeddings_esm3_nonzero_chk CHECK (vector_norm(embedding) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS protein_embeddings_esm3_run_id_idx
+  ON public.protein_embeddings_esm3 (run_id);
+
+-- HNSW (vs IVFFLAT) — see header. Matches protein_embeddings_esm2.
+CREATE INDEX IF NOT EXISTS protein_embeddings_esm3_hnsw_idx
+  ON public.protein_embeddings_esm3
+  USING hnsw (embedding vector_cosine_ops);
+
+COMMENT ON TABLE public.protein_embeddings_esm3 IS
+  'ESM-3 protein embeddings, vector(1536) HNSW cosine-indexed, one row per proteins.uid, linked to a protein_embedding_runs provenance row. Postgres rejects any non-1536 vector at the type-cast boundary (cross-model guardrail); a CHECK rejects the zero vector.';
+
+-- ─── RLS enable ───────────────────────────────────────────────────────────
+ALTER TABLE public.protein_embedding_runs    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.arabidopsis_accessions    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.protein_embeddings_esm3   ENABLE ROW LEVEL SECURITY;
+
+-- ─── RLS policies: admin_all / agent_read / user_read / writer_* ───────────
+
+-- protein_embedding_runs
+DROP POLICY IF EXISTS admin_all_protein_embedding_runs    ON public.protein_embedding_runs;
+CREATE POLICY admin_all_protein_embedding_runs
+  ON public.protein_embedding_runs FOR ALL    TO bloom_admin  USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS agent_read_protein_embedding_runs   ON public.protein_embedding_runs;
+CREATE POLICY agent_read_protein_embedding_runs
+  ON public.protein_embedding_runs FOR SELECT TO bloom_agent  USING (true);
+DROP POLICY IF EXISTS user_read_protein_embedding_runs    ON public.protein_embedding_runs;
+CREATE POLICY user_read_protein_embedding_runs
+  ON public.protein_embedding_runs FOR SELECT TO bloom_user   USING (true);
+DROP POLICY IF EXISTS writer_read_protein_embedding_runs  ON public.protein_embedding_runs;
+CREATE POLICY writer_read_protein_embedding_runs
+  ON public.protein_embedding_runs FOR SELECT TO bloom_writer USING (true);
+DROP POLICY IF EXISTS writer_insert_protein_embedding_runs ON public.protein_embedding_runs;
+CREATE POLICY writer_insert_protein_embedding_runs
+  ON public.protein_embedding_runs FOR INSERT TO bloom_writer WITH CHECK (true);
+DROP POLICY IF EXISTS writer_update_protein_embedding_runs ON public.protein_embedding_runs;
+CREATE POLICY writer_update_protein_embedding_runs
+  ON public.protein_embedding_runs FOR UPDATE TO bloom_writer USING (true) WITH CHECK (true);
+
+-- arabidopsis_accessions
+DROP POLICY IF EXISTS admin_all_arabidopsis_accessions    ON public.arabidopsis_accessions;
+CREATE POLICY admin_all_arabidopsis_accessions
+  ON public.arabidopsis_accessions FOR ALL    TO bloom_admin  USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS agent_read_arabidopsis_accessions   ON public.arabidopsis_accessions;
+CREATE POLICY agent_read_arabidopsis_accessions
+  ON public.arabidopsis_accessions FOR SELECT TO bloom_agent  USING (true);
+DROP POLICY IF EXISTS user_read_arabidopsis_accessions    ON public.arabidopsis_accessions;
+CREATE POLICY user_read_arabidopsis_accessions
+  ON public.arabidopsis_accessions FOR SELECT TO bloom_user   USING (true);
+DROP POLICY IF EXISTS writer_read_arabidopsis_accessions  ON public.arabidopsis_accessions;
+CREATE POLICY writer_read_arabidopsis_accessions
+  ON public.arabidopsis_accessions FOR SELECT TO bloom_writer USING (true);
+DROP POLICY IF EXISTS writer_insert_arabidopsis_accessions ON public.arabidopsis_accessions;
+CREATE POLICY writer_insert_arabidopsis_accessions
+  ON public.arabidopsis_accessions FOR INSERT TO bloom_writer WITH CHECK (true);
+DROP POLICY IF EXISTS writer_update_arabidopsis_accessions ON public.arabidopsis_accessions;
+CREATE POLICY writer_update_arabidopsis_accessions
+  ON public.arabidopsis_accessions FOR UPDATE TO bloom_writer USING (true) WITH CHECK (true);
+
+-- protein_embeddings_esm3
+DROP POLICY IF EXISTS admin_all_protein_embeddings_esm3    ON public.protein_embeddings_esm3;
+CREATE POLICY admin_all_protein_embeddings_esm3
+  ON public.protein_embeddings_esm3 FOR ALL    TO bloom_admin  USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS agent_read_protein_embeddings_esm3   ON public.protein_embeddings_esm3;
+CREATE POLICY agent_read_protein_embeddings_esm3
+  ON public.protein_embeddings_esm3 FOR SELECT TO bloom_agent  USING (true);
+DROP POLICY IF EXISTS user_read_protein_embeddings_esm3    ON public.protein_embeddings_esm3;
+CREATE POLICY user_read_protein_embeddings_esm3
+  ON public.protein_embeddings_esm3 FOR SELECT TO bloom_user   USING (true);
+DROP POLICY IF EXISTS writer_read_protein_embeddings_esm3  ON public.protein_embeddings_esm3;
+CREATE POLICY writer_read_protein_embeddings_esm3
+  ON public.protein_embeddings_esm3 FOR SELECT TO bloom_writer USING (true);
+DROP POLICY IF EXISTS writer_insert_protein_embeddings_esm3 ON public.protein_embeddings_esm3;
+CREATE POLICY writer_insert_protein_embeddings_esm3
+  ON public.protein_embeddings_esm3 FOR INSERT TO bloom_writer WITH CHECK (true);
+DROP POLICY IF EXISTS writer_update_protein_embeddings_esm3 ON public.protein_embeddings_esm3;
+CREATE POLICY writer_update_protein_embeddings_esm3
+  ON public.protein_embeddings_esm3 FOR UPDATE TO bloom_writer USING (true) WITH CHECK (true);
+
+-- ─── Table-level GRANTs (PostgREST requires both policy AND grant) ─────────
+GRANT SELECT                 ON public.protein_embedding_runs  TO bloom_user, bloom_agent;
+GRANT SELECT, INSERT, UPDATE ON public.protein_embedding_runs  TO bloom_writer;
+GRANT ALL                    ON public.protein_embedding_runs  TO bloom_admin;
+GRANT USAGE, SELECT          ON SEQUENCE public.protein_embedding_runs_id_seq TO bloom_writer, bloom_admin;
+
+GRANT SELECT                 ON public.arabidopsis_accessions  TO bloom_user, bloom_agent;
+GRANT SELECT, INSERT, UPDATE ON public.arabidopsis_accessions  TO bloom_writer;
+GRANT ALL                    ON public.arabidopsis_accessions  TO bloom_admin;
+GRANT USAGE, SELECT          ON SEQUENCE public.arabidopsis_accessions_id_seq TO bloom_writer, bloom_admin;
+
+GRANT SELECT                 ON public.protein_embeddings_esm3 TO bloom_user, bloom_agent;
+GRANT SELECT, INSERT, UPDATE ON public.protein_embeddings_esm3 TO bloom_writer;
+GRANT ALL                    ON public.protein_embeddings_esm3 TO bloom_admin;
+
+COMMIT;

--- a/supabase/migrations/20260708000100_accession_comparison_rpcs.sql
+++ b/supabase/migrations/20260708000100_accession_comparison_rpcs.sql
@@ -1,0 +1,237 @@
+-- =============================================================================
+-- 20260708000100_accession_comparison_rpcs.sql
+--
+-- Query surface for the single-species Arabidopsis-accession embedding layer
+-- added in 20260708000000. Two comparison surfaces + one autocomplete, plus a
+-- scoping fix to the cross-species search_genes so the two surfaces stay
+-- disjoint now that they share the proteins table.
+--
+--   knn_search_esm3(query_uid, match_count)
+--       Surface B — pan-proteome KNN across accession proteins by ESM-3 cosine.
+--       Filtered to accession_id IS NOT NULL so an ESM-3 embedding accidentally
+--       loaded for a cross-species protein can never bleed in (isolation in the
+--       RPC, not just the picker).
+--
+--   compare_gene_across_accessions(target_gene_id, reference_uid, match_count)
+--       Surface A — for a fixed gene_id, each accession's variant ranked by
+--       ESM-3 cosine similarity to a reference. Reference precedence:
+--       explicit reference_uid → the is_reference accession's variant →
+--       lexicographically-first variant. A reference_uid from a different gene
+--       returns zero rows. The reference row (similarity 1.0) always sorts
+--       first, so it survives truncation.
+--
+--   search_accession_genes(partial_id, max_results)
+--       Autocomplete over accession proteins only (accession_id IS NOT NULL).
+--
+--   search_genes(partial_id, max_results)  [scoped]
+--       Adds accession_id IS NULL so the cross-species AI Orthologs picker
+--       never surfaces accession proteins. Signature unchanged.
+--
+-- This migration references proteins.accession_id, added by 20260708000000, so
+-- it must never be applied without that migration (timestamp order guarantees).
+--
+-- Idempotent: DROP FUNCTION IF EXISTS before each CREATE where the signature
+-- is new; CREATE OR REPLACE for search_genes (unchanged signature).
+-- =============================================================================
+
+BEGIN;
+
+-- ─── knn_search_esm3 (Surface B) ──────────────────────────────────────────
+DROP FUNCTION IF EXISTS public.knn_search_esm3(text, int);
+
+CREATE OR REPLACE FUNCTION public.knn_search_esm3(
+  query_uid   text,
+  match_count int DEFAULT 20
+)
+RETURNS TABLE (
+  uid            text,
+  accession_id   bigint,
+  accession_name text,
+  gene_id        text,
+  similarity     float
+)
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  query_vec vector(1536);
+BEGIN
+  SELECT embedding INTO query_vec
+    FROM public.protein_embeddings_esm3
+   WHERE protein_embeddings_esm3.uid = query_uid;
+
+  IF query_vec IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- accession_id IS NOT NULL keeps Surface B scoped to accession proteins even
+  -- if ESM-3 rows are ever loaded for a cross-species protein. Hard cap 1000.
+  RETURN QUERY
+    SELECT p.uid,
+           p.accession_id,
+           a.common_name AS accession_name,
+           p.gene_id,
+           (1 - (e.embedding <=> query_vec))::float AS similarity
+      FROM public.protein_embeddings_esm3 e
+      JOIN public.proteins p               ON p.uid = e.uid
+      JOIN public.arabidopsis_accessions a ON a.id  = p.accession_id
+     WHERE p.accession_id IS NOT NULL
+     ORDER BY e.embedding <=> query_vec
+     LIMIT LEAST(match_count, 1000);
+END;
+$$;
+
+COMMENT ON FUNCTION public.knn_search_esm3(text, int) IS
+  'Surface B. Returns the match_count nearest accession proteins to query_uid by ESM-3 cosine similarity, most-similar-first. Restricted to accession_id IS NOT NULL. similarity = 1 - cosine_distance. match_count hard-capped at 1000.';
+
+-- ─── compare_gene_across_accessions (Surface A) ───────────────────────────
+DROP FUNCTION IF EXISTS public.compare_gene_across_accessions(text, text, int);
+
+CREATE OR REPLACE FUNCTION public.compare_gene_across_accessions(
+  target_gene_id text,
+  reference_uid  text DEFAULT NULL,
+  match_count    int  DEFAULT 1000
+)
+RETURNS TABLE (
+  uid            text,
+  accession_id   bigint,
+  accession_name text,
+  gene_id        text,
+  similarity     float,
+  is_reference   boolean
+)
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  ref_uid text;
+  ref_vec vector(1536);
+BEGIN
+  IF char_length(btrim(coalesce(target_gene_id, ''))) < 1 THEN
+    RETURN;
+  END IF;
+
+  IF reference_uid IS NOT NULL THEN
+    -- Explicit reference must belong to target_gene_id, be an accession
+    -- protein, and have an ESM-3 embedding. Otherwise return nothing rather
+    -- than rank one gene's variants against another gene's embedding.
+    SELECT p.uid INTO ref_uid
+      FROM public.proteins p
+      JOIN public.protein_embeddings_esm3 e ON e.uid = p.uid
+     WHERE p.uid          = reference_uid
+       AND p.gene_id      = target_gene_id
+       AND p.accession_id IS NOT NULL;
+    IF ref_uid IS NULL THEN
+      RETURN;
+    END IF;
+  ELSE
+    -- Default reference: the is_reference accession's variant of this gene,
+    -- else the lexicographically-first variant. Deterministic.
+    SELECT p.uid INTO ref_uid
+      FROM public.proteins p
+      JOIN public.protein_embeddings_esm3 e ON e.uid = p.uid
+      JOIN public.arabidopsis_accessions a  ON a.id  = p.accession_id
+     WHERE p.gene_id      = target_gene_id
+       AND p.accession_id IS NOT NULL
+     ORDER BY a.is_reference DESC, p.uid ASC
+     LIMIT 1;
+    IF ref_uid IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  SELECT embedding INTO ref_vec
+    FROM public.protein_embeddings_esm3
+   WHERE protein_embeddings_esm3.uid = ref_uid;
+
+  -- Reference row sorts first (its similarity is 1.0), so it always survives
+  -- the LEAST(match_count, 1000) truncation.
+  RETURN QUERY
+    SELECT p.uid,
+           p.accession_id,
+           a.common_name AS accession_name,
+           p.gene_id,
+           (1 - (e.embedding <=> ref_vec))::float AS similarity,
+           (p.uid = ref_uid) AS is_reference
+      FROM public.protein_embeddings_esm3 e
+      JOIN public.proteins p               ON p.uid = e.uid
+      JOIN public.arabidopsis_accessions a ON a.id  = p.accession_id
+     WHERE p.gene_id      = target_gene_id
+       AND p.accession_id IS NOT NULL
+     ORDER BY (p.uid = ref_uid) DESC, similarity DESC, p.uid ASC
+     LIMIT LEAST(match_count, 1000);
+END;
+$$;
+
+COMMENT ON FUNCTION public.compare_gene_across_accessions(text, text, int) IS
+  'Surface A. For a fixed target_gene_id, returns each accession variant that has an ESM-3 embedding, ranked by cosine similarity to a reference variant. Reference precedence: reference_uid → is_reference accession → lexicographically-first. reference_uid from a different gene returns zero rows. Reference row is is_reference=true, similarity=1.0, always included. match_count hard-capped at 1000.';
+
+-- ─── search_accession_genes (autocomplete, accession-scoped) ──────────────
+DROP FUNCTION IF EXISTS public.search_accession_genes(text, int);
+
+CREATE OR REPLACE FUNCTION public.search_accession_genes(
+  partial_id  text,
+  max_results int DEFAULT 20
+)
+RETURNS TABLE (
+  uid            text,
+  accession_id   bigint,
+  accession_name text,
+  gene_id        text
+)
+LANGUAGE sql STABLE
+AS $$
+  -- Empty / whitespace-only / NULL partial_id returns zero rows (same gate as
+  -- search_genes). Scoped to accession proteins only. Hard cap at 1000.
+  SELECT p.uid, p.accession_id, a.common_name AS accession_name, p.gene_id
+    FROM public.proteins p
+    JOIN public.arabidopsis_accessions a ON a.id = p.accession_id
+   WHERE p.accession_id IS NOT NULL
+     AND char_length(btrim(partial_id)) >= 1
+     AND ( p.uid     ILIKE '%' || partial_id || '%'
+        OR p.gene_id ILIKE '%' || partial_id || '%' )
+   ORDER BY p.uid
+   LIMIT LEAST(max_results, 1000);
+$$;
+
+COMMENT ON FUNCTION public.search_accession_genes(text, int) IS
+  'Case-insensitive substring match on accession proteins (accession_id IS NOT NULL) by uid or gene_id, joined to the accession name. Mirror of search_genes for the accession gene picker. Empty/whitespace/NULL returns zero rows; max_results hard-capped at 1000.';
+
+-- ─── search_genes (scoped to cross-species proteins) ──────────────────────
+-- Signature unchanged, so CREATE OR REPLACE (no DROP). Adds accession_id IS
+-- NULL so accession proteins never appear in the cross-species picker.
+CREATE OR REPLACE FUNCTION public.search_genes(
+  partial_id  text,
+  max_results int DEFAULT 20
+)
+RETURNS TABLE (
+  uid     text,
+  species text,
+  gene_id text
+)
+LANGUAGE sql STABLE
+AS $$
+  -- accession_id IS NULL restricts to cross-species proteins. Empty /
+  -- whitespace-only / NULL partial_id returns zero rows. Hard cap at 1000.
+  SELECT uid, species, gene_id
+    FROM public.proteins
+   WHERE accession_id IS NULL
+     AND char_length(btrim(partial_id)) >= 1
+     AND ( uid     ILIKE '%' || partial_id || '%'
+        OR gene_id ILIKE '%' || partial_id || '%' )
+   ORDER BY uid
+   LIMIT LEAST(max_results, 1000);
+$$;
+
+COMMENT ON FUNCTION public.search_genes(text, int) IS
+  'Case-insensitive substring match on proteins.uid or proteins.gene_id, restricted to cross-species proteins (accession_id IS NULL) so accession proteins never surface in the cross-species AI Orthologs picker. Empty/whitespace/NULL returns zero rows; max_results hard-capped at 1000.';
+
+-- ─── Function-level GRANTs ────────────────────────────────────────────────
+GRANT EXECUTE ON FUNCTION public.knn_search_esm3(text, int)
+  TO bloom_user, bloom_agent, bloom_admin;
+GRANT EXECUTE ON FUNCTION public.compare_gene_across_accessions(text, text, int)
+  TO bloom_user, bloom_agent, bloom_admin;
+GRANT EXECUTE ON FUNCTION public.search_accession_genes(text, int)
+  TO bloom_user, bloom_agent, bloom_admin;
+GRANT EXECUTE ON FUNCTION public.search_genes(text, int)
+  TO bloom_user, bloom_agent, bloom_admin;
+
+COMMIT;

--- a/supabase/migrations/20260708000100_accession_comparison_rpcs.sql
+++ b/supabase/migrations/20260708000100_accession_comparison_rpcs.sql
@@ -64,7 +64,10 @@ BEGIN
   END IF;
 
   -- accession_id IS NOT NULL keeps Surface B scoped to accession proteins even
-  -- if ESM-3 rows are ever loaded for a cross-species protein. Hard cap 1000.
+  -- if ESM-3 rows are ever loaded for a cross-species protein. The query
+  -- protein is excluded (e.uid <> query_uid) so match_count returns exactly
+  -- that many NEIGHBORS (the self-match at distance 0 would otherwise consume
+  -- one slot). Hard cap 1000.
   RETURN QUERY
     SELECT p.uid,
            p.accession_id,
@@ -75,13 +78,14 @@ BEGIN
       JOIN public.proteins p               ON p.uid = e.uid
       JOIN public.arabidopsis_accessions a ON a.id  = p.accession_id
      WHERE p.accession_id IS NOT NULL
+       AND e.uid <> query_uid
      ORDER BY e.embedding <=> query_vec
-     LIMIT LEAST(match_count, 1000);
+     LIMIT GREATEST(1, LEAST(match_count, 1000));
 END;
 $$;
 
 COMMENT ON FUNCTION public.knn_search_esm3(text, int) IS
-  'Surface B. Returns the match_count nearest accession proteins to query_uid by ESM-3 cosine similarity, most-similar-first. Restricted to accession_id IS NOT NULL. similarity = 1 - cosine_distance. match_count hard-capped at 1000.';
+  'Surface B. Returns the match_count nearest accession proteins to query_uid by ESM-3 cosine similarity, most-similar-first, EXCLUDING query_uid itself so match_count = number of neighbors. Restricted to accession_id IS NOT NULL. similarity = 1 - cosine_distance. match_count hard-capped at 1000.';
 
 -- ─── compare_gene_across_accessions (Surface A) ───────────────────────────
 DROP FUNCTION IF EXISTS public.compare_gene_across_accessions(text, text, int);
@@ -157,7 +161,7 @@ BEGIN
      WHERE p.gene_id      = target_gene_id
        AND p.accession_id IS NOT NULL
      ORDER BY (p.uid = ref_uid) DESC, similarity DESC, p.uid ASC
-     LIMIT LEAST(match_count, 1000);
+     LIMIT GREATEST(1, LEAST(match_count, 1000));
 END;
 $$;
 
@@ -189,7 +193,7 @@ AS $$
      AND ( p.uid     ILIKE '%' || partial_id || '%'
         OR p.gene_id ILIKE '%' || partial_id || '%' )
    ORDER BY p.uid
-   LIMIT LEAST(max_results, 1000);
+   LIMIT GREATEST(1, LEAST(max_results, 1000));
 $$;
 
 COMMENT ON FUNCTION public.search_accession_genes(text, int) IS
@@ -218,7 +222,7 @@ AS $$
      AND ( uid     ILIKE '%' || partial_id || '%'
         OR gene_id ILIKE '%' || partial_id || '%' )
    ORDER BY uid
-   LIMIT LEAST(max_results, 1000);
+   LIMIT GREATEST(1, LEAST(max_results, 1000));
 $$;
 
 COMMENT ON FUNCTION public.search_genes(text, int) IS

--- a/supabase/migrations/20260708000200_scope_knn_search_esm2.sql
+++ b/supabase/migrations/20260708000200_scope_knn_search_esm2.sql
@@ -1,0 +1,66 @@
+-- =============================================================================
+-- 20260708000200_scope_knn_search_esm2.sql
+--
+-- Makes the cross-species / accession isolation symmetric. The accession
+-- surface's knn_search_esm3 (20260708000100) filters accession_id IS NOT NULL;
+-- this adds the mirror guard to the cross-species knn_search_esm2 so that if an
+-- accession protein ever receives an ESM-2 embedding it can never bleed into
+-- the cross-species graph. Also hardens the LIMIT to GREATEST(1, LEAST(...))
+-- so a negative match_count (reachable via direct PostgREST) can't error.
+--
+-- Unlike knn_search_esm3, this KEEPS the query's own row (self-match, similarity
+-- 1.0) — the /app/embedtree UI relies on the query appearing at the top of its
+-- graph, and the integration test asserts it. Only the accession scope and the
+-- LIMIT guard change; ordering and shape are unchanged.
+--
+-- CREATE OR REPLACE (signature unchanged). Idempotent.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.knn_search_esm2(
+  query_uid   text,
+  match_count int DEFAULT 20
+)
+RETURNS TABLE (
+  uid        text,
+  species    text,
+  gene_id    text,
+  similarity float
+)
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  query_vec vector(1280);
+BEGIN
+  SELECT embedding INTO query_vec
+    FROM public.protein_embeddings_esm2
+   WHERE protein_embeddings_esm2.uid = query_uid;
+
+  IF query_vec IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- accession_id IS NULL keeps the cross-species graph free of accession
+  -- proteins (mirror of knn_search_esm3's accession_id IS NOT NULL guard).
+  -- LIMIT guarded so a negative match_count clamps to 1 instead of erroring.
+  RETURN QUERY
+    SELECT p.uid,
+           p.species,
+           p.gene_id,
+           (1 - (e.embedding <=> query_vec))::float AS similarity
+      FROM public.protein_embeddings_esm2 e
+      JOIN public.proteins p ON p.uid = e.uid
+     WHERE p.accession_id IS NULL
+     ORDER BY e.embedding <=> query_vec
+     LIMIT GREATEST(1, LEAST(match_count, 1000));
+END;
+$$;
+
+COMMENT ON FUNCTION public.knn_search_esm2(text, int) IS
+  'Returns the match_count nearest ESM-2 embeddings to query_uid by cosine similarity, most-similar-first, restricted to cross-species proteins (accession_id IS NULL). Includes the query itself. similarity = 1 - cosine_distance. match_count clamped to [1, 1000].';
+
+GRANT EXECUTE ON FUNCTION public.knn_search_esm2(text, int)
+  TO bloom_user, bloom_agent, bloom_admin;
+
+COMMIT;

--- a/supabase/rollbacks/20260708000000_register_esm3_and_accessions_rollback.sql
+++ b/supabase/rollbacks/20260708000000_register_esm3_and_accessions_rollback.sql
@@ -1,0 +1,26 @@
+-- Manual rollback for 20260708000000_register_esm3_and_accessions.sql
+--
+-- Drops the accession embedding layer in explicit FK order:
+--   protein_embeddings_esm3 → proteins.accession_id (+ indexes) →
+--   arabidopsis_accessions → protein_embedding_runs → the esm3 registry row.
+-- Apply the RPC rollback (20260708000100_..._rollback.sql) FIRST — its
+-- functions reference these objects.
+--
+-- Dropping proteins.accession_id is safe: all cross-species rows have it NULL,
+-- and no accession rows exist unless data was loaded (drop those first if so).
+
+BEGIN;
+
+DROP TABLE IF EXISTS public.protein_embeddings_esm3;
+
+DROP INDEX IF EXISTS public.proteins_accession_gene_uidx;
+DROP INDEX IF EXISTS public.proteins_accession_id_idx;
+ALTER TABLE public.proteins DROP COLUMN IF EXISTS accession_id;
+
+DROP TABLE IF EXISTS public.arabidopsis_accessions;
+DROP TABLE IF EXISTS public.protein_embedding_runs;
+
+DELETE FROM public.protein_embedding_models
+ WHERE model_id = 'esm3_open_small_1p4B';
+
+COMMIT;

--- a/supabase/rollbacks/20260708000100_accession_comparison_rpcs_rollback.sql
+++ b/supabase/rollbacks/20260708000100_accession_comparison_rpcs_rollback.sql
@@ -1,0 +1,38 @@
+-- Manual rollback for 20260708000100_accession_comparison_rpcs.sql
+--
+-- Drops the three new accession comparison RPCs and restores search_genes to
+-- its pre-scoping body (the unscoped version from 20260610000000, without the
+-- accession_id IS NULL filter). Apply this BEFORE the M1 rollback, since
+-- search_genes here still references proteins but no longer accession_id.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.knn_search_esm3(text, int);
+DROP FUNCTION IF EXISTS public.compare_gene_across_accessions(text, text, int);
+DROP FUNCTION IF EXISTS public.search_accession_genes(text, int);
+
+-- Restore the original unscoped search_genes (verbatim from 20260610000000).
+CREATE OR REPLACE FUNCTION public.search_genes(
+  partial_id  text,
+  max_results int DEFAULT 20
+)
+RETURNS TABLE (
+  uid     text,
+  species text,
+  gene_id text
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT uid, species, gene_id
+    FROM public.proteins
+   WHERE char_length(btrim(partial_id)) >= 1
+     AND ( uid     ILIKE '%' || partial_id || '%'
+        OR gene_id ILIKE '%' || partial_id || '%' )
+   ORDER BY uid
+   LIMIT LEAST(max_results, 1000);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.search_genes(text, int)
+  TO bloom_user, bloom_agent, bloom_admin;
+
+COMMIT;

--- a/supabase/rollbacks/20260708000200_scope_knn_search_esm2_rollback.sql
+++ b/supabase/rollbacks/20260708000200_scope_knn_search_esm2_rollback.sql
@@ -1,0 +1,46 @@
+-- Manual rollback for 20260708000200_scope_knn_search_esm2.sql
+--
+-- Restores knn_search_esm2 to its original body (from 20260610000000): no
+-- accession_id filter, plain LEAST(match_count, 1000) LIMIT.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.knn_search_esm2(
+  query_uid   text,
+  match_count int DEFAULT 20
+)
+RETURNS TABLE (
+  uid        text,
+  species    text,
+  gene_id    text,
+  similarity float
+)
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  query_vec vector(1280);
+BEGIN
+  SELECT embedding INTO query_vec
+    FROM public.protein_embeddings_esm2
+   WHERE protein_embeddings_esm2.uid = query_uid;
+
+  IF query_vec IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+    SELECT p.uid,
+           p.species,
+           p.gene_id,
+           (1 - (e.embedding <=> query_vec))::float AS similarity
+      FROM public.protein_embeddings_esm2 e
+      JOIN public.proteins p USING (uid)
+     ORDER BY e.embedding <=> query_vec
+     LIMIT LEAST(match_count, 1000);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.knn_search_esm2(text, int)
+  TO bloom_user, bloom_agent, bloom_admin;
+
+COMMIT;

--- a/tests/integration/test_accession_esm3_schema.py
+++ b/tests/integration/test_accession_esm3_schema.py
@@ -1,0 +1,524 @@
+"""
+Integration tests for the Arabidopsis-accession ESM-3 layer. Covers: the esm3
+registry row, protein_embedding_runs provenance, arabidopsis_accessions
+(natural key + one-reference + NOT NULLs), proteins.accession_id (FK, one
+locus per accession, cross-species rows stay NULL), protein_embeddings_esm3
+(vector(1536) dimension guardrail, zero-vector CHECK, run FK, ON DELETE
+CASCADE, HNSW index / no ivfflat), the three comparison RPCs (knn_search_esm3,
+compare_gene_across_accessions, search_accession_genes) and the search_genes
+scoping change, plus RLS (anon blocked via REST; read matrix for every bloom_*
+role; write-denial for user/agent; writer can ingest) and a six-policy drift
+detector.
+
+  uv run --extra test pytest tests/integration/test_accession_esm3_schema.py -v
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+# 'atest:' prefix avoids colliding with real ingested UIDs or the embedtree
+# test's 'test:' UIDs.
+REF_UID = "atest:1:AT1G01010"      # Col-0 variant  (reference accession)
+ALT_UID = "atest:2:AT1G01010"      # Ler-0 variant  (same gene, other accession)
+SOLO_UID = "atest:2:AT2G00001"     # gene present in only one accession
+XSPEC_UID = "atest:xspec:AT1G01010"  # cross-species protein, accession_id NULL
+ACCESSION_UIDS = (REF_UID, ALT_UID, SOLO_UID)
+ALL_UIDS = (*ACCESSION_UIDS, XSPEC_UID)
+
+COL0_SRC, COL0_EXT = "1001 Genomes", "atest-6909"
+LER0_SRC, LER0_EXT = "1001 Genomes", "atest-6932"
+
+ESM3_DIM = 1536
+
+
+def _make_vec(dim: int, fill: dict[int, float]) -> list[float]:
+    v = [0.0] * dim
+    for i, x in fill.items():
+        v[i] = x
+    return v
+
+
+def _to_pgvector(v: list[float]) -> str:
+    return "[" + ",".join(f"{x:.8f}" for x in v) + "]"
+
+
+# Q identical to itself; ALT cosine≈0.9 vs Q; SOLO orthogonal (cosine 0).
+_NEAR_X = 0.9
+_NEAR_Y = (1.0 - _NEAR_X * _NEAR_X) ** 0.5
+REF_VEC = _make_vec(ESM3_DIM, {0: 1.0})
+ALT_VEC = _make_vec(ESM3_DIM, {0: _NEAR_X, 1: _NEAR_Y})
+SOLO_VEC = _make_vec(ESM3_DIM, {1: 1.0})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def accession_seed(pg_conn):
+    """
+    Seed 2 accessions (Col-0 is_reference, Ler-0), one embedding run, three
+    accession proteins (AT1G01010 in both accessions, AT2G00001 in Ler-0 only),
+    a cross-species protein sharing the AT1G01010 gene_id, and ESM-3 embeddings
+    for the three accession proteins. Teardown is reverse-FK order.
+    """
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO public.arabidopsis_accessions "
+            "  (common_name, external_id, id_source, is_reference) "
+            "VALUES (%s, %s, %s, true) RETURNING id",
+            ("atest-Col-0", COL0_EXT, COL0_SRC),
+        )
+        (col0_id,) = cur.fetchone()
+        cur.execute(
+            "INSERT INTO public.arabidopsis_accessions "
+            "  (common_name, external_id, id_source, is_reference) "
+            "VALUES (%s, %s, %s, false) RETURNING id",
+            ("atest-Ler-0", LER0_EXT, LER0_SRC),
+        )
+        (ler0_id,) = cur.fetchone()
+
+        cur.execute(
+            "INSERT INTO public.protein_embedding_runs "
+            "  (model_id, checkpoint_hash, pooling, layer, sequence_source, software_version) "
+            "VALUES ('esm3_open_small_1p4B', %s, 'mean', 36, %s, 'atest-1.0') RETURNING id",
+            ("atest-checkpoint-hash", "Araport11 primary transcript"),
+        )
+        (run_id,) = cur.fetchone()
+
+        proteins = [
+            (REF_UID, "arabidopsis", "AT1G01010", col0_id),
+            (ALT_UID, "arabidopsis", "AT1G01010", ler0_id),
+            (SOLO_UID, "arabidopsis", "AT2G00001", ler0_id),
+            (XSPEC_UID, "arabidopsis", "AT1G01010", None),
+        ]
+        for uid, species, gene_id, accession_id in proteins:
+            cur.execute(
+                "INSERT INTO public.proteins (uid, species, gene_id, accession_id) "
+                "VALUES (%s, %s, %s, %s)",
+                (uid, species, gene_id, accession_id),
+            )
+        for uid, vec in ((REF_UID, REF_VEC), (ALT_UID, ALT_VEC), (SOLO_UID, SOLO_VEC)):
+            cur.execute(
+                "INSERT INTO public.protein_embeddings_esm3 (uid, embedding, run_id) "
+                "VALUES (%s, %s::vector(1536), %s)",
+                (uid, _to_pgvector(vec), run_id),
+            )
+        pg_conn.commit()
+
+    yield {"col0_id": col0_id, "ler0_id": ler0_id, "run_id": run_id}
+
+    with pg_conn.cursor() as cur:
+        cur.execute("DELETE FROM public.protein_embeddings_esm3 WHERE uid = ANY(%s)", (list(ALL_UIDS),))
+        cur.execute("DELETE FROM public.proteins WHERE uid = ANY(%s)", (list(ALL_UIDS),))
+        cur.execute(
+            "DELETE FROM public.protein_embedding_runs WHERE checkpoint_hash = %s",
+            ("atest-checkpoint-hash",),
+        )
+        cur.execute(
+            "DELETE FROM public.arabidopsis_accessions WHERE external_id = ANY(%s)",
+            ([COL0_EXT, LER0_EXT],),
+        )
+        pg_conn.commit()
+
+
+def _expect_violation(pg_conn, sql, params=None, sqlstate_prefix=None):
+    """Run sql inside a savepoint; assert it raises, roll back to the savepoint."""
+    import psycopg
+
+    with pg_conn.cursor() as cur:
+        cur.execute("SAVEPOINT sp")
+        raised = None
+        try:
+            cur.execute(sql, params or ())
+        except psycopg.Error as exc:
+            raised = exc
+        cur.execute("ROLLBACK TO SAVEPOINT sp")
+    assert raised is not None, f"expected a violation but the statement succeeded: {sql}"
+    if sqlstate_prefix:
+        assert (raised.sqlstate or "").startswith(sqlstate_prefix), (
+            f"expected SQLSTATE {sqlstate_prefix}*, got {raised.sqlstate}: {raised}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1. Registry + provenance
+# ---------------------------------------------------------------------------
+
+def test_esm3_model_registered(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT dimension, table_suffix FROM public.protein_embedding_models "
+            "WHERE model_id = 'esm3_open_small_1p4B'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "esm3 model row missing from protein_embedding_models"
+    assert row[0] == 1536
+    assert row[1] == "esm3"
+
+
+def test_embedding_run_requires_provenance(pg_conn):
+    """model_id/checkpoint_hash/pooling/sequence_source are NOT NULL."""
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.protein_embedding_runs (model_id, checkpoint_hash, pooling, sequence_source) "
+        "VALUES ('esm3_open_small_1p4B', NULL, 'mean', 'src')",
+        sqlstate_prefix="23",
+    )
+
+
+def test_embedding_run_id_resolves(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT r.pooling, r.checkpoint_hash, r.sequence_source "
+            "FROM public.protein_embeddings_esm3 e "
+            "JOIN public.protein_embedding_runs r ON r.id = e.run_id "
+            "WHERE e.uid = %s",
+            (REF_UID,),
+        )
+        row = cur.fetchone()
+    assert row == ("mean", "atest-checkpoint-hash", "Araport11 primary transcript")
+
+
+# ---------------------------------------------------------------------------
+# 2. arabidopsis_accessions
+# ---------------------------------------------------------------------------
+
+def test_accession_natural_key_and_reference(pg_conn, accession_seed):
+    # Same external_id, different source → allowed.
+    with pg_conn.cursor() as cur:
+        cur.execute("SAVEPOINT sp")
+        cur.execute(
+            "INSERT INTO public.arabidopsis_accessions (common_name, external_id, id_source) "
+            "VALUES ('atest-other', %s, 'TAIR')",
+            (COL0_EXT,),
+        )
+        cur.execute("ROLLBACK TO SAVEPOINT sp")
+
+    # Duplicate (id_source, external_id) → rejected.
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.arabidopsis_accessions (common_name, external_id, id_source) "
+        "VALUES ('atest-dup', %s, %s)",
+        (COL0_EXT, COL0_SRC),
+        sqlstate_prefix="23",
+    )
+    # A second is_reference=true → rejected (partial unique index).
+    _expect_violation(
+        pg_conn,
+        "UPDATE public.arabidopsis_accessions SET is_reference = true WHERE external_id = %s",
+        (LER0_EXT,),
+        sqlstate_prefix="23",
+    )
+    # NULL required column → rejected.
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.arabidopsis_accessions (common_name, external_id, id_source) "
+        "VALUES (NULL, 'x', 'y')",
+        sqlstate_prefix="23",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. proteins.accession_id
+# ---------------------------------------------------------------------------
+
+def test_accession_id_fk_and_uniqueness(pg_conn, accession_seed):
+    col0_id = accession_seed["col0_id"]
+
+    # FK: unknown accession_id rejected.
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.proteins (uid, gene_id, accession_id) VALUES ('atest:bad', 'G', 2147483000)",
+        sqlstate_prefix="23",
+    )
+    # Same gene across accessions → distinct uids already seeded; assert both exist.
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(DISTINCT uid) FROM public.proteins "
+            "WHERE gene_id = 'AT1G01010' AND accession_id IS NOT NULL"
+        )
+        assert cur.fetchone()[0] == 2
+    # One locus per accession: duplicate (accession_id, gene_id) rejected.
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.proteins (uid, gene_id, accession_id) VALUES ('atest:dup', 'AT1G01010', %s)",
+        (col0_id,),
+        sqlstate_prefix="23",
+    )
+    # Cross-species rows (accession_id NULL) may repeat a gene_id.
+    with pg_conn.cursor() as cur:
+        cur.execute("SAVEPOINT sp")
+        cur.execute(
+            "INSERT INTO public.proteins (uid, gene_id, accession_id) VALUES ('atest:xspec2', 'AT1G01010', NULL)"
+        )
+        cur.execute("ROLLBACK TO SAVEPOINT sp")
+
+
+# ---------------------------------------------------------------------------
+# 4. protein_embeddings_esm3 guardrails
+# ---------------------------------------------------------------------------
+
+def test_embedding_dimension_guardrail(pg_conn, accession_seed):
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.protein_embeddings_esm3 (uid, embedding, run_id) "
+        "VALUES (%s, '[1,0,0]'::vector(3), %s)",
+        (SOLO_UID, accession_seed["run_id"]),
+    )
+
+
+def test_embedding_zero_vector_rejected(pg_conn, accession_seed):
+    zero = _to_pgvector(_make_vec(ESM3_DIM, {}))
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.protein_embeddings_esm3 (uid, embedding, run_id) "
+        "VALUES ('atest:zero', %s::vector(1536), %s)",
+        (zero, accession_seed["run_id"]),
+        sqlstate_prefix="23",  # check_violation
+    )
+
+
+def test_embedding_run_fk_enforced(pg_conn, accession_seed):
+    vec = _to_pgvector(_make_vec(ESM3_DIM, {0: 1.0}))
+    # Need a fresh protein uid so the PK doesn't fire first.
+    with pg_conn.cursor() as cur:
+        cur.execute("SAVEPOINT outer_sp")
+        cur.execute(
+            "INSERT INTO public.proteins (uid, gene_id, accession_id) VALUES ('atest:frfk', 'AT3G0', %s)",
+            (accession_seed["ler0_id"],),
+        )
+        raised = None
+        import psycopg
+        try:
+            cur.execute(
+                "INSERT INTO public.protein_embeddings_esm3 (uid, embedding, run_id) "
+                "VALUES ('atest:frfk', %s::vector(1536), 2147483000)",
+                (vec,),
+            )
+        except psycopg.Error as exc:
+            raised = exc
+        cur.execute("ROLLBACK TO SAVEPOINT outer_sp")
+    assert raised is not None and (raised.sqlstate or "").startswith("23")
+
+
+def test_embedding_cascades_on_protein_delete(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute("SAVEPOINT sp")
+        cur.execute("DELETE FROM public.proteins WHERE uid = %s", (SOLO_UID,))
+        cur.execute("SELECT count(*) FROM public.protein_embeddings_esm3 WHERE uid = %s", (SOLO_UID,))
+        remaining = cur.fetchone()[0]
+        cur.execute("ROLLBACK TO SAVEPOINT sp")
+    assert remaining == 0, "ON DELETE CASCADE did not remove the embedding"
+
+
+def test_hnsw_index_present_no_ivfflat(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname='public' AND tablename='protein_embeddings_esm3'"
+        )
+        defs = [r[0].lower() for r in cur.fetchall()]
+    assert any("hnsw" in d and "vector_cosine_ops" in d for d in defs), "HNSW cosine index missing"
+    assert not any("ivfflat" in d for d in defs), "ivfflat index must not be used"
+
+
+# ---------------------------------------------------------------------------
+# 5. RPCs
+# ---------------------------------------------------------------------------
+
+def test_knn_search_esm3_ordering_and_scope(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT uid, accession_name, gene_id, similarity "
+            "FROM public.knn_search_esm3(%s, 10)",
+            (REF_UID,),
+        )
+        rows = cur.fetchall()
+    uids = [r[0] for r in rows]
+    assert uids == [REF_UID, ALT_UID, SOLO_UID], f"unexpected KNN order: {uids}"
+    assert abs(rows[0][3] - 1.0) < 1e-6
+    assert rows[0][3] > rows[1][3] > rows[2][3]
+    assert rows[0][1] == "atest-Col-0"  # accession_name joined
+    assert XSPEC_UID not in uids  # accession-only scope
+
+
+def test_knn_search_esm3_missing_query_returns_empty(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM public.knn_search_esm3('atest:nope', 10)")
+        assert cur.fetchone()[0] == 0
+
+
+def test_compare_default_reference_is_col0(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT uid, is_reference, similarity "
+            "FROM public.compare_gene_across_accessions('AT1G01010')"
+        )
+        rows = cur.fetchall()
+    assert rows[0][0] == REF_UID and rows[0][1] is True
+    assert abs(rows[0][2] - 1.0) < 1e-6
+    assert {r[0] for r in rows} == {REF_UID, ALT_UID}  # accession variants only
+
+
+def test_compare_explicit_reference(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT uid, is_reference FROM public.compare_gene_across_accessions('AT1G01010', %s)",
+            (ALT_UID,),
+        )
+        rows = cur.fetchall()
+    assert rows[0][0] == ALT_UID and rows[0][1] is True
+
+
+def test_compare_reference_from_other_gene_returns_empty(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM public.compare_gene_across_accessions('AT1G01010', %s)",
+            (SOLO_UID,),  # SOLO_UID's gene is AT2G00001, not AT1G01010
+        )
+        assert cur.fetchone()[0] == 0
+
+
+def test_compare_single_accession_gene(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT uid, is_reference, similarity "
+            "FROM public.compare_gene_across_accessions('AT2G00001')"
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == SOLO_UID and rows[0][1] is True and abs(rows[0][2] - 1.0) < 1e-6
+
+
+def test_compare_unknown_gene_returns_empty(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM public.compare_gene_across_accessions('AT9G99999')")
+        assert cur.fetchone()[0] == 0
+
+
+def test_search_accession_genes_scope(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT uid FROM public.search_accession_genes('AT1G01010', 20)")
+        uids = {r[0] for r in cur.fetchall()}
+    assert uids == {REF_UID, ALT_UID}  # accession-only; excludes XSPEC_UID
+
+
+def test_search_accession_genes_empty_input(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM public.search_accession_genes('   ', 20)")
+        assert cur.fetchone()[0] == 0
+
+
+def test_search_genes_excludes_accession_proteins(pg_conn, accession_seed):
+    """The cross-species picker must return only the accession_id-NULL protein."""
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT uid FROM public.search_genes('AT1G01010', 20)")
+        uids = {r[0] for r in cur.fetchall()}
+    assert XSPEC_UID in uids
+    assert not (uids & set(ACCESSION_UIDS)), f"accession proteins leaked into search_genes: {uids}"
+
+
+# ---------------------------------------------------------------------------
+# 6. RLS: anon blocked, read matrix, write-denial, drift
+# ---------------------------------------------------------------------------
+
+NEW_TABLES = ["arabidopsis_accessions", "protein_embedding_runs", "protein_embeddings_esm3"]
+
+
+@pytest.mark.parametrize("table", NEW_TABLES)
+def test_anon_cannot_read_new_tables_via_postgrest(api, anon_key, accession_seed, table):
+    status, body = api(f"/api/rest/v1/{table}?select=*&limit=5", api_key=anon_key)
+    if status in (401, 403):
+        return
+    if status == 200 and isinstance(body, list) and len(body) == 0:
+        return
+    pytest.fail(f"anon role appears to read public.{table} (status={status}, body={body!r})")
+
+
+@pytest.mark.parametrize("role", ["bloom_user", "bloom_agent", "bloom_admin", "bloom_writer"])
+@pytest.mark.parametrize("table", NEW_TABLES)
+def test_each_role_can_select(pg_conn, accession_seed, role, table):
+    with pg_conn.cursor() as cur:
+        cur.execute("BEGIN")
+        try:
+            cur.execute(f"SET LOCAL ROLE {role}")
+            cur.execute(f"SELECT count(*) FROM public.{table}")
+            assert cur.fetchone()[0] is not None
+        finally:
+            cur.execute("ROLLBACK")
+
+
+@pytest.mark.parametrize("role", ["bloom_user", "bloom_agent"])
+def test_read_only_roles_cannot_insert(pg_conn, accession_seed, role):
+    import psycopg
+
+    with pg_conn.cursor() as cur:
+        cur.execute("BEGIN")
+        try:
+            cur.execute(f"SET LOCAL ROLE {role}")
+            raised = None
+            try:
+                cur.execute(
+                    "INSERT INTO public.arabidopsis_accessions (common_name, external_id, id_source) "
+                    "VALUES ('atest-denied', 'atest-x', 'atest-src')"
+                )
+            except psycopg.Error as exc:
+                raised = exc
+            assert raised is not None, f"{role} was able to INSERT — write path is not denied"
+            assert (raised.sqlstate or "").startswith("42"), (
+                f"expected insufficient_privilege (42501), got {raised.sqlstate}"
+            )
+        finally:
+            cur.execute("ROLLBACK")
+
+
+def test_writer_role_can_ingest(pg_conn):
+    """bloom_writer can insert an accession, a run, and an embedding."""
+    with pg_conn.cursor() as cur:
+        cur.execute("BEGIN")
+        try:
+            cur.execute("SET LOCAL ROLE bloom_writer")
+            cur.execute(
+                "INSERT INTO public.arabidopsis_accessions (common_name, external_id, id_source) "
+                "VALUES ('atest-writer', 'atest-w', 'atest-wsrc') RETURNING id"
+            )
+            assert cur.fetchone()[0] is not None
+            cur.execute(
+                "INSERT INTO public.protein_embedding_runs "
+                "  (model_id, checkpoint_hash, pooling, sequence_source) "
+                "VALUES ('esm3_open_small_1p4B', 'atest-wh', 'mean', 'src') RETURNING id"
+            )
+            assert cur.fetchone()[0] is not None
+        finally:
+            cur.execute("ROLLBACK")  # never persist writer test rows
+
+
+EXPECTED_POLICY_PREFIXES = (
+    "admin_all_", "agent_read_", "user_read_",
+    "writer_read_", "writer_insert_", "writer_update_",
+)
+
+
+def test_pg_policies_six_policy_pattern(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT tablename, policyname FROM pg_policies "
+            "WHERE schemaname='public' AND tablename = ANY(%s)",
+            (NEW_TABLES,),
+        )
+        rows = cur.fetchall()
+    by_table: dict[str, set[str]] = {t: set() for t in NEW_TABLES}
+    for tbl, policy in rows:
+        by_table[tbl].add(policy)
+    missing = [
+        f"{prefix}{tbl}"
+        for tbl in NEW_TABLES
+        for prefix in EXPECTED_POLICY_PREFIXES
+        if f"{prefix}{tbl}" not in by_table[tbl]
+    ]
+    assert not missing, f"missing RLS policies (drift): {missing}"

--- a/tests/integration/test_accession_esm3_schema.py
+++ b/tests/integration/test_accession_esm3_schema.py
@@ -273,13 +273,33 @@ def test_embedding_dimension_guardrail(pg_conn, accession_seed):
 
 
 def test_embedding_zero_vector_rejected(pg_conn, accession_seed):
+    """The non-zero CHECK (not the FK) rejects an all-zeros vector. Uses a
+    fresh, valid protein uid so the only constraint that can fire is the CHECK
+    — asserting the exact SQLSTATE 23514 so removing the CHECK is detectable."""
+    import psycopg
+
     zero = _to_pgvector(_make_vec(ESM3_DIM, {}))
-    _expect_violation(
-        pg_conn,
-        "INSERT INTO public.protein_embeddings_esm3 (uid, embedding, run_id) "
-        "VALUES ('atest:zero', %s::vector(1536), %s)",
-        (zero, accession_seed["run_id"]),
-        sqlstate_prefix="23",  # check_violation
+    with pg_conn.cursor() as cur:
+        cur.execute("SAVEPOINT sp")
+        cur.execute(
+            "INSERT INTO public.proteins (uid, gene_id, accession_id) "
+            "VALUES ('atest:zerop', 'ATZERO', %s)",
+            (accession_seed["col0_id"],),
+        )
+        raised = None
+        try:
+            cur.execute(
+                "INSERT INTO public.protein_embeddings_esm3 (uid, embedding, run_id) "
+                "VALUES ('atest:zerop', %s::vector(1536), %s)",
+                (zero, accession_seed["run_id"]),
+            )
+        except psycopg.Error as exc:
+            raised = exc
+        cur.execute("ROLLBACK TO SAVEPOINT sp")
+    assert raised is not None, "zero vector was accepted"
+    assert raised.sqlstate == "23514", (
+        f"expected check_violation 23514 (the non-zero CHECK), got "
+        f"{raised.sqlstate}: {raised}"
     )
 
 
@@ -331,7 +351,7 @@ def test_hnsw_index_present_no_ivfflat(pg_conn):
 # 5. RPCs
 # ---------------------------------------------------------------------------
 
-def test_knn_search_esm3_ordering_and_scope(pg_conn, accession_seed):
+def test_knn_search_esm3_excludes_self_and_orders(pg_conn, accession_seed):
     with pg_conn.cursor() as cur:
         cur.execute(
             "SELECT uid, accession_name, gene_id, similarity "
@@ -340,11 +360,23 @@ def test_knn_search_esm3_ordering_and_scope(pg_conn, accession_seed):
         )
         rows = cur.fetchall()
     uids = [r[0] for r in rows]
-    assert uids == [REF_UID, ALT_UID, SOLO_UID], f"unexpected KNN order: {uids}"
-    assert abs(rows[0][3] - 1.0) < 1e-6
-    assert rows[0][3] > rows[1][3] > rows[2][3]
-    assert rows[0][1] == "atest-Col-0"  # accession_name joined
+    # The query protein is excluded; only the two other accession proteins
+    # remain, nearest-first (ALT cosine ~0.9, SOLO ~0).
+    assert uids == [ALT_UID, SOLO_UID], f"unexpected KNN result: {uids}"
+    assert REF_UID not in uids  # query itself is never returned
     assert XSPEC_UID not in uids  # accession-only scope
+    assert rows[0][1] == "atest-Ler-0"  # nearest neighbor's accession_name
+    assert rows[0][3] > rows[1][3]  # descending similarity
+
+
+def test_knn_search_esm3_match_count_is_neighbor_count(pg_conn, accession_seed):
+    """match_count = number of NEIGHBORS returned (query excluded), so a
+    request for K yields K real neighbors, not K-1."""
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT uid FROM public.knn_search_esm3(%s, 1)", (REF_UID,))
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == ALT_UID  # the single nearest neighbor, not self
 
 
 def test_knn_search_esm3_missing_query_returns_empty(pg_conn, accession_seed):
@@ -478,7 +510,10 @@ def test_read_only_roles_cannot_insert(pg_conn, accession_seed, role):
 
 
 def test_writer_role_can_ingest(pg_conn):
-    """bloom_writer can insert an accession, a run, and an embedding."""
+    """bloom_writer can insert an accession, a run, a protein, and an ESM-3
+    embedding — the full ingest path, including the one table with the vector
+    CHECK and a writer_insert policy."""
+    vec = _to_pgvector(_make_vec(ESM3_DIM, {0: 1.0}))
     with pg_conn.cursor() as cur:
         cur.execute("BEGIN")
         try:
@@ -487,15 +522,74 @@ def test_writer_role_can_ingest(pg_conn):
                 "INSERT INTO public.arabidopsis_accessions (common_name, external_id, id_source) "
                 "VALUES ('atest-writer', 'atest-w', 'atest-wsrc') RETURNING id"
             )
-            assert cur.fetchone()[0] is not None
+            acc_id = cur.fetchone()[0]
+            assert acc_id is not None
             cur.execute(
                 "INSERT INTO public.protein_embedding_runs "
                 "  (model_id, checkpoint_hash, pooling, sequence_source) "
                 "VALUES ('esm3_open_small_1p4B', 'atest-wh', 'mean', 'src') RETURNING id"
             )
-            assert cur.fetchone()[0] is not None
+            run_id = cur.fetchone()[0]
+            assert run_id is not None
+            cur.execute(
+                "INSERT INTO public.proteins (uid, gene_id, accession_id) "
+                "VALUES ('atest:writer:G', 'GW', %s)",
+                (acc_id,),
+            )
+            cur.execute(
+                "INSERT INTO public.protein_embeddings_esm3 (uid, embedding, run_id) "
+                "VALUES ('atest:writer:G', %s::vector(1536), %s)",
+                (vec, run_id),
+            )  # succeeds → writer can ingest embeddings
         finally:
             cur.execute("ROLLBACK")  # never persist writer test rows
+
+
+def test_embedding_run_model_id_fk(pg_conn):
+    """protein_embedding_runs.model_id FKs to protein_embedding_models — a run
+    naming an unregistered model is rejected."""
+    _expect_violation(
+        pg_conn,
+        "INSERT INTO public.protein_embedding_runs "
+        "  (model_id, checkpoint_hash, pooling, sequence_source) "
+        "VALUES ('no_such_model', 'h', 'mean', 'src')",
+        sqlstate_prefix="23",  # 23503 foreign_key_violation
+    )
+
+
+def test_rpc_match_count_bounds_do_not_crash(pg_conn, accession_seed):
+    """Negative match_count clamps to >=1 (no LIMIT -n error); huge caps at 1000."""
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM public.knn_search_esm3(%s, -5)", (REF_UID,))
+        assert cur.fetchone()[0] >= 1  # clamped, no runtime error
+        cur.execute("SELECT count(*) FROM public.knn_search_esm3(%s, 100000)", (REF_UID,))
+        assert cur.fetchone()[0] <= 1000
+        cur.execute(
+            "SELECT count(*) FROM public.compare_gene_across_accessions('AT1G01010', NULL, -1)"
+        )
+        assert cur.fetchone()[0] >= 1
+
+
+def test_compare_reference_survives_truncation(pg_conn, accession_seed):
+    """AT1G01010 has 2 accession variants; match_count=1 must still return the
+    reference (it sorts first), not merely the most-similar non-reference."""
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT uid, is_reference "
+            "FROM public.compare_gene_across_accessions('AT1G01010', NULL, 1)"
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == REF_UID and rows[0][1] is True
+
+
+def test_compare_empty_gene_returns_empty(pg_conn, accession_seed):
+    with pg_conn.cursor() as cur:
+        for g in ("", "   "):
+            cur.execute(
+                "SELECT count(*) FROM public.compare_gene_across_accessions(%s)", (g,)
+            )
+            assert cur.fetchone()[0] == 0, f"empty gene {g!r} should return no rows"
 
 
 EXPECTED_POLICY_PREFIXES = (

--- a/web/app/app/embedtree/page.tsx
+++ b/web/app/app/embedtree/page.tsx
@@ -1,16 +1,16 @@
 import { redirect } from "next/navigation";
 import { getUser } from "@/lib/supabase/server";
-import { EmbedtreePage } from "@/components/embedtree/embedtree-page";
+import { OrthoVecPage } from "@/components/embedtree/orthovec-page";
 
 export const metadata = {
-  title: "AI Orthologs | Bloom",
+  title: "OrthoVec | Bloom",
   description:
-    "Find predicted orthologs across plant species using ESM-2 protein embeddings.",
+    "Protein-embedding similarity: predicted orthologs across species (ESM-2) and Arabidopsis accession comparison (ESM-3).",
 };
 
 export default async function EmbedtreeRoute() {
   const user = await getUser();
   if (!user) redirect("/login");
 
-  return <EmbedtreePage />;
+  return <OrthoVecPage />;
 }

--- a/web/app/app/layout.tsx
+++ b/web/app/app/layout.tsx
@@ -30,7 +30,7 @@ const navSections = [
     items: [
       { name: "Bloom Assistant", href: "/chat" },
       { name: "OrthoBrowser", href: "/app/orthofinder" },
-      { name: "AI\nOrthologs", href: "/app/embedtree" },
+      { name: "OrthoVec", href: "/app/embedtree" },
     ],
   },
   {

--- a/web/components/accessions/accession-gene-picker.tsx
+++ b/web/components/accessions/accession-gene-picker.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import { accessionColor } from "./constants";
+
+const DEBOUNCE_MS = 300;
+const PAGE_SIZE = 20;
+
+// Loose RPC type until web/lib/database.types.ts is regenerated to know about
+// the accession RPCs (search_accession_genes). Drop when types catch up.
+type RpcCall = (name: string, args: object) => Promise<{
+  data: unknown;
+  error: { message?: string } | null;
+}>;
+
+export type AccessionGeneRow = {
+  uid: string;
+  accession_id: number;
+  accession_name: string | null;
+  gene_id: string | null;
+};
+
+type Props = {
+  onSelect: (row: AccessionGeneRow) => void;
+  placeholder?: string;
+  // Gene-level search: collapse the per-accession rows to one row per gene_id
+  // (Per-gene surface picks a locus, not a specific accession's protein).
+  dedupeByGene?: boolean;
+};
+
+/**
+ * Debounced autocomplete over `search_accession_genes(partial, max_results)`.
+ *
+ * Scoped to accession proteins only. Every request is tagged with a sequence
+ * number so a slow response can't overwrite a fresher one. With `dedupeByGene`
+ * the dropdown shows one entry per gene_id (locus-level); otherwise it shows
+ * each accession's protein separately (protein-level).
+ */
+export function AccessionGenePicker({
+  onSelect,
+  placeholder = "Search accession gene (e.g. AT1G01010)…",
+  dedupeByGene = false,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [rows, setRows] = useState<AccessionGeneRow[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [hoverIdx, setHoverIdx] = useState(0);
+
+  const supabase = createClientSupabaseClient();
+  const seqRef = useRef(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const runSearch = useCallback(
+    async (partial: string, seq: number) => {
+      setLoading(true);
+      const { data, error } = await (supabase.rpc as unknown as RpcCall)(
+        "search_accession_genes",
+        { partial_id: partial, max_results: PAGE_SIZE },
+      );
+      if (seq !== seqRef.current) return; // stale
+      setLoading(false);
+      if (error) {
+        setRows([]);
+        return;
+      }
+      let next = (data ?? []) as AccessionGeneRow[];
+      if (dedupeByGene) {
+        const seen = new Set<string>();
+        next = next.filter((r) => {
+          const key = r.gene_id ?? r.uid;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+      }
+      setRows(next);
+      setHoverIdx(0);
+    },
+    [supabase, dedupeByGene],
+  );
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const trimmed = query.trim();
+    if (trimmed.length < 1) {
+      setRows([]);
+      return;
+    }
+    const seq = ++seqRef.current;
+    debounceRef.current = setTimeout(() => void runSearch(trimmed, seq), DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, runSearch]);
+
+  const choose = useCallback(
+    (row: AccessionGeneRow) => {
+      setQuery(
+        dedupeByGene
+          ? (row.gene_id ?? row.uid)
+          : `${row.gene_id ?? row.uid} · ${row.accession_name ?? ""}`.trim(),
+      );
+      setOpen(false);
+      onSelect(row);
+    },
+    [onSelect, dedupeByGene],
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || rows.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHoverIdx((i) => Math.min(i + 1, rows.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHoverIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      choose(rows[hoverIdx]);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative w-96">
+      <input
+        type="text"
+        value={query}
+        placeholder={placeholder}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+        className="w-full rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm shadow-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+      />
+      {loading && (
+        <span className="absolute right-3 top-2 text-xs text-neutral-400">…</span>
+      )}
+      {open && rows.length > 0 && (
+        <ul className="absolute z-10 mt-1 max-h-72 w-full overflow-y-auto rounded-md border border-stone-200 bg-white shadow-lg">
+          {rows.map((row, i) => (
+            <li
+              key={row.uid}
+              onMouseEnter={() => setHoverIdx(i)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                choose(row);
+              }}
+              className={`flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm ${
+                i === hoverIdx ? "bg-blue-50" : ""
+              }`}
+            >
+              {!dedupeByGene && (
+                <span
+                  className="inline-block h-2 w-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: accessionColor(row.accession_id) }}
+                  aria-hidden
+                />
+              )}
+              <span className="font-mono text-neutral-800">{row.gene_id ?? row.uid}</span>
+              {!dedupeByGene && (
+                <span className="ml-auto text-xs text-neutral-500">
+                  {row.accession_name}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/components/accessions/accession-gene-picker.tsx
+++ b/web/components/accessions/accession-gene-picker.tsx
@@ -22,6 +22,10 @@ export type AccessionGeneRow = {
 };
 
 type Props = {
+  // Controlled input text — the parent owns it so a programmatic change
+  // (e.g. a neighbor-click pivot) stays in sync with what is actually searched.
+  value: string;
+  onValueChange: (text: string) => void;
   onSelect: (row: AccessionGeneRow) => void;
   placeholder?: string;
   // Gene-level search: collapse the per-accession rows to one row per gene_id
@@ -30,19 +34,25 @@ type Props = {
 };
 
 /**
- * Debounced autocomplete over `search_accession_genes(partial, max_results)`.
+ * Controlled, debounced autocomplete over `search_accession_genes(partial,
+ * max_results)`.
  *
- * Scoped to accession proteins only. Every request is tagged with a sequence
- * number so a slow response can't overwrite a fresher one. With `dedupeByGene`
- * the dropdown shows one entry per gene_id (locus-level); otherwise it shows
- * each accession's protein separately (protein-level).
+ * The input text is owned by the parent (`value` / `onValueChange`) so the box
+ * always reflects the current selection — including when the parent changes it
+ * programmatically (a neighbor-click pivot). Autocomplete only runs on genuine
+ * keystrokes: a programmatic `value` change neither opens the dropdown nor
+ * fires a search. Every request is tagged with a sequence number so a slow
+ * response can't overwrite a fresher one, and clearing the box discards any
+ * in-flight response. With `dedupeByGene` the dropdown shows one entry per
+ * gene_id (locus-level); otherwise each accession's protein separately.
  */
 export function AccessionGenePicker({
+  value,
+  onValueChange,
   onSelect,
   placeholder = "Search accession gene (e.g. AT1G01010)…",
   dedupeByGene = false,
 }: Props) {
-  const [query, setQuery] = useState("");
   const [rows, setRows] = useState<AccessionGeneRow[]>([]);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -51,6 +61,10 @@ export function AccessionGenePicker({
   const supabase = createClientSupabaseClient();
   const seqRef = useRef(0);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // True only for the value change caused by the user's own keystroke. A
+  // programmatic value change (pivot / selection) leaves it false, so the
+  // effect below skips searching and opening the dropdown.
+  const typedRef = useRef(false);
 
   const runSearch = useCallback(
     async (partial: string, seq: number) => {
@@ -83,8 +97,13 @@ export function AccessionGenePicker({
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    const trimmed = query.trim();
+    // Consume the keystroke flag; only search when the change was typed.
+    const typed = typedRef.current;
+    typedRef.current = false;
+    if (!typed) return;
+    const trimmed = value.trim();
     if (trimmed.length < 1) {
+      seqRef.current++; // discard any in-flight response
       setRows([]);
       return;
     }
@@ -93,11 +112,12 @@ export function AccessionGenePicker({
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [query, runSearch]);
+  }, [value, runSearch]);
 
   const choose = useCallback(
     (row: AccessionGeneRow) => {
-      setQuery(
+      typedRef.current = false;
+      onValueChange(
         dedupeByGene
           ? (row.gene_id ?? row.uid)
           : `${row.gene_id ?? row.uid} · ${row.accession_name ?? ""}`.trim(),
@@ -105,7 +125,7 @@ export function AccessionGenePicker({
       setOpen(false);
       onSelect(row);
     },
-    [onSelect, dedupeByGene],
+    [onSelect, onValueChange, dedupeByGene],
   );
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -128,13 +148,15 @@ export function AccessionGenePicker({
     <div className="relative w-96">
       <input
         type="text"
-        value={query}
+        value={value}
         placeholder={placeholder}
         onChange={(e) => {
-          setQuery(e.target.value);
+          typedRef.current = true;
+          onValueChange(e.target.value);
           setOpen(true);
         }}
         onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
         onKeyDown={onKeyDown}
         className="w-full rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm shadow-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
       />

--- a/web/components/accessions/accession-knn.tsx
+++ b/web/components/accessions/accession-knn.tsx
@@ -53,8 +53,9 @@ export function AccessionKnn({ queryUid, queryLabel, k, onSelectNeighbor }: Prop
         setNeighbors([]);
         return;
       }
-      // Drop the query's own row (self-match, similarity 1.0).
-      setNeighbors(((data ?? []) as AccessionNeighbor[]).filter((n) => n.uid !== queryUid));
+      // knn_search_esm3 already excludes the query itself, so match_count rows
+      // are all genuine neighbors.
+      setNeighbors((data ?? []) as AccessionNeighbor[]);
     })();
     return () => {
       cancelled = true;

--- a/web/components/accessions/accession-knn.tsx
+++ b/web/components/accessions/accession-knn.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 import { accessionColor } from "./constants";
+import { downloadCsv, toCsv } from "./csv";
 
 type RpcCall = (name: string, args: object) => Promise<{
   data: unknown;
@@ -60,13 +61,38 @@ export function AccessionKnn({ queryUid, queryLabel, k, onSelectNeighbor }: Prop
     };
   }, [supabase, queryUid, k]);
 
+  const handleDownload = () => {
+    const csv = toCsv(
+      ["rank", "gene_id", "accession_name", "accession_id", "uid", "cosine_similarity"],
+      neighbors.map((n, i) => [
+        i + 1,
+        n.gene_id,
+        n.accession_name,
+        n.accession_id,
+        n.uid,
+        n.similarity.toFixed(6),
+      ]),
+    );
+    downloadCsv(`${queryUid.replace(/[^\w.-]+/g, "_")}_neighbors.csv`, csv);
+  };
+
   return (
     <div className="rounded-md border border-stone-200 bg-white">
       <div className="flex items-center justify-between border-b border-stone-200 px-3 py-2">
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
           Nearest neighbors of {queryLabel}
         </span>
-        {loading && <span className="text-xs text-neutral-500">Running KNN…</span>}
+        <div className="flex items-center gap-3">
+          {loading && <span className="text-xs text-neutral-500">Running KNN…</span>}
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={neighbors.length === 0}
+            className="rounded-md border border-stone-300 bg-white px-2.5 py-1 text-xs font-medium text-neutral-700 shadow-sm transition-colors hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Download CSV
+          </button>
+        </div>
       </div>
 
       {error && <p className="px-3 py-2 text-xs text-red-600">Error: {error}</p>}

--- a/web/components/accessions/accession-knn.tsx
+++ b/web/components/accessions/accession-knn.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import { accessionColor } from "./constants";
+
+type RpcCall = (name: string, args: object) => Promise<{
+  data: unknown;
+  error: { message?: string } | null;
+}>;
+
+export type AccessionNeighbor = {
+  uid: string;
+  accession_id: number;
+  accession_name: string | null;
+  gene_id: string | null;
+  similarity: number;
+};
+
+type Props = {
+  queryUid: string;
+  queryLabel: string;
+  k: number;
+  onSelectNeighbor: (neighbor: AccessionNeighbor) => void;
+};
+
+/**
+ * Surface B — pan-proteome nearest neighbors across accession proteins,
+ * backed by `knn_search_esm3`. Each neighbor shows its gene_id and accession,
+ * colored by accession. A ranked list (not the cross-species force-directed
+ * graph, which is hard-wired to species and reused via a follow-up).
+ */
+export function AccessionKnn({ queryUid, queryLabel, k, onSelectNeighbor }: Props) {
+  const supabase = createClientSupabaseClient();
+  const [neighbors, setNeighbors] = useState<AccessionNeighbor[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      const { data, error: rpcErr } = await (supabase.rpc as unknown as RpcCall)(
+        "knn_search_esm3",
+        { query_uid: queryUid, match_count: k },
+      );
+      if (cancelled) return;
+      setLoading(false);
+      if (rpcErr) {
+        setError(rpcErr.message ?? String(rpcErr));
+        setNeighbors([]);
+        return;
+      }
+      // Drop the query's own row (self-match, similarity 1.0).
+      setNeighbors(((data ?? []) as AccessionNeighbor[]).filter((n) => n.uid !== queryUid));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase, queryUid, k]);
+
+  return (
+    <div className="rounded-md border border-stone-200 bg-white">
+      <div className="flex items-center justify-between border-b border-stone-200 px-3 py-2">
+        <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          Nearest neighbors of {queryLabel}
+        </span>
+        {loading && <span className="text-xs text-neutral-500">Running KNN…</span>}
+      </div>
+
+      {error && <p className="px-3 py-2 text-xs text-red-600">Error: {error}</p>}
+
+      <div className="max-h-96 overflow-y-auto">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 bg-stone-50 text-xs uppercase tracking-wider text-neutral-500">
+            <tr>
+              <th className="w-12 px-3 py-2 text-right font-medium">Rank</th>
+              <th className="px-3 py-2 text-left font-medium">Gene</th>
+              <th className="px-3 py-2 text-left font-medium">Accession</th>
+              <th className="w-40 px-3 py-2 text-right font-medium">Cosine similarity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {neighbors.map((n, i) => (
+              <tr
+                key={n.uid}
+                onClick={() => onSelectNeighbor(n)}
+                className="cursor-pointer border-t border-stone-100 hover:bg-stone-50"
+              >
+                <td className="px-3 py-1.5 text-right font-mono text-xs text-neutral-400">
+                  {i + 1}
+                </td>
+                <td className="px-3 py-1.5 font-mono text-neutral-800">{n.gene_id ?? n.uid}</td>
+                <td className="px-3 py-1.5">
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: accessionColor(n.accession_id) }}
+                      aria-hidden
+                    />
+                    <span className="text-neutral-700">{n.accession_name}</span>
+                  </span>
+                </td>
+                <td className="px-3 py-1.5 text-right font-mono text-neutral-700">
+                  {n.similarity.toFixed(4)}
+                </td>
+              </tr>
+            ))}
+            {!loading && neighbors.length === 0 && !error && (
+              <tr>
+                <td colSpan={4} className="px-3 py-6 text-center text-sm text-neutral-500">
+                  No neighbors found for this protein.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web/components/accessions/accession-page.tsx
+++ b/web/components/accessions/accession-page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { AccessionGenePicker, type AccessionGeneRow } from "./accession-gene-picker";
+import { AccessionRankingPanel } from "./accession-ranking-panel";
+import { AccessionKnn } from "./accession-knn";
+import { ACCESSION_DISCLAIMER, DEFAULT_K, K_MAX, K_MIN } from "./constants";
+
+type Tab = "pergene" | "neighborhood";
+
+type ProteinSel = {
+  uid: string;
+  accession_id: number;
+  accession_name: string | null;
+  gene_id: string | null;
+};
+
+function TabButton({
+  active,
+  label,
+  hint,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  hint: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex flex-col items-start rounded-md border px-3 py-2 text-left transition-colors ${
+        active
+          ? "border-blue-500 bg-blue-50"
+          : "border-stone-300 bg-white hover:bg-stone-50"
+      }`}
+      aria-pressed={active}
+    >
+      <span className={`text-sm font-medium ${active ? "text-blue-700" : "text-neutral-700"}`}>
+        {label}
+      </span>
+      <span className="text-xs text-neutral-500">{hint}</span>
+    </button>
+  );
+}
+
+/**
+ * Accessions tab body. Two surfaces, each with its OWN search:
+ *   - Per-gene (Surface A): search a gene (locus-level) → rank all accessions
+ *     for that gene against the reference (Col-0 by default).
+ *   - Neighborhood (Surface B): search a specific accession protein → nearest
+ *     neighbors across the accession pan-proteome.
+ */
+export function AccessionPage() {
+  const [tab, setTab] = useState<Tab>("pergene");
+
+  // Independent selections — the two searches don't share state.
+  const [gene, setGene] = useState<string | null>(null);
+  const [protein, setProtein] = useState<ProteinSel | null>(null);
+  const [k, setK] = useState(DEFAULT_K);
+
+  const handleGene = useCallback((row: AccessionGeneRow) => {
+    setGene(row.gene_id);
+  }, []);
+
+  const handleProtein = useCallback((row: AccessionGeneRow) => {
+    setProtein({
+      uid: row.uid,
+      accession_id: row.accession_id,
+      accession_name: row.accession_name,
+      gene_id: row.gene_id,
+    });
+  }, []);
+
+  const proteinLabel = protein
+    ? `${protein.gene_id ?? protein.uid} · ${protein.accession_name ?? ""}`.trim()
+    : "";
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4">
+      <header className="flex flex-col gap-1">
+        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          <span className="font-semibold">Predicted, not verified.</span>{" "}
+          {ACCESSION_DISCLAIMER}
+        </p>
+      </header>
+
+      <section className="flex gap-3">
+        <TabButton
+          active={tab === "pergene"}
+          label="Per-gene"
+          hint="Rank accessions for one gene"
+          onClick={() => setTab("pergene")}
+        />
+        <TabButton
+          active={tab === "neighborhood"}
+          label="Neighborhood"
+          hint="Nearest proteins across accessions"
+          onClick={() => setTab("neighborhood")}
+        />
+      </section>
+
+      {tab === "pergene" ? (
+        <section className="flex flex-1 flex-col gap-4 overflow-y-auto">
+          <div className="flex flex-wrap items-center gap-3">
+            <AccessionGenePicker
+              onSelect={handleGene}
+              placeholder="Search a gene (e.g. AT1G01010)…"
+              dedupeByGene
+            />
+            <span className="text-xs text-neutral-500">
+              Ranks every accession&apos;s variant of the gene vs. the reference (Col-0).
+            </span>
+          </div>
+          {gene ? (
+            <AccessionRankingPanel geneId={gene} />
+          ) : (
+            <EmptyState text="Search for a gene to rank its variants across accessions." />
+          )}
+        </section>
+      ) : (
+        <section className="flex flex-1 flex-col gap-4 overflow-y-auto">
+          <div className="flex flex-wrap items-center gap-3">
+            <AccessionGenePicker
+              onSelect={handleProtein}
+              placeholder="Search an accession protein (gene · accession)…"
+            />
+            <label className="flex items-center gap-2 text-sm text-neutral-700">
+              K
+              <input
+                type="number"
+                min={K_MIN}
+                max={K_MAX}
+                value={k}
+                onChange={(e) =>
+                  setK(Math.max(K_MIN, Math.min(K_MAX, Math.round(Number(e.target.value)))))
+                }
+                className="w-16 rounded-md border border-stone-300 bg-white px-2 py-1 text-sm shadow-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              />
+            </label>
+          </div>
+          {protein ? (
+            <AccessionKnn
+              queryUid={protein.uid}
+              queryLabel={proteinLabel}
+              k={k}
+              onSelectNeighbor={(n) =>
+                setProtein({
+                  uid: n.uid,
+                  accession_id: n.accession_id,
+                  accession_name: n.accession_name,
+                  gene_id: n.gene_id,
+                })
+              }
+            />
+          ) : (
+            <EmptyState text="Search for an accession protein to see its nearest neighbors." />
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="flex h-72 w-full max-w-3xl items-center justify-center rounded-md border border-dashed border-stone-300 bg-stone-50 text-sm text-neutral-500">
+      {text}
+    </div>
+  );
+}

--- a/web/components/accessions/accession-page.tsx
+++ b/web/components/accessions/accession-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
 import { AccessionGenePicker, type AccessionGeneRow } from "./accession-gene-picker";
 import { AccessionRankingPanel } from "./accession-ranking-panel";
 import { AccessionKnn } from "./accession-knn";
@@ -8,29 +9,53 @@ import { ACCESSION_DISCLAIMER, DEFAULT_K, K_MAX, K_MIN } from "./constants";
 
 type Tab = "pergene" | "neighborhood";
 
-type ProteinSel = {
-  uid: string;
-  accession_id: number;
-  accession_name: string | null;
-  gene_id: string | null;
+// Loose table type until web/lib/database.types.ts is regenerated to know the
+// accession tables.
+type LooseFrom = (table: string) => {
+  select: (cols: string) => any;
 };
+
+type Accession = { id: number; common_name: string };
+
+function InfoDot({ text }: { text: string }) {
+  return (
+    <span className="group/info absolute right-2 top-2">
+      <span
+        tabIndex={0}
+        role="img"
+        aria-label={text}
+        className="flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-stone-300 text-[10px] font-semibold italic text-neutral-400 outline-none focus:ring-1 focus:ring-blue-500"
+      >
+        i
+      </span>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute right-0 top-6 z-20 w-64 rounded-md border border-stone-200 bg-white px-3 py-2 text-xs font-normal leading-snug text-neutral-600 opacity-0 shadow-lg transition-opacity group-hover/info:opacity-100 group-focus-within/info:opacity-100"
+      >
+        {text}
+      </span>
+    </span>
+  );
+}
 
 function TabButton({
   active,
   label,
   hint,
+  info,
   onClick,
 }: {
   active: boolean;
   label: string;
   hint: string;
+  info: string;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`flex flex-col items-start rounded-md border px-3 py-2 text-left transition-colors ${
+      className={`relative flex flex-col items-start rounded-md border px-3 py-2 pr-8 text-left transition-colors ${
         active
           ? "border-blue-500 bg-blue-50"
           : "border-stone-300 bg-white hover:bg-stone-50"
@@ -41,41 +66,77 @@ function TabButton({
         {label}
       </span>
       <span className="text-xs text-neutral-500">{hint}</span>
+      <InfoDot text={info} />
     </button>
   );
 }
 
+const searchBtn =
+  "rounded-md bg-blue-600 px-3.5 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50";
+
 /**
- * Accessions tab body. Two surfaces, each with its OWN search:
- *   - Per-gene (Surface A): search a gene (locus-level) → rank all accessions
- *     for that gene against the reference (Col-0 by default).
- *   - Neighborhood (Surface B): search a specific accession protein → nearest
- *     neighbors across the accession pan-proteome.
+ * Accessions tab body. Two surfaces, each with an autocomplete + explicit
+ * Search button (nothing runs until Search is pressed):
+ *   - Compare a gene (Surface A): search a gene → rank all accessions for it.
+ *   - Find similar proteins (Surface B): pick an accession + a gene → that
+ *     specific protein's nearest neighbors across the accession pan-proteome.
  */
 export function AccessionPage() {
+  const supabase = createClientSupabaseClient();
   const [tab, setTab] = useState<Tab>("pergene");
 
-  // Independent selections — the two searches don't share state.
+  // Surface A — `gene` is the picked suggestion; `submittedGene` is what the
+  // panel actually queries (set on Search).
   const [gene, setGene] = useState<string | null>(null);
-  const [protein, setProtein] = useState<ProteinSel | null>(null);
+  const [submittedGene, setSubmittedGene] = useState<string | null>(null);
+
+  // Surface B — accession + gene selections; `query` is committed on Search.
+  const [accessions, setAccessions] = useState<Accession[]>([]);
+  const [accId, setAccId] = useState<number | null>(null);
+  const [nbhdGene, setNbhdGene] = useState<string | null>(null);
   const [k, setK] = useState(DEFAULT_K);
+  const [query, setQuery] = useState<{ uid: string; label: string; k: number } | null>(null);
+  const [resolveMsg, setResolveMsg] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
 
-  const handleGene = useCallback((row: AccessionGeneRow) => {
-    setGene(row.gene_id);
-  }, []);
+  // Load the accession list once for the Surface B dropdown.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const { data } = await (supabase.from as unknown as LooseFrom)("arabidopsis_accessions")
+        .select("id, common_name")
+        .order("common_name");
+      if (!cancelled) setAccessions((data ?? []) as Accession[]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase]);
 
-  const handleProtein = useCallback((row: AccessionGeneRow) => {
-    setProtein({
-      uid: row.uid,
-      accession_id: row.accession_id,
-      accession_name: row.accession_name,
-      gene_id: row.gene_id,
-    });
-  }, []);
+  const accName = accessions.find((a) => a.id === accId)?.common_name ?? null;
 
-  const proteinLabel = protein
-    ? `${protein.gene_id ?? protein.uid} · ${protein.accession_name ?? ""}`.trim()
-    : "";
+  const handleGene = useCallback((row: AccessionGeneRow) => setGene(row.gene_id), []);
+  const handleNbhdGene = useCallback((row: AccessionGeneRow) => setNbhdGene(row.gene_id), []);
+
+  // Surface B: resolve (accession, gene) → protein uid, then commit the query.
+  const findNeighbors = useCallback(async () => {
+    if (accId == null || !nbhdGene) return;
+    setResolving(true);
+    setResolveMsg(null);
+    const { data } = await (supabase.from as unknown as LooseFrom)("proteins")
+      .select("uid")
+      .eq("accession_id", accId)
+      .eq("gene_id", nbhdGene)
+      .limit(1);
+    setResolving(false);
+    const rows = (data ?? []) as { uid: string }[];
+    if (rows.length === 0) {
+      setQuery(null);
+      setResolveMsg(`${accName ?? "This accession"} has no variant of ${nbhdGene}.`);
+      return;
+    }
+    setQuery({ uid: rows[0].uid, label: `${nbhdGene} · ${accName ?? ""}`.trim(), k });
+  }, [supabase, accId, nbhdGene, accName, k]);
 
   return (
     <div className="flex h-full flex-col gap-4 p-4">
@@ -89,14 +150,16 @@ export function AccessionPage() {
       <section className="flex gap-3">
         <TabButton
           active={tab === "pergene"}
-          label="Per-gene"
-          hint="Rank accessions for one gene"
+          label="Compare a gene across accessions"
+          hint="How one gene's protein varies between accessions"
+          info="Pick one gene. Every accession's version of that gene is ranked by how similar its protein is to the reference (Col-0). A score near 1.00 means nearly identical; lower means more divergent — so you can see which accessions vary most at that gene."
           onClick={() => setTab("pergene")}
         />
         <TabButton
           active={tab === "neighborhood"}
-          label="Neighborhood"
-          hint="Nearest proteins across accessions"
+          label="Find similar proteins"
+          hint="Nearest proteins across all accessions"
+          info="Pick an accession and a gene to choose a specific protein. It then finds the most similar proteins across every gene and accession. The same gene in other accessions usually ranks near the top, followed by related genes."
           onClick={() => setTab("neighborhood")}
         />
       </section>
@@ -109,23 +172,50 @@ export function AccessionPage() {
               placeholder="Search a gene (e.g. AT1G01010)…"
               dedupeByGene
             />
+            <button
+              type="button"
+              className={searchBtn}
+              disabled={!gene}
+              onClick={() => setSubmittedGene(gene)}
+            >
+              Search
+            </button>
             <span className="text-xs text-neutral-500">
               Ranks every accession&apos;s variant of the gene vs. the reference (Col-0).
             </span>
           </div>
-          {gene ? (
-            <AccessionRankingPanel geneId={gene} />
+          {submittedGene ? (
+            <AccessionRankingPanel geneId={submittedGene} />
           ) : (
             <EmptyState text="Search for a gene to rank its variants across accessions." />
           )}
         </section>
       ) : (
         <section className="flex flex-1 flex-col gap-4 overflow-y-auto">
-          <div className="flex flex-wrap items-center gap-3">
-            <AccessionGenePicker
-              onSelect={handleProtein}
-              placeholder="Search an accession protein (gene · accession)…"
-            />
+          <div className="flex flex-wrap items-end gap-3">
+            <label className="flex flex-col gap-1 text-xs text-neutral-500">
+              Accession
+              <select
+                value={accId ?? ""}
+                onChange={(e) => setAccId(e.target.value ? Number(e.target.value) : null)}
+                className="w-48 rounded-md border border-stone-300 bg-white px-2 py-1.5 text-sm text-neutral-800 shadow-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              >
+                <option value="">Select accession…</option>
+                {accessions.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.common_name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-neutral-500">
+              Gene
+              <AccessionGenePicker
+                onSelect={handleNbhdGene}
+                placeholder="Search a gene (e.g. AT1G01010)…"
+                dedupeByGene
+              />
+            </label>
             <label className="flex items-center gap-2 text-sm text-neutral-700">
               K
               <input
@@ -139,23 +229,35 @@ export function AccessionPage() {
                 className="w-16 rounded-md border border-stone-300 bg-white px-2 py-1 text-sm shadow-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
               />
             </label>
+            <button
+              type="button"
+              className={searchBtn}
+              disabled={accId == null || !nbhdGene || resolving}
+              onClick={() => void findNeighbors()}
+            >
+              {resolving ? "Searching…" : "Search"}
+            </button>
           </div>
-          {protein ? (
+          {resolveMsg && <p className="text-xs text-amber-700">{resolveMsg}</p>}
+          {query ? (
             <AccessionKnn
-              queryUid={protein.uid}
-              queryLabel={proteinLabel}
-              k={k}
-              onSelectNeighbor={(n) =>
-                setProtein({
+              queryUid={query.uid}
+              queryLabel={query.label}
+              k={query.k}
+              onSelectNeighbor={(n) => {
+                setAccId(n.accession_id);
+                setNbhdGene(n.gene_id);
+                setQuery({
                   uid: n.uid,
-                  accession_id: n.accession_id,
-                  accession_name: n.accession_name,
-                  gene_id: n.gene_id,
-                })
-              }
+                  label: `${n.gene_id ?? n.uid} · ${n.accession_name ?? ""}`.trim(),
+                  k: query.k,
+                });
+              }}
             />
           ) : (
-            <EmptyState text="Search for an accession protein to see its nearest neighbors." />
+            !resolveMsg && (
+              <EmptyState text="Pick an accession and a gene, then press Search." />
+            )
           )}
         </section>
       )}

--- a/web/components/accessions/accession-page.tsx
+++ b/web/components/accessions/accession-page.tsx
@@ -9,11 +9,17 @@ import { ACCESSION_DISCLAIMER, DEFAULT_K, K_MAX, K_MIN } from "./constants";
 
 type Tab = "pergene" | "neighborhood";
 
-// Loose table type until web/lib/database.types.ts is regenerated to know the
-// accession tables.
-type LooseFrom = (table: string) => {
-  select: (cols: string) => any;
-};
+// Loose PostgREST builder type until web/lib/database.types.ts is regenerated
+// to know the accession tables. Chain methods return the builder; awaiting it
+// yields { data, error } (no `any`).
+type LooseResult = { data: unknown; error: { message?: string } | null };
+interface LooseQuery extends PromiseLike<LooseResult> {
+  select: (cols: string) => LooseQuery;
+  order: (col: string) => LooseQuery;
+  eq: (col: string, val: unknown) => LooseQuery;
+  limit: (n: number) => LooseQuery;
+}
+type LooseFrom = (table: string) => LooseQuery;
 
 type Accession = { id: number; common_name: string };
 
@@ -85,28 +91,39 @@ export function AccessionPage() {
   const supabase = createClientSupabaseClient();
   const [tab, setTab] = useState<Tab>("pergene");
 
-  // Surface A — `gene` is the picked suggestion; `submittedGene` is what the
+  // Surface A — `geneText` is the picker box; `gene` is the committed
+  // selection (only set by picking a suggestion); `submittedGene` is what the
   // panel actually queries (set on Search).
+  const [geneText, setGeneText] = useState("");
   const [gene, setGene] = useState<string | null>(null);
   const [submittedGene, setSubmittedGene] = useState<string | null>(null);
 
   // Surface B — accession + gene selections; `query` is committed on Search.
   const [accessions, setAccessions] = useState<Accession[]>([]);
   const [accId, setAccId] = useState<number | null>(null);
+  const [nbhdGeneText, setNbhdGeneText] = useState("");
   const [nbhdGene, setNbhdGene] = useState<string | null>(null);
   const [k, setK] = useState(DEFAULT_K);
   const [query, setQuery] = useState<{ uid: string; label: string; k: number } | null>(null);
-  const [resolveMsg, setResolveMsg] = useState<string | null>(null);
+  const [resolveMsg, setResolveMsg] = useState<string | null>(null); // benign "no variant"
+  const [searchError, setSearchError] = useState<string | null>(null); // actual failure
+  const [accListError, setAccListError] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
 
   // Load the accession list once for the Surface B dropdown.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const { data } = await (supabase.from as unknown as LooseFrom)("arabidopsis_accessions")
+      const { data, error } = await (supabase.from as unknown as LooseFrom)("arabidopsis_accessions")
         .select("id, common_name")
         .order("common_name");
-      if (!cancelled) setAccessions((data ?? []) as Accession[]);
+      if (cancelled) return;
+      if (error) {
+        setAccListError(error.message ?? "Failed to load accessions.");
+        return;
+      }
+      setAccListError(null);
+      setAccessions((data ?? []) as Accession[]);
     })();
     return () => {
       cancelled = true;
@@ -123,12 +140,20 @@ export function AccessionPage() {
     if (accId == null || !nbhdGene) return;
     setResolving(true);
     setResolveMsg(null);
-    const { data } = await (supabase.from as unknown as LooseFrom)("proteins")
+    setSearchError(null);
+    // limit(1) is safe: UNIQUE (accession_id, gene_id) allows at most one row.
+    const { data, error } = await (supabase.from as unknown as LooseFrom)("proteins")
       .select("uid")
       .eq("accession_id", accId)
       .eq("gene_id", nbhdGene)
       .limit(1);
     setResolving(false);
+    if (error) {
+      // A real failure — do NOT claim the variant is missing.
+      setQuery(null);
+      setSearchError(error.message ?? "Lookup failed. Please try again.");
+      return;
+    }
     const rows = (data ?? []) as { uid: string }[];
     if (rows.length === 0) {
       setQuery(null);
@@ -152,7 +177,7 @@ export function AccessionPage() {
           active={tab === "pergene"}
           label="Compare a gene across accessions"
           hint="How one gene's protein varies between accessions"
-          info="Pick one gene. Every accession's version of that gene is ranked by how similar its protein is to the reference (Col-0). A score near 1.00 means nearly identical; lower means more divergent — so you can see which accessions vary most at that gene."
+          info="Pick one gene. Every accession's version of that gene is ranked by how similar its protein is to the reference accession (Col-0 by default). A score near 1.00 means nearly identical; lower means more divergent — so you can see which accessions vary most at that gene."
           onClick={() => setTab("pergene")}
         />
         <TabButton
@@ -168,6 +193,11 @@ export function AccessionPage() {
         <section className="flex flex-1 flex-col gap-4 overflow-y-auto">
           <div className="flex flex-wrap items-center gap-3">
             <AccessionGenePicker
+              value={geneText}
+              onValueChange={(t) => {
+                setGeneText(t);
+                setGene(null); // typing invalidates the committed selection
+              }}
               onSelect={handleGene}
               placeholder="Search a gene (e.g. AT1G01010)…"
               dedupeByGene
@@ -181,7 +211,8 @@ export function AccessionPage() {
               Search
             </button>
             <span className="text-xs text-neutral-500">
-              Ranks every accession&apos;s variant of the gene vs. the reference (Col-0).
+              Ranks every accession&apos;s variant against the reference accession
+              (Col-0 by default; marked below).
             </span>
           </div>
           {submittedGene ? (
@@ -211,6 +242,11 @@ export function AccessionPage() {
             <label className="flex flex-col gap-1 text-xs text-neutral-500">
               Gene
               <AccessionGenePicker
+                value={nbhdGeneText}
+                onValueChange={(t) => {
+                  setNbhdGeneText(t);
+                  setNbhdGene(null); // typing invalidates the committed selection
+                }}
                 onSelect={handleNbhdGene}
                 placeholder="Search a gene (e.g. AT1G01010)…"
                 dedupeByGene
@@ -238,6 +274,10 @@ export function AccessionPage() {
               {resolving ? "Searching…" : "Search"}
             </button>
           </div>
+          {accListError && (
+            <p className="text-xs text-red-600">Couldn&apos;t load accessions: {accListError}</p>
+          )}
+          {searchError && <p className="text-xs text-red-600">{searchError}</p>}
           {resolveMsg && <p className="text-xs text-amber-700">{resolveMsg}</p>}
           {query ? (
             <AccessionKnn
@@ -245,8 +285,11 @@ export function AccessionPage() {
               queryLabel={query.label}
               k={query.k}
               onSelectNeighbor={(n) => {
+                // Pivot every input to the clicked neighbor so the box, the
+                // committed gene, the dropdown, and the results all agree.
                 setAccId(n.accession_id);
                 setNbhdGene(n.gene_id);
+                setNbhdGeneText(n.gene_id ?? "");
                 setQuery({
                   uid: n.uid,
                   label: `${n.gene_id ?? n.uid} · ${n.accession_name ?? ""}`.trim(),

--- a/web/components/accessions/accession-ranking-panel.tsx
+++ b/web/components/accessions/accession-ranking-panel.tsx
@@ -60,10 +60,17 @@ export function AccessionRankingPanel({ geneId, referenceUid }: Props) {
     };
   }, [supabase, geneId, referenceUid ?? null]);
 
-  // Ordering is within noise if every similarity sits within EPSILON of the top.
+  // The actual reference accession (RPC precedence: is_reference → fallback),
+  // read from the returned rows rather than assumed to be Col-0.
+  const referenceName = rows.find((r) => r.is_reference)?.accession_name ?? null;
+
+  // Ordering is within noise if the RANKED (non-reference) variants are all
+  // within EPSILON of each other — measure their pairwise spread, not their
+  // distance to the reference (which is ~1.0 and would mask a tight cluster
+  // sitting well below the reference).
+  const ranked = rows.filter((r) => !r.is_reference).map((r) => r.similarity);
   const withinNoise =
-    rows.length > 1 &&
-    rows.every((r) => Math.abs(rows[0].similarity - r.similarity) <= NOISE_EPSILON);
+    ranked.length > 1 && Math.max(...ranked) - Math.min(...ranked) <= NOISE_EPSILON;
 
   const handleDownload = () => {
     const csv = toCsv(
@@ -86,6 +93,11 @@ export function AccessionRankingPanel({ geneId, referenceUid }: Props) {
       <div className="flex items-center justify-between border-b border-stone-200 px-3 py-2">
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
           {geneId} across accessions
+          {referenceName && (
+            <span className="ml-2 normal-case font-normal tracking-normal text-neutral-400">
+              vs. {referenceName}
+            </span>
+          )}
         </span>
         <div className="flex items-center gap-3">
           {loading && <span className="text-xs text-neutral-500">Loading…</span>}

--- a/web/components/accessions/accession-ranking-panel.tsx
+++ b/web/components/accessions/accession-ranking-panel.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClientSupabaseClient } from "@/lib/supabase/client";
+import { accessionColor, NOISE_EPSILON } from "./constants";
+import { downloadCsv, toCsv } from "./csv";
+
+type RpcCall = (name: string, args: object) => Promise<{
+  data: unknown;
+  error: { message?: string } | null;
+}>;
+
+export type AccessionRankRow = {
+  uid: string;
+  accession_id: number;
+  accession_name: string | null;
+  gene_id: string | null;
+  similarity: number;
+  is_reference: boolean;
+};
+
+type Props = {
+  geneId: string;
+  // Omit to let the RPC default the reference to the designated (Col-0)
+  // accession; pass a uid to rank against a specific accession's variant.
+  referenceUid?: string;
+};
+
+/**
+ * Surface A — per-gene across accessions. For a fixed gene_id, ranks each
+ * accession's protein variant by ESM-3 cosine similarity to the reference
+ * (the selected protein). Backed by `compare_gene_across_accessions`.
+ */
+export function AccessionRankingPanel({ geneId, referenceUid }: Props) {
+  const supabase = createClientSupabaseClient();
+  const [rows, setRows] = useState<AccessionRankRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      const { data, error: rpcErr } = await (supabase.rpc as unknown as RpcCall)(
+        "compare_gene_across_accessions",
+        { target_gene_id: geneId, reference_uid: referenceUid ?? null, match_count: 1000 },
+      );
+      if (cancelled) return;
+      setLoading(false);
+      if (rpcErr) {
+        setError(rpcErr.message ?? String(rpcErr));
+        setRows([]);
+        return;
+      }
+      setRows((data ?? []) as AccessionRankRow[]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase, geneId, referenceUid ?? null]);
+
+  // Ordering is within noise if every similarity sits within EPSILON of the top.
+  const withinNoise =
+    rows.length > 1 &&
+    rows.every((r) => Math.abs(rows[0].similarity - r.similarity) <= NOISE_EPSILON);
+
+  const handleDownload = () => {
+    const csv = toCsv(
+      ["rank", "accession_name", "accession_id", "uid", "gene_id", "cosine_similarity", "is_reference"],
+      rows.map((r, i) => [
+        r.is_reference ? "" : i,
+        r.accession_name,
+        r.accession_id,
+        r.uid,
+        r.gene_id,
+        r.similarity.toFixed(6),
+        r.is_reference,
+      ]),
+    );
+    downloadCsv(`${geneId}_accession_ranking.csv`, csv);
+  };
+
+  return (
+    <div className="rounded-md border border-stone-200 bg-white">
+      <div className="flex items-center justify-between border-b border-stone-200 px-3 py-2">
+        <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          {geneId} across accessions
+        </span>
+        <div className="flex items-center gap-3">
+          {loading && <span className="text-xs text-neutral-500">Loading…</span>}
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={rows.length === 0}
+            className="rounded-md border border-stone-300 bg-white px-2.5 py-1 text-xs font-medium text-neutral-700 shadow-sm transition-colors hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Download CSV
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="px-3 py-2 text-xs text-red-600">Error: {error}</p>}
+
+      {withinNoise && (
+        <p className="border-b border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-900">
+          All variants are within {NOISE_EPSILON} cosine of each other — the ordering
+          here is within noise, not a confident ranking.
+        </p>
+      )}
+
+      <div className="max-h-96 overflow-y-auto">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 bg-stone-50 text-xs uppercase tracking-wider text-neutral-500">
+            <tr>
+              <th className="w-12 px-3 py-2 text-right font-medium">Rank</th>
+              <th className="px-3 py-2 text-left font-medium">Accession</th>
+              <th className="w-40 px-3 py-2 text-right font-medium">Cosine similarity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr
+                key={row.uid}
+                className={`border-t border-stone-100 ${
+                  row.is_reference ? "bg-blue-50/50" : ""
+                }`}
+              >
+                <td className="px-3 py-1.5 text-right font-mono text-xs text-neutral-400">
+                  {row.is_reference ? "—" : i}
+                </td>
+                <td className="px-3 py-1.5">
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: accessionColor(row.accession_id) }}
+                      aria-hidden
+                    />
+                    <span className="text-neutral-800">{row.accession_name}</span>
+                    {row.is_reference && (
+                      <span className="rounded-full bg-blue-600 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-white">
+                        Reference
+                      </span>
+                    )}
+                  </span>
+                </td>
+                <td className="px-3 py-1.5 text-right font-mono text-neutral-700">
+                  {row.similarity.toFixed(4)}
+                </td>
+              </tr>
+            ))}
+            {!loading && rows.length === 0 && !error && (
+              <tr>
+                <td colSpan={3} className="px-3 py-6 text-center text-sm text-neutral-500">
+                  No accession variants with an ESM-3 embedding for {geneId}.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web/components/accessions/constants.test.ts
+++ b/web/components/accessions/constants.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { accessionColor, NOISE_EPSILON } from "./constants";
+
+describe("accessionColor", () => {
+  it("returns the neutral color for null or undefined", () => {
+    expect(accessionColor(null)).toBe("#9ca3af");
+    expect(accessionColor(undefined)).toBe("#9ca3af");
+  });
+
+  it("is deterministic for the same id", () => {
+    expect(accessionColor(7)).toBe(accessionColor(7));
+  });
+
+  it("returns an hsl() string for a real id", () => {
+    expect(accessionColor(1)).toMatch(/^hsl\([\d.]+, 62%, 52%\)$/);
+  });
+
+  it("gives adjacent ids distinct hues (golden-angle spacing)", () => {
+    expect(accessionColor(1)).not.toBe(accessionColor(2));
+    expect(accessionColor(2)).not.toBe(accessionColor(3));
+  });
+});
+
+describe("NOISE_EPSILON", () => {
+  it("is a small positive cosine band", () => {
+    expect(NOISE_EPSILON).toBeGreaterThan(0);
+    expect(NOISE_EPSILON).toBeLessThan(0.1);
+  });
+});

--- a/web/components/accessions/constants.ts
+++ b/web/components/accessions/constants.ts
@@ -8,10 +8,14 @@ export const DEFAULT_K = 20;
 export const K_MIN = 5;
 export const K_MAX = 50;
 
-// If every similarity in a per-gene ranking falls within this band of the
-// top value, the ordering is within numerical noise (accession variants that
-// differ by few/no residues) and the UI says so rather than implying a
-// confident ranking.
+// If the ranked (non-reference) variants in a per-gene comparison all fall
+// within this cosine band of each other, the ordering is within numerical
+// noise (accession variants that differ by few/no residues) and the UI says so
+// rather than implying a confident ranking.
+// PROVISIONAL: 0.001 is a placeholder until we can calibrate it against real
+// ESM-3 pooled embeddings of near-identical accession variants; mean-pooled
+// ESM cosine between single-residue variants often sits at 0.99–0.999, so this
+// threshold should be revisited once data is loaded.
 export const NOISE_EPSILON = 0.001;
 
 // Deterministic HSL color for an accession, keyed on its numeric id so the

--- a/web/components/accessions/constants.ts
+++ b/web/components/accessions/constants.ts
@@ -1,0 +1,31 @@
+// Shared constants for the single-species Arabidopsis accession comparison UI.
+//
+// Unlike the cross-species embedtree (a fixed handful of species), accessions
+// are open-ended (~1000+ in the 1001 Genomes panel), so colors are derived
+// deterministically from the accession id rather than a hand-maintained map.
+
+export const DEFAULT_K = 20;
+export const K_MIN = 5;
+export const K_MAX = 50;
+
+// If every similarity in a per-gene ranking falls within this band of the
+// top value, the ordering is within numerical noise (accession variants that
+// differ by few/no residues) and the UI says so rather than implying a
+// confident ranking.
+export const NOISE_EPSILON = 0.001;
+
+// Deterministic HSL color for an accession, keyed on its numeric id so the
+// same accession is the same color across surfaces. Golden-angle hue spacing
+// keeps adjacent ids visually distinct.
+export function accessionColor(accessionId: number | null | undefined): string {
+  if (accessionId == null) return "#9ca3af"; // neutral-400
+  const hue = (accessionId * 137.508) % 360;
+  return `hsl(${hue.toFixed(1)}, 62%, 52%)`;
+}
+
+// Single source of truth for the disclaimer copy.
+export const ACCESSION_DISCLAIMER =
+  "Neighbors and rankings are by ESM-3 protein-embedding cosine similarity — " +
+  "a proxy for protein divergence, not a verified functional or orthology " +
+  "call. Accession variants often differ by few residues, so small similarity " +
+  "gaps may be within noise.";

--- a/web/components/accessions/csv.test.ts
+++ b/web/components/accessions/csv.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { toCsv, downloadCsv } from "./csv";
+
+describe("toCsv", () => {
+  it("joins header and rows with CRLF and cells with commas", () => {
+    expect(toCsv(["a", "b"], [["1", "2"], ["3", "4"]])).toBe("a,b\r\n1,2\r\n3,4");
+  });
+
+  it("quotes a field containing a comma", () => {
+    expect(toCsv(["x"], [["a,b"]])).toBe('x\r\n"a,b"');
+  });
+
+  it("doubles embedded quotes and wraps the field in quotes", () => {
+    expect(toCsv(["x"], [['he said "hi"']])).toBe('x\r\n"he said ""hi"""');
+  });
+
+  it("quotes fields containing newlines or carriage returns", () => {
+    expect(toCsv(["x"], [["line1\nline2"]])).toBe('x\r\n"line1\nline2"');
+    expect(toCsv(["x"], [["a\rb"]])).toBe('x\r\n"a\rb"');
+  });
+
+  it("renders null and undefined as empty strings", () => {
+    expect(toCsv(["x", "y"], [[null, undefined]])).toBe("x,y\r\n,");
+  });
+
+  it("stringifies numbers and booleans", () => {
+    expect(toCsv(["n", "b"], [[42, true]])).toBe("n,b\r\n42,true");
+  });
+
+  it("leaves plain values unquoted", () => {
+    expect(toCsv(["gene"], [["AT1G01010"]])).toBe("gene\r\nAT1G01010");
+  });
+
+  it("handles an empty row set (headers only)", () => {
+    expect(toCsv(["a", "b"], [])).toBe("a,b");
+  });
+});
+
+describe("downloadCsv", () => {
+  it("is a no-op on the server (no document) and does not throw", () => {
+    expect(() => downloadCsv("f.csv", "a,b")).not.toThrow();
+  });
+});

--- a/web/components/accessions/csv.ts
+++ b/web/components/accessions/csv.ts
@@ -1,0 +1,30 @@
+// Minimal, dependency-free CSV helpers for the accession comparison exports.
+
+type Cell = string | number | boolean | null | undefined;
+
+// RFC-4180-ish: quote a field if it contains a comma, quote, or newline;
+// escape embedded quotes by doubling them.
+function escapeCell(value: Cell): string {
+  const s = value == null ? "" : String(value);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export function toCsv(headers: string[], rows: Cell[][]): string {
+  return [headers, ...rows]
+    .map((row) => row.map(escapeCell).join(","))
+    .join("\r\n");
+}
+
+// Trigger a client-side download of `csv` as `filename`. No-op on the server.
+export function downloadCsv(filename: string, csv: string): void {
+  if (typeof document === "undefined") return;
+  const blob = new Blob(["﻿", csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/web/components/embedtree/embedtree-page.tsx
+++ b/web/components/embedtree/embedtree-page.tsx
@@ -158,9 +158,6 @@ export function EmbedtreePage() {
   return (
     <div className="flex h-full flex-col gap-4 p-4">
       <header className="flex flex-col gap-1">
-        <h1 className="text-xl font-semibold text-neutral-800">
-          AI Orthologs
-        </h1>
         <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
           <span className="font-semibold">Predicted, not verified.</span>{" "}
           {SIMILARITY_DISCLAIMER}

--- a/web/components/embedtree/orthovec-page.tsx
+++ b/web/components/embedtree/orthovec-page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { EmbedtreePage } from "./embedtree-page";
+import { AccessionPage } from "@/components/accessions/accession-page";
+
+type Tab = "crossspecies" | "accessions";
+
+function TabButton({
+  active,
+  label,
+  hint,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  hint: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-t-md border-b-2 px-3 py-2 text-left transition-colors ${
+        active
+          ? "border-blue-500 text-blue-700"
+          : "border-transparent text-neutral-500 hover:text-neutral-700"
+      }`}
+      aria-pressed={active}
+    >
+      <span className="block text-sm font-medium">{label}</span>
+      <span className="block text-xs text-neutral-400">{hint}</span>
+    </button>
+  );
+}
+
+/**
+ * OrthoVec — protein-embedding similarity tools. Two surfaces:
+ *   - Cross-species: predicted orthologs across plant species (ESM-2).
+ *   - Arabidopsis accessions: single-species accession comparison (ESM-3).
+ */
+export function OrthoVecPage() {
+  const [tab, setTab] = useState<Tab>("crossspecies");
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-wrap items-end justify-between gap-2 border-b border-stone-200 px-4 pt-4">
+        <div>
+          <h1 className="text-xl font-semibold text-neutral-800">OrthoVec</h1>
+          <p className="text-sm text-neutral-500">
+            Predicted orthologs and accession variants from protein-embedding
+            similarity.
+          </p>
+        </div>
+        <nav className="flex gap-1" aria-label="OrthoVec surfaces">
+          <TabButton
+            active={tab === "crossspecies"}
+            label="Cross-species"
+            hint="Orthologs across species · ESM-2"
+            onClick={() => setTab("crossspecies")}
+          />
+          <TabButton
+            active={tab === "accessions"}
+            label="Arabidopsis accessions"
+            hint="Single-species variants · ESM-3"
+            onClick={() => setTab("accessions")}
+          />
+        </nav>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {tab === "crossspecies" ? <EmbedtreePage /> : <AccessionPage />}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Requirements to explore Arabidopsis accessions in OrthoVec by ESM-3 protein-embedding similarity.

**Schema** (additive migrations + rollbacks)
- Register ESM3 (`vector(1536)`); `protein_embedding_runs` provenance
- `arabidopsis_accessions` registry + nullable `proteins.accession_id`
- `protein_embeddings_esm3` (HNSW, zero-vector guard)
- RPCs: `knn_search_esm3`, `compare_gene_across_accessions`, `search_accession_genes`; `search_genes` scoped to cross-species
- admin/agent/user/writer RLS + grants; 25+ integration tests