### PR TITLE
docs(dev-setup): correct stale MinIO storage setup steps

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -85,27 +85,30 @@ Only needed for specific features / conflicts:
 
 ## MinIO Storage Setup
 
-### Step 1: Create Storage Directory
+MinIO (S3-compatible object storage) needs **no manual setup** in the default
+flow — `make init` and `make dev-up` provision everything:
 
-```bash
-# Create directory (adjust path to match MINIO_DATA_PATH)
-mkdir -p ~/minio
+- **Data directory:** `make init` sets `MINIO_DATA_PATH=./volumes/minio-dev` (a
+  gitignored, repo-relative path) in `.env.dev`. Docker creates that directory
+  the first time the stack starts, so you do **not** need to create it yourself.
+- **Buckets:** the `minio-init` service (see `docker-compose.dev.yml`) runs
+  `minio/init/create-buckets.sh` automatically on `make dev-up`, creating the
+  `bloom-storage` bucket and applying its access policies.
 
-# Set permissions
-chmod 755 ~/minio
-```
+Leave the `MINIO_*` values in `.env.dev` at their generated defaults.
 
-### Step 2: Verify Path Configuration
+### Optional: custom data path or a native-Linux permission fix
 
-Ensure `MINIO_DATA_PATH` in `.env.dev` matches your created directory:
-
-```bash
-# Example for macOS/Linux
-MINIO_DATA_PATH=/Users/yourusername/minio
-
-# Or use full path
-MINIO_DATA_PATH=$(pwd)/minio
-```
+- **Custom location:** to store MinIO data elsewhere, set `MINIO_DATA_PATH` in
+  `.env.dev` to any absolute or repo-relative path before `make dev-up`.
+- **Native Linux only** (not Docker Desktop on macOS / Windows-WSL2): a
+  bind-mount source directory that Docker auto-creates is owned by `root`, which
+  can stop the MinIO container from writing to it. If you hit a MinIO permission
+  error, pre-create the directory yourself before starting the stack:
+  ```bash
+  mkdir -p ./volumes/minio-dev   # or your custom MINIO_DATA_PATH
+  chmod 777 ./volumes/minio-dev  # if MinIO still can't write
+  ```
 
 ---
 


### PR DESCRIPTION
## What

Fixes the **MinIO Storage Setup** section of `DEV_SETUP.md`, which gave manual steps that contradict how the stack actually provisions MinIO.

### The problem

The section told developers to:
```bash
mkdir -p ~/minio && chmod 755 ~/minio
# then set MINIO_DATA_PATH=/Users/yourusername/minio
```

But in reality:
- **`make init` already sets `MINIO_DATA_PATH=./volumes/minio-dev`** — the committed default in [`.env.dev.example`](.env.dev.example) (a gitignored, repo-relative path). The `~/minio` example points developers at a *different* directory than the stack uses.
- **Docker auto-creates the bind-mount source dir** (`${MINIO_DATA_PATH}:/data`) on the first `make dev-up`, so no manual `mkdir` is needed with the default path.
- **Buckets are already created automatically** by the `minio-init` service (`minio/init/create-buckets.sh`) on `make dev-up` — as the "Starting the Stack" section itself notes ("Initialize MinIO buckets automatically").

So the manual step was redundant *and* inconsistent with the default, and could send new developers (e.g. onboarding onto bloommcp) down a confusing path.

## Changes

- Rewrite **MinIO Storage Setup** to state MinIO needs **no manual setup** by default, and explain what `make init` / `make dev-up` provision (data dir + buckets).
- Keep the manual `mkdir`/`chmod` only as an **optional native-Linux permission fix** (root-owned bind-mount source), explicitly noting Docker Desktop on macOS / Windows-WSL2 is unaffected.

## Verification

- `MINIO_DATA_PATH=./volumes/minio-dev` confirmed as the default in `.env.dev.example`.
- `volumes/` confirmed gitignored (`.gitignore:79`), so the runtime data dir is never committed.
- `minio-init` service + `minio/init/create-buckets.sh` confirmed in `docker-compose.dev.yml`.

Docs-only change; no code or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)