### PR TITLE
feat(bloomctl): add 'cyl experiments list'

### DIFF
--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
   unique traits (`get <name>`, via the `cyl_dataset_trait_names` view), and create one
   via the `create_cyl_dataset` RPC (`--qc-set-name`,
   `--timepoints`). Ports the legacy `cyl datasets` commands (`list`/`create`) and adds `get`.
+- `bloomctl cyl experiments list` — list cylinder experiments (species, name, id),
+  sorted by species then name, with `--json` output. Ports the legacy
+  `cyl experiments list` command.
 - `bloomctl cyl ingest-result <envelope>` — write a per-scan `ResultEnvelope`
   back to Bloom via the `insert_cyl_result_envelope` RPC. Reads from a path or
   stdin (`-`), validates against `sleap-roots-contracts`, sends the original JSON

--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -24,6 +24,8 @@ command is tagged **[read]** or **[write]** — see [Access & roles](#access--ro
   unique traits it contains, via the `cyl_dataset_trait_names` view (`--json` output).
 - **[write]** `bloomctl cyl datasets create <name> <experiment_id> <trait_source_name>` —
   create a trait dataset (`--qc-set-name` to exclude a QC set, `--timepoints`).
+- **[read]** `bloomctl cyl experiments list` — list cylinder experiments (species,
+  name, id), sorted by species then name (`--json` for machine-readable output).
 
 (Full `login`/`cyl download` usage docs are still forthcoming; run any command
 with `--help` in the meantime. `cyl ingest-result` and `cyl download-for-predict`

--- a/bloomcli/src/bloomctl/cyl/__init__.py
+++ b/bloomcli/src/bloomctl/cyl/__init__.py
@@ -3,7 +3,8 @@
 One file per entity (grouped by entity; verbs live inside each entity):
   - download.py  `cyl download`       pull an experiment/scan: scans.csv + images
   - ingest.py    `cyl ingest-result`  write a per-scan ResultEnvelope back via RPC (new; no legacy equivalent)
-  - datasets.py  `cyl datasets`       list/create cylinder trait datasets
+  - datasets.py     `cyl datasets`      list/get/create cylinder trait datasets
+  - experiments.py  `cyl experiments`   list cylinder experiments
 
 Add a command: new file here, register it below.
 """
@@ -16,6 +17,7 @@ import click
 from .datasets import datasets as datasets_cmd
 from .download import download as download_cmd
 from .download_for_predict import download_for_predict as download_for_predict_cmd
+from .experiments import experiments as experiments_cmd
 from .ingest import ingest_result as ingest_result_cmd
 
 
@@ -28,3 +30,4 @@ cyl.add_command(download_cmd)
 cyl.add_command(download_for_predict_cmd)
 cyl.add_command(ingest_result_cmd)
 cyl.add_command(datasets_cmd)
+cyl.add_command(experiments_cmd)

--- a/bloomcli/src/bloomctl/cyl/experiments.py
+++ b/bloomcli/src/bloomctl/cyl/experiments.py
@@ -19,16 +19,18 @@ def experiments() -> None:
     """Cylinder experiment commands."""
 
 
-def experiment_sort_key(exp: dict[str, Any]) -> tuple[str, str]:
-    """Sort by species common name, then experiment name (matches legacy ordering)."""
+def experiment_sort_key(exp: dict[str, Any]) -> tuple[str, str, int]:
+    """Sort by species common name, then experiment name, then id (id breaks ties so
+    output is deterministic run-to-run)."""
     species = (exp.get("species") or {}).get("common_name") or ""
-    return (species, exp.get("name") or "")
+    return (species, exp.get("name") or "", exp.get("id") or 0)
 
 
 def build_experiment_row(exp: dict[str, Any]) -> list[str]:
     """Shape a cyl_experiments row (with joined species) into a display row."""
     species = (exp.get("species") or {}).get("common_name") or ""
-    return [species, exp.get("name") or "", str(exp.get("id", ""))]
+    eid = exp.get("id")
+    return [species, exp.get("name") or "", "" if eid is None else str(eid)]
 
 
 def build_experiment_record(exp: dict[str, Any]) -> dict[str, Any]:
@@ -40,12 +42,25 @@ def build_experiment_record(exp: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-# --- supabase / storage I/O ---
+# --- supabase I/O ---
 
 
 def fetch_experiments(client: Any) -> list[dict[str, Any]]:
-    """All cyl experiments with their joined species relation."""
-    return client.table("cyl_experiments").select("*, species(*)").execute().data or []
+    """Live cyl experiments (soft-deleted excluded) with their joined species relation.
+
+    Filters ``deleted_at IS NULL`` server-side rather than relying on RLS: only the
+    bloom_user policy hides soft-deletes, while bloom_writer/bloom_admin read with
+    ``USING (true)`` and would otherwise see tombstoned experiments.
+    """
+    return (
+        client.table("cyl_experiments")
+        .select("*, species(*)")
+        .is_("deleted_at", "null")
+        .order("id")
+        .execute()
+        .data
+        or []
+    )
 
 
 @experiments.command(name="list")
@@ -65,9 +80,14 @@ def fetch_experiments(client: Any) -> list[dict[str, Any]]:
 def list_experiments(as_json: bool, profile: str) -> None:
     """List cylinder experiments."""
     from ..cli import _authed_client
+    from postgrest import APIError
 
     client = _authed_client(profile)
-    rows_data = sorted(fetch_experiments(client), key=experiment_sort_key)
+    try:
+        raw = fetch_experiments(client)
+    except APIError as exc:
+        raise click.ClickException(getattr(exc, "message", str(exc))) from exc
+    rows_data = sorted(raw, key=experiment_sort_key)
 
     if as_json:
         click.echo(json.dumps([build_experiment_record(e) for e in rows_data]))

--- a/bloomcli/src/bloomctl/cyl/experiments.py
+++ b/bloomcli/src/bloomctl/cyl/experiments.py
@@ -1,0 +1,77 @@
+"""`bloomctl cyl experiments` — cylinder experiment commands (list)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from ..credentials import DEFAULT_PROFILE
+from ._output import print_table
+
+# Table columns for `experiments list`, in display order.
+EXPERIMENT_COLUMNS = ["Species", "Experiment", "Experiment ID"]
+
+
+@click.group(name="experiments")
+def experiments() -> None:
+    """Cylinder experiment commands."""
+
+
+def experiment_sort_key(exp: dict[str, Any]) -> tuple[str, str]:
+    """Sort by species common name, then experiment name (matches legacy ordering)."""
+    species = (exp.get("species") or {}).get("common_name") or ""
+    return (species, exp.get("name") or "")
+
+
+def build_experiment_row(exp: dict[str, Any]) -> list[str]:
+    """Shape a cyl_experiments row (with joined species) into a display row."""
+    species = (exp.get("species") or {}).get("common_name") or ""
+    return [species, exp.get("name") or "", str(exp.get("id", ""))]
+
+
+def build_experiment_record(exp: dict[str, Any]) -> dict[str, Any]:
+    """Machine-readable experiment record (mirrors the table columns)."""
+    return {
+        "species": (exp.get("species") or {}).get("common_name"),
+        "experiment": exp.get("name"),
+        "experiment_id": exp.get("id"),
+    }
+
+
+# --- supabase / storage I/O ---
+
+
+def fetch_experiments(client: Any) -> list[dict[str, Any]]:
+    """All cyl experiments with their joined species relation."""
+    return client.table("cyl_experiments").select("*, species(*)").execute().data or []
+
+
+@experiments.command(name="list")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit experiments as a JSON array.",
+)
+@click.option(
+    "-p",
+    "--profile",
+    default=DEFAULT_PROFILE,
+    show_default=True,
+    help="Credentials profile to use.",
+)
+def list_experiments(as_json: bool, profile: str) -> None:
+    """List cylinder experiments."""
+    from ..cli import _authed_client
+
+    client = _authed_client(profile)
+    rows_data = sorted(fetch_experiments(client), key=experiment_sort_key)
+
+    if as_json:
+        click.echo(json.dumps([build_experiment_record(e) for e in rows_data]))
+        return
+
+    rows = [build_experiment_row(e) for e in rows_data]
+    print_table("Experiments", EXPERIMENT_COLUMNS, rows, empty="No experiments found.")

--- a/bloomcli/tests/test_cyl_experiments.py
+++ b/bloomcli/tests/test_cyl_experiments.py
@@ -42,15 +42,32 @@ def test_sort_key_orders_species_then_name():
     assert [e["id"] for e in ordered] == [3, 1, 2]  # Canola/Alpha, Canola/Beta, Rice/Alpha
 
 
+def test_sort_key_breaks_ties_by_id():
+    # same species AND name → id decides order, so output is deterministic run-to-run.
+    tied = [
+        {"id": 205, "name": "Wave A", "species": {"common_name": "Rice"}},
+        {"id": 101, "name": "Wave A", "species": {"common_name": "Rice"}},
+    ]
+    assert [e["id"] for e in sorted(tied, key=ex.experiment_sort_key)] == [101, 205]
+
+
 # --- query ------------------------------------------------------------------
 
 
 def test_fetch_experiments_builds_query():
-    captured = {}
+    captured = {"is_": None, "order": None}
 
     class _Q:
         def select(self, sel):
             captured["select"] = sel
+            return self
+
+        def is_(self, col, val):
+            captured["is_"] = (col, val)
+            return self
+
+        def order(self, col, **kw):
+            captured["order"] = col
             return self
 
         def execute(self):
@@ -64,7 +81,9 @@ def test_fetch_experiments_builds_query():
     out = ex.fetch_experiments(_Client())
     assert out == EXPS
     assert captured["table"] == "cyl_experiments"
-    assert "species(*)" in captured["select"]
+    assert captured["select"] == "*, species(*)"  # full select: id/name + species
+    assert captured["is_"] == ("deleted_at", "null")  # soft-deleted experiments excluded
+    assert captured["order"] == "id"  # deterministic base order
 
 
 def test_fetch_experiments_empty():
@@ -72,6 +91,12 @@ def test_fetch_experiments_empty():
         def table(self, name):
             class _Q:
                 def select(self, *a):
+                    return self
+
+                def is_(self, *a):
+                    return self
+
+                def order(self, *a, **k):
                     return self
 
                 def execute(self):
@@ -91,7 +116,23 @@ def test_list_renders_table(monkeypatch):
     res = CliRunner().invoke(cli, ["cyl", "experiments", "list"])
     assert res.exit_code == 0, res.output
     assert "Experiments" in res.output  # table title
-    assert "Canola" in res.output and "Rice" in res.output
+    # species, names, and ids all rendered — fails if a column is dropped or swapped
+    for token in ("Canola", "Rice", "Alpha", "Beta", "1", "2", "3"):
+        assert token in res.output, f"{token!r} missing from table output"
+
+
+def test_list_surfaces_api_error(monkeypatch):
+    from postgrest import APIError
+
+    _patch_authed(monkeypatch)
+
+    def _boom(client):
+        raise APIError({"message": "permission denied", "code": "42501"})
+
+    monkeypatch.setattr(ex, "fetch_experiments", _boom)
+    res = CliRunner().invoke(cli, ["cyl", "experiments", "list"])
+    assert res.exit_code != 0
+    assert "permission denied" in res.output  # clean message, not a raw traceback
 
 
 def test_list_json_sorted(monkeypatch):

--- a/bloomcli/tests/test_cyl_experiments.py
+++ b/bloomcli/tests/test_cyl_experiments.py
@@ -1,0 +1,131 @@
+"""bloomctl cyl experiments — list (row shaping, sort, json; mocked client)."""
+
+import json
+
+from click.testing import CliRunner
+
+import bloomctl.cli as climod
+import bloomctl.cyl.experiments as ex
+from bloomctl.cli import cli
+
+# Species deliberately out of order to prove the (species, name) sort.
+EXPS = [
+    {"id": 2, "name": "Alpha", "species": {"common_name": "Rice"}},
+    {"id": 1, "name": "Beta", "species": {"common_name": "Canola"}},
+    {"id": 3, "name": "Alpha", "species": {"common_name": "Canola"}},
+]
+
+
+def _patch_authed(monkeypatch):
+    monkeypatch.setattr(climod, "_authed_client", lambda profile: object())
+
+
+# --- row shaping ------------------------------------------------------------
+
+
+def test_build_experiment_row():
+    row = ex.build_experiment_row({"id": 7, "name": "Exp 7", "species": {"common_name": "Canola"}})
+    assert row == ["Canola", "Exp 7", "7"]
+
+
+def test_build_experiment_row_tolerates_null_species():
+    assert ex.build_experiment_row({"id": 5, "name": "Exp 5", "species": None}) == ["", "Exp 5", "5"]
+
+
+def test_build_experiment_record():
+    rec = ex.build_experiment_record({"id": 7, "name": "Exp 7", "species": {"common_name": "Canola"}})
+    assert rec == {"species": "Canola", "experiment": "Exp 7", "experiment_id": 7}
+
+
+def test_sort_key_orders_species_then_name():
+    ordered = sorted(EXPS, key=ex.experiment_sort_key)
+    assert [e["id"] for e in ordered] == [3, 1, 2]  # Canola/Alpha, Canola/Beta, Rice/Alpha
+
+
+# --- query ------------------------------------------------------------------
+
+
+def test_fetch_experiments_builds_query():
+    captured = {}
+
+    class _Q:
+        def select(self, sel):
+            captured["select"] = sel
+            return self
+
+        def execute(self):
+            return type("R", (), {"data": EXPS})()
+
+    class _Client:
+        def table(self, name):
+            captured["table"] = name
+            return _Q()
+
+    out = ex.fetch_experiments(_Client())
+    assert out == EXPS
+    assert captured["table"] == "cyl_experiments"
+    assert "species(*)" in captured["select"]
+
+
+def test_fetch_experiments_empty():
+    class _Client:
+        def table(self, name):
+            class _Q:
+                def select(self, *a):
+                    return self
+
+                def execute(self):
+                    return type("R", (), {"data": None})()
+
+            return _Q()
+
+    assert ex.fetch_experiments(_Client()) == []
+
+
+# --- command ----------------------------------------------------------------
+
+
+def test_list_renders_table(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(ex, "fetch_experiments", lambda client: EXPS)
+    res = CliRunner().invoke(cli, ["cyl", "experiments", "list"])
+    assert res.exit_code == 0, res.output
+    assert "Experiments" in res.output  # table title
+    assert "Canola" in res.output and "Rice" in res.output
+
+
+def test_list_json_sorted(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(ex, "fetch_experiments", lambda client: EXPS)
+    res = CliRunner().invoke(cli, ["cyl", "experiments", "list", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert [e["experiment_id"] for e in payload] == [3, 1, 2]  # sorted by species, then name
+    assert payload[0] == {"species": "Canola", "experiment": "Alpha", "experiment_id": 3}
+
+
+def test_list_empty(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(ex, "fetch_experiments", lambda client: [])
+    res = CliRunner().invoke(cli, ["cyl", "experiments", "list"])
+    assert res.exit_code == 0
+    assert "No experiments found" in res.output
+
+
+def test_list_empty_json(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(ex, "fetch_experiments", lambda client: [])
+    res = CliRunner().invoke(cli, ["cyl", "experiments", "list", "--json"])
+    assert res.exit_code == 0
+    assert res.output.strip() == "[]"
+
+
+# --- grouping ---------------------------------------------------------------
+
+
+def test_experiments_grouped_under_cyl_not_top_level():
+    root = CliRunner().invoke(cli, ["--help"])
+    assert "experiments" not in root.output  # not a top-level command
+    sub = CliRunner().invoke(cli, ["cyl", "experiments", "--help"])
+    assert "list" in sub.output
+    assert "experiments" in CliRunner().invoke(cli, ["cyl", "--help"]).output


### PR DESCRIPTION
## What

Ports the legacy `cli/src/commands/cyl/experiments/list.ts` to `bloomctl` as `cyl experiments list`.

## Command

- **`cyl experiments list`** — fetch all cylinder experiments (+ `species`), sorted by **species then name**, rendered as a **Species / Experiment / Experiment ID** table. `--json` for a machine-readable array.

Sorting is done **client-side** (robust to PostgREST embedded-order quirks; the result set is small). Reuses the shared `_output.print_table`.

## No server changes

Reads the existing `cyl_experiments` table (+ `species` relation). No RPC/schema/migration changes.

## Tests

11 new tests (`CliRunner` + `monkeypatch` fakes): row shaping, null-species tolerance, sort order, query shape, table/json/empty output, and command grouping. **Full suite: 124 passed, 2 skipped; ruff clean.**

## Sequencing

- **Stacked on #441** (reuses `_output.print_table` introduced there). Base is `feat/bloomctl-cyl-datasets`; **retarget to `staging` once #441 merges**.
- Ports the `cyl experiments list` that #441's `cyl datasets create` error hints already reference.
