### PR TITLE
feat(bloomctl): add 'cyl accessions' (list + sample-counts)

### DIFF
--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
   sorted by species then name, with `--json` output. Ports the legacy
   `cyl experiments list` command.
 - `bloomctl cyl accessions list --experiment-id N` / `sample-counts [--species X]` —
-  list the accessions used in an experiment, and the sample (plant) count per
+  list the accessions used in an experiment, and the plant count per
   accession per species, with `--json`. Read the server-side `cyl_experiment_accessions`
   and `cyl_accession_sample_counts` views (new capability; no legacy equivalent).
 - `bloomctl cyl ingest-result <envelope>` — write a per-scan `ResultEnvelope`

--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
 - `bloomctl cyl experiments list` — list cylinder experiments (species, name, id),
   sorted by species then name, with `--json` output. Ports the legacy
   `cyl experiments list` command.
+- `bloomctl cyl accessions list --experiment-id N` / `sample-counts [--species X]` —
+  list the accessions used in an experiment, and the sample (plant) count per
+  accession per species, with `--json`. Read the server-side `cyl_experiment_accessions`
+  and `cyl_accession_sample_counts` views (new capability; no legacy equivalent).
 - `bloomctl cyl ingest-result <envelope>` — write a per-scan `ResultEnvelope`
   back to Bloom via the `insert_cyl_result_envelope` RPC. Reads from a path or
   stdin (`-`), validates against `sleap-roots-contracts`, sends the original JSON

--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -60,6 +60,10 @@ command is tagged **[read]** or **[write]** — see [Access & roles](#access--ro
   create a trait dataset (`--qc-set-name` to exclude a QC set, `--timepoints`).
 - **[read]** `bloomctl cyl experiments list` — list cylinder experiments (species,
   name, id), sorted by species then name (`--json` for machine-readable output).
+- **[read]** `bloomctl cyl accessions list --experiment-id N` — list the accessions
+  used in an experiment (`--json`).
+- **[read]** `bloomctl cyl accessions sample-counts [--species X]` — sample (plant)
+  count per accession, per species (`--json`).
 
 (Full `cyl download` usage docs are still forthcoming; run any command
 with `--help` in the meantime. `cyl ingest-result` and `cyl download-for-predict`

--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -62,8 +62,8 @@ command is tagged **[read]** or **[write]** — see [Access & roles](#access--ro
   name, id), sorted by species then name (`--json` for machine-readable output).
 - **[read]** `bloomctl cyl accessions list --experiment-id N` — list the accessions
   used in an experiment (`--json`).
-- **[read]** `bloomctl cyl accessions sample-counts [--species X]` — sample (plant)
-  count per accession, per species (`--json`).
+- **[read]** `bloomctl cyl accessions sample-counts [--species X]` — plant count per
+  accession, per species (`--json`).
 
 (Full `cyl download` usage docs are still forthcoming; run any command
 with `--help` in the meantime. `cyl ingest-result` and `cyl download-for-predict`

--- a/bloomcli/README.pypi.md
+++ b/bloomcli/README.pypi.md
@@ -47,6 +47,8 @@ Run `bloomctl --help` or `bloomctl <command> --help` for the full option list.
 - `bloomctl cyl datasets list | get <name> | create <name> <experiment_id> <trait_source_name>`
   — list, inspect, or create cylinder trait datasets.
 - `bloomctl cyl experiments list` — list cylinder experiments.
+- `bloomctl cyl accessions list | sample-counts` — list the accessions in an
+  experiment, or the plant count per accession per species.
 
 Read commands work for any logged-in user; write commands (`ingest-result`,
 `datasets create`) require an account with write access.

--- a/bloomcli/src/bloomctl/cyl/__init__.py
+++ b/bloomcli/src/bloomctl/cyl/__init__.py
@@ -5,6 +5,7 @@ One file per entity (grouped by entity; verbs live inside each entity):
   - ingest.py    `cyl ingest-result`  write a per-scan ResultEnvelope back via RPC (new; no legacy equivalent)
   - datasets.py     `cyl datasets`      list/get/create cylinder trait datasets
   - experiments.py  `cyl experiments`   list cylinder experiments
+  - accessions.py   `cyl accessions`    list accessions per experiment; sample counts
 
 Add a command: new file here, register it below.
 """
@@ -14,6 +15,7 @@ from __future__ import annotations
 import click
 
 # Alias so the command objects don't shadow the same-named submodules.
+from .accessions import accessions as accessions_cmd
 from .datasets import datasets as datasets_cmd
 from .download import download as download_cmd
 from .download_for_predict import download_for_predict as download_for_predict_cmd
@@ -31,3 +33,4 @@ cyl.add_command(download_for_predict_cmd)
 cyl.add_command(ingest_result_cmd)
 cyl.add_command(datasets_cmd)
 cyl.add_command(experiments_cmd)
+cyl.add_command(accessions_cmd)

--- a/bloomcli/src/bloomctl/cyl/accessions.py
+++ b/bloomcli/src/bloomctl/cyl/accessions.py
@@ -24,9 +24,10 @@ def accessions() -> None:
     """Cylinder accession commands."""
 
 
-def accession_sort_key(rec: dict[str, Any]) -> str:
-    """Sort accessions by name."""
-    return rec.get("accession_name") or ""
+def accession_sort_key(rec: dict[str, Any]) -> tuple[str, int]:
+    """Sort accessions by name, then id (id breaks ties so output is
+    deterministic run-to-run)."""
+    return (rec.get("accession_name") or "", rec.get("accession_id") or 0)
 
 
 def build_accession_row(rec: dict[str, Any]) -> list[str]:
@@ -40,9 +41,14 @@ def build_accession_record(rec: dict[str, Any]) -> dict[str, Any]:
     return {"accession_id": rec.get("accession_id"), "accession_name": rec.get("accession_name")}
 
 
-def sample_count_sort_key(rec: dict[str, Any]) -> tuple[str, str]:
-    """Sort sample counts by species, then accession name."""
-    return (rec.get("species_name") or "", rec.get("accession_name") or "")
+def sample_count_sort_key(rec: dict[str, Any]) -> tuple[str, str, int]:
+    """Sort sample counts by species, then accession name, then id (id breaks
+    ties so output is deterministic run-to-run)."""
+    return (
+        rec.get("species_name") or "",
+        rec.get("accession_name") or "",
+        rec.get("accession_id") or 0,
+    )
 
 
 def build_sample_count_row(rec: dict[str, Any]) -> list[str]:
@@ -108,8 +114,9 @@ def fetch_accession_sample_counts(client: Any, species: str | None = None) -> li
 )
 def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
     """List the accessions used in a cylinder experiment."""
-    from ..cli import _authed_client
     from postgrest import APIError
+
+    from ..cli import _authed_client
 
     client = _authed_client(profile)
     try:
@@ -127,7 +134,11 @@ def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
 
 
 @accessions.command(name="sample-counts")
-@click.option("--species", default=None, help="Filter to one species (common name).")
+@click.option(
+    "--species",
+    default=None,
+    help="Filter to one species by common name (case-sensitive, e.g. 'sorghum').",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit counts as a JSON array.")
 @click.option(
     "-p",
@@ -137,9 +148,15 @@ def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
     help="Credentials profile to use.",
 )
 def sample_counts(species: str | None, as_json: bool, profile: str) -> None:
-    """Show the plant count per accession, per species (one plant = one biological replicate)."""
-    from ..cli import _authed_client
+    """Show the plant count per accession, per species (one plant = one biological replicate).
+
+    Counts are across all experiments in the database (not scoped to one
+    experiment, unlike `accessions list`). Plants not assigned to an accession
+    are excluded, so summing the counts can be lower than the total plant count.
+    """
     from postgrest import APIError
+
+    from ..cli import _authed_client
 
     client = _authed_client(profile)
     try:

--- a/bloomcli/src/bloomctl/cyl/accessions.py
+++ b/bloomcli/src/bloomctl/cyl/accessions.py
@@ -55,8 +55,10 @@ def build_sample_count_row(rec: dict[str, Any]) -> list[str]:
 
 
 def build_sample_count_record(rec: dict[str, Any]) -> dict[str, Any]:
-    """Machine-readable sample-count record."""
+    """Machine-readable sample-count record. Includes accession_id (unique) so this
+    output can be joined to `accessions list --json` on the id, not the ambiguous name."""
     return {
+        "accession_id": rec.get("accession_id"),
         "species": rec.get("species_name"),
         "accession": rec.get("accession_name"),
         "plant_count": rec.get("plant_count"),
@@ -151,4 +153,7 @@ def sample_counts(species: str | None, as_json: bool, profile: str) -> None:
         return
 
     rows = [build_sample_count_row(r) for r in data]
-    print_table("Sample counts per accession", SAMPLE_COUNT_COLUMNS, rows, empty="No sample counts found.")
+    empty = (
+        f"No sample counts found for species '{species}'." if species else "No sample counts found."
+    )
+    print_table("Sample counts per accession", SAMPLE_COUNT_COLUMNS, rows, empty=empty)

--- a/bloomcli/src/bloomctl/cyl/accessions.py
+++ b/bloomcli/src/bloomctl/cyl/accessions.py
@@ -16,7 +16,7 @@ from ..credentials import DEFAULT_PROFILE
 from ._output import print_table
 
 ACCESSION_COLUMNS = ["Accession", "Accession ID"]
-SAMPLE_COUNT_COLUMNS = ["Species", "Accession", "Samples"]
+SAMPLE_COUNT_COLUMNS = ["Species", "Accession", "Plants"]
 
 
 @click.group(name="accessions")
@@ -50,7 +50,7 @@ def build_sample_count_row(rec: dict[str, Any]) -> list[str]:
     return [
         rec.get("species_name") or "",
         rec.get("accession_name") or "",
-        str(rec.get("samples", "")),
+        str(rec.get("plant_count", "")),
     ]
 
 
@@ -59,7 +59,7 @@ def build_sample_count_record(rec: dict[str, Any]) -> dict[str, Any]:
     return {
         "species": rec.get("species_name"),
         "accession": rec.get("accession_name"),
-        "samples": rec.get("samples"),
+        "plant_count": rec.get("plant_count"),
     }
 
 
@@ -81,7 +81,7 @@ def fetch_experiment_accessions(client: Any, experiment_id: int) -> list[dict[st
 def fetch_accession_sample_counts(client: Any, species: str | None = None) -> list[dict[str, Any]]:
     """Sample count per accession per species, via the cyl_accession_sample_counts view."""
     query = client.table("cyl_accession_sample_counts").select(
-        "species_name, accession_id, accession_name, samples"
+        "species_name, accession_id, accession_name, plant_count"
     )
     if species is not None:
         query = query.eq("species_name", species)
@@ -130,7 +130,7 @@ def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
     help="Credentials profile to use.",
 )
 def sample_counts(species: str | None, as_json: bool, profile: str) -> None:
-    """Show the sample (plant) count per accession, per species."""
+    """Show the plant count per accession, per species (one plant = one biological replicate)."""
     from ..cli import _authed_client
 
     client = _authed_client(profile)

--- a/bloomcli/src/bloomctl/cyl/accessions.py
+++ b/bloomcli/src/bloomctl/cyl/accessions.py
@@ -1,0 +1,144 @@
+"""`bloomctl cyl accessions` — cylinder accession commands (list, sample-counts).
+
+Both read server-side views (see the `cyl_experiment_accessions` /
+`cyl_accession_sample_counts` migration), which do the DISTINCT / GROUP BY server-side
+so the CLI reads a small result and never hits the PostgREST row cap.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from ..credentials import DEFAULT_PROFILE
+from ._output import print_table
+
+ACCESSION_COLUMNS = ["Accession", "Accession ID"]
+SAMPLE_COUNT_COLUMNS = ["Species", "Accession", "Samples"]
+
+
+@click.group(name="accessions")
+def accessions() -> None:
+    """Cylinder accession commands."""
+
+
+def accession_sort_key(rec: dict[str, Any]) -> str:
+    """Sort accessions by name."""
+    return rec.get("accession_name") or ""
+
+
+def build_accession_row(rec: dict[str, Any]) -> list[str]:
+    """Shape a cyl_experiment_accessions row into a display row."""
+    aid = rec.get("accession_id")
+    return [rec.get("accession_name") or "", "" if aid is None else str(aid)]
+
+
+def build_accession_record(rec: dict[str, Any]) -> dict[str, Any]:
+    """Machine-readable accession record."""
+    return {"accession_id": rec.get("accession_id"), "accession_name": rec.get("accession_name")}
+
+
+def sample_count_sort_key(rec: dict[str, Any]) -> tuple[str, str]:
+    """Sort sample counts by species, then accession name."""
+    return (rec.get("species_name") or "", rec.get("accession_name") or "")
+
+
+def build_sample_count_row(rec: dict[str, Any]) -> list[str]:
+    """Shape a cyl_accession_sample_counts row into a display row."""
+    return [
+        rec.get("species_name") or "",
+        rec.get("accession_name") or "",
+        str(rec.get("samples", "")),
+    ]
+
+
+def build_sample_count_record(rec: dict[str, Any]) -> dict[str, Any]:
+    """Machine-readable sample-count record."""
+    return {
+        "species": rec.get("species_name"),
+        "accession": rec.get("accession_name"),
+        "samples": rec.get("samples"),
+    }
+
+
+# --- supabase / storage I/O ---
+
+
+def fetch_experiment_accessions(client: Any, experiment_id: int) -> list[dict[str, Any]]:
+    """Distinct accessions used in one experiment, via the cyl_experiment_accessions view."""
+    return (
+        client.table("cyl_experiment_accessions")
+        .select("accession_id, accession_name")
+        .eq("experiment_id", experiment_id)
+        .execute()
+        .data
+        or []
+    )
+
+
+def fetch_accession_sample_counts(client: Any, species: str | None = None) -> list[dict[str, Any]]:
+    """Sample count per accession per species, via the cyl_accession_sample_counts view."""
+    query = client.table("cyl_accession_sample_counts").select(
+        "species_name, accession_id, accession_name, samples"
+    )
+    if species is not None:
+        query = query.eq("species_name", species)
+    return query.execute().data or []
+
+
+@accessions.command(name="list")
+@click.option(
+    "--experiment-id",
+    "--experiment_id",
+    type=int,
+    required=True,
+    help="List the accessions used in this experiment (id).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit accessions as a JSON array.")
+@click.option(
+    "-p",
+    "--profile",
+    default=DEFAULT_PROFILE,
+    show_default=True,
+    help="Credentials profile to use.",
+)
+def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
+    """List the accessions used in a cylinder experiment."""
+    from ..cli import _authed_client
+
+    client = _authed_client(profile)
+    data = sorted(fetch_experiment_accessions(client, experiment_id), key=accession_sort_key)
+
+    if as_json:
+        click.echo(json.dumps([build_accession_record(r) for r in data]))
+        return
+
+    rows = [build_accession_row(r) for r in data]
+    print_table("Accessions", ACCESSION_COLUMNS, rows, empty="No accessions found for that experiment.")
+
+
+@accessions.command(name="sample-counts")
+@click.option("--species", default=None, help="Filter to one species (common name).")
+@click.option("--json", "as_json", is_flag=True, help="Emit counts as a JSON array.")
+@click.option(
+    "-p",
+    "--profile",
+    default=DEFAULT_PROFILE,
+    show_default=True,
+    help="Credentials profile to use.",
+)
+def sample_counts(species: str | None, as_json: bool, profile: str) -> None:
+    """Show the sample (plant) count per accession, per species."""
+    from ..cli import _authed_client
+
+    client = _authed_client(profile)
+    data = sorted(fetch_accession_sample_counts(client, species), key=sample_count_sort_key)
+
+    if as_json:
+        click.echo(json.dumps([build_sample_count_record(r) for r in data]))
+        return
+
+    rows = [build_sample_count_row(r) for r in data]
+    print_table("Sample counts per accession", SAMPLE_COUNT_COLUMNS, rows, empty="No sample counts found.")

--- a/bloomcli/src/bloomctl/cyl/accessions.py
+++ b/bloomcli/src/bloomctl/cyl/accessions.py
@@ -50,7 +50,7 @@ def build_sample_count_row(rec: dict[str, Any]) -> list[str]:
     return [
         rec.get("species_name") or "",
         rec.get("accession_name") or "",
-        str(rec.get("plant_count", "")),
+        "" if rec.get("plant_count") is None else str(rec.get("plant_count")),
     ]
 
 
@@ -83,7 +83,7 @@ def fetch_accession_sample_counts(client: Any, species: str | None = None) -> li
     query = client.table("cyl_accession_sample_counts").select(
         "species_name, accession_id, accession_name, plant_count"
     )
-    if species is not None:
+    if species:
         query = query.eq("species_name", species)
     return query.execute().data or []
 
@@ -107,9 +107,14 @@ def fetch_accession_sample_counts(client: Any, species: str | None = None) -> li
 def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
     """List the accessions used in a cylinder experiment."""
     from ..cli import _authed_client
+    from postgrest import APIError
 
     client = _authed_client(profile)
-    data = sorted(fetch_experiment_accessions(client, experiment_id), key=accession_sort_key)
+    try:
+        raw = fetch_experiment_accessions(client, experiment_id)
+    except APIError as exc:
+        raise click.ClickException(getattr(exc, "message", str(exc))) from exc
+    data = sorted(raw, key=accession_sort_key)
 
     if as_json:
         click.echo(json.dumps([build_accession_record(r) for r in data]))
@@ -132,9 +137,14 @@ def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
 def sample_counts(species: str | None, as_json: bool, profile: str) -> None:
     """Show the plant count per accession, per species (one plant = one biological replicate)."""
     from ..cli import _authed_client
+    from postgrest import APIError
 
     client = _authed_client(profile)
-    data = sorted(fetch_accession_sample_counts(client, species), key=sample_count_sort_key)
+    try:
+        raw = fetch_accession_sample_counts(client, species)
+    except APIError as exc:
+        raise click.ClickException(getattr(exc, "message", str(exc))) from exc
+    data = sorted(raw, key=sample_count_sort_key)
 
     if as_json:
         click.echo(json.dumps([build_sample_count_record(r) for r in data]))

--- a/bloomcli/src/bloomctl/cyl/accessions.py
+++ b/bloomcli/src/bloomctl/cyl/accessions.py
@@ -61,8 +61,9 @@ def build_sample_count_row(rec: dict[str, Any]) -> list[str]:
 
 
 def build_sample_count_record(rec: dict[str, Any]) -> dict[str, Any]:
-    """Machine-readable sample-count record. Includes accession_id (unique) so this
-    output can be joined to `accessions list --json` on the id, not the ambiguous name."""
+    """Machine-readable sample-count record. Includes accession_id (the stable primary
+    key) so this output can be joined to `accessions list --json` on the id, without
+    depending on the human-editable name."""
     return {
         "accession_id": rec.get("accession_id"),
         "species": rec.get("species_name"),
@@ -71,7 +72,7 @@ def build_sample_count_record(rec: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-# --- supabase / storage I/O ---
+# --- supabase I/O ---
 
 
 def fetch_experiment_accessions(client: Any, experiment_id: int) -> list[dict[str, Any]]:
@@ -100,6 +101,7 @@ def fetch_accession_sample_counts(client: Any, species: str | None = None) -> li
 @click.option(
     "--experiment-id",
     "--experiment_id",
+    "experiment_id",
     type=int,
     required=True,
     help="List the accessions used in this experiment (id).",
@@ -122,7 +124,7 @@ def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
     try:
         raw = fetch_experiment_accessions(client, experiment_id)
     except APIError as exc:
-        raise click.ClickException(getattr(exc, "message", str(exc))) from exc
+        raise click.ClickException(getattr(exc, "message", None) or str(exc)) from exc
     data = sorted(raw, key=accession_sort_key)
 
     if as_json:
@@ -130,7 +132,9 @@ def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
         return
 
     rows = [build_accession_row(r) for r in data]
-    print_table("Accessions", ACCESSION_COLUMNS, rows, empty="No accessions found for that experiment.")
+    print_table(
+        "Accessions", ACCESSION_COLUMNS, rows, empty="No accessions found for that experiment."
+    )
 
 
 @accessions.command(name="sample-counts")
@@ -148,11 +152,14 @@ def list_accessions(experiment_id: int, as_json: bool, profile: str) -> None:
     help="Credentials profile to use.",
 )
 def sample_counts(species: str | None, as_json: bool, profile: str) -> None:
-    """Show the plant count per accession, per species (one plant = one biological replicate).
+    """Show the plant count per accession, per species (one plant = one individual grown).
 
-    Counts are across all experiments in the database (not scoped to one
-    experiment, unlike `accessions list`). Plants not assigned to an accession
-    are excluded, so summing the counts can be lower than the total plant count.
+    Counts are pooled across all experiments in the database (not scoped to one
+    experiment, unlike `accessions list`), so this is a total headcount, not a
+    per-condition replicate count. An accession grown under more than one species
+    appears as multiple rows, so a per-name total must sum across those rows.
+    Plants not assigned to an accession are excluded, so summing the counts can be
+    lower than the total plant count.
     """
     from postgrest import APIError
 
@@ -162,7 +169,7 @@ def sample_counts(species: str | None, as_json: bool, profile: str) -> None:
     try:
         raw = fetch_accession_sample_counts(client, species)
     except APIError as exc:
-        raise click.ClickException(getattr(exc, "message", str(exc))) from exc
+        raise click.ClickException(getattr(exc, "message", None) or str(exc)) from exc
     data = sorted(raw, key=sample_count_sort_key)
 
     if as_json:

--- a/bloomcli/tests/test_cyl_accessions.py
+++ b/bloomcli/tests/test_cyl_accessions.py
@@ -53,9 +53,14 @@ def test_build_sample_count_row():
 
 def test_build_sample_count_record():
     rec = acc.build_sample_count_record(
-        {"species_name": "Canola", "accession_name": "Bay-0", "plant_count": 5}
+        {"accession_id": 4, "species_name": "Canola", "accession_name": "Bay-0", "plant_count": 5}
     )
-    assert rec == {"species": "Canola", "accession": "Bay-0", "plant_count": 5}
+    assert rec == {
+        "accession_id": 4,
+        "species": "Canola",
+        "accession": "Bay-0",
+        "plant_count": 5,
+    }
 
 
 def test_sample_count_sort_key_species_then_name():
@@ -201,6 +206,16 @@ def test_sample_counts_empty(monkeypatch):
     res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts"])
     assert res.exit_code == 0
     assert "No sample counts found" in res.output
+
+
+def test_sample_counts_empty_echoes_species_filter(monkeypatch):
+    # an empty result with --species should name the filter, so a mistyped /
+    # case-mismatched species is distinguishable from an empty database.
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", lambda client, species=None: [])
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts", "--species", "Canola"])
+    assert res.exit_code == 0
+    assert "No sample counts found for species 'Canola'." in res.output
 
 
 # --- grouping ---------------------------------------------------------------

--- a/bloomcli/tests/test_cyl_accessions.py
+++ b/bloomcli/tests/test_cyl_accessions.py
@@ -16,9 +16,9 @@ EXP_ACC = [
 
 # cyl_accession_sample_counts rows (out of order, to prove species-then-name sort).
 COUNTS = [
-    {"species_name": "Rice", "accession_id": 1, "accession_name": "IR64", "samples": 12},
-    {"species_name": "Canola", "accession_id": 4, "accession_name": "Bay-0", "samples": 5},
-    {"species_name": "Canola", "accession_id": 2, "accession_name": "Ames", "samples": 8},
+    {"species_name": "Rice", "accession_id": 1, "accession_name": "IR64", "plant_count": 12},
+    {"species_name": "Canola", "accession_id": 4, "accession_name": "Bay-0", "plant_count": 5},
+    {"species_name": "Canola", "accession_id": 2, "accession_name": "Ames", "plant_count": 8},
 ]
 
 
@@ -46,16 +46,16 @@ def test_build_accession_record():
 
 def test_build_sample_count_row():
     row = acc.build_sample_count_row(
-        {"species_name": "Canola", "accession_name": "Bay-0", "samples": 5}
+        {"species_name": "Canola", "accession_name": "Bay-0", "plant_count": 5}
     )
     assert row == ["Canola", "Bay-0", "5"]
 
 
 def test_build_sample_count_record():
     rec = acc.build_sample_count_record(
-        {"species_name": "Canola", "accession_name": "Bay-0", "samples": 5}
+        {"species_name": "Canola", "accession_name": "Bay-0", "plant_count": 5}
     )
-    assert rec == {"species": "Canola", "accession": "Bay-0", "samples": 5}
+    assert rec == {"species": "Canola", "accession": "Bay-0", "plant_count": 5}
 
 
 def test_sample_count_sort_key_species_then_name():
@@ -183,7 +183,7 @@ def test_sample_counts_json_sorted(monkeypatch):
         ("Canola", "Bay-0"),
         ("Rice", "IR64"),
     ]
-    assert payload[0]["samples"] == 8
+    assert payload[0]["plant_count"] == 8
 
 
 def test_sample_counts_table(monkeypatch):

--- a/bloomcli/tests/test_cyl_accessions.py
+++ b/bloomcli/tests/test_cyl_accessions.py
@@ -169,6 +169,17 @@ def test_list_json_sorted(monkeypatch):
     assert [r["accession_name"] for r in payload] == ["Bay-0", "Col-0"]  # sorted by name
 
 
+def test_list_renders_table(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_experiment_accessions", lambda client, eid: EXP_ACC)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "list", "--experiment-id", "7"])
+    assert res.exit_code == 0, res.output
+    assert "Accessions" in res.output  # table title
+    # names and ids both rendered — fails if a column is dropped/swapped
+    for token in ("Bay-0", "Col-0", "4", "9"):
+        assert token in res.output, f"{token!r} missing from table output"
+
+
 def test_list_empty(monkeypatch):
     _patch_authed(monkeypatch)
     monkeypatch.setattr(acc, "fetch_experiment_accessions", lambda client, eid: [])
@@ -189,6 +200,22 @@ def test_sample_counts_json_sorted(monkeypatch):
         ("Rice", "IR64"),
     ]
     assert payload[0]["plant_count"] == 8
+
+
+def test_sample_counts_species_passed_to_fetch(monkeypatch):
+    # the --species option must actually reach fetch (a dropped arg would still
+    # pass the fetch-function test, so assert it at the command level).
+    _patch_authed(monkeypatch)
+    captured = {}
+
+    def _fetch(client, species=None):
+        captured["species"] = species
+        return []
+
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", _fetch)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts", "--species", "Canola"])
+    assert res.exit_code == 0, res.output
+    assert captured["species"] == "Canola"
 
 
 def test_sample_counts_table(monkeypatch):

--- a/bloomcli/tests/test_cyl_accessions.py
+++ b/bloomcli/tests/test_cyl_accessions.py
@@ -213,3 +213,65 @@ def test_accessions_grouped_under_cyl_not_top_level():
     assert "list" in sub.output
     assert "sample-counts" in sub.output
     assert "accessions" in CliRunner().invoke(cli, ["cyl", "--help"]).output
+
+
+# --- edge cases / error handling -------------------------------------------
+
+
+def test_build_sample_count_row_tolerates_null_count():
+    # count(*) never yields NULL, but a null must render as "" not "None".
+    row = acc.build_sample_count_row(
+        {"species_name": "Rice", "accession_name": "IR64", "plant_count": None}
+    )
+    assert row == ["Rice", "IR64", ""]
+
+
+def test_fetch_sample_counts_empty_species_omits_eq():
+    captured = {"eq": None}
+
+    class _Q:
+        def select(self, sel):
+            return self
+
+        def eq(self, col, val):
+            captured["eq"] = (col, val)
+            return self
+
+        def execute(self):
+            return type("R", (), {"data": COUNTS})()
+
+    class _Client:
+        def table(self, name):
+            return _Q()
+
+    # empty --species means "no filter", not .eq("species_name", "")
+    acc.fetch_accession_sample_counts(_Client(), "")
+    assert captured["eq"] is None
+
+
+def test_list_maps_apierror_to_clickexception(monkeypatch):
+    from postgrest import APIError
+
+    _patch_authed(monkeypatch)
+
+    def _boom(client, experiment_id):
+        raise APIError({"message": "permission denied", "code": "42501"})
+
+    monkeypatch.setattr(acc, "fetch_experiment_accessions", _boom)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "list", "--experiment-id", "7"])
+    assert res.exit_code != 0
+    assert "permission denied" in res.output  # clean message, not a raw traceback
+
+
+def test_sample_counts_maps_apierror_to_clickexception(monkeypatch):
+    from postgrest import APIError
+
+    _patch_authed(monkeypatch)
+
+    def _boom(client, species=None):
+        raise APIError({"message": "permission denied", "code": "42501"})
+
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", _boom)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts"])
+    assert res.exit_code != 0
+    assert "permission denied" in res.output

--- a/bloomcli/tests/test_cyl_accessions.py
+++ b/bloomcli/tests/test_cyl_accessions.py
@@ -72,6 +72,35 @@ def test_sample_count_sort_key_species_then_name():
     ]
 
 
+def test_accession_sort_key_orders_by_name():
+    unsorted = [
+        {"accession_id": 9, "accession_name": "Col-0"},
+        {"accession_id": 4, "accession_name": "Bay-0"},
+    ]
+    ordered = sorted(unsorted, key=acc.accession_sort_key)
+    assert [r["accession_name"] for r in ordered] == ["Bay-0", "Col-0"]
+
+
+def test_accession_sort_key_breaks_name_ties_by_id():
+    # same name, different id → id decides order (deterministic run-to-run).
+    tied = [
+        {"accession_id": 20, "accession_name": "Col-0"},
+        {"accession_id": 7, "accession_name": "Col-0"},
+    ]
+    ordered = sorted(tied, key=acc.accession_sort_key)
+    assert [r["accession_id"] for r in ordered] == [7, 20]
+
+
+def test_sample_count_sort_key_breaks_ties_by_id():
+    # same species AND name, different id → id decides order.
+    tied = [
+        {"species_name": "Rice", "accession_id": 30, "accession_name": "IR64", "plant_count": 1},
+        {"species_name": "Rice", "accession_id": 3, "accession_name": "IR64", "plant_count": 1},
+    ]
+    ordered = sorted(tied, key=acc.sample_count_sort_key)
+    assert [r["accession_id"] for r in ordered] == [3, 30]
+
+
 # --- query shape ------------------------------------------------------------
 
 
@@ -126,6 +155,9 @@ def test_fetch_sample_counts_species_filter():
     acc.fetch_accession_sample_counts(_Client(), "Canola")
     assert captured["table"] == "cyl_accession_sample_counts"
     assert captured["eq"] == ("species_name", "Canola")
+    # a dropped column would silently blank the output — assert the select carries them.
+    for col in ("species_name", "accession_id", "accession_name", "plant_count"):
+        assert col in captured["select"], f"{col!r} missing from select"
 
 
 def test_fetch_sample_counts_no_filter_omits_eq():
@@ -188,6 +220,15 @@ def test_list_empty(monkeypatch):
     assert "No accessions found" in res.output
 
 
+def test_list_json_empty_is_empty_array(monkeypatch):
+    # --json must always emit parseable JSON, even when empty (not the human message).
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_experiment_accessions", lambda client, eid: [])
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "list", "--experiment-id", "7", "--json"])
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output) == []
+
+
 def test_sample_counts_json_sorted(monkeypatch):
     _patch_authed(monkeypatch)
     monkeypatch.setattr(acc, "fetch_accession_sample_counts", lambda client, species=None: COUNTS)
@@ -233,6 +274,14 @@ def test_sample_counts_empty(monkeypatch):
     res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts"])
     assert res.exit_code == 0
     assert "No sample counts found" in res.output
+
+
+def test_sample_counts_json_empty_is_empty_array(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", lambda client, species=None: [])
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts", "--json"])
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output) == []
 
 
 def test_sample_counts_empty_echoes_species_filter(monkeypatch):
@@ -317,3 +366,35 @@ def test_sample_counts_maps_apierror_to_clickexception(monkeypatch):
     res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts"])
     assert res.exit_code != 0
     assert "permission denied" in res.output
+
+
+def test_list_apierror_without_message_falls_back(monkeypatch):
+    # APIError.message is None when the body has no "message" key; fall back to str(exc)
+    # so the diagnostic (code/details) survives instead of printing "Error: None".
+    from postgrest import APIError
+
+    _patch_authed(monkeypatch)
+
+    def _boom(client, experiment_id):
+        raise APIError({"code": "42P01", "details": "relation does not exist"})
+
+    monkeypatch.setattr(acc, "fetch_experiment_accessions", _boom)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "list", "--experiment-id", "7"])
+    assert res.exit_code != 0
+    assert "None" not in res.output  # not "Error: None"
+    assert "42P01" in res.output or "relation does not exist" in res.output
+
+
+def test_sample_counts_apierror_without_message_falls_back(monkeypatch):
+    from postgrest import APIError
+
+    _patch_authed(monkeypatch)
+
+    def _boom(client, species=None):
+        raise APIError({"code": "42P01", "details": "relation does not exist"})
+
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", _boom)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts"])
+    assert res.exit_code != 0
+    assert "None" not in res.output
+    assert "42P01" in res.output or "relation does not exist" in res.output

--- a/bloomcli/tests/test_cyl_accessions.py
+++ b/bloomcli/tests/test_cyl_accessions.py
@@ -1,0 +1,215 @@
+"""bloomctl cyl accessions — list + sample-counts (shaping, sort, json; mocked client)."""
+
+import json
+
+from click.testing import CliRunner
+
+import bloomctl.cli as climod
+import bloomctl.cyl.accessions as acc
+from bloomctl.cli import cli
+
+# cyl_experiment_accessions rows (out of order, to prove the name sort).
+EXP_ACC = [
+    {"accession_id": 9, "accession_name": "Col-0"},
+    {"accession_id": 4, "accession_name": "Bay-0"},
+]
+
+# cyl_accession_sample_counts rows (out of order, to prove species-then-name sort).
+COUNTS = [
+    {"species_name": "Rice", "accession_id": 1, "accession_name": "IR64", "samples": 12},
+    {"species_name": "Canola", "accession_id": 4, "accession_name": "Bay-0", "samples": 5},
+    {"species_name": "Canola", "accession_id": 2, "accession_name": "Ames", "samples": 8},
+]
+
+
+def _patch_authed(monkeypatch):
+    monkeypatch.setattr(climod, "_authed_client", lambda profile: object())
+
+
+# --- shaping / sort ---------------------------------------------------------
+
+
+def test_build_accession_row():
+    assert acc.build_accession_row({"accession_id": 9, "accession_name": "Col-0"}) == ["Col-0", "9"]
+
+
+def test_build_accession_row_tolerates_nulls():
+    assert acc.build_accession_row({"accession_id": None, "accession_name": None}) == ["", ""]
+
+
+def test_build_accession_record():
+    assert acc.build_accession_record({"accession_id": 9, "accession_name": "Col-0"}) == {
+        "accession_id": 9,
+        "accession_name": "Col-0",
+    }
+
+
+def test_build_sample_count_row():
+    row = acc.build_sample_count_row(
+        {"species_name": "Canola", "accession_name": "Bay-0", "samples": 5}
+    )
+    assert row == ["Canola", "Bay-0", "5"]
+
+
+def test_build_sample_count_record():
+    rec = acc.build_sample_count_record(
+        {"species_name": "Canola", "accession_name": "Bay-0", "samples": 5}
+    )
+    assert rec == {"species": "Canola", "accession": "Bay-0", "samples": 5}
+
+
+def test_sample_count_sort_key_species_then_name():
+    ordered = sorted(COUNTS, key=acc.sample_count_sort_key)
+    assert [(r["species_name"], r["accession_name"]) for r in ordered] == [
+        ("Canola", "Ames"),
+        ("Canola", "Bay-0"),
+        ("Rice", "IR64"),
+    ]
+
+
+# --- query shape ------------------------------------------------------------
+
+
+def test_fetch_experiment_accessions_builds_query():
+    captured = {}
+
+    class _Q:
+        def select(self, sel):
+            captured["select"] = sel
+            return self
+
+        def eq(self, col, val):
+            captured["eq"] = (col, val)
+            return self
+
+        def execute(self):
+            return type("R", (), {"data": EXP_ACC})()
+
+    class _Client:
+        def table(self, name):
+            captured["table"] = name
+            return _Q()
+
+    out = acc.fetch_experiment_accessions(_Client(), 7)
+    assert out == EXP_ACC
+    assert captured["table"] == "cyl_experiment_accessions"
+    assert captured["eq"] == ("experiment_id", 7)
+    assert "accession_name" in captured["select"]
+
+
+def test_fetch_sample_counts_species_filter():
+    captured = {"eq": None}
+
+    class _Q:
+        def select(self, sel):
+            captured["select"] = sel
+            return self
+
+        def eq(self, col, val):
+            captured["eq"] = (col, val)
+            return self
+
+        def execute(self):
+            return type("R", (), {"data": COUNTS})()
+
+    class _Client:
+        def table(self, name):
+            captured["table"] = name
+            return _Q()
+
+    # with a species filter → an .eq() on species_name
+    acc.fetch_accession_sample_counts(_Client(), "Canola")
+    assert captured["table"] == "cyl_accession_sample_counts"
+    assert captured["eq"] == ("species_name", "Canola")
+
+
+def test_fetch_sample_counts_no_filter_omits_eq():
+    captured = {"eq": None}
+
+    class _Q:
+        def select(self, sel):
+            return self
+
+        def eq(self, col, val):
+            captured["eq"] = (col, val)
+            return self
+
+        def execute(self):
+            return type("R", (), {"data": COUNTS})()
+
+    class _Client:
+        def table(self, name):
+            return _Q()
+
+    acc.fetch_accession_sample_counts(_Client(), None)
+    assert captured["eq"] is None  # no filter → no .eq() call
+
+
+# --- commands ---------------------------------------------------------------
+
+
+def test_list_requires_experiment_id(monkeypatch):
+    _patch_authed(monkeypatch)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "list"])
+    assert res.exit_code != 0
+    assert "experiment-id" in res.output.lower() or "experiment_id" in res.output.lower()
+
+
+def test_list_json_sorted(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_experiment_accessions", lambda client, eid: EXP_ACC)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "list", "--experiment-id", "7", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert [r["accession_name"] for r in payload] == ["Bay-0", "Col-0"]  # sorted by name
+
+
+def test_list_empty(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_experiment_accessions", lambda client, eid: [])
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "list", "--experiment-id", "7"])
+    assert res.exit_code == 0
+    assert "No accessions found" in res.output
+
+
+def test_sample_counts_json_sorted(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", lambda client, species=None: COUNTS)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert [(r["species"], r["accession"]) for r in payload] == [
+        ("Canola", "Ames"),
+        ("Canola", "Bay-0"),
+        ("Rice", "IR64"),
+    ]
+    assert payload[0]["samples"] == 8
+
+
+def test_sample_counts_table(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", lambda client, species=None: COUNTS)
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts"])
+    assert res.exit_code == 0, res.output
+    assert "Sample counts per accession" in res.output
+    assert "Canola" in res.output and "Rice" in res.output
+
+
+def test_sample_counts_empty(monkeypatch):
+    _patch_authed(monkeypatch)
+    monkeypatch.setattr(acc, "fetch_accession_sample_counts", lambda client, species=None: [])
+    res = CliRunner().invoke(cli, ["cyl", "accessions", "sample-counts"])
+    assert res.exit_code == 0
+    assert "No sample counts found" in res.output
+
+
+# --- grouping ---------------------------------------------------------------
+
+
+def test_accessions_grouped_under_cyl_not_top_level():
+    root = CliRunner().invoke(cli, ["--help"])
+    assert "accessions" not in root.output  # not a top-level command
+    sub = CliRunner().invoke(cli, ["cyl", "accessions", "--help"])
+    assert "list" in sub.output
+    assert "sample-counts" in sub.output
+    assert "accessions" in CliRunner().invoke(cli, ["cyl", "--help"]).output


### PR DESCRIPTION
## What

Adds a new `cyl accessions` command group — two **read-only** commands (no legacy equivalent; new capability).

## Commands

- **`cyl accessions list --experiment-id N`** — the accessions used in an experiment. Reads the `cyl_experiment_accessions` view. `--json`.
- **`cyl accessions sample-counts [--species X]`** — plant count per accession, per species (one plant = one individual grown; counts are pooled across all experiments in the DB). Reads the `cyl_accession_sample_counts` view. `--json`.

The `DISTINCT` / `GROUP BY` runs **server-side in the views**, so the CLI reads a small aggregated result. Client-side sort (by name / species then name, tie-broken by `accession_id` for run-to-run determinism). Reuses `_output.print_table`.

## Dependencies

The accession views (`cyl_experiment_accessions`, `cyl_accession_sample_counts`) landed in #450, which is **already merged and deployed on staging** — this PR is rebased onto it, so there is no longer any deploy-ordering dependency. Both views are `security_invoker` and `revoke all … from anon` (no anonymous reads).

## Sequencing

Rebased directly onto `staging` (0 behind). `cyl qc list-sets` (#452) is stacked on top of this branch and retargets to `staging` once this merges.

## Since the last (dismissed) review

All findings from the prior review and a follow-up 5-subagent review are addressed:

- `--profile` help fixed (was a copy-paste of `--json`); `APIError` now caught in **both** commands and surfaced as a clean `ClickException` — and a message-less `APIError` falls back to `str(exc)` instead of printing `Error: None`.
- Null `plant_count` renders blank (not `"None"`); `--species ""` means "no filter"; the empty-result message names the species filter; `sample-counts --json` includes `accession_id` (the stable key) so it joins to `list --json`.
- Sorts tie-break on `accession_id` for determinism; `--species` help notes case-sensitivity; docstring states the DB-wide scope.

## Tests

**30** unit tests (`CliRunner` + `monkeypatch` fakes): pure-helper shaping + null tolerance, both sort keys **including the id tie-break**, query shape (+ `--species` filter + selected columns), table / `--json` / empty for both commands, `--json` empty-array, CLI `--species` wiring, and `APIError` handling **including the null-message path**. Full suite green; `ruff check` + `ruff format --check` clean; CI green.

