### PR TITLE
ci(#454): timeout-cap python-audit + tier flaky oracle tests as integration

### DIFF
--- a/.claude/commands/pre-merge.md
+++ b/.claude/commands/pre-merge.md
@@ -44,6 +44,12 @@ Audits each service's full transitive dependency tree via its lockfile. A temp f
 )
 ```
 
+`python-audit`'s per-PR CI run excludes bloommcp's `integration`-marked tests (`bloommcp/tests/test_oracle.py`'s full-fixture `statsmodels`/`umap` heritability/UMAP oracles — known to intermittently stall in CI containers, #454). Run them here instead so numeric drift is still caught before merge:
+
+```bash
+cd bloommcp && uv run --extra test pytest tests/ -m integration -v --tb=short
+```
+
 ## Step 3: Docker Builds (matches `docker-build` job)
 
 Build each image individually. `docker compose build` against `docker-compose.prod.yml` needs a populated `.env.dev` to resolve volume paths, which is not always available locally — the individual `docker build` commands don't.
@@ -158,11 +164,16 @@ cd web && npx tsc --noEmit && npm run build && cd ..
     (cd "$svc" && uv export --frozen --no-hashes > /tmp/reqs.txt && uvx pip-audit@2.10.0 -r /tmp/reqs.txt) || exit 1
   done
 )
+
+# bloommcp integration-marked oracle tests (if bloommcp/tests/test_oracle.py or
+# delegated statsmodels/umap code touched) — per-PR CI excludes these (#454).
+cd bloommcp && uv run --extra test pytest tests/ -m integration -v --tb=short && cd ..
 ```
 
 ## Pre-Merge Checklist
 
 - [ ] All CI jobs pass (`gh pr checks`)
+- [ ] bloommcp integration-marked oracle tests run if `bloommcp/tests/test_oracle.py` or delegated statsmodels/umap code touched (excluded from per-PR CI, see Step 2)
 - [ ] Code reviewed and approved
 - [ ] Review comments addressed
 - [ ] Branch up to date with the PR's base branch (`gh pr view <PR_NUMBER> --json baseRefName` — usually `staging`)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -137,7 +137,10 @@ jobs:
         run: uv run --extra test pytest tests/unit/ -v --tb=short
 
       - name: Run bloom_mcp package tests
-        run: cd bloommcp && uv run --frozen --extra test pytest tests/ -v --tb=short
+        # Excludes the integration-marked full-fixture heritability/UMAP oracle
+        # tests (bloommcp/tests/test_oracle.py) — they're known to intermittently
+        # stall in CI containers (#454) and run instead via /pre-merge.
+        run: cd bloommcp && uv run --frozen --extra test pytest tests/ -m "not integration" -v --tb=short
         env:
           SUPABASE_URL: ""
           BLOOM_AGENT_KEY: ""

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -121,6 +121,11 @@ jobs:
   python-audit:
     name: Python Security Audit for CVEs
     runs-on: ubuntu-latest
+    # A hang anywhere in this job's chain (unit tests, the bloommcp/bloomcli
+    # suites, the wheel build, or pip-audit itself) would otherwise run until
+    # GitHub Actions' 360-minute default cap with zero output (#454). Matches
+    # docker-build (30m) / compose-health-check (30m) / dev-stack-smoke (20m).
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/bloommcp/pyproject.toml
+++ b/bloommcp/pyproject.toml
@@ -73,6 +73,9 @@ module-root = "src"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+markers = [
+    "integration: full-fixture statsmodels/umap oracle tests over turface_19 — slow, intermittently stalls in CI containers; excluded from per-PR CI, run via /pre-merge or pytest -m integration",
+]
 
 [tool.ruff.lint.per-file-ignores]
 # Pre-existing lint debt in the vendored analysis modules (former source/*) and

--- a/bloommcp/tests/test_oracle.py
+++ b/bloommcp/tests/test_oracle.py
@@ -153,6 +153,7 @@ def test_shipped_correlations_reproduce_recorded_offdiagonal(turface_19):
 _WRAPPER_CONSUMED_TRAIT_KEYS = ("heritability", "var_genetic", "var_residual")
 
 
+@pytest.mark.integration
 def test_external_library_heritability_matches_recorded_oracle(turface_19):
     """The delegated heritability path reproduces the recorded #120 mean H².
 
@@ -184,6 +185,7 @@ def test_external_library_heritability_matches_recorded_oracle(turface_19):
     assert sum(1 for v in h2 if v >= 0.5) == golden["heritability_n_above_0.5"]
 
 
+@pytest.mark.integration
 def test_delegated_heritability_returns_wrapper_consumed_keys(turface_19):
     """Delegation-boundary contract: every per-trait result the wrappers plot carries
     the keys they read (heritability, var_genetic, var_residual), non-defaulted.
@@ -256,6 +258,7 @@ def _umap_trustworthiness(df, trait_cols, embedding, n_neighbors=15) -> float:
     return float(trustworthiness(standardized, embedding, n_neighbors=n_neighbors))
 
 
+@pytest.mark.integration
 def test_external_library_umap_is_deterministic_and_structural(turface_19):
     """Fixed-seed UMAP is reproducible AND preserves local structure.
 
@@ -287,6 +290,7 @@ def test_external_library_umap_is_deterministic_and_structural(turface_19):
     assert t == pytest.approx(golden["umap_trustworthiness"], abs=0.05)
 
 
+@pytest.mark.integration
 def test_umap_trustworthiness_floor_rejects_wrong_parameters(turface_19):
     """The structural floor actually discriminates: a wrong n_neighbors collapses it.
 

--- a/openspec/changes/update-python-audit-ci-reliability/proposal.md
+++ b/openspec/changes/update-python-audit-ci-reliability/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+The `python-audit` job in `.github/workflows/pr-checks.yml` has no `timeout-minutes`, unlike every other slow job in the same workflow (`docker-build`: 30m, `compose-health-check`: 30m, `dev-stack-smoke`: 20m). When a step inside it hangs, the job blocks for GitHub Actions' default 360-minute (6-hour) job cap before failing, with zero output in between — CI looks stuck rather than clearly failing (#454).
+
+This has already happened twice on PR #405 (runs `29353244406` and `29441421235`): `bloommcp/tests/test_oracle.py`'s heritability/UMAP tests — which run `statsmodels` MixedLM and `numba`-JIT UMAP over the full 19-genotype `turface_19` fixture — intermittently stall in CI containers (thread-pool contention between OpenBLAS/numba, or MixedLM optimizer non-convergence). A related fix already landed for the same class of problem (`3a700fd`, swapping the full fixture for a 15-row synthetic one in `test_local_mode.py`); `test_oracle.py`'s heritability/UMAP tests were added later (`e4d8015`) and never got the same treatment. These tests are numeric-drift oracles, not per-PR-relevant correctness checks, so they don't need to run on every PR.
+
+## What Changes
+
+- Add `timeout-minutes: 20` to the `python-audit` job so a stall fails fast and visibly instead of silently burning hours.
+- Add an `integration` pytest marker to `bloommcp/pyproject.toml` (matching the existing convention in `bloomcli/pyproject.toml` and the root `pyproject.toml`) and mark the four full-fixture heritability/UMAP tests in `bloommcp/tests/test_oracle.py` with `@pytest.mark.integration`.
+- Exclude the marker from the `Run bloom_mcp package tests` step in `python-audit` (`pytest tests/ -m "not integration"`), matching how the `Run bloomctl package tests` step in the same job already excludes its own `integration` marker.
+- Add a step to `/pre-merge` (`.claude/commands/pre-merge.md`) that runs the integration-marked bloommcp tests locally, referenced from all three of its checklist surfaces (Step 2, the "Quick Pre-Merge (Minimum)" path, and the final "Pre-Merge Checklist"), so numeric drift is still caught before merge without blocking every PR's CI.
+
+## Impact
+
+- Affected specs: `python-dependency-management` (owns the `python-audit` CI job's behavior)
+- Affected code: `.github/workflows/pr-checks.yml`, `bloommcp/pyproject.toml`, `bloommcp/tests/test_oracle.py`, `.claude/commands/pre-merge.md`
+- Trade-off: the four full-fixture oracle tests no longer run on every PR — only when a developer follows `/pre-merge` (any of its three checklist surfaces reference the step) or manually runs `pytest -m integration`. A PR that skips `/pre-merge` entirely could merge with undetected numeric drift in the delegated `statsmodels`/`umap` calls until the next `/pre-merge` run catches it.

--- a/openspec/changes/update-python-audit-ci-reliability/specs/python-dependency-management/spec.md
+++ b/openspec/changes/update-python-audit-ci-reliability/specs/python-dependency-management/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: CI SHALL validate lockfile freshness and audit transitive dependencies
+
+The `python-audit` CI job SHALL:
+1. Install uv via the `astral-sh/setup-uv` GitHub Action, pinned per the "CI actions SHALL be pinned to immutable commit SHAs" requirement below (not via `pip install uv`)
+2. Export pinned versions from `uv.lock` via `uv export --frozen --no-hashes` and pipe to `uvx pip-audit` for vulnerability scanning, with `pip-audit` version-pinned per the "CI security-scanning tools SHALL be pinned to specific versions" requirement below
+3. Audit all three services: `langchain/`, `bloommcp/`, and `services/video-worker/`
+
+The job SHALL set `timeout-minutes: 20`, matching the cap already used by `docker-build` (30m), `compose-health-check` (30m), and `dev-stack-smoke` (20m) in the same workflow, so a hang in any step — the unit tests, the bloommcp/bloomcli suites, the wheel build, or the pip-audit calls themselves — fails visibly within a bounded window instead of running until GitHub Actions' 360-minute default job cap.
+
+The `compose-health-check` CI job SHALL also use the SHA-pinned `astral-sh/setup-uv` action instead of `pip install uv`.
+
+#### Scenario: Transitive dependency with known CVE
+
+- **WHEN** a transitive dependency in `uv.lock` has a known vulnerability
+- **THEN** `uvx pip-audit` SHALL report it in the CI output
+
+#### Scenario: CI detects lockfile drift
+
+- **WHEN** a PR modifies `pyproject.toml` without regenerating `uv.lock`
+- **THEN** `uv sync --frozen` SHALL fail and the CI job SHALL not pass
+
+#### Scenario: CI installs uv via setup-uv action
+
+- **WHEN** any CI job needs uv
+- **THEN** uv is installed via the `astral-sh/setup-uv` action, pinned to a 40-char commit SHA with a trailing `# v7.x.y` comment
+- **AND** pip is NOT used to install uv
+- **AND** the bare `@v7` tag reference is NOT used
+
+#### Scenario: A step inside python-audit hangs
+
+- **WHEN** any step within the `python-audit` job stalls and produces no further output
+- **THEN** GitHub Actions cancels the job after 20 minutes
+- **AND** the job is reported as failed rather than left running for up to 6 hours
+
+## ADDED Requirements
+
+### Requirement: bloommcp full-fixture oracle tests SHALL be tiered as integration tests and excluded from per-PR CI
+
+`bloommcp/pyproject.toml` SHALL declare a `markers` entry for `integration` under `[tool.pytest.ini_options]` with the description `"integration: full-fixture statsmodels/umap oracle tests over turface_19 — slow, intermittently stalls in CI containers; excluded from per-PR CI, run via /pre-merge or pytest -m integration"`. This description is specific to bloommcp — it is deliberately NOT copied verbatim from the root `pyproject.toml`'s (`"marks tests that require the compose stack to be running"`) or `bloomcli/pyproject.toml`'s (`"requires live staging credentials..."`) `integration` markers, since bloommcp's reason for the marker (slow, intermittently-stalling numeric-drift oracle; no external infra dependency) is unrelated to either of those. The following tests in `bloommcp/tests/test_oracle.py` — which run `statsmodels` MixedLM heritability and `numba`-JIT UMAP over the full 19-genotype `turface_19` fixture, and are known to intermittently stall in CI containers — SHALL be marked `@pytest.mark.integration`:
+- `test_external_library_heritability_matches_recorded_oracle`
+- `test_delegated_heritability_returns_wrapper_consumed_keys`
+- `test_external_library_umap_is_deterministic_and_structural`
+- `test_umap_trustworthiness_floor_rejects_wrong_parameters`
+
+The `Run bloom_mcp package tests` step in the `python-audit` CI job SHALL invoke `uv run --frozen --extra test pytest tests/ -m "not integration" -v --tb=short` (preserving the existing `--frozen --extra test` flags and `SUPABASE_URL`/`BLOOM_AGENT_KEY` env vars), matching the exclusion pattern already used by the `Run bloomctl package tests` step in the same job.
+
+#### Scenario: Per-PR CI skips the full-fixture oracle tests
+
+- **WHEN** a PR triggers the `python-audit` job
+- **THEN** the `Run bloom_mcp package tests` step excludes tests marked `integration`
+- **AND** the four full-fixture heritability/UMAP tests do not run
+
+#### Scenario: Marked tests still run when explicitly requested
+
+- **WHEN** a developer runs `cd bloommcp && uv run --extra test pytest tests/ -m integration -v --tb=short`
+- **THEN** the four integration-marked oracle tests execute normally
+
+#### Scenario: Exactly the intended four tests carry the marker
+
+- **WHEN** a developer runs `cd bloommcp && uv run --extra test pytest tests/ -m integration --collect-only -q`
+- **THEN** exactly the four named tests are collected — no fewer (which would indicate a typo'd or dropped marker silently leaving a stalling test in the per-PR `not integration` bucket) and no more (which would indicate marker scope creep)
+
+### Requirement: The Pre-Merge command SHALL run the bloommcp integration-marked oracle tests
+
+`.claude/commands/pre-merge.md` SHALL reference a step that runs the bloommcp tests marked `integration` (the full-fixture heritability/UMAP oracle tests excluded from per-PR CI) from all three of its checklist surfaces — the "Step 2: Python Audit" section, the "Quick Pre-Merge (Minimum)" section, and the final "Pre-Merge Checklist" — so numeric drift in the delegated `statsmodels`/`umap` calls is still caught before merge regardless of which checklist path a developer follows, even though the tests no longer block every PR's CI.
+
+#### Scenario: Developer follows the full /pre-merge Step 2
+
+- **WHEN** a developer follows the `/pre-merge` checklist's "Step 2: Python Audit" section
+- **THEN** the section includes running `cd bloommcp && uv run --extra test pytest tests/ -m integration -v --tb=short`
+- **AND** following it exercises the four full-fixture oracle tests that per-PR CI skips
+
+#### Scenario: Developer follows the Quick Pre-Merge (Minimum) path
+
+- **WHEN** a developer follows only the "Quick Pre-Merge (Minimum)" section (the sanctioned fast path for small changes)
+- **THEN** that section also references the bloommcp integration-marked test run
+- **AND** the developer is not silently left believing the oracle tests were covered by CI when they were excluded from it
+
+#### Scenario: Final Pre-Merge Checklist reflects the exclusion
+
+- **WHEN** a developer reviews the final "Pre-Merge Checklist" before merging
+- **THEN** it includes a checklist item for the bloommcp integration-marked oracle tests, distinct from the general "All CI jobs pass" item (since CI no longer runs them)

--- a/openspec/changes/update-python-audit-ci-reliability/tasks.md
+++ b/openspec/changes/update-python-audit-ci-reliability/tasks.md
@@ -1,0 +1,39 @@
+## 1. Commit the OpenSpec proposal
+
+- [ ] 1.1 Commit `openspec/changes/update-python-audit-ci-reliability/**` on its own (`docs(#454): openspec proposal — CI reliability for python-audit job`)
+
+## 2. Tier the full-fixture oracle tests as integration tests
+
+- [x] 2.1 Add a `markers` entry to `bloommcp/pyproject.toml`'s `[tool.pytest.ini_options]` with the exact description: `"integration: full-fixture statsmodels/umap oracle tests over turface_19 — slow, intermittently stalls in CI containers; excluded from per-PR CI, run via /pre-merge or pytest -m integration"` (deliberately not copied from `bloomcli`'s or the root's `integration` marker text — those describe different, infra-gated reasons that don't apply here)
+- [x] 2.2 Mark these four tests in `bloommcp/tests/test_oracle.py` with `@pytest.mark.integration`:
+  - `test_external_library_heritability_matches_recorded_oracle`
+  - `test_delegated_heritability_returns_wrapper_consumed_keys`
+  - `test_external_library_umap_is_deterministic_and_structural`
+  - `test_umap_trustworthiness_floor_rejects_wrong_parameters`
+- [x] 2.3 Prove the partition locally, before CI depends on it: run `cd bloommcp && uv run --extra test pytest tests/ -m integration --collect-only -q` and confirm exactly the 4 tests above are collected (no fewer — a typo'd marker would silently leave a stalling test in the per-PR bucket — and no more). **Verified**: `4/421 tests collected (417 deselected)`, exactly the 4 named tests.
+- [x] 2.4 Run `cd bloommcp && uv run --extra test pytest tests/ -m "not integration" --collect-only -q` and confirm the same 4 tests are absent and no other test in the suite is affected. **Verified**: `417/421 tests collected (4 deselected)` — 4 + 417 = 421, no other test affected.
+- [ ] 2.5 Commit `bloommcp/pyproject.toml` + `bloommcp/tests/test_oracle.py` together (`test(#454): tier bloommcp oracle heritability/UMAP tests as integration`)
+
+## 3. CI: timeout + exclude the marker from per-PR CI
+
+- [x] 3.1 Add `timeout-minutes: 20` to the `python-audit` job in `.github/workflows/pr-checks.yml` (alongside `runs-on:`, before `steps:`, matching `docker-build`/`compose-health-check`/`dev-stack-smoke`'s placement)
+- [x] 3.2 Update the `Run bloom_mcp package tests` step's `run:` line from
+      `cd bloommcp && uv run --frozen --extra test pytest tests/ -v --tb=short`
+      to
+      `cd bloommcp && uv run --frozen --extra test pytest tests/ -m "not integration" -v --tb=short`
+      — preserved `--frozen --extra test` and the existing `SUPABASE_URL`/`BLOOM_AGENT_KEY` env vars on the step unchanged.
+- [ ] 3.3 Commit `timeout-minutes: 20` on its own (`ci(#454): cap python-audit job at timeout-minutes: 20`) so it can be reverted independently of the marker-exclusion change below if the value ever proves too tight
+- [ ] 3.4 Commit the `-m "not integration"` change on its own (`ci(#454): exclude integration-marked tests from python-audit per-PR run`)
+
+## 4. Wire into all three `/pre-merge` checklist surfaces
+
+- [x] 4.1 "Step 2: Python Audit" section: added `cd bloommcp && uv run --extra test pytest tests/ -m integration -v --tb=short`
+- [x] 4.2 "Quick Pre-Merge (Minimum)" section: added the same command so a developer following only the fast path still sees it
+- [x] 4.3 Final "Pre-Merge Checklist": added a distinct checklist item, separate from "All CI jobs pass", since CI no longer runs these
+- [ ] 4.4 Commit `.claude/commands/pre-merge.md` on its own (`docs(#454): run bloommcp integration oracle tests in /pre-merge`)
+
+## 5. Validate
+
+- [x] 5.1 Hand-verified against `openspec/AGENTS.md` format rules (`openspec` CLI is unavailable in this environment — checked PATH, npm/npx, pipx, common install dirs; none found, so `openspec validate --strict` could not be run)
+- [x] 5.2 Confirmed `tests/unit/test_ci_workflow_uv_conventions.py` still passes (3 passed) — the new `run:` line keeps `--extra test` and does not introduce `--with`
+- [x] 5.3 Confirmed unaffected: ran the full bloommcp suite with `-m "not integration"` (417 passed, 4 deselected, ~62s) and with `-m integration` (4 passed, 417 deselected, ~13s) — `bloomcli`'s pre-existing `-m "not integration"` step and the wheel-build step (no pytest invocation) are untouched by this change

--- a/openspec/changes/update-python-audit-ci-reliability/tasks.md
+++ b/openspec/changes/update-python-audit-ci-reliability/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Commit the OpenSpec proposal
 
-- [ ] 1.1 Commit `openspec/changes/update-python-audit-ci-reliability/**` on its own (`docs(#454): openspec proposal — CI reliability for python-audit job`)
+- [x] 1.1 Commit `openspec/changes/update-python-audit-ci-reliability/**` on its own (`docs(#454): openspec proposal — CI reliability for python-audit job`)
 
 ## 2. Tier the full-fixture oracle tests as integration tests
 
@@ -12,7 +12,7 @@
   - `test_umap_trustworthiness_floor_rejects_wrong_parameters`
 - [x] 2.3 Prove the partition locally, before CI depends on it: run `cd bloommcp && uv run --extra test pytest tests/ -m integration --collect-only -q` and confirm exactly the 4 tests above are collected (no fewer — a typo'd marker would silently leave a stalling test in the per-PR bucket — and no more). **Verified**: `4/421 tests collected (417 deselected)`, exactly the 4 named tests.
 - [x] 2.4 Run `cd bloommcp && uv run --extra test pytest tests/ -m "not integration" --collect-only -q` and confirm the same 4 tests are absent and no other test in the suite is affected. **Verified**: `417/421 tests collected (4 deselected)` — 4 + 417 = 421, no other test affected.
-- [ ] 2.5 Commit `bloommcp/pyproject.toml` + `bloommcp/tests/test_oracle.py` together (`test(#454): tier bloommcp oracle heritability/UMAP tests as integration`)
+- [x] 2.5 Commit `bloommcp/pyproject.toml` + `bloommcp/tests/test_oracle.py` together (`test(#454): tier bloommcp oracle heritability/UMAP tests as integration`)
 
 ## 3. CI: timeout + exclude the marker from per-PR CI
 
@@ -22,15 +22,15 @@
       to
       `cd bloommcp && uv run --frozen --extra test pytest tests/ -m "not integration" -v --tb=short`
       — preserved `--frozen --extra test` and the existing `SUPABASE_URL`/`BLOOM_AGENT_KEY` env vars on the step unchanged.
-- [ ] 3.3 Commit `timeout-minutes: 20` on its own (`ci(#454): cap python-audit job at timeout-minutes: 20`) so it can be reverted independently of the marker-exclusion change below if the value ever proves too tight
-- [ ] 3.4 Commit the `-m "not integration"` change on its own (`ci(#454): exclude integration-marked tests from python-audit per-PR run`)
+- [x] 3.3 Commit `timeout-minutes: 20` on its own (`ci(#454): cap python-audit job at timeout-minutes: 20`) so it can be reverted independently of the marker-exclusion change below if the value ever proves too tight
+- [x] 3.4 Commit the `-m "not integration"` change on its own (`ci(#454): exclude integration-marked tests from python-audit per-PR run`)
 
 ## 4. Wire into all three `/pre-merge` checklist surfaces
 
 - [x] 4.1 "Step 2: Python Audit" section: added `cd bloommcp && uv run --extra test pytest tests/ -m integration -v --tb=short`
 - [x] 4.2 "Quick Pre-Merge (Minimum)" section: added the same command so a developer following only the fast path still sees it
 - [x] 4.3 Final "Pre-Merge Checklist": added a distinct checklist item, separate from "All CI jobs pass", since CI no longer runs these
-- [ ] 4.4 Commit `.claude/commands/pre-merge.md` on its own (`docs(#454): run bloommcp integration oracle tests in /pre-merge`)
+- [x] 4.4 Commit `.claude/commands/pre-merge.md` on its own (`docs(#454): run bloommcp integration oracle tests in /pre-merge`)
 
 ## 5. Validate
 


### PR DESCRIPTION
## Summary

Fixes #454 — the `python-audit` job had no `timeout-minutes`, so a hang anywhere in its chain ran until GitHub Actions' 360-minute default cap with zero output. This happened twice on PR #405 (runs `29353244406`, `29441421235`): `bloommcp/tests/test_oracle.py`'s heritability/UMAP oracle tests (`statsmodels` MixedLM + `numba`-JIT UMAP over the full 19-genotype `turface_19` fixture) intermittently stall in CI containers.

- Add `timeout-minutes: 20` to `python-audit` (matches `docker-build`/`compose-health-check`: 30m, `dev-stack-smoke`: 20m)
- Tier the 4 slow/flaky oracle tests as `@pytest.mark.integration` (new marker declared in `bloommcp/pyproject.toml`) and exclude them from the per-PR `python-audit` run via `-m "not integration"`, mirroring the pattern `bloomcli` already uses in the same job
- Wire `pytest -m integration` into all three `/pre-merge` checklist surfaces (Step 2, the Quick path, and the final checklist) so the excluded tests are still run before merge
- OpenSpec proposal at `openspec/changes/update-python-audit-ci-reliability/`, reviewed by a 5-agent review team (spec quality, TDD/testing, CI/CD, docs, git workflow) and revised per their findings

## Test plan

- [x] `cd bloommcp && uv run --extra test pytest tests/ -m integration --collect-only -q` → exactly the 4 named tests (417 deselected)
- [x] `cd bloommcp && uv run --extra test pytest tests/ -m "not integration" --collect-only -q` → 417 collected, 4 deselected, no other test affected
- [x] Full `-m "not integration"` run: 417 passed in ~62s
- [x] Full `-m integration` run: 4 passed in ~13s
- [x] `tests/unit/test_ci_workflow_uv_conventions.py`: 3 passed (new `run:` line keeps `--extra test`, no `--with`)
- [ ] `gh pr checks` green on this PR, including `python-audit` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)