### PR TITLE
feat(bloomctl): add cyl download-for-predict command

### DIFF
--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
   (preserving the producer's `idempotency_key`), reports the first-writer-wins
   no-op distinctly from an error, maps RPC validation failures to actionable
   messages, and supports `--json` output (#397).
+- `bloomctl cyl download-for-predict <scan-id> <out>` — stage one cylinder scan
+  into the layout `sleap_roots_predict.discover_scans` expects (frames beside a
+  `scan_metadata.json` sidecar authored from live DB metadata), for A4 per-scan
+  pipeline stage-in. Distinct from `cyl download`'s legacy `images/Wave{n}/…` +
+  `scans.csv` layout (#411).
 
 ## [0.1.0a1] - 2026-06-30
 

--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -12,11 +12,49 @@ credentials. Successor to the Node `@salk-hpi/bloom-cli`. Tracked by issue #347.
   credentials per profile.
 - `bloomctl cyl download <out_dir> …` — download a cylinder experiment or single
   scan (metadata `scans.csv` + per-frame images).
+- `bloomctl cyl download-for-predict <scan-id> <out>` — stage one scan into the
+  predict-ready layout (see below); produces a **different** output tree than
+  `cyl download` — use this only for A4 pipeline stage-in.
 - `bloomctl cyl ingest-result <envelope>` — write a per-scan pipeline
   `ResultEnvelope` back to Bloom (see below).
 
 (Full `login`/`cyl download` usage docs are still forthcoming; run any command
-with `--help` in the meantime.)
+with `--help` in the meantime. `cyl ingest-result` and `cyl download-for-predict`
+are documented in full below.)
+
+## `bloomctl cyl download-for-predict`
+
+Stage one cylinder scan into the layout the warm-predict container expects.
+Unlike `cyl download` (which writes `images/Wave{n}/…` + `scans.csv`), this
+command co-locates frames with a `scan_metadata.json` sidecar so
+`sleap_roots_predict.discover_scans` can find them — use it for A4 per-scan
+pipeline stage-in, not as a replacement for `cyl download`.
+
+```
+bloomctl cyl download-for-predict <scan-id> <out>   [-p/--profile PROFILE]
+```
+
+- Writes frames to `<out>/scan_<scan_id>/<frame_number><ext>`.
+- Authors `<out>/scan_<scan_id>/scan_<scan_id>.scan_metadata.json` with:
+  - `scan_key` — `scan_<scan_id>` (matches the filename stem).
+  - `params` — `{species, mode, age}`, resolved via `sleap-roots-contracts`
+    (`mode` is always `"cylinder"`).
+  - `image_ids` — real `cyl_images.id` values, required for the write-back RPC
+    to resolve the scan (see rationale in design.md / bloom#411).
+  - `images_checksum` — `sha256:<hex>` over the downloaded frame bytes.
+- Exits non-zero with a readable message if the scan isn't found, has no
+  frames, or any frame fails to download — on a frame-download failure, no
+  sidecar is written (successfully-downloaded frames remain on disk).
+- A successful re-run reconciles away any stray frame file left by an earlier
+  failed attempt, so the directory always matches the written sidecar exactly.
+
+Auth: same saved login profile as other `cyl` commands.
+
+Example:
+
+```
+bloomctl cyl download-for-predict 1 ./staged
+```
 
 ## `bloomctl cyl ingest-result`
 

--- a/bloomcli/pyproject.toml
+++ b/bloomcli/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     # the emitters' contract_version (stricter than bloommcp's a1 on purpose); no
     # [pandas] extra — only the pydantic models are needed (pydantic already present
     # transitively via supabase->postgrest).
-    "sleap-roots-contracts>=0.1.0a3",
+    "sleap-roots-contracts>=0.1.0a4",
 ]
 
 [project.scripts]

--- a/bloomcli/src/bloomctl/cyl/__init__.py
+++ b/bloomcli/src/bloomctl/cyl/__init__.py
@@ -6,6 +6,7 @@ import click
 
 # Alias so the command objects don't shadow the same-named submodules.
 from .download import download as download_cmd
+from .download_for_predict import download_for_predict as download_for_predict_cmd
 from .ingest import ingest_result as ingest_result_cmd
 
 
@@ -15,4 +16,5 @@ def cyl() -> None:
 
 
 cyl.add_command(download_cmd)
+cyl.add_command(download_for_predict_cmd)
 cyl.add_command(ingest_result_cmd)

--- a/bloomcli/src/bloomctl/cyl/download_for_predict.py
+++ b/bloomcli/src/bloomctl/cyl/download_for_predict.py
@@ -1,0 +1,176 @@
+"""`bloomctl cyl download-for-predict`: stage one scan in the layout
+`sleap_roots_predict.discover_scans` expects.
+
+Pure helpers (sidecar assembly, path derivation, checksum) are separated from
+the supabase/storage I/O so the contract is unit-testable without a live
+server — mirroring ``download.py`` and ``ingest.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from ..credentials import DEFAULT_PROFILE
+from .download import DownloadResult, FrameResult, fetch_images, fetch_scan
+
+# Matches sleap_roots_predict.batch._IMAGE_EXTENSIONS — the exact set discover_scans
+# globs for, so stray-frame reconciliation removes anything predict would pick up.
+_IMAGE_EXTENSIONS = frozenset({".png", ".tif", ".tiff", ".jpg", ".jpeg"})
+
+
+def scan_key_for(scan_id: Any) -> str:
+    """The sidecar's scan_key — must equal the filename stem (predict validates this)."""
+    return f"scan_{scan_id}"
+
+
+def frame_dest_for_predict(scan_dir: Path, image: dict[str, Any]) -> Path:
+    """Absolute destination for one frame, co-located with the sidecar."""
+    ext = Path(image.get("object_path", "")).suffix or ".png"
+    return Path(scan_dir) / f"{image['frame_number']}{ext}"
+
+
+def compute_checksum(frame_bytes_list: list[bytes]) -> str:
+    """sha256 over frame bytes concatenated in the given (DB frame_number) order."""
+    digest = hashlib.sha256()
+    for data in frame_bytes_list:
+        digest.update(data)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def build_sidecar(
+    scan: dict[str, Any], images: list[dict[str, Any]], frame_bytes_list: list[bytes]
+) -> dict[str, Any]:
+    """Assemble the scan_metadata.json sidecar dict for one scan.
+
+    `mode` is forced via `resolve_params`'s documented `overrides` mechanism (not
+    row augmentation — see design.md) since every `cyl` scan is cylinder-scanner.
+    """
+    from sleap_roots_contracts import resolve_params
+
+    resolved = resolve_params(scan, overrides={"mode": "cylinder"})
+    return {
+        "scan_key": scan_key_for(scan["scan_id"]),
+        "params": resolved.values,
+        "image_ids": [image["id"] for image in images],
+        "images_checksum": compute_checksum(frame_bytes_list),
+    }
+
+
+def write_sidecar(sidecar: dict[str, Any], path: Path) -> None:
+    """Write the sidecar as valid UTF-8 JSON, creating the parent dir if absent."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(sidecar), encoding="utf-8")
+
+
+def reconcile_stray_frames(scan_dir: Path, written: list[Path]) -> None:
+    """Delete any image-extension file in scan_dir not among the just-written frames.
+
+    Guards against a stale frame surviving from an earlier failed attempt whose
+    cyl_images rows have since changed (see design.md): discover_scans globs every
+    image-extension file physically present in the sidecar's directory, not just
+    the ones named in image_ids, so a leftover file would silently be fed to
+    predict as an unaccounted-for frame.
+    """
+    if not scan_dir.exists():
+        return
+    written_names = {p.name for p in written}
+    for entry in scan_dir.iterdir():
+        if (
+            entry.is_file()
+            and entry.suffix.lower() in _IMAGE_EXTENSIONS
+            and entry.name not in written_names
+        ):
+            entry.unlink()
+
+
+# --- supabase / storage I/O -------------------------------------------------
+
+
+def download_frames_for_predict(
+    client: Any, scan: dict[str, Any], images: list[dict[str, Any]], scan_dir: Path
+) -> tuple[DownloadResult, list[bytes]]:
+    """Download every frame for one scan into the nested predict layout.
+
+    Returns the aggregate result plus each successfully-downloaded frame's bytes
+    in DB frame_number order (for the checksum) — a failed frame contributes no
+    bytes entry, mirroring ``download.py``'s per-frame failure isolation.
+    """
+    bucket = client.storage.from_("images")
+    frames: list[FrameResult] = []
+    frame_bytes: list[bytes] = []
+    for image in images:
+        object_path = image.get("object_path", "")
+        result = FrameResult(scan.get("scan_id"), image.get("frame_number"), object_path, ok=False)
+        try:
+            data = bucket.download(object_path)
+            if data is None:
+                raise ValueError("empty response from storage")
+            dest = frame_dest_for_predict(scan_dir, image)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(data)
+            result.ok = True
+            frame_bytes.append(data)
+        except Exception as exc:  # per-frame: record and continue
+            result.error = str(exc)
+        frames.append(result)
+    return DownloadResult(frames), frame_bytes
+
+
+# --- command ----------------------------------------------------------------
+
+
+@click.command(name="download-for-predict")
+@click.argument("scan_id", type=int)
+@click.argument("out_dir", type=click.Path(file_okay=False, path_type=Path))
+@click.option(
+    "-p",
+    "--profile",
+    default=DEFAULT_PROFILE,
+    show_default=True,
+    help="Credentials profile to use.",
+)
+def download_for_predict(scan_id: int, out_dir: Path, profile: str) -> None:
+    """Stage one cylinder scan (SCAN_ID) into OUT_DIR in the layout
+    sleap_roots_predict.discover_scans expects — frames co-located with a
+    scan_metadata.json sidecar. Distinct from `cyl download`'s scans.csv layout."""
+    from .. import auth
+    from ..credentials import load_credentials
+
+    try:
+        creds = load_credentials(profile)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(f"{exc} — run `bloomctl login`.") from exc
+    try:
+        client = auth.make_authed_client(creds)
+    except auth.AuthError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    scan = fetch_scan(client, scan_id)
+    if scan is None:
+        raise click.ClickException(f"Scan {scan_id} not found.")
+
+    images = fetch_images(client, scan_id)
+    if not images:
+        raise click.ClickException(f"No frames found for scan {scan_id}.")
+
+    scan_dir = Path(out_dir) / scan_key_for(scan_id)
+    result, frame_bytes = download_frames_for_predict(client, scan, images, scan_dir)
+
+    if result.failed:
+        raise click.ClickException(
+            f"{result.failed} of {result.total} frames failed to download — "
+            f"successfully downloaded frames remain in {scan_dir}; no sidecar written."
+        )
+
+    written = [frame_dest_for_predict(scan_dir, image) for image in images]
+    reconcile_stray_frames(scan_dir, written)
+
+    sidecar = build_sidecar(scan, images, frame_bytes)
+    sidecar_path = scan_dir / f"{scan_key_for(scan_id)}.scan_metadata.json"
+    write_sidecar(sidecar, sidecar_path)
+    click.echo(f"Staged {result.ok}/{result.total} frames -> {scan_dir}  (sidecar: {sidecar_path})")

--- a/bloomcli/src/bloomctl/cyl/download_for_predict.py
+++ b/bloomcli/src/bloomctl/cyl/download_for_predict.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +21,7 @@ from ..credentials import DEFAULT_PROFILE
 from .download import DownloadResult, FrameResult, fetch_images, fetch_scan
 
 # Matches sleap_roots_predict.batch._IMAGE_EXTENSIONS — the exact set discover_scans
-# globs for, so stray-frame reconciliation removes anything predict would pick up.
+# globs for, so clearing the stage directory removes anything predict would pick up.
 _IMAGE_EXTENSIONS = frozenset({".png", ".tif", ".tiff", ".jpg", ".jpeg"})
 
 
@@ -30,7 +32,7 @@ def scan_key_for(scan_id: Any) -> str:
 
 def frame_dest_for_predict(scan_dir: Path, image: dict[str, Any]) -> Path:
     """Absolute destination for one frame, co-located with the sidecar."""
-    ext = Path(image.get("object_path", "")).suffix or ".png"
+    ext = Path(image["object_path"]).suffix or ".png"
     return Path(scan_dir) / f"{image['frame_number']}{ext}"
 
 
@@ -42,50 +44,91 @@ def compute_checksum(frame_bytes_list: list[bytes]) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
-def build_sidecar(
-    scan: dict[str, Any], images: list[dict[str, Any]], frame_bytes_list: list[bytes]
-) -> dict[str, Any]:
-    """Assemble the scan_metadata.json sidecar dict for one scan.
+def validate_frame_numbers(images: list[dict[str, Any]]) -> None:
+    """Raise ValueError if any frame_number is null or duplicated across images.
+
+    A null/duplicate frame_number would map two cyl_images rows onto the same
+    on-disk filename, so the sidecar's image_ids/images_checksum would no
+    longer describe what's actually written to disk (see design.md).
+    """
+    seen: set[Any] = set()
+    for image in images:
+        frame_number = image.get("frame_number")
+        if frame_number is None:
+            raise ValueError(f"cyl_images row {image.get('id')} has a null frame_number")
+        if frame_number in seen:
+            raise ValueError(f"duplicate frame_number {frame_number!r} in cyl_images")
+        seen.add(frame_number)
+
+
+def resolve_sidecar_params(scan: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the sidecar's params via the contracts oracle.
 
     `mode` is forced via `resolve_params`'s documented `overrides` mechanism (not
     row augmentation — see design.md) since every `cyl` scan is cylinder-scanner.
+    Extracted from `build_sidecar` so callers can validate scan metadata resolves
+    cleanly *before* any destructive filesystem action (see design.md).
     """
     from sleap_roots_contracts import resolve_params
 
-    resolved = resolve_params(scan, overrides={"mode": "cylinder"})
+    return resolve_params(scan, overrides={"mode": "cylinder"}).values
+
+
+def build_sidecar(
+    scan: dict[str, Any],
+    images: list[dict[str, Any]],
+    frame_bytes_list: list[bytes],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the scan_metadata.json sidecar dict for one scan.
+
+    `params` is the already-resolved dict from `resolve_sidecar_params` — resolved
+    ahead of time so a metadata-resolution failure surfaces before any download or
+    directory-clearing happens, not after.
+    """
     return {
         "scan_key": scan_key_for(scan["scan_id"]),
-        "params": resolved.values,
+        "params": params,
         "image_ids": [image["id"] for image in images],
         "images_checksum": compute_checksum(frame_bytes_list),
     }
 
 
-def write_sidecar(sidecar: dict[str, Any], path: Path) -> None:
-    """Write the sidecar as valid UTF-8 JSON, creating the parent dir if absent."""
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write bytes so a crash mid-write can never leave a truncated file at `path`."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(sidecar), encoding="utf-8")
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, path)
 
 
-def reconcile_stray_frames(scan_dir: Path, written: list[Path]) -> None:
-    """Delete any image-extension file in scan_dir not among the just-written frames.
+def write_sidecar(sidecar: dict[str, Any], path: Path) -> None:
+    """Write the sidecar as valid UTF-8 JSON, creating the parent dir if absent.
 
-    Guards against a stale frame surviving from an earlier failed attempt whose
-    cyl_images rows have since changed (see design.md): discover_scans globs every
-    image-extension file physically present in the sidecar's directory, not just
-    the ones named in image_ids, so a leftover file would silently be fed to
-    predict as an unaccounted-for frame.
+    Atomic (temp file + `os.replace`) — a crash mid-write leaves the destination
+    either absent or with its prior content, never truncated.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(sidecar), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def clear_scan_dir(scan_dir: Path) -> list[str]:
+    """Remove scan_dir entirely if it exists; return the names removed.
+
+    Called at the *start* of every invocation, before any download, so no frame
+    or sidecar from a previous invocation can survive into — or be silently
+    mistaken for part of — this invocation's output (see design.md: this
+    supersedes the narrower end-of-run stray-frame reconciliation, which didn't
+    close the case of a stale sidecar from an earlier successful run surviving a
+    later partial-failure retry).
     """
     if not scan_dir.exists():
-        return
-    written_names = {p.name for p in written}
-    for entry in scan_dir.iterdir():
-        if (
-            entry.is_file()
-            and entry.suffix.lower() in _IMAGE_EXTENSIONS
-            and entry.name not in written_names
-        ):
-            entry.unlink()
+        return []
+    removed = sorted(p.name for p in scan_dir.iterdir())
+    shutil.rmtree(scan_dir)
+    return removed
 
 
 # --- supabase / storage I/O -------------------------------------------------
@@ -111,8 +154,7 @@ def download_frames_for_predict(
             if data is None:
                 raise ValueError("empty response from storage")
             dest = frame_dest_for_predict(scan_dir, image)
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_bytes(data)
+            _atomic_write_bytes(dest, data)
             result.ok = True
             frame_bytes.append(data)
         except Exception as exc:  # per-frame: record and continue
@@ -138,17 +180,9 @@ def download_for_predict(scan_id: int, out_dir: Path, profile: str) -> None:
     """Stage one cylinder scan (SCAN_ID) into OUT_DIR in the layout
     sleap_roots_predict.discover_scans expects — frames co-located with a
     scan_metadata.json sidecar. Distinct from `cyl download`'s scans.csv layout."""
-    from .. import auth
-    from ..credentials import load_credentials
+    from ..cli import _authed_client
 
-    try:
-        creds = load_credentials(profile)
-    except (FileNotFoundError, ValueError) as exc:
-        raise click.ClickException(f"{exc} — run `bloomctl login`.") from exc
-    try:
-        client = auth.make_authed_client(creds)
-    except auth.AuthError as exc:
-        raise click.ClickException(str(exc)) from exc
+    client = _authed_client(profile)
 
     scan = fetch_scan(client, scan_id)
     if scan is None:
@@ -158,19 +192,26 @@ def download_for_predict(scan_id: int, out_dir: Path, profile: str) -> None:
     if not images:
         raise click.ClickException(f"No frames found for scan {scan_id}.")
 
+    try:
+        validate_frame_numbers(images)
+        params = resolve_sidecar_params(scan)
+    except ValueError as exc:
+        raise click.ClickException(f"Scan {scan_id}: {exc}") from exc
+
     scan_dir = Path(out_dir) / scan_key_for(scan_id)
+    removed = clear_scan_dir(scan_dir)
+    if removed:
+        click.echo(f"Cleared {len(removed)} existing file(s) from a previous run: {scan_dir}")
+
     result, frame_bytes = download_frames_for_predict(client, scan, images, scan_dir)
 
     if result.failed:
         raise click.ClickException(
             f"{result.failed} of {result.total} frames failed to download — "
-            f"successfully downloaded frames remain in {scan_dir}; no sidecar written."
+            f"frames downloaded this run remain in {scan_dir}; no sidecar written."
         )
 
-    written = [frame_dest_for_predict(scan_dir, image) for image in images]
-    reconcile_stray_frames(scan_dir, written)
-
-    sidecar = build_sidecar(scan, images, frame_bytes)
+    sidecar = build_sidecar(scan, images, frame_bytes, params)
     sidecar_path = scan_dir / f"{scan_key_for(scan_id)}.scan_metadata.json"
     write_sidecar(sidecar, sidecar_path)
     click.echo(f"Staged {result.ok}/{result.total} frames -> {scan_dir}  (sidecar: {sidecar_path})")

--- a/bloomcli/tests/test_cyl_download_for_predict.py
+++ b/bloomcli/tests/test_cyl_download_for_predict.py
@@ -19,6 +19,7 @@ IMAGES = [
     {"id": 1002, "frame_number": 1, "object_path": "cyl-images/b.png"},
 ]
 FRAME_BYTES = [b"frame-0-bytes", b"frame-1-bytes"]
+PARAMS = {"species": "pennycress", "mode": "cylinder", "age": 14}
 
 
 class _FakeBucket:
@@ -51,6 +52,9 @@ class _FakeClient:
 def test_oracle_sidecar_is_accepted_by_discover_scans(tmp_path):
     """Manual, dev-machine only (see tasks.md §3 note) — self-skips in CI."""
     sleap_roots_predict = pytest.importorskip("sleap_roots_predict")
+    predict_batch = pytest.importorskip("sleap_roots_predict.batch")
+
+    assert dfp._IMAGE_EXTENSIONS == frozenset(predict_batch._IMAGE_EXTENSIONS)
 
     scan_dir = tmp_path / "scan_1"
     scan_dir.mkdir()
@@ -58,7 +62,7 @@ def test_oracle_sidecar_is_accepted_by_discover_scans(tmp_path):
         dest = dfp.frame_dest_for_predict(scan_dir, image)
         dest.write_bytes(data)
 
-    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES, PARAMS)
     assert sidecar["scan_key"] == "scan_1"
     assert set(sidecar["params"]) == {"species", "mode", "age"}
     assert sidecar["params"]["mode"] == "cylinder"
@@ -93,6 +97,11 @@ def test_frame_dest_for_predict_defaults_to_png_when_extension_missing(tmp_path)
     assert dest == tmp_path / "3.png"
 
 
+def test_frame_dest_for_predict_raises_on_missing_object_path(tmp_path):
+    with pytest.raises(KeyError):
+        dfp.frame_dest_for_predict(tmp_path, {"frame_number": 3})
+
+
 def test_compute_checksum_is_sha256_prefixed_and_order_sensitive():
     checksum = dfp.compute_checksum(FRAME_BYTES)
     assert checksum.startswith("sha256:")
@@ -106,27 +115,39 @@ def test_compute_checksum_empty_list_is_well_defined():
 
 
 def test_build_sidecar_assembles_all_fields_in_input_order():
-    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES, PARAMS)
     assert set(sidecar) == {"scan_key", "params", "image_ids", "images_checksum"}
     assert sidecar["scan_key"] == dfp.scan_key_for(SCAN["scan_id"])
     assert sidecar["image_ids"] == [1001, 1002]
+    assert sidecar["params"] == PARAMS
 
 
-def test_build_sidecar_passes_mode_override_to_resolve_params(monkeypatch):
+def test_resolve_sidecar_params_passes_mode_override(monkeypatch):
     captured = {}
     real_resolve_params = sleap_roots_contracts.resolve_params
 
     def spy(metadata, overrides=None):
-        captured["metadata"] = metadata
         captured["overrides"] = overrides
         return real_resolve_params(metadata, overrides=overrides)
 
     monkeypatch.setattr(sleap_roots_contracts, "resolve_params", spy)
 
-    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    params = dfp.resolve_sidecar_params(SCAN)
 
     assert captured["overrides"] == {"mode": "cylinder"}
-    assert sidecar["params"]["mode"] == "cylinder"
+    assert params["mode"] == "cylinder"
+
+
+def test_resolve_sidecar_params_canonicalizes_species_and_age():
+    params = dfp.resolve_sidecar_params(SCAN)
+    assert params["species"] == "pennycress"
+    assert params["age"] == 14
+
+
+def test_resolve_sidecar_params_raises_valueerror_on_missing_metadata():
+    bad_scan = {**SCAN, "species_name": None}
+    with pytest.raises(ValueError):
+        dfp.resolve_sidecar_params(bad_scan)
 
 
 def test_resolve_params_ignores_mode_on_pinned_contracts_version():
@@ -139,17 +160,89 @@ def test_resolve_params_ignores_mode_on_pinned_contracts_version():
 
 
 def test_write_sidecar_round_trips_through_json(tmp_path):
-    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES, PARAMS)
     path = tmp_path / "scan_1.scan_metadata.json"
     dfp.write_sidecar(sidecar, path)
     assert json.loads(path.read_text(encoding="utf-8")) == sidecar
 
 
 def test_write_sidecar_creates_parent_dir(tmp_path):
-    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES, PARAMS)
     path = tmp_path / "nested" / "scan_1.scan_metadata.json"
     dfp.write_sidecar(sidecar, path)
     assert path.exists()
+
+
+def test_write_sidecar_is_atomic_on_write_failure(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    path = tmp_path / "scan_1.scan_metadata.json"
+    path.write_text('{"old": "content"}', encoding="utf-8")
+
+    def _boom(self, data, **kwargs):
+        raise OSError("simulated crash mid-write")
+
+    monkeypatch.setattr(Path, "write_text", _boom)
+
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES, PARAMS)
+    with pytest.raises(OSError):
+        dfp.write_sidecar(sidecar, path)
+
+    assert path.read_text(encoding="utf-8") == '{"old": "content"}'
+
+
+def test_atomic_write_bytes_is_atomic_on_write_failure(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    dest = tmp_path / "0.png"
+    dest.write_bytes(b"old-bytes")
+
+    def _boom(self, data):
+        raise OSError("simulated crash mid-write")
+
+    monkeypatch.setattr(Path, "write_bytes", _boom)
+
+    with pytest.raises(OSError):
+        dfp._atomic_write_bytes(dest, b"new-bytes")
+
+    assert dest.read_bytes() == b"old-bytes"
+
+
+def test_validate_frame_numbers_accepts_unique_non_null():
+    dfp.validate_frame_numbers(IMAGES)  # must not raise
+
+
+def test_validate_frame_numbers_rejects_null():
+    images = [{"id": 1, "frame_number": None, "object_path": "a.png"}]
+    with pytest.raises(ValueError):
+        dfp.validate_frame_numbers(images)
+
+
+def test_validate_frame_numbers_rejects_duplicates():
+    images = [
+        {"id": 1, "frame_number": 0, "object_path": "a.png"},
+        {"id": 2, "frame_number": 0, "object_path": "b.png"},
+    ]
+    with pytest.raises(ValueError):
+        dfp.validate_frame_numbers(images)
+
+
+def test_clear_scan_dir_removes_existing_contents_and_returns_names(tmp_path):
+    scan_dir = tmp_path / "scan_1"
+    scan_dir.mkdir()
+    (scan_dir / "0.png").write_bytes(b"x")
+    (scan_dir / "scan_1.scan_metadata.json").write_text("{}")
+
+    removed = dfp.clear_scan_dir(scan_dir)
+
+    assert not scan_dir.exists()
+    assert set(removed) == {"0.png", "scan_1.scan_metadata.json"}
+
+
+def test_clear_scan_dir_noop_when_absent(tmp_path):
+    scan_dir = tmp_path / "scan_1"
+    assert dfp.clear_scan_dir(scan_dir) == []
+    assert not scan_dir.exists()
 
 
 # --- 5.x command wiring -------------------------------------------------------
@@ -157,6 +250,18 @@ def test_write_sidecar_creates_parent_dir(tmp_path):
 
 def test_fetch_scan_is_reused_not_duplicated():
     assert dfp.fetch_scan is dl.fetch_scan
+
+
+def test_fetch_images_is_reused_not_duplicated():
+    assert dfp.fetch_images is dl.fetch_images
+
+
+def test_frame_result_is_reused_not_duplicated():
+    assert dfp.FrameResult is dl.FrameResult
+
+
+def test_download_result_is_reused_not_duplicated():
+    assert dfp.DownloadResult is dl.DownloadResult
 
 
 def _patch_common(monkeypatch, images=None, storage_responses=None):
@@ -201,6 +306,48 @@ def test_cli_scan_not_found_exits_nonzero(tmp_path, monkeypatch):
     assert result.exit_code != 0
     assert "not found" in result.output.lower()
     assert not out.exists()
+
+
+def test_cli_missing_species_name_exits_cleanly_without_deleting_existing_dir(
+    tmp_path, monkeypatch
+):
+    bad_scan = {**SCAN, "species_name": None}
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(dfp, "fetch_scan", lambda client, scan_id: bad_scan)
+
+    out = tmp_path / "out"
+    scan_dir = out / "scan_1"
+    scan_dir.mkdir(parents=True)
+    existing = scan_dir / "existing.png"
+    existing.write_bytes(b"must survive a metadata-resolution failure")
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code != 0
+    assert result.exception is None or not isinstance(result.exception, ValueError)
+    assert existing.exists()
+    assert existing.read_bytes() == b"must survive a metadata-resolution failure"
+
+
+def test_cli_duplicate_frame_number_exits_cleanly_without_deleting_existing_dir(
+    tmp_path, monkeypatch
+):
+    dup_images = [
+        {"id": 1001, "frame_number": 0, "object_path": "cyl-images/a.png"},
+        {"id": 1002, "frame_number": 0, "object_path": "cyl-images/b.png"},
+    ]
+    _patch_common(monkeypatch, images=dup_images)
+
+    out = tmp_path / "out"
+    scan_dir = out / "scan_1"
+    scan_dir.mkdir(parents=True)
+    existing = scan_dir / "existing.png"
+    existing.write_bytes(b"must survive a frame_number validation failure")
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code != 0
+    assert existing.exists()
 
 
 def test_cli_partial_frame_failure_no_sidecar_written(tmp_path, monkeypatch):
@@ -332,7 +479,7 @@ def test_checksum_changes_when_frame_content_changes(tmp_path, monkeypatch):
     assert sidecar_a["images_checksum"] != sidecar_b["images_checksum"]
 
 
-def test_stale_frame_reconciled_away_on_successful_retry(tmp_path, monkeypatch):
+def test_stale_frame_cleared_on_successful_retry(tmp_path, monkeypatch):
     _patch_common(monkeypatch)
     out = tmp_path / "out"
     scan_dir = out / "scan_1"
@@ -346,3 +493,48 @@ def test_stale_frame_reconciled_away_on_successful_retry(tmp_path, monkeypatch):
     assert not stale.exists()
     assert (scan_dir / "0.png").exists()
     assert (scan_dir / "1.png").exists()
+
+
+def test_cli_stale_sidecar_does_not_survive_a_partial_failure_retry(tmp_path, monkeypatch):
+    _patch_common(monkeypatch)
+    out = tmp_path / "out"
+
+    result1 = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+    assert result1.exit_code == 0, result1.output
+    sidecar_path = out / "scan_1" / "scan_1.scan_metadata.json"
+    assert sidecar_path.exists()
+
+    def _flaky_download(object_path):
+        if object_path == "cyl-images/b.png":
+            raise ConnectionError("simulated storage failure")
+        return f"bytes::{object_path}::changed".encode()
+
+    class _FlakyClient(_FakeClient):
+        def __init__(self):
+            super().__init__()
+            self.storage._bucket.download = _flaky_download
+
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FlakyClient())
+
+    result2 = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result2.exit_code != 0
+    assert not sidecar_path.exists()
+
+
+def test_cli_echoes_what_it_cleared_on_rerun(tmp_path, monkeypatch):
+    # NB: assert an exact, deliberately-chosen count/phrase, not a loose substring like
+    # "clear" — pytest truncates tmp_path's directory name to 30 chars of the test's own
+    # name, and that truncated path is embedded in the CLI's own path-containing output, so
+    # a generic word can coincidentally "pass" via the directory name rather than real output.
+    _patch_common(monkeypatch)
+    out = tmp_path / "out"
+
+    result1 = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+    assert result1.exit_code == 0, result1.output
+    assert "existing file" not in result1.output.lower()
+
+    result2 = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+    assert result2.exit_code == 0, result2.output
+    # 0.png, 1.png, scan_1.scan_metadata.json from the first run.
+    assert "3 existing file" in result2.output.lower()

--- a/bloomcli/tests/test_cyl_download_for_predict.py
+++ b/bloomcli/tests/test_cyl_download_for_predict.py
@@ -1,0 +1,348 @@
+"""`bloomctl cyl download-for-predict` — sidecar helpers + command wiring (mocked client)."""
+
+import hashlib
+import json
+
+import pytest
+import sleap_roots_contracts
+from click.testing import CliRunner
+from test_download_metadata import SCAN
+
+import bloomctl.auth as auth
+import bloomctl.cyl.download as dl
+import bloomctl.cyl.download_for_predict as dfp
+from bloomctl.cli import cli
+from bloomctl.credentials import Credentials
+
+IMAGES = [
+    {"id": 1001, "frame_number": 0, "object_path": "cyl-images/a.png"},
+    {"id": 1002, "frame_number": 1, "object_path": "cyl-images/b.png"},
+]
+FRAME_BYTES = [b"frame-0-bytes", b"frame-1-bytes"]
+
+
+class _FakeBucket:
+    def __init__(self, responses=None):
+        self._responses = responses or {}
+
+    def download(self, object_path):
+        if object_path in self._responses:
+            return self._responses[object_path]
+        return f"bytes::{object_path}".encode()
+
+
+class _FakeStorage:
+    def __init__(self, responses=None):
+        self._bucket = _FakeBucket(responses)
+
+    def from_(self, bucket):
+        assert bucket == "images"
+        return self._bucket
+
+
+class _FakeClient:
+    def __init__(self, responses=None):
+        self.storage = _FakeStorage(responses)
+
+
+# --- 3.x oracle / acceptance test -------------------------------------------
+
+
+def test_oracle_sidecar_is_accepted_by_discover_scans(tmp_path):
+    """Manual, dev-machine only (see tasks.md §3 note) — self-skips in CI."""
+    sleap_roots_predict = pytest.importorskip("sleap_roots_predict")
+
+    scan_dir = tmp_path / "scan_1"
+    scan_dir.mkdir()
+    for image, data in zip(IMAGES, FRAME_BYTES):
+        dest = dfp.frame_dest_for_predict(scan_dir, image)
+        dest.write_bytes(data)
+
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    assert sidecar["scan_key"] == "scan_1"
+    assert set(sidecar["params"]) == {"species", "mode", "age"}
+    assert sidecar["params"]["mode"] == "cylinder"
+    assert sidecar["image_ids"] == [1001, 1002]
+    assert sidecar["images_checksum"].startswith("sha256:")
+
+    dfp.write_sidecar(sidecar, scan_dir / "scan_1.scan_metadata.json")
+
+    scans = sleap_roots_predict.discover_scans(tmp_path)
+    assert len(scans) == 1
+    assert scans[0].scan_key == "scan_1"
+    assert scans[0].error is None
+    assert scans[0].params is not None
+
+
+# --- 4.x pure helpers --------------------------------------------------------
+
+
+def test_scan_key_for_integer_and_string():
+    assert dfp.scan_key_for(1) == "scan_1"
+    assert dfp.scan_key_for("1") == "scan_1"
+
+
+def test_frame_dest_for_predict_uses_frame_number_and_extension(tmp_path):
+    dest = dfp.frame_dest_for_predict(tmp_path, IMAGES[0])
+    assert dest == tmp_path / "0.png"
+
+
+def test_frame_dest_for_predict_defaults_to_png_when_extension_missing(tmp_path):
+    image = {"frame_number": 3, "object_path": "cyl-images/no-extension"}
+    dest = dfp.frame_dest_for_predict(tmp_path, image)
+    assert dest == tmp_path / "3.png"
+
+
+def test_compute_checksum_is_sha256_prefixed_and_order_sensitive():
+    checksum = dfp.compute_checksum(FRAME_BYTES)
+    assert checksum.startswith("sha256:")
+    expected = hashlib.sha256(b"".join(FRAME_BYTES)).hexdigest()
+    assert checksum == f"sha256:{expected}"
+    assert dfp.compute_checksum(list(reversed(FRAME_BYTES))) != checksum
+
+
+def test_compute_checksum_empty_list_is_well_defined():
+    assert dfp.compute_checksum([]) == f"sha256:{hashlib.sha256(b'').hexdigest()}"
+
+
+def test_build_sidecar_assembles_all_fields_in_input_order():
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    assert set(sidecar) == {"scan_key", "params", "image_ids", "images_checksum"}
+    assert sidecar["scan_key"] == dfp.scan_key_for(SCAN["scan_id"])
+    assert sidecar["image_ids"] == [1001, 1002]
+
+
+def test_build_sidecar_passes_mode_override_to_resolve_params(monkeypatch):
+    captured = {}
+    real_resolve_params = sleap_roots_contracts.resolve_params
+
+    def spy(metadata, overrides=None):
+        captured["metadata"] = metadata
+        captured["overrides"] = overrides
+        return real_resolve_params(metadata, overrides=overrides)
+
+    monkeypatch.setattr(sleap_roots_contracts, "resolve_params", spy)
+
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+
+    assert captured["overrides"] == {"mode": "cylinder"}
+    assert sidecar["params"]["mode"] == "cylinder"
+
+
+def test_resolve_params_ignores_mode_on_pinned_contracts_version():
+    """Documents that overrides={"mode": "cylinder"} is not currently load-bearing:
+    resolve_params already returns mode="cylinder" with no override at all on the
+    pinned sleap-roots-contracts version. If a future bump makes mode
+    metadata-driven, this assertion starts failing and flags the divergence."""
+    resolved = sleap_roots_contracts.resolve_params(SCAN)
+    assert resolved.values["mode"] == "cylinder"
+
+
+def test_write_sidecar_round_trips_through_json(tmp_path):
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    path = tmp_path / "scan_1.scan_metadata.json"
+    dfp.write_sidecar(sidecar, path)
+    assert json.loads(path.read_text(encoding="utf-8")) == sidecar
+
+
+def test_write_sidecar_creates_parent_dir(tmp_path):
+    sidecar = dfp.build_sidecar(SCAN, IMAGES, FRAME_BYTES)
+    path = tmp_path / "nested" / "scan_1.scan_metadata.json"
+    dfp.write_sidecar(sidecar, path)
+    assert path.exists()
+
+
+# --- 5.x command wiring -------------------------------------------------------
+
+
+def test_fetch_scan_is_reused_not_duplicated():
+    assert dfp.fetch_scan is dl.fetch_scan
+
+
+def _patch_common(monkeypatch, images=None, storage_responses=None):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FakeClient(storage_responses))
+    monkeypatch.setattr(dfp, "fetch_scan", lambda client, scan_id: SCAN)
+    monkeypatch.setattr(
+        dfp, "fetch_images", lambda client, scan_id: images if images is not None else IMAGES
+    )
+
+
+def test_cli_happy_path_writes_frames_and_sidecar(tmp_path, monkeypatch):
+    _patch_common(monkeypatch)
+    out = tmp_path / "out"
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code == 0, result.output
+    assert (out / "scan_1" / "0.png").exists()
+    assert (out / "scan_1" / "1.png").exists()
+    sidecar = json.loads((out / "scan_1" / "scan_1.scan_metadata.json").read_text())
+    assert sidecar["scan_key"] == "scan_1"
+    assert sidecar["image_ids"] == [1001, 1002]
+    assert sidecar["params"]["mode"] == "cylinder"
+    assert sidecar["images_checksum"].startswith("sha256:")
+
+
+def test_cli_scan_not_found_exits_nonzero(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FakeClient())
+    monkeypatch.setattr(dfp, "fetch_scan", lambda client, scan_id: None)
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "999", str(out)])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+    assert not out.exists()
+
+
+def test_cli_partial_frame_failure_no_sidecar_written(tmp_path, monkeypatch):
+    def _flaky_download(object_path):
+        if object_path == "cyl-images/b.png":
+            raise ConnectionError("simulated storage failure")
+        return f"bytes::{object_path}".encode()
+
+    _patch_common(monkeypatch)
+    out = tmp_path / "out"
+
+    class _FlakyClient(_FakeClient):
+        def __init__(self):
+            super().__init__()
+            self.storage._bucket.download = _flaky_download
+
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FlakyClient())
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code != 0
+    assert "1" in result.output
+    assert (out / "scan_1" / "0.png").exists()
+    assert not (out / "scan_1" / "scan_1.scan_metadata.json").exists()
+
+
+def test_cli_storage_none_response_is_treated_as_failure(tmp_path, monkeypatch):
+    _patch_common(monkeypatch, storage_responses={"cyl-images/b.png": None})
+    out = tmp_path / "out"
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code != 0
+    assert (out / "scan_1" / "0.png").exists()
+    assert not (out / "scan_1" / "scan_1.scan_metadata.json").exists()
+
+
+def test_fetch_scans_experiment_path_never_called(tmp_path, monkeypatch):
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        dl,
+        "fetch_scans",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("fetch_scans (experiment path) must not run for download-for-predict")
+        ),
+    )
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_discover_scans_smoke_after_happy_path(tmp_path, monkeypatch):
+    """Manual, dev-machine only (see tasks.md §3 note) — self-skips in CI."""
+    sleap_roots_predict = pytest.importorskip("sleap_roots_predict")
+
+    _patch_common(monkeypatch)
+    out = tmp_path / "out"
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+    assert result.exit_code == 0, result.output
+
+    scans = sleap_roots_predict.discover_scans(out)
+    assert len(scans) == 1
+    assert scans[0].error is None
+
+
+def test_cli_registration_shows_in_help():
+    result = CliRunner().invoke(cli, ["cyl", "--help"])
+    assert "download-for-predict" in result.output
+
+
+def test_cli_missing_credentials_hints_login(tmp_path, monkeypatch):
+    import bloomctl.credentials as creds
+
+    monkeypatch.setattr(creds, "default_config_dir", lambda: tmp_path / ".bloom")
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(tmp_path / "out")])
+
+    assert result.exit_code != 0
+    assert "login" in result.output.lower()
+
+
+def test_cli_zero_frame_scan_exits_nonzero(tmp_path, monkeypatch):
+    _patch_common(monkeypatch, images=[])
+    out = tmp_path / "out"
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code != 0
+    assert "no frames found" in result.output.lower()
+    assert not out.exists()
+
+
+def test_cli_profile_option_passed_through(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_load_credentials(profile):
+        captured["profile"] = profile
+        return Credentials("https://x/api", "KEY", "u@s.edu", "pw")
+
+    monkeypatch.setattr("bloomctl.credentials.load_credentials", fake_load_credentials)
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FakeClient())
+    monkeypatch.setattr(dfp, "fetch_scan", lambda client, scan_id: SCAN)
+    monkeypatch.setattr(dfp, "fetch_images", lambda client, scan_id: IMAGES)
+
+    out = tmp_path / "out"
+    result = CliRunner().invoke(
+        cli, ["cyl", "download-for-predict", "1", str(out), "-p", "staging"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["profile"] == "staging"
+
+
+def test_checksum_changes_when_frame_content_changes(tmp_path, monkeypatch):
+    _patch_common(monkeypatch, storage_responses={"cyl-images/a.png": b"version-1"})
+    out_a = tmp_path / "out_a"
+    result_a = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out_a)])
+    assert result_a.exit_code == 0, result_a.output
+    sidecar_a = json.loads((out_a / "scan_1" / "scan_1.scan_metadata.json").read_text())
+
+    _patch_common(monkeypatch, storage_responses={"cyl-images/a.png": b"version-2-different"})
+    out_b = tmp_path / "out_b"
+    result_b = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out_b)])
+    assert result_b.exit_code == 0, result_b.output
+    sidecar_b = json.loads((out_b / "scan_1" / "scan_1.scan_metadata.json").read_text())
+
+    assert sidecar_a["images_checksum"] != sidecar_b["images_checksum"]
+
+
+def test_stale_frame_reconciled_away_on_successful_retry(tmp_path, monkeypatch):
+    _patch_common(monkeypatch)
+    out = tmp_path / "out"
+    scan_dir = out / "scan_1"
+    scan_dir.mkdir(parents=True)
+    stale = scan_dir / "2.png"
+    stale.write_bytes(b"leftover from a failed attempt whose cyl_images row is now gone")
+
+    result = CliRunner().invoke(cli, ["cyl", "download-for-predict", "1", str(out)])
+
+    assert result.exit_code == 0, result.output
+    assert not stale.exists()
+    assert (scan_dir / "0.png").exists()
+    assert (scan_dir / "1.png").exists()

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -36,23 +36,14 @@ sequenced it first, and added `read-path` #298); the design doc uses the `A–H`
 **Currently pinned: `v0.1.0a4`.** These are the _contract_ types (from the JSON Schema), distinct
 from the Supabase `database.types.ts` (generated from the database by `make gen-types`).
 
-> Note on `v0.1.0a4`: re-pinned from `v0.1.0a3` for Bloom change `add-cyl-download-for-predict`
-> (#411) — an **`$id`-only structural no-op for the JSON Schema** (verified by diffing the fetched
-> `v0.1.0a4` schema against the vendored `a3` schema with the version string normalized out: no
-> other bytes differ). `BlobRef`/`Provenance` are unchanged and the generated TS is byte-identical
-> apart from the `$id` line. The substantive addition in this contracts release is on the Python
-> package side — `sleap_roots_contracts.resolve_params`, the canonical species/age-normalization
-> oracle bloomctl now calls when authoring `scan_metadata.json` sidecars for the A4 per-scan
-> pipeline stage-in — not a schema field, so it doesn't surface in the drift-guard diff.
+> Note on `v0.1.0a4`: re-pinned from `v0.1.0a3` for Bloom change `add-cyl-download-for-predict` (#411) — an **`$id`-only structural no-op for the JSON Schema** (verified by diffing the fetched `v0.1.0a4` schema against the vendored `a3` schema with the version string normalized out: no other bytes differ). `BlobRef`/`Provenance` are unchanged and the generated TS is byte-identical apart from the `$id` line. The substantive addition in this contracts release is on the Python package side — `sleap_roots_contracts.resolve_params`, the canonical species/age-normalization oracle bloomctl now calls when authoring `scan_metadata.json` sidecars for the A4 per-scan pipeline stage-in — not a schema field, so it doesn't surface in the drift-guard diff.
 
 > Note on `v0.1.0a3`: re-pinned from `v0.1.0a2` for Bloom change `repin-cyl-contract-a3` (#393) —
 > a **real contract revision**, not a `$id` no-op, but **additive and non-breaking**. `Provenance`
 > gained two optional, nullable fields (`predict_inference_config`, `predict_output_params`); no field
 > was removed or retyped and `BlobRef` is unchanged. Because `Provenance` is a plain object with
-> `properties`, the generated TS **does** surface the two new optional fields (unlike the `BlobRef`
-> `anyOf` caveat below) — an expected, reviewed drift-guard diff. Both fields ride inside the opaque
-> `cyl_trait_sources.metadata` jsonb, so no Bloom DB column or migration is needed. The bare-vs-`v`
-> `contract_version` convention (the write-back RPC now matches prefix-tolerantly) is tracked upstream
+> `properties`, the generated TS **does** surface the two new optional fields (unlike the `BlobRef` > `anyOf` caveat below) — an expected, reviewed drift-guard diff. Both fields ride inside the opaque
+> `cyl_trait_sources.metadata` jsonb, so no Bloom DB column or migration is needed. The bare-vs-`v` > `contract_version` convention (the write-back RPC now matches prefix-tolerantly) is tracked upstream
 > in `talmolab/sleap-roots-contracts` (companion issue — link `#N` when filed).
 
 > Note on `v0.1.0a2`: re-pinned from `v0.1.0a1` for Bloom change C

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -33,8 +33,17 @@ sequenced it first, and added `read-path` #298); the design doc uses the `A–H`
 | `pin.json`                           | The pin manifest: `package`, `version`, full schema `$id`, `source`, file paths                              | The declared pin                                          |
 | `generated/result-envelope.ts`       | TypeScript types (`ResultEnvelope`/`Provenance`/`TraitValue`/`BlobRef` + sub-defs) generated from the schema | Emitted by codegen — **do not edit by hand**              |
 
-**Currently pinned: `v0.1.0a3`.** These are the _contract_ types (from the JSON Schema), distinct
+**Currently pinned: `v0.1.0a4`.** These are the _contract_ types (from the JSON Schema), distinct
 from the Supabase `database.types.ts` (generated from the database by `make gen-types`).
+
+> Note on `v0.1.0a4`: re-pinned from `v0.1.0a3` for Bloom change `add-cyl-download-for-predict`
+> (#411) — an **`$id`-only structural no-op for the JSON Schema** (verified by diffing the fetched
+> `v0.1.0a4` schema against the vendored `a3` schema with the version string normalized out: no
+> other bytes differ). `BlobRef`/`Provenance` are unchanged and the generated TS is byte-identical
+> apart from the `$id` line. The substantive addition in this contracts release is on the Python
+> package side — `sleap_roots_contracts.resolve_params`, the canonical species/age-normalization
+> oracle bloomctl now calls when authoring `scan_metadata.json` sidecars for the A4 per-scan
+> pipeline stage-in — not a schema field, so it doesn't surface in the drift-guard diff.
 
 > Note on `v0.1.0a3`: re-pinned from `v0.1.0a2` for Bloom change `repin-cyl-contract-a3` (#393) —
 > a **real contract revision**, not a `$id` no-op, but **additive and non-breaking**. `Provenance`

--- a/contracts/pin.json
+++ b/contracts/pin.json
@@ -1,8 +1,8 @@
 {
   "package": "sleap-roots-contracts",
-  "version": "v0.1.0a3",
-  "id": "https://github.com/talmolab/sleap-roots-contracts/schema/v0.1.0a3/result_envelope.schema.json",
-  "source": "https://github.com/talmolab/sleap-roots-contracts/blob/v0.1.0a3/schema/result_envelope.schema.json",
+  "version": "v0.1.0a4",
+  "id": "https://github.com/talmolab/sleap-roots-contracts/schema/v0.1.0a4/result_envelope.schema.json",
+  "source": "https://github.com/talmolab/sleap-roots-contracts/blob/v0.1.0a4/schema/result_envelope.schema.json",
   "schema": "schema/result_envelope.schema.json",
   "generated": "generated/result-envelope.ts"
 }

--- a/contracts/schema/result_envelope.schema.json
+++ b/contracts/schema/result_envelope.schema.json
@@ -385,7 +385,7 @@
       "type": "object"
     }
   },
-  "$id": "https://github.com/talmolab/sleap-roots-contracts/schema/v0.1.0a3/result_envelope.schema.json",
+  "$id": "https://github.com/talmolab/sleap-roots-contracts/schema/v0.1.0a4/result_envelope.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "One per-scan result: 1 envelope : 1 source row : 1 scan.",
   "properties": {

--- a/openspec/changes/add-cyl-download-for-predict/design.md
+++ b/openspec/changes/add-cyl-download-for-predict/design.md
@@ -1,0 +1,177 @@
+## Context
+
+`bloomctl cyl download` (download.py) writes the legacy layout for experiment-level and
+single-scan downloads. The new warm-predict container (`sleap_roots_predict.batch.discover_scans`,
+batch.py:66-102) ignores that layout — it globs for `*.scan_metadata.json` sidecars and uses each
+sidecar's parent directory as that scan's frame folder. The sidecar must carry `image_ids` (the
+real `cyl_images.id` values from the DB) because the write-back RPC
+`insert_cyl_result_envelope` resolves `inputs.image_ids → cyl_images.scan_id`; fake ids produce a
+"no matching scan" rejection at write-back time, not at predict time (predict never validates
+`image_ids`). The A4 PoC (sleap-roots-pipeline PR #23) hand-authored a sidecar with synthetic ids
+to get a green predict run; this change provides the real stage-in.
+
+## Goals / Non-Goals
+
+- **Goals**: a `download-for-predict <scan-id> <out>` command that (1) writes frames into
+  `<out>/scan_{id}/<frame_number>{ext}`, (2) authors `<out>/scan_{id}/scan_{id}.scan_metadata.json`
+  with valid `scan_key`, `params`, `image_ids`, and `images_checksum`, (3) produces output that
+  `discover_scans()` loads without error, (4) produces `image_ids` that the write-back RPC can
+  resolve. Pure helpers separated from Supabase I/O for unit-testability.
+- **Non-Goals**: modifying existing `cyl download` (untouched); bulk/experiment predict layout;
+  non-interactive auth (#398); blob upload (#407); RPC grants (#404).
+
+## Decisions
+
+- **New subcommand, not a flag on `download`.** `bloomctl cyl download-for-predict <scan-id>
+  <out>` rather than modifying `download --scan-id`. The two commands produce fundamentally
+  different output trees; a flag would silently break any existing caller of `download --scan-id`
+  that expects `scans.csv`. A dedicated subcommand is self-documenting and non-breaking. The name
+  `download-for-predict` is the one named by contracts PR #16's follow-up notes — the canonical
+  reference for this command.
+- **`scan_key = "scan_{scan_id}"`.** `cyl_scans_extended` has no `scan_key` column — bloomctl
+  authors it. The key must be unique within a stage-in directory (predict raises on duplicate
+  scan_keys), stable (so write-back can trace), and safe to use as a directory/filename stem. The
+  DB primary key `scan_id` satisfies all three. The sidecar's `scan_key` field must equal the
+  filename stem (predict's `_load_scan` validates this at batch.py:111).
+- **`mode = "cylinder"` passed via `resolve_params(scan, overrides={"mode": "cylinder"})` — not
+  row augmentation (corrected after review).** All scans under `bloomctl cyl` are
+  cylinder-scanner scans; the multiplant dicot pipeline is retired. **Correction**: the original
+  rationale here claimed `resolve_params` reads `mode` from the metadata row, and had bloomctl
+  inject `mode: "cylinder"` directly into the row dict before calling it. Verified against the
+  actual released `sleap-roots-contracts>=0.1.0a4`: that claim is false.
+  `sleap_roots_contracts.params._mode_for_scan(metadata)` ignores its `metadata` argument entirely
+  and unconditionally returns the literal `"cylinder"` — row augmentation is not part of the
+  documented contract at all (`resolve_params`'s own docstring: "Other columns are ignored").
+  Fix: use `resolve_params`'s actual documented mechanism for this instead —
+  `resolve_params(scan_row, overrides={"mode": "cylinder"})`. `overrides` is explicitly documented
+  as "a param-space dict whose keys are a subset of `{species, mode, age}`... each key wins its
+  field over the derived value" — the sanctioned way for "callers who know the assay type" (which
+  is exactly bloomctl's situation) to force a value. Verified all three of no-override,
+  `overrides=`, and row-augmentation currently produce identical output (since `_mode_for_scan`
+  ignores its input either way), but `overrides=` is forward-compatible via contracts' actual
+  public API, where row augmentation was relying on undocumented (if currently harmless)
+  behavior.
+- **`params` via `resolve_params(scan_row, overrides={"mode": "cylinder"}).values` from contracts
+  >=0.1.0a4.** The canonical
+  `resolve_params` oracle is now in `sleap-roots-contracts` (PR #16, v0.1.0a4). It normalises
+  species names and age types; duplicating the logic here would create a second normalization path
+  and could diverge `param_hash → idempotency_key` between bloomctl and predict (exactly the
+  silent corruption that contracts PR #16 exists to prevent). The sidecar stores the flat
+  `.values` dict `{species, mode, age}` — predict's `_load_scan` builds `ResolvedParams` from it.
+- **`image_ids` in DB `frame_number` order, stored as integers.** `fetch_images` already returns
+  rows ordered by `frame_number`; re-using that order is consistent and requires no second sort.
+  The DB returns integer ids; JSON serialises them as numbers, which the RPC's `^[0-9]+$` check
+  accepts.
+- **`images_checksum` over frame bytes in DB `frame_number` order.** The DB is the authoritative
+  source of what was ingested; `frame_number` is the stable, per-scan ordering. Computing over
+  filesystem natural-sort order (predict's video-creation order) would produce a different checksum
+  if a frame were uploaded with a non-integer name, silently breaking provenance tracing.
+  `sha256:` prefix matches the pattern used by `cyl_scan_intermediates` (change C).
+- **Full contracts re-pin.** contracts PR #16 requires downstream consumers to do a full re-pin
+  (`pin.json` + vendored schema `$id` + regenerated TS), not merely a pip-floor bump, because the
+  schema `$id` URL changes with the version. The TS generated contract in `contracts/generated/`
+  and the vendored schema in `contracts/schema/` both get the `$id`-only diff.
+- **Module structure mirrors `download.py` and `ingest.py`.** New
+  `bloomcli/src/bloomctl/cyl/download_for_predict.py` with pure helpers above the
+  `# --- supabase / storage I/O ---` marker. Reuses `fetch_scan` and `fetch_images` from
+  `download.py` directly (imported, not duplicated). Registered in `cyl/__init__.py`.
+- **No sidecar is written on partial frame-download failure (added after review).** If any frame
+  fails to download, the command exits non-zero and successfully-downloaded frame files remain on
+  disk for debugging, but `scan_{scan_id}.scan_metadata.json` is **not** written. Rationale: a
+  written sidecar is a claim that `image_ids`/`images_checksum` accurately describe what's on
+  disk; a sidecar written over a partial frame set would let `discover_scans` silently load a scan
+  that doesn't have all its frames, with a checksum that can't be reproduced by a successful
+  re-run. Failing to write the sidecar means `discover_scans` simply doesn't see the scan at all —
+  a safe, glob-invisible failure mode — until a clean re-run succeeds.
+- **Stray frame files are reconciled away before the sidecar is written (added after second
+  review round).** Verified against the real `sleap_roots_predict.batch._load_scan`
+  (`c:\repos\sleap-roots-predict\sleap_roots_predict\batch.py`): frame discovery globs **every**
+  image-extension file physically present in the sidecar's parent directory — it does not consult
+  `image_ids` or a frame count. So "no sidecar on failure" alone doesn't fully protect the
+  provenance guarantee across retries: if attempt 1 downloads frames for `image_ids [1001, 1002,
+  1003]` and fails on 1003 (files `0.png`, `1.png` on disk, no sidecar), and between attempt 1 and
+  a later successful attempt 2 the scan's `cyl_images` rows change (e.g. row 1002 is deleted or
+  renumbered) such that attempt 2 only writes `0.png` and a differently-numbered replacement,
+  `1.png` from attempt 1 could survive on disk and be picked up as an extra, unaccounted-for frame
+  by `discover_scans` — even though the freshly-written sidecar's `image_ids`/`images_checksum`
+  never counted it. Fix: immediately before writing the sidecar on a fully successful run, delete
+  any file in `scan_dir` with a recognized image extension that is not one of the frame paths just
+  written this run. This is a no-op on the common case (plain retry, same `frame_number`s
+  overwrite in place) and only actually removes files in the narrower stale-data case. Failed
+  runs are unaffected (no sidecar is written either way, so no reconciliation happens on failure —
+  partial frames intentionally remain for debugging, per the bullet above).
+- **The cross-repo "oracle" tests (3.1, 5.6) are not a CI gate — deferred, not dependency-added
+  (added after review).** These tests assert the sidecar is accepted by the real
+  `sleap_roots_predict.discover_scans`/`_load_scan`. Adding `sleap-roots-predict` as a bloomcli
+  test dependency was considered and rejected: it isn't published to PyPI (git-only), and as of
+  this review its `pyproject.toml` exact-pins `sleap-roots-contracts==0.1.0a3`, which conflicts
+  with this proposal's `>=0.1.0a4` floor and would break dependency resolution outright, not just
+  skip a test. Per Elizabeth (2026-07-15): the sleap-roots-predict repo is actively being re-pinned
+  to the newest sleap-roots-contracts as a separate, in-flight piece of work — once that lands,
+  add `sleap-roots-predict` as a git dependency in a new bloomcli test extra and wire tests 3.1/5.6
+  into CI for real. Until then, they remain `pytest.importorskip`-guarded, run manually on a dev
+  machine with `sleap-roots-predict` installed locally, and are not treated as verifying anything
+  in CI. The non-skipped tests (4.x/5.x) independently assert every shape fact predict's code is
+  documented to require, without importing predict.
+
+## Risks / Trade-offs
+
+- **`resolve_params`'s `mode` handling is currently a no-op regardless of how it's called
+  (corrected after review; see Decisions).** Confirmed by direct inspection of
+  `sleap_roots_contracts.params._mode_for_scan` (v0.1.0a4): it ignores its `metadata` argument and
+  always returns `"cylinder"`, so `overrides={"mode": "cylinder"}` is not currently load-bearing
+  either — but it is the documented API surface, unlike the row-augmentation it replaces.
+  Mitigation: task 4.5 asserts the actual `overrides` argument passed to `resolve_params` (via
+  monkeypatch/spy) is `{"mode": "cylinder"}`, plus a companion test that documents
+  `resolve_params(scan)` (no override at all) already returning `mode="cylinder"` on the pinned
+  version — so a future contracts bump that makes `mode` metadata-driven is visible as a
+  test-behavior change, not a silent gap.
+- **Cross-repo oracle tests (3.1, 5.6) don't run in CI.** See the new Decisions bullet above —
+  `sleap-roots-predict` is not added as a dependency (PyPI-absent, and its `pyproject.toml`
+  exact-pins a conflicting contracts version). Mitigation: tracked as a follow-up once
+  sleap-roots-predict's own re-pin (in progress per Elizabeth) lands; until then the shape-only
+  tests (4.x/5.x) are the enforced contract, and 3.1/5.6 are run manually on a dev machine before
+  merge.
+- **Duplicate or non-integer `frame_number` in `cyl_images` (accepted, pre-existing limitation,
+  not introduced by this change).** `frame_dest_for_predict` derives each frame's filename from
+  `frame_number` alone (`f"{image['frame_number']}{ext}"`), matching `download.py`'s existing
+  `image_dest` helper, which has made the identical assumption since the original `cyl download`
+  command shipped. Two `cyl_images` rows sharing a `frame_number` would overwrite each other's
+  frame file on disk; a non-integer/`None` `frame_number` would produce a malformed filename. Not
+  addressed here because it isn't a new risk this change introduces — `cyl_images.frame_number`
+  data quality is an upstream-ingestion concern shared by both download commands.
+- **`image_ids` as integers vs strings.** The test fixture (`scan0K9E8BI.result.json`) carries
+  `image_ids: ['1001', '1002']` as strings (emitted by the trait-extractor). bloomctl will write
+  integers. The RPC validates numeric-ness (`^[0-9]+$` / `non-numeric image_id`) and resolves by
+  `::bigint` cast; both integer and string-numeric representations pass. Mitigation: the
+  integration test confirms resolution.
+- **Full re-pin diff size.** The `$id`-only schema diff touches `contracts/schema/` and
+  `contracts/generated/`; reviewers may flag this as unrelated. Mitigation: note in the PR
+  description that this is a mechanical follow-up required by contracts PR #16.
+- **The `$id`-only-diff assumption is not automatically safe (added after review).** Verified this
+  time by diffing the fetched `v0.1.0a4` schema against the vendored `a3` schema (version string
+  normalized out): byte-identical, confirming the GitHub release notes' claim. But
+  `contracts/README.md`'s own history shows the prior two re-pins (`a1→a2`, `a2→a3`) were **both**
+  real revisions, not no-ops — a 0-for-2 track record for "expect only `$id`". Mitigation: task
+  2.2 now requires actually diffing the fetched schema against the vendored one before
+  regenerating TS, not assuming the diff shape in advance.
+
+## Migration Plan
+
+No schema/RPC/DB migration. Rollout: land command + tests in one PR on `staging`. After merge,
+hand the `bloomctl cyl download-for-predict` invocation to the A4 pipeline stage-in step
+(sleap-roots-pipeline EPIC #10). Rollback is code-only (revert PR); no data effects.
+
+## Open Questions
+
+- None blocking. (Resolved during two `/review-openspec` rounds, 2026-07-15 — see reconciliation
+  notes above and in `tasks.md`/`specs/cyl-download-for-predict/spec.md`. Round 1: the
+  `resolve_params`/`mode` claim was corrected to use `overrides=`, the cross-repo oracle tests
+  were reframed as non-CI dev-machine checks pending sleap-roots-predict's in-progress contracts
+  re-pin, the partial-frame-failure sidecar behavior was decided (no sidecar written), and a
+  scope-mismatched write-back scenario was removed from this change's spec. Round 2 (adversarial
+  re-check): found and fixed a stale row-augmentation reference left behind in spec.md by round
+  1's partial fix, and — verified against the real `sleap_roots_predict.batch._load_scan` code —
+  added the stray-frame-reconciliation decision above, since "no sidecar on failure" alone doesn't
+  fully protect provenance across retries where the scan's `cyl_images` rows changed between
+  attempts.)

--- a/openspec/changes/add-cyl-download-for-predict/design.md
+++ b/openspec/changes/add-cyl-download-for-predict/design.md
@@ -109,10 +109,15 @@ to get a green predict run; this change provides the real stage-in.
   skip a test. Per Elizabeth (2026-07-15): the sleap-roots-predict repo is actively being re-pinned
   to the newest sleap-roots-contracts as a separate, in-flight piece of work — once that lands,
   add `sleap-roots-predict` as a git dependency in a new bloomcli test extra and wire tests 3.1/5.6
-  into CI for real. Until then, they remain `pytest.importorskip`-guarded, run manually on a dev
-  machine with `sleap-roots-predict` installed locally, and are not treated as verifying anything
-  in CI. The non-skipped tests (4.x/5.x) independently assert every shape fact predict's code is
-  documented to require, without importing predict.
+  into CI for real. Until then, they remain `pytest.importorskip`-guarded and are not treated as
+  verifying anything in CI. Manually verified once during implementation (task 8.6) using
+  `sleap-roots-predict`'s own `uv`-managed `cpu` extra (`uv run --with
+"sleap-roots-predict[cpu] @ file:///path/to/sleap-roots-predict" --extra test pytest ...` — this
+  repo's convention is `uv`, not a hand-maintained conda env, which is why an earlier attempt
+  against a stale pre-existing conda env failed for an unrelated reason and was abandoned): both
+  passed (`2 passed, 22 deselected`). The non-skipped tests (4.x/5.x) independently assert every
+  shape fact predict's code is documented to require, without importing predict — that remains
+  the CI-enforced contract; 3.1/5.6 are a valuable but not CI-gated extra confirmation.
 
 ## Risks / Trade-offs
 
@@ -130,8 +135,8 @@ to get a green predict run; this change provides the real stage-in.
   `sleap-roots-predict` is not added as a dependency (PyPI-absent, and its `pyproject.toml`
   exact-pins a conflicting contracts version). Mitigation: tracked as a follow-up once
   sleap-roots-predict's own re-pin (in progress per Elizabeth) lands; until then the shape-only
-  tests (4.x/5.x) are the enforced contract, and 3.1/5.6 are run manually on a dev machine before
-  merge.
+  tests (4.x/5.x) are the enforced contract. 3.1/5.6 were manually run before merge and passed
+  (task 8.6).
 - **Duplicate or non-integer `frame_number` in `cyl_images` (accepted, pre-existing limitation,
   not introduced by this change).** `frame_dest_for_predict` derives each frame's filename from
   `frame_number` alone (`f"{image['frame_number']}{ext}"`), matching `download.py`'s existing

--- a/openspec/changes/add-cyl-download-for-predict/design.md
+++ b/openspec/changes/add-cyl-download-for-predict/design.md
@@ -23,7 +23,7 @@ to get a green predict run; this change provides the real stage-in.
 ## Decisions
 
 - **New subcommand, not a flag on `download`.** `bloomctl cyl download-for-predict <scan-id>
-  <out>` rather than modifying `download --scan-id`. The two commands produce fundamentally
+<out>` rather than modifying `download --scan-id`. The two commands produce fundamentally
   different output trees; a flag would silently break any existing caller of `download --scan-id`
   that expects `scans.csv`. A dedicated subcommand is self-documenting and non-breaking. The name
   `download-for-predict` is the one named by contracts PR #16's follow-up notes — the canonical
@@ -52,12 +52,12 @@ to get a green predict run; this change provides the real stage-in.
   public API, where row augmentation was relying on undocumented (if currently harmless)
   behavior.
 - **`params` via `resolve_params(scan_row, overrides={"mode": "cylinder"}).values` from contracts
-  >=0.1.0a4.** The canonical
-  `resolve_params` oracle is now in `sleap-roots-contracts` (PR #16, v0.1.0a4). It normalises
-  species names and age types; duplicating the logic here would create a second normalization path
-  and could diverge `param_hash → idempotency_key` between bloomctl and predict (exactly the
-  silent corruption that contracts PR #16 exists to prevent). The sidecar stores the flat
-  `.values` dict `{species, mode, age}` — predict's `_load_scan` builds `ResolvedParams` from it.
+  `>=0.1.0a4`.** The canonical `resolve_params` oracle is now in `sleap-roots-contracts` (PR #16,
+  v0.1.0a4). It normalises species names and age types; duplicating the logic here would create a
+  second normalization path and could diverge `param_hash → idempotency_key` between bloomctl and
+  predict (exactly the silent corruption that contracts PR #16 exists to prevent). The sidecar
+  stores the flat `.values` dict `{species, mode, age}` — predict's `_load_scan` builds
+  `ResolvedParams` from it.
 - **`image_ids` in DB `frame_number` order, stored as integers.** `fetch_images` already returns
   rows ordered by `frame_number`; re-using that order is consistent and requires no second sort.
   The DB returns integer ids; JSON serialises them as numbers, which the RPC's `^[0-9]+$` check
@@ -89,7 +89,7 @@ to get a green predict run; this change provides the real stage-in.
   image-extension file physically present in the sidecar's parent directory — it does not consult
   `image_ids` or a frame count. So "no sidecar on failure" alone doesn't fully protect the
   provenance guarantee across retries: if attempt 1 downloads frames for `image_ids [1001, 1002,
-  1003]` and fails on 1003 (files `0.png`, `1.png` on disk, no sidecar), and between attempt 1 and
+1003]` and fails on 1003 (files `0.png`, `1.png` on disk, no sidecar), and between attempt 1 and
   a later successful attempt 2 the scan's `cyl_images` rows change (e.g. row 1002 is deleted or
   renumbered) such that attempt 2 only writes `0.png` and a differently-numbered replacement,
   `1.png` from attempt 1 could survive on disk and be picked up as an extra, unaccounted-for frame

--- a/openspec/changes/add-cyl-download-for-predict/design.md
+++ b/openspec/changes/add-cyl-download-for-predict/design.md
@@ -83,23 +83,90 @@ to get a green predict run; this change provides the real stage-in.
   that doesn't have all its frames, with a checksum that can't be reproduced by a successful
   re-run. Failing to write the sidecar means `discover_scans` simply doesn't see the scan at all —
   a safe, glob-invisible failure mode — until a clean re-run succeeds.
-- **Stray frame files are reconciled away before the sidecar is written (added after second
-  review round).** Verified against the real `sleap_roots_predict.batch._load_scan`
-  (`c:\repos\sleap-roots-predict\sleap_roots_predict\batch.py`): frame discovery globs **every**
-  image-extension file physically present in the sidecar's parent directory — it does not consult
-  `image_ids` or a frame count. So "no sidecar on failure" alone doesn't fully protect the
-  provenance guarantee across retries: if attempt 1 downloads frames for `image_ids [1001, 1002,
-1003]` and fails on 1003 (files `0.png`, `1.png` on disk, no sidecar), and between attempt 1 and
-  a later successful attempt 2 the scan's `cyl_images` rows change (e.g. row 1002 is deleted or
-  renumbered) such that attempt 2 only writes `0.png` and a differently-numbered replacement,
-  `1.png` from attempt 1 could survive on disk and be picked up as an extra, unaccounted-for frame
-  by `discover_scans` — even though the freshly-written sidecar's `image_ids`/`images_checksum`
-  never counted it. Fix: immediately before writing the sidecar on a fully successful run, delete
-  any file in `scan_dir` with a recognized image extension that is not one of the frame paths just
-  written this run. This is a no-op on the common case (plain retry, same `frame_number`s
-  overwrite in place) and only actually removes files in the narrower stale-data case. Failed
-  runs are unaffected (no sidecar is written either way, so no reconciliation happens on failure —
-  partial frames intentionally remain for debugging, per the bullet above).
+- **Superseded: end-of-run stray-frame reconciliation → start-of-run full directory clear (revised
+  after PR #458 review).** The original decision (kept below, struck through in spirit, for
+  history) deleted only files not among the current run's just-written frames, computed
+  _immediately before writing the sidecar_ on a fully successful run. PR review reproduced a gap
+  this didn't cover: if `scan_dir` already holds a valid sidecar from an earlier _successful_ run,
+  and a later re-run partially fails, the end-of-run reconcile+write never runs (the failure path
+  exits first) — so the old sidecar survives untouched, now describing frame bytes that a partial
+  retry may have already overwritten in place. A diff-based, end-of-run fix can't close this: the
+  problem is that stale state can outlive a failed run at all. Fix: **clear `scan_dir` entirely at
+  the start of every invocation**, before downloading any frame — not just reconcile stray files
+  at the end. This is a strictly simpler model (idempotent "stage fresh," not "diff against a
+  moving target") that closes the stale-sidecar gap by construction: a failed run has nothing to
+  leave _behind_ to go stale, because whatever was there before this run started is already gone.
+  The command echoes what it clears, so this isn't silent (PR review also flagged the original
+  reconcile as too quiet). See the next two bullets for how this composes safely with validation.
+  <details><summary>Original decision (superseded, kept for history)</summary>
+  Verified against the real `sleap_roots_predict.batch._load_scan`: frame discovery globs every
+  image-extension file physically present in the sidecar's parent directory, not just
+  `image_ids`. Fix (at the time): immediately before writing the sidecar on success, delete any
+  file in `scan_dir` not among the frame paths just written. This correctly closed the
+  "renumbered-frame" case but not the "prior success, later partial failure" case above.
+  </details>
+- **Validate everything that can fail _before_ clearing the directory or downloading anything
+  (added after PR #458 review — closes a reproduced crash).** PR review reproduced: a scan with a
+  null `species_name`/`plant_age_days` makes `resolve_params` raise a bare, uncaught `ValueError`
+  from inside `build_sidecar`, which was called _after_ the (then end-of-run) reconcile step — so
+  the crash left destructive cleanup already done, with no `ClickException`, just a raw traceback.
+  Fix: extract the `resolve_params` call into its own pure helper (`resolve_sidecar_params`),
+  call it — and the new frame-number validation below — right after `fetch_images`, wrapped in
+  `try/except ValueError` → `ClickException`, **before** the directory clear or any download. The
+  already-resolved `params` dict is threaded into `build_sidecar` (new required parameter) rather
+  than re-resolved later, so there's no duplicate call and no way to reach the destructive/download
+  steps with metadata that can't produce a valid sidecar.
+- **Reject duplicate or null `frame_number` values before downloading (added after PR #458
+  review).** `cyl_images.frame_number` is nullable and `UNIQUE(scan_id, frame_number)` doesn't
+  block `NULL` (Postgres never considers two `NULL`s equal for uniqueness), so two rows can share
+  a null/duplicate `frame_number` for one scan. Reproduced: without a guard, both rows map to the
+  same on-disk path (`frame_dest_for_predict` derives the filename from `frame_number` alone), the
+  second overwrites the first, yet _both_ ids land in `image_ids` and _both_ frames' bytes get
+  hashed into `images_checksum` — a checksum that no longer describes what's on disk, silently.
+  Fix: new pure helper `validate_frame_numbers(images)` raises `ValueError` (caught the same way as
+  the metadata-resolution failure above) if any `frame_number` is `None` or duplicated, before any
+  destructive action. `cyl download`'s equivalent data-quality gap (documented below, in Risks) is
+  otherwise unaffected — this fix is scoped to `download-for-predict` alone, since only its sidecar
+  makes a checksum/`image_ids` claim that duplicate frame numbers would falsify.
+- **Reuse `cli.py`'s `_authed_client` instead of duplicating `download.py`'s auth-error-handling
+  block (added after PR #458 review).** The command's `load_credentials`/`make_authed_client`
+  try/except pair was copy-pasted byte-for-byte from `download.py`, when `ingest.py` (a sibling
+  command in this same `cyl` group) already extracted this exact pattern into
+  `cli._authed_client(profile)`. Switching to it produces the identical error messages (verified:
+  same `ClickException` text, same "run `bloomctl login`" hint), so no test changes are needed —
+  it's a pure de-duplication, not a behavior change.
+- **`frame_dest_for_predict` fails loudly on a missing `object_path`, matching `download.py`'s
+  `image_dest` (added after PR #458 review).** Was `image.get("object_path", "")`, silently
+  degrading a malformed row to a bare `.png` extension; `download.py`'s equivalent helper does
+  `image["object_path"]` and raises `KeyError` on the identical bad input. Two helpers doing the
+  same job should fail the same way. Fix: switch to `image["object_path"]`. The `KeyError` is
+  still caught per-frame inside `download_frames_for_predict`'s existing `try/except Exception`
+  (unchanged), so a single malformed row still surfaces as a clean per-frame failure, not a crash —
+  only the _manner_ of that per-frame failure detection changed (loud vs. silently-wrong).
+- **Sidecar and frame writes are atomic (write-to-temp, then `os.replace`) (added after PR #458
+  review).** `write_sidecar`/frame writes were direct `write_text`/`write_bytes` calls — a process
+  killed mid-write could leave a truncated-but-present file. `os.replace` is atomic on both POSIX
+  and Windows (unlike `os.rename`, which fails on Windows if the destination exists), so this is a
+  small, portable fix. Low-probability risk, but this module's whole design rests on "a written
+  file accurately represents its claimed content" — worth closing given how cheap it is.
+- **Concurrent invocations of the same `scan_id`/`out_dir` remain unsupported (accepted, not fixed,
+  added after PR #458 review).** PR review reproduced a race: two processes staging the same scan
+  into the same directory at once can have one process's directory-clear or write step interleave
+  with the other's, since there is no file lock anywhere in this command (nor in sibling `cyl`
+  commands). A real fix needs a lock file or DB advisory lock — disproportionate for what is a
+  single-operator, run-once-per-scan CLI tool, not a batch-parallel service. The intended usage
+  pattern is one invocation per scan, sequential retries, not concurrent runs of the _same_
+  scan_id. Accepted as a known limitation; the clear-upfront design (above) doesn't make this
+  worse than the previous end-of-run-reconcile design, just differently-shaped.
+- **The oracle tests now assert `_IMAGE_EXTENSIONS` equality against predict's real constant
+  (added after PR #458 review).** The hardcoded `_IMAGE_EXTENSIONS` frozenset is the safety-
+  critical basis for what the directory-clear step (and, previously, stray-frame reconciliation)
+  treats as an image file — a drift from predict's real `sleap_roots_predict.batch
+._IMAGE_EXTENSIONS` would silently change what gets cleared/protected, in either direction, with
+  no signal. Since the two oracle tests already import `sleap_roots_predict` when available, they
+  now also assert `dfp._IMAGE_EXTENSIONS == frozenset(sleap_roots_predict.batch._IMAGE_EXTENSIONS)`
+  — this is the one place that assumption is actually checked, even though only manually/dev-machine
+  (per the existing non-CI-gate decision below).
 - **The cross-repo "oracle" tests (3.1, 5.6) are not a CI gate — deferred, not dependency-added
   (added after review).** These tests assert the sidecar is accepted by the real
   `sleap_roots_predict.discover_scans`/`_load_scan`. Adding `sleap-roots-predict` as a bloomcli
@@ -179,4 +246,12 @@ hand the `bloomctl cyl download-for-predict` invocation to the A4 pipeline stage
   1's partial fix, and — verified against the real `sleap_roots_predict.batch._load_scan` code —
   added the stray-frame-reconciliation decision above, since "no sidecar on failure" alone doesn't
   fully protect provenance across retries where the scan's `cyl_images` rows changed between
-  attempts.)
+  attempts. Round 3 (`/review-pr` on the merged implementation, PR #458, 2026-07-15): reproduced a
+  real crash (uncaught `ValueError` from `resolve_params` on missing scan metadata, with the
+  destructive reconcile step already having run) and a real data-integrity gap the round-2 fix
+  didn't fully close (a prior successful run's sidecar surviving stale after a later partial-
+  failure retry). Superseded end-of-run stray-frame reconciliation with start-of-run full
+  directory clear; added frame-number duplicate/null validation, metadata-resolution validation
+  before any destructive action, atomic writes, `_authed_client` reuse, loud `frame_dest_for_predict`
+  failure, and an `_IMAGE_EXTENSIONS`-equality assertion in the oracle tests. Accepted (not fixed):
+  concurrent invocations of the same scan_id/out_dir remain unsupported — see Risks.)

--- a/openspec/changes/add-cyl-download-for-predict/proposal.md
+++ b/openspec/changes/add-cyl-download-for-predict/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+The A4 pipeline's warm-predict container expects a `*.scan_metadata.json` sidecar layout that
+`bloomctl cyl download` doesn't produce, causing a silent 0-scan no-op; the sidecar also needs
+real `cyl_images` ids or the write-back RPC rejects it with "no matching scan." This adds
+`bloomctl cyl download-for-predict <scan-id> <out>` to stage one scan correctly (closes bloom
+#411). (Mechanism detail: see `design.md` Context.)
+
+## What Changes
+
+- Add **`bloomctl cyl download-for-predict <scan-id> <out>`** (new Click subcommand under the
+  existing `cyl` group, alongside `download` and `ingest-result`):
+  - Write frame files into `<out>/scan_{scan_id}/<frame_number>{ext}` (frames co-located with
+    the sidecar, not the old `images/Wave{n}/…` tree).
+  - Author `<out>/scan_{scan_id}/scan_{scan_id}.scan_metadata.json` with:
+    - `scan_key` — `"scan_{scan_id}"` (must equal filename stem; predict validates this).
+    - `params` — `{species, mode, age}` flat dict from
+      `resolve_params(scan_row, overrides={"mode": "cylinder"}).values`
+      (`sleap-roots-contracts>=0.1.0a4`); `mode` is always `"cylinder"` for cyl-scanner scans.
+    - `image_ids` — list of `cyl_images.id` integers in DB `frame_number` order; the write-back
+      RPC resolves these to the scan (fake ids → "no matching scan").
+    - `images_checksum` — `sha256:<hex>` over frame bytes concatenated in DB `frame_number`
+      order, tying provenance to what was actually downloaded.
+- Bump `sleap-roots-contracts>=0.1.0a3` → `>=0.1.0a4` in `bloomcli/pyproject.toml`; do the
+  **full re-pin** per contracts PR #16 instructions: update `contracts/pin.json` (version,
+  `$id`/source URL), update the vendored `contracts/schema/result_envelope.schema.json` (verified
+  `$id`-only diff against the fetched `v0.1.0a4` schema), regenerate
+  `contracts/generated/result-envelope.ts`, and update `contracts/README.md`'s "Currently pinned"
+  line plus a new dated re-pin note.
+- **Existing `bloomctl cyl download`** is untouched — `--experiment-id`, `--scan-id`, and
+  `scans.csv` output are unchanged.
+- Implementation lands in the **same PR** as this proposal (bundled proposal + implementation).
+
+## Impact
+
+- **New capability**: `cyl-download-for-predict` (the stage-in command for the A4 per-scan
+  pipeline). Consumes `cyl_scans_extended` (read), `cyl_images` (read), and Storage `images`
+  bucket (download via existing Supabase Storage client). No server/RPC/schema changes.
+- **Contracts re-pin**: `bloomcli/pyproject.toml` floor `>=0.1.0a4`; `contracts/pin.json` +
+  vendored schema `$id` + regenerated TS (verified `$id`-only diff, no logic change) +
+  `contracts/README.md` pin line and re-pin note.
+- **Affected code**: new `bloomcli/src/bloomctl/cyl/download_for_predict.py`;
+  `bloomcli/src/bloomctl/cyl/__init__.py` (register new command); `bloomcli/pyproject.toml`
+  (dep floor); `contracts/pin.json`, `contracts/schema/result_envelope.schema.json`,
+  `contracts/generated/result-envelope.ts`, `contracts/README.md` (re-pin); new
+  `bloomcli/tests/test_cyl_download_for_predict.py`; `bloomcli/README.md`, `bloomcli/CHANGELOG.md`.
+- **Not added**: `sleap-roots-predict` as a test dependency (considered, rejected — see
+  `design.md` Decisions/Risks: not on PyPI, and its `pyproject.toml` currently exact-pins a
+  conflicting `sleap-roots-contracts` version; its own re-pin is in progress separately).
+- **Out of scope** (separate follow-ups): non-interactive auth (#398); blob upload (#407); RPC
+  grants (#404); bulk/experiment-level predict layout (future). Consumer: the A4 stage-in step
+  (EPIC `talmolab/sleap-roots-pipeline#10`).
+- **Coordination**: same `cyl` group and Storage download pattern as `download.py`; branch
+  protection requires a non-author reviewer.

--- a/openspec/changes/add-cyl-download-for-predict/specs/cyl-download-for-predict/spec.md
+++ b/openspec/changes/add-cyl-download-for-predict/specs/cyl-download-for-predict/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: Cyl download-for-predict command stages frames in the predict-ready layout
+
+The `bloomctl` CLI SHALL provide a `cyl download-for-predict <scan-id> <out>` command that
+downloads a single cylinder scan's frame files into the layout expected by
+`sleap_roots_predict.discover_scans`: all frame files co-located with the sidecar under
+`<out>/scan_{scan_id}/`, named `{frame_number}{original_ext}`. The command SHALL accept a
+`--profile` / `-p` option (defaulting to the shared default profile). The command SHALL exit
+non-zero and print a readable error if the scan does not exist in `cyl_scans_extended`; it SHALL
+NOT create a partial output directory in that case.
+
+#### Scenario: Frames written into the nested predict layout
+
+- **WHEN** the user runs `bloomctl cyl download-for-predict 7 /tmp/stage` for a scan that exists
+- **THEN** each frame is written to `/tmp/stage/scan_7/<frame_number>{ext}` (co-located with the
+  sidecar), and `sleap_roots_predict.discover_scans("/tmp/stage")` returns exactly one
+  `ScanInput` with `scan_key="scan_7"` and no `error`
+
+#### Scenario: A successful re-run reconciles stray frame files from an earlier failed attempt
+
+- **WHEN** an earlier failed attempt left a frame file on disk under `scan_{scan_id}/` (e.g. from
+  a `cyl_images` row later deleted or renumbered) that a fully successful later run does not
+  re-download
+- **THEN** the successful run deletes that stray file before writing the sidecar, so every
+  image-extension file remaining under `scan_{scan_id}/` corresponds to an entry in the written
+  sidecar's `image_ids`
+
+#### Scenario: Scan not found exits non-zero
+
+- **WHEN** the scan-id does not exist in `cyl_scans_extended`
+- **THEN** the command exits non-zero with a readable "not found" message and no output directory
+  is created
+
+#### Scenario: Frame download failure is surfaced non-zero and no sidecar is written
+
+- **WHEN** one or more frames cannot be downloaded from Storage
+- **THEN** the command exits non-zero and reports the failure count; successfully downloaded
+  frames remain on disk; the `scan_{scan_id}.scan_metadata.json` sidecar is NOT written, so
+  `discover_scans` does not see a partial scan on a later run over the same output directory
+
+#### Scenario: Scan with zero cyl_images rows exits non-zero
+
+- **WHEN** the scan exists in `cyl_scans_extended` but has no `cyl_images` rows
+- **THEN** the command exits non-zero with a readable "no frames found" message and no output
+  directory is created (treated like a not-found scan, since a frameless stage-in directory is
+  never useful to `discover_scans`)
+
+### Requirement: Sidecar scan_key equals the directory name and filename stem
+
+The command SHALL write the sidecar as
+`<out>/scan_{scan_id}/scan_{scan_id}.scan_metadata.json` and set the sidecar's `scan_key` field
+to `"scan_{scan_id}"`. The `scan_key` field MUST equal the filename stem of the sidecar
+(without the `.scan_metadata.json` suffix) because `sleap_roots_predict._load_scan` rejects a
+mismatch with an error.
+
+#### Scenario: Sidecar scan_key matches filename stem
+
+- **WHEN** the command writes the sidecar for scan 7
+- **THEN** the file is named `scan_7.scan_metadata.json`, the sidecar's `"scan_key"` field is
+  `"scan_7"`, and `sleap_roots_predict._load_scan` accepts it (no `error` on the returned
+  `ScanInput`)
+
+#### Scenario: scan_key is unique within a stage directory
+
+- **WHEN** `discover_scans` is called on an output directory containing exactly one staged scan
+- **THEN** it returns exactly one `ScanInput` (no `ValueError` for duplicate scan_keys)
+
+### Requirement: Sidecar params are resolved from Bloom metadata via the contracts oracle
+
+The command SHALL populate the sidecar's `params` field with the flat dict
+`{species, mode, age}` obtained by calling `resolve_params` from `sleap-roots-contracts>=0.1.0a4`
+on the scan's `cyl_scans_extended` row with `overrides={"mode": "cylinder"}`, and writing
+`resolved.values`. The `mode` value MUST always be `"cylinder"` for the `cyl` command family;
+`species` and `age` come from `species_name` and `plant_age_days` in the scan row. The command
+SHALL NOT duplicate the normalization logic of `resolve_params`; it MUST import and call the
+oracle from `sleap-roots-contracts`.
+
+#### Scenario: Params dict has the required keys with canonical values
+
+- **WHEN** the sidecar is written for a scan with `species_name="Pennycress"`,
+  `plant_age_days=14`
+- **THEN** the sidecar's `params` dict has keys `species`, `mode`, `age`; `mode` is `"cylinder"`;
+  `species` and `age` are the canonicalized values from `resolve_params`; and
+  `sleap_roots_predict._load_scan` accepts the params without error
+
+#### Scenario: Params satisfy predict's required-param-keys check
+
+- **WHEN** `discover_scans` loads the staged scan
+- **THEN** the returned `ScanInput.params` is a `ResolvedParams` (not None) and the `ScanInput`
+  has no `error`
+
+### Requirement: Sidecar image_ids are the real cyl_images ids for the scan
+
+The command SHALL populate the sidecar's `image_ids` field with the list of `cyl_images.id`
+integer values for the scan, in DB `frame_number` ascending order. These ids MUST be the real
+database ids because the write-back RPC `insert_cyl_result_envelope` resolves
+`inputs.image_ids → cyl_images.scan_id`; synthetic or wrong ids cause a "no matching scan"
+rejection at write-back time.
+
+#### Scenario: image_ids equal the scan's cyl_images ids
+
+- **WHEN** the sidecar is written for a scan whose `cyl_images` rows have ids `[1001, 1002]` in
+  frame_number order
+- **THEN** the sidecar's `image_ids` field is `[1001, 1002]` (integers, same order)
+
+Note: whether a `ResultEnvelope` produced downstream from this sidecar actually resolves via the
+write-back RPC (`insert_cyl_result_envelope`) is owned and tested by the `cyl-trait-writeback`
+capability (see `bloomcli/tests/test_cyl_ingest.py`), not this one — this capability's contract
+ends at producing correct, real `cyl_images.id` values in the sidecar.
+
+### Requirement: Sidecar images_checksum ties provenance to the downloaded frames
+
+The command SHALL populate the sidecar's `images_checksum` field with a `"sha256:<hex>"` digest
+computed over the frame bytes concatenated in DB `frame_number` ascending order (the same order
+as `image_ids`). The checksum MUST be computed over the bytes that were actually written to disk.
+
+#### Scenario: Checksum is sha256-prefixed and computed in frame_number order
+
+- **WHEN** the sidecar is written after downloading frames with frame_numbers 0 and 1
+- **THEN** the `images_checksum` field starts with `"sha256:"` and equals the sha256 of the
+  frame-0 bytes concatenated with the frame-1 bytes (in that order)
+
+#### Scenario: Checksum changes when frame content changes
+
+- **WHEN** the same scan is staged twice but with different frame bytes for one frame
+- **THEN** the two sidecars have different `images_checksum` values
+
+### Requirement: Authentication uses an existing profile
+
+The command SHALL authenticate using an existing `bloomctl` credentials profile (interactive
+login), and SHALL surface a clear error when credentials are missing or invalid.
+
+#### Scenario: Missing credentials
+
+- **WHEN** no credentials profile exists or the profile is invalid
+- **THEN** the command exits non-zero and prints guidance to run `bloomctl login`

--- a/openspec/changes/add-cyl-download-for-predict/specs/cyl-download-for-predict/spec.md
+++ b/openspec/changes/add-cyl-download-for-predict/specs/cyl-download-for-predict/spec.md
@@ -17,14 +17,14 @@ NOT create a partial output directory in that case.
   sidecar), and `sleap_roots_predict.discover_scans("/tmp/stage")` returns exactly one
   `ScanInput` with `scan_key="scan_7"` and no `error`
 
-#### Scenario: A successful re-run reconciles stray frame files from an earlier failed attempt
+#### Scenario: Re-running into an existing stage directory starts fresh (revised after PR #458 review)
 
-- **WHEN** an earlier failed attempt left a frame file on disk under `scan_{scan_id}/` (e.g. from
-  a `cyl_images` row later deleted or renumbered) that a fully successful later run does not
-  re-download
-- **THEN** the successful run deletes that stray file before writing the sidecar, so every
-  image-extension file remaining under `scan_{scan_id}/` corresponds to an entry in the written
-  sidecar's `image_ids`
+- **WHEN** `scan_{scan_id}/` already exists under `<out>` (e.g. from an earlier successful run, or
+  a failed attempt whose `cyl_images` rows have since changed) and the command is invoked again
+  for the same scan
+- **THEN** the command clears `scan_{scan_id}/` entirely before downloading any frames for this
+  invocation, and announces what it cleared; no frame file or sidecar from a previous invocation
+  can survive into — or be silently mistaken for part of — this invocation's output
 
 #### Scenario: Scan not found exits non-zero
 
@@ -35,9 +35,32 @@ NOT create a partial output directory in that case.
 #### Scenario: Frame download failure is surfaced non-zero and no sidecar is written
 
 - **WHEN** one or more frames cannot be downloaded from Storage
-- **THEN** the command exits non-zero and reports the failure count; successfully downloaded
-  frames remain on disk; the `scan_{scan_id}.scan_metadata.json` sidecar is NOT written, so
-  `discover_scans` does not see a partial scan on a later run over the same output directory
+- **THEN** the command exits non-zero and reports the failure count; frames downloaded during
+  this invocation remain on disk; the `scan_{scan_id}.scan_metadata.json` sidecar is NOT written,
+  so `discover_scans` does not see a partial scan on a later run over the same output directory
+
+### Requirement: Sidecar metadata resolution is validated before any destructive action
+
+The command SHALL resolve the sidecar's `params` (via the contracts oracle) and validate the
+scan's `cyl_images` rows (frame-number uniqueness) before clearing any existing output directory
+or downloading any frame. A resolution failure (e.g. missing `species_name`/`plant_age_days`, or
+duplicate/null `frame_number` values) SHALL exit non-zero with a readable message and SHALL NOT
+have deleted any pre-existing directory contents.
+
+#### Scenario: Missing required scan metadata exits non-zero without deleting anything
+
+- **WHEN** the scan's `species_name` or `plant_age_days` is null or blank, so the params oracle
+  cannot resolve required values
+- **THEN** the command exits non-zero with a readable message (not a raw traceback), and if
+  `scan_{scan_id}/` already existed, its contents are unchanged
+
+#### Scenario: Duplicate or null frame_number values exit non-zero without deleting anything
+
+- **WHEN** the scan's `cyl_images` rows contain a null `frame_number` or two rows sharing the same
+  `frame_number`
+- **THEN** the command exits non-zero with a readable message before downloading any frame or
+  clearing any existing output directory (a checksum computed over an ambiguous frame set would
+  no longer describe what's on disk)
 
 #### Scenario: Scan with zero cyl_images rows exits non-zero
 
@@ -81,8 +104,9 @@ oracle from `sleap-roots-contracts`.
 - **WHEN** the sidecar is written for a scan with `species_name="Pennycress"`,
   `plant_age_days=14`
 - **THEN** the sidecar's `params` dict has keys `species`, `mode`, `age`; `mode` is `"cylinder"`;
-  `species` and `age` are the canonicalized values from `resolve_params`; and
-  `sleap_roots_predict._load_scan` accepts the params without error
+  `species` is the canonicalized value from `resolve_params` (`"pennycress"`) and `age` is `14`
+  (not merely present — the exact canonicalized values, so a `resolve_params` regression is
+  caught); and `sleap_roots_predict._load_scan` accepts the params without error
 
 #### Scenario: Params satisfy predict's required-param-keys check
 

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -206,18 +206,18 @@ str(out), "-p", "staging"])` with monkeypatched `load_credentials` capturing its
 
 ## 8. Verify
 
-- [ ] 8.1 `openspec validate add-cyl-download-for-predict --strict` passes.
-- [ ] 8.2 bloomcli unit suite green using the CI invocation:
+- [x] 8.1 `openspec validate add-cyl-download-for-predict --strict` passes.
+- [x] 8.2 bloomcli unit suite green using the CI invocation:
       `cd bloomcli && uv run --extra test pytest tests/ -m "not integration" -v --tb=short`.
       Run the release-time ruff gate manually:
       `uvx ruff@0.9.9 check bloomcli && uvx ruff@0.9.9 format --check bloomcli`.
       Run `pre-commit run --files` over new `.py`/`.md` files; confirm gitleaks is clean.
-- [ ] 8.3 Confirm no `TBD` or placeholder remains in `proposal.md` / `design.md`.
-- [ ] 8.4 Re-run task 2.1's installability check
+- [x] 8.3 Confirm no `TBD` or placeholder remains in `proposal.md` / `design.md`.
+- [x] 8.4 Re-run task 2.1's installability check
       (`uv run --no-project --with 'sleap-roots-contracts>=0.1.0a4' python -c "from
 sleap_roots_contracts import resolve_params; print('ok')"`) as a final gate, not just a
       one-off at the start of §2.
-- [ ] 8.5 Run `npm run contracts:check` at the repo root to confirm the re-pin (task 2.2) passes
+- [x] 8.5 Run `npm run contracts:check` at the repo root to confirm the re-pin (task 2.2) passes
       the drift guard before committing.
 - [ ] 8.6 Manually run tests 3.1 (`test_oracle_sidecar_is_accepted_by_discover_scans`) and 5.6
       (`test_discover_scans_smoke_after_happy_path`) with `sleap-roots-predict` installed locally

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -35,11 +35,11 @@ unregistered command fails CLI-invocation tests outright, not silently). Land as
 
 ## 2. Package + repo setup (pre-req; lands before tests that import it)
 
-- [ ] 2.1 Bump `sleap-roots-contracts>=0.1.0a3` → `>=0.1.0a4` in `bloomcli/pyproject.toml`.
+- [x] 2.1 Bump `sleap-roots-contracts>=0.1.0a3` → `>=0.1.0a4` in `bloomcli/pyproject.toml`.
       Verify installability: `uv run --no-project --with 'sleap-roots-contracts>=0.1.0a4' python -c
       "from sleap_roots_contracts import resolve_params; print('ok')"`. bloomcli has no `uv.lock` —
       no lock refresh needed.
-- [ ] 2.2 Full contracts re-pin per contracts PR #16 instructions:
+- [x] 2.2 Full contracts re-pin per contracts PR #16 instructions:
       (a) update `contracts/pin.json`: version `v0.1.0a3` → `v0.1.0a4`, `$id` and `source` URLs;
       (b) fetch updated `contracts/schema/result_envelope.schema.json` from
           `github.com/talmolab/sleap-roots-contracts` at tag `v0.1.0a4` and **diff it against the

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -17,15 +17,16 @@ Proposal + implementation land in the **same PR** (bloom #411).
 
 **Commit plan (reconciled after `/review-openspec`)** — §3-5's RED tasks cannot be their own
 commits before §6's GREEN implementation without going red on every intermediate push (an
-unregistered command fails CLI-invocation tests outright, not silently). Land as:
+unregistered command fails CLI-invocation tests outright, not silently). Landed as (commits 3+4
+merged during implementation — the reviewer noted this split was optional, not CI-mandatory,
+since one module file + its full test suite + registration is a single coherent, already-GREEN
+unit; see round-1 git-workflow review):
 1. `docs(openspec): add proposal for cyl download-for-predict (#411)` — §1 (this proposal).
 2. `chore(contracts): bump sleap-roots-contracts to v0.1.0a4 (bloomcli floor + full re-pin)` —
    §2, verified installable (2.1) and re-pin diff confirmed `$id`-only (2.2) before committing.
-3. `feat(bloomcli): add download_for_predict pure helpers + oracle test (#411)` — §3 (oracle test)
-   + §4 (pure helpers) + the pure-helper half of §6.1 (no CLI registration yet).
-4. `feat(bloomctl): register cyl download-for-predict command (#411)` — §5 (command-wiring tests)
-   + the I/O/CLI half of §6.1 + §6.2 (registration).
-5. `docs(bloomcli): document cyl download-for-predict command` — §7.
+3. `feat(bloomctl): add cyl download-for-predict command (#411)` — §3-§6 (oracle test, pure
+   helpers, command-wiring tests, implementation, and registration together).
+4. `docs(bloomcli): document cyl download-for-predict command` — §7.
 §8 (verify) is a gate applied across all commits during review, not its own commit.
 
 ## 1. Proposal & specs (this change)
@@ -72,7 +73,7 @@ CI**; run it manually on a dev machine with `sleap-roots-predict` installed (e.g
 every shape fact predict's code is documented to require, without importing predict — that suite,
 not this test, is the CI-enforced contract for this change.
 
-- [ ] 3.1 **Oracle / acceptance test (manual, dev-machine only — see note above):**
+- [x] 3.1 **Oracle / acceptance test (manual, dev-machine only — see note above):**
       Given the SCAN fixture row (from `test_download_metadata.py`), a list of two fake
       `cyl_images` rows (`id=1001, frame_number=0, object_path="cyl-images/a.png"` and `id=1002,
       frame_number=1, object_path="cyl-images/b.png"`), and fake frame bytes per image:
@@ -91,17 +92,17 @@ not this test, is the CI-enforced contract for this change.
 
 Each test must FAIL before `download_for_predict.py` exists.
 
-- [ ] 4.1 `scan_key_for(scan_id)` returns `f"scan_{scan_id}"` for integer and string inputs.
-- [ ] 4.2 `frame_dest_for_predict(scan_dir, image)` returns
+- [x] 4.1 `scan_key_for(scan_id)` returns `f"scan_{scan_id}"` for integer and string inputs.
+- [x] 4.2 `frame_dest_for_predict(scan_dir, image)` returns
       `scan_dir / f"{image['frame_number']}{suffix}"` where suffix is the original extension of
       `image['object_path']` (or `.png` when missing).
-- [ ] 4.3 `compute_checksum(frame_bytes_list)` returns a string starting with `"sha256:"` whose
+- [x] 4.3 `compute_checksum(frame_bytes_list)` returns a string starting with `"sha256:"` whose
       hex suffix is the sha256 of all bytes concatenated in list order; an empty list produces a
       well-defined checksum (sha256 of `b""`).
-- [ ] 4.4 `build_sidecar(scan, images, frame_bytes_list)` assembles the sidecar dict — all four
+- [x] 4.4 `build_sidecar(scan, images, frame_bytes_list)` assembles the sidecar dict — all four
       fields present (`scan_key`, `params`, `image_ids`, `images_checksum`); `image_ids` order
       matches the input `images` list order; `scan_key` equals `scan_key_for(scan["scan_id"])`.
-- [ ] 4.5 `build_sidecar` calls `resolve_params(scan, overrides={"mode": "cylinder"})` — assert
+- [x] 4.5 `build_sidecar` calls `resolve_params(scan, overrides={"mode": "cylinder"})` — assert
       the actual call, not just the output (monkeypatch/spy on `resolve_params` to capture the
       `overrides` argument it receives), and assert it is exactly `{"mode": "cylinder"}`.
       (Asserting only `params["mode"] == "cylinder"` is insufficient: `sleap-roots-contracts
@@ -109,18 +110,18 @@ Each test must FAIL before `download_for_predict.py` exists.
       returns `"cylinder"` regardless of how — or whether — `resolve_params` is called, so that
       assertion alone can't distinguish "the override was passed" from "the oracle ignores every
       caller.")
-- [ ] 4.5b Add `test_resolve_params_ignores_mode_on_pinned_contracts_version`: call
+- [x] 4.5b Add `test_resolve_params_ignores_mode_on_pinned_contracts_version`: call
       `resolve_params(SCAN)` directly (no `overrides` at all) against the pinned
       `sleap-roots-contracts>=0.1.0a4`, and assert `result.values["mode"] == "cylinder"` anyway.
       Documents that `overrides={"mode": "cylinder"}` in `build_sidecar` is not currently
       load-bearing on this contracts version; if a future contracts bump makes `mode`
       metadata-driven, this test starts failing and flags the divergence instead of it going
       unnoticed.
-- [ ] 4.6 `write_sidecar(sidecar, path)` writes valid UTF-8 JSON to `path` (parent created if
+- [x] 4.6 `write_sidecar(sidecar, path)` writes valid UTF-8 JSON to `path` (parent created if
       absent); round-trips back to the original dict via `json.loads`.
-- [ ] 4.7 `frame_dest_for_predict` with `image["object_path"]` lacking an extension (e.g.
+- [x] 4.7 `frame_dest_for_predict` with `image["object_path"]` lacking an extension (e.g.
       `"cyl-images/a"`) returns a path ending in `.png` (the documented default).
-- [ ] 4.8 `compute_checksum` and `build_sidecar` with an empty `images` / `frame_bytes_list`
+- [x] 4.8 `compute_checksum` and `build_sidecar` with an empty `images` / `frame_bytes_list`
       produce `image_ids: []` and `images_checksum == "sha256:" + hashlib.sha256(b"").hexdigest()`
       — documents the pure helpers are well-defined on empty input. (Note: this path is not
       actually exercised by 5.9's CLI behavior — the command short-circuits on zero `cyl_images`
@@ -129,47 +130,47 @@ Each test must FAIL before `download_for_predict.py` exists.
 
 ## 5. RED — command wiring (`bloomcli/tests/test_cyl_download_for_predict.py`)
 
-- [ ] 5.1 Confirm `fetch_scan` is reused from `download.py`, not duplicated: import
+- [x] 5.1 Confirm `fetch_scan` is reused from `download.py`, not duplicated: import
       `bloomctl.cyl.download_for_predict` and assert `download_for_predict.fetch_scan is
       download.fetch_scan` (mirrors the intent of `test_fetch_scan_returns_single_row`, which
       exercises `fetch_scan` itself — this task instead pins the no-duplication contract).
-- [ ] 5.2 Happy-path CLI: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
+- [x] 5.2 Happy-path CLI: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
       str(out)])` with faked `fetch_scan` → SCAN, faked `fetch_images` → two image rows, faked
       Storage bucket, monkeypatched creds/auth → exit 0; assert:
       - `out/scan_1/0.png` and `out/scan_1/1.png` exist;
       - `out/scan_1/scan_1.scan_metadata.json` is valid JSON with `scan_key="scan_1"`,
         `image_ids=[1001, 1002]`, `params.mode="cylinder"`, `images_checksum` starts with
         `"sha256:"`.
-- [ ] 5.3 Scan not found: faked `fetch_scan` returns `None` → exit non-zero, "not found" in
+- [x] 5.3 Scan not found: faked `fetch_scan` returns `None` → exit non-zero, "not found" in
       output, no directory created.
-- [ ] 5.4 Partial frame failure: one frame download raises → exit non-zero, failure count in
+- [x] 5.4 Partial frame failure: one frame download raises → exit non-zero, failure count in
       output; assert the successfully-downloaded frame file(s) still exist on disk; assert
       `scan_1.scan_metadata.json` is **not** written (per the design decision: a sidecar is a
       claim that `image_ids`/`images_checksum` match what's on disk — see design.md).
-- [ ] 5.5 `fetch_scans` (experiment path) is never called in `download-for-predict` — assert via
+- [x] 5.5 `fetch_scans` (experiment path) is never called in `download-for-predict` — assert via
       monkeypatch that raises if called.
-- [ ] 5.6 `discover_scans` smoke (manual, dev-machine only — same non-CI-gate note as 3.1): after
+- [x] 5.6 `discover_scans` smoke (manual, dev-machine only — same non-CI-gate note as 3.1): after
       the happy-path run, `sleap_roots_predict.discover_scans` on `out` finds one scan (same
       `pytest.importorskip` guard as 3.1).
-- [ ] 5.7 Registration smoke: `CliRunner().invoke(cli, ["cyl", "--help"])` output contains
+- [x] 5.7 Registration smoke: `CliRunner().invoke(cli, ["cyl", "--help"])` output contains
       `"download-for-predict"`.
-- [ ] 5.8 Missing credentials → non-zero exit, "login" in output (mirror
+- [x] 5.8 Missing credentials → non-zero exit, "login" in output (mirror
       `test_cli_missing_credentials_hints_login`'s pattern of monkeypatching
       `creds.default_config_dir`, adapted to whichever of `load_credentials`/`_authed_client`
       `download_for_predict.py`'s command actually calls).
-- [ ] 5.9 Zero-frame scan: faked `fetch_images` → `[]` → exit non-zero, "no frames found" (or
+- [x] 5.9 Zero-frame scan: faked `fetch_images` → `[]` → exit non-zero, "no frames found" (or
       equivalent readable message) in output, no output directory created.
-- [ ] 5.10 `--profile` passthrough: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
+- [x] 5.10 `--profile` passthrough: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
       str(out), "-p", "staging"])` with monkeypatched `load_credentials` capturing its `profile`
       argument → assert it received `"staging"`.
-- [ ] 5.11 Checksum changes when frame content changes: run the happy-path CLI invocation twice
+- [x] 5.11 Checksum changes when frame content changes: run the happy-path CLI invocation twice
       into two different output dirs with different fake bytes for the same frame; assert the two
       resulting sidecars' `images_checksum` values differ.
-- [ ] 5.12 Storage bucket returns `None` (not raising) for one frame: assert this is treated as a
+- [x] 5.12 Storage bucket returns `None` (not raising) for one frame: assert this is treated as a
       per-frame failure (same handling as `download.py`'s `download_images`, which raises
       `ValueError("empty response from storage")` on a `None` response) — same non-zero exit /
       failure-count / no-sidecar assertions as 5.4.
-- [ ] 5.13 Stale-frame reconciliation on retry (added after second review round): pre-create
+- [x] 5.13 Stale-frame reconciliation on retry (added after second review round): pre-create
       `out/scan_1/` with an extra image file not among the current run's frames (e.g. `2.png`,
       simulating a leftover from an earlier attempt whose `cyl_images` row was since deleted/
       renumbered); run the happy-path CLI invocation into that same `out`; assert `2.png` no
@@ -179,7 +180,7 @@ Each test must FAIL before `download_for_predict.py` exists.
 
 ## 6. GREEN — implementation
 
-- [ ] 6.1 Create `bloomcli/src/bloomctl/cyl/download_for_predict.py`:
+- [x] 6.1 Create `bloomcli/src/bloomctl/cyl/download_for_predict.py`:
       Pure helpers (`scan_key_for`, `frame_dest_for_predict`, `compute_checksum`, `build_sidecar`,
       `write_sidecar`) above the `# --- supabase / storage I/O ---` marker. Import and reuse
       `fetch_scan`, `fetch_images`, `FrameResult`, `DownloadResult` from `download.py` (no
@@ -189,7 +190,7 @@ Each test must FAIL before `download_for_predict.py` exists.
       image-extension file in `scan_dir` that isn't one of the frame paths just written (task
       5.13; see design.md's stray-frame-reconciliation decision). Add the
       `@click.command(name="download-for-predict")` command.
-- [ ] 6.2 Register `download_for_predict_cmd` in `bloomcli/src/bloomctl/cyl/__init__.py`
+- [x] 6.2 Register `download_for_predict_cmd` in `bloomcli/src/bloomctl/cyl/__init__.py`
       (alias + `cyl.add_command`, matching the pattern for `download_cmd` and `ingest_result_cmd`).
       Iterate until tasks 3–5 are GREEN.
 
@@ -221,7 +222,12 @@ Each test must FAIL before `download_for_predict.py` exists.
       one-off at the start of §2.
 - [ ] 8.5 Run `npm run contracts:check` at the repo root to confirm the re-pin (task 2.2) passes
       the drift guard before committing.
-- [ ] 8.6 Manually run tests 3.1 and 5.6 with `sleap-roots-predict` installed locally (e.g. the
-      `sleap-roots-predict-dev` environment) and confirm they pass; paste the passing output into
-      the PR description — this is the only place these two tests are demonstrated to pass, since
-      they self-skip in CI (see §3 note).
+- [ ] 8.6 Manually run tests 3.1 (`test_oracle_sidecar_is_accepted_by_discover_scans`) and 5.6
+      (`test_discover_scans_smoke_after_happy_path`) with `sleap-roots-predict` installed locally
+      and confirm they pass; paste the passing output into the PR description. **Attempted during
+      implementation, blocked** — the local `sleap-roots-predict-dev` conda env has `sleap-nn
+      0.0.1` installed while `sleap-roots-predict`'s own `pyproject.toml` pins `sleap-nn==0.3.0`;
+      `import sleap_roots_predict` fails on `ImportError: cannot import name 'Predictor' from
+      'sleap_nn.inference'` before `discover_scans` is even reachable. This is a pre-existing,
+      broken environment issue in a separate repo, unrelated to this change — re-run once that
+      env is fixed (worth flagging to whoever owns `sleap-roots-predict-dev`'s setup).

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -1,0 +1,227 @@
+# Tasks — bloomctl cyl download-for-predict (A4 stage-in)
+
+TDD throughout: write the failing test first, confirm RED, then implement to GREEN. This is a
+staging-first, protected repo — every pushed commit must keep CI green, so new tests and the code
+they exercise land **in the same commit** (no standalone red-tests commit). Unit tests use
+`click.testing.CliRunner` + `monkeypatch` fakes, mirroring `bloomcli/tests/test_download_scan.py`
+and `test_cyl_ingest.py`. The module structure mirrors `download.py` and `ingest.py` (pure helpers
+above the `# --- supabase / storage I/O ---` marker).
+
+CI note (verified from `add-cyl-ingest-cli` tasks): `.github/workflows/pr-checks.yml` runs
+`cd bloomcli && uv run --extra test pytest tests/ -m "not integration"` — bloomcli has no
+`uv.lock`, is excluded from `check-uv-locks.py` and `pip-audit`, and is outside the black/ruff
+pre-commit globs (ruff runs only at release). The `-m "not integration"` flag is already in
+place.
+
+Proposal + implementation land in the **same PR** (bloom #411).
+
+**Commit plan (reconciled after `/review-openspec`)** — §3-5's RED tasks cannot be their own
+commits before §6's GREEN implementation without going red on every intermediate push (an
+unregistered command fails CLI-invocation tests outright, not silently). Land as:
+1. `docs(openspec): add proposal for cyl download-for-predict (#411)` — §1 (this proposal).
+2. `chore(contracts): bump sleap-roots-contracts to v0.1.0a4 (bloomcli floor + full re-pin)` —
+   §2, verified installable (2.1) and re-pin diff confirmed `$id`-only (2.2) before committing.
+3. `feat(bloomcli): add download_for_predict pure helpers + oracle test (#411)` — §3 (oracle test)
+   + §4 (pure helpers) + the pure-helper half of §6.1 (no CLI registration yet).
+4. `feat(bloomctl): register cyl download-for-predict command (#411)` — §5 (command-wiring tests)
+   + the I/O/CLI half of §6.1 + §6.2 (registration).
+5. `docs(bloomcli): document cyl download-for-predict command` — §7.
+§8 (verify) is a gate applied across all commits during review, not its own commit.
+
+## 1. Proposal & specs (this change)
+
+- [x] 1.1 Author `proposal.md`, `design.md`, and the `cyl-download-for-predict` spec delta.
+      Run `openspec validate add-cyl-download-for-predict --strict` and resolve all issues.
+
+## 2. Package + repo setup (pre-req; lands before tests that import it)
+
+- [ ] 2.1 Bump `sleap-roots-contracts>=0.1.0a3` → `>=0.1.0a4` in `bloomcli/pyproject.toml`.
+      Verify installability: `uv run --no-project --with 'sleap-roots-contracts>=0.1.0a4' python -c
+      "from sleap_roots_contracts import resolve_params; print('ok')"`. bloomcli has no `uv.lock` —
+      no lock refresh needed.
+- [ ] 2.2 Full contracts re-pin per contracts PR #16 instructions:
+      (a) update `contracts/pin.json`: version `v0.1.0a3` → `v0.1.0a4`, `$id` and `source` URLs;
+      (b) fetch updated `contracts/schema/result_envelope.schema.json` from
+          `github.com/talmolab/sleap-roots-contracts` at tag `v0.1.0a4` and **diff it against the
+          currently-vendored `a3` schema with the version string normalized out** — do not assume
+          the diff shape in advance (the prior two re-pins, `a1→a2` and `a2→a3`, were both real
+          revisions, not `$id`-only no-ops). Confirmed during review: for `a4` this diff IS
+          `$id`-only;
+      (c) regenerate `contracts/generated/result-envelope.ts` from the updated schema (`npm run
+          contracts:gen`, per `contracts/README.md`'s re-pin procedure) and run
+          `npm run contracts:check` locally to confirm it passes before committing;
+      (d) update `contracts/README.md`: bump the "Currently pinned: `v0.1.0a3`" line to
+          `v0.1.0a4`, and add a new dated "> Note on `v0.1.0a4`: ..." paragraph above the existing
+          `v0.1.0a3` note (matching that note's structure) explaining that this re-pin is an
+          `$id`-only structural no-op for the JSON Schema, and that the substantive addition
+          (`resolve_params`) is on the Python package side, not the schema.
+
+## 3. RED — oracle test (write FIRST; must fail before implementation)
+
+Write the following test in `bloomcli/tests/test_cyl_download_for_predict.py`. It must be RED
+before any implementation code exists.
+
+**Not a CI gate (reconciled after `/review-openspec`).** `sleap-roots-predict` is not published
+to PyPI and its `pyproject.toml` currently exact-pins `sleap-roots-contracts==0.1.0a3`, which
+conflicts with this proposal's `>=0.1.0a4` floor — adding it as a bloomcli test dependency today
+would break dependency resolution outright. Its own re-pin to the newer contracts version is
+in progress separately (per Elizabeth). Until that lands and `sleap-roots-predict` can be added
+as a git dependency, this test is `pytest.importorskip`-guarded and **will always self-skip in
+CI**; run it manually on a dev machine with `sleap-roots-predict` installed (e.g. via the local
+`sleap-roots-predict-dev` environment) before merge. Tasks 4.x/5.x below independently assert
+every shape fact predict's code is documented to require, without importing predict — that suite,
+not this test, is the CI-enforced contract for this change.
+
+- [ ] 3.1 **Oracle / acceptance test (manual, dev-machine only — see note above):**
+      Given the SCAN fixture row (from `test_download_metadata.py`), a list of two fake
+      `cyl_images` rows (`id=1001, frame_number=0, object_path="cyl-images/a.png"` and `id=1002,
+      frame_number=1, object_path="cyl-images/b.png"`), and fake frame bytes per image:
+      - `build_sidecar(scan, images, frame_bytes)` returns a dict whose `scan_key` equals
+        `"scan_1"` (scan_id=1 from SCAN fixture);
+      - the dict's `params` has keys `species`, `mode`, `age`; `mode` is `"cylinder"`;
+      - the dict's `image_ids` is `[1001, 1002]`;
+      - the dict's `images_checksum` starts with `"sha256:"`;
+      - **cross-repo oracle**: write the sidecar to `tmp_path/scan_1/scan_1.scan_metadata.json`
+        alongside two fake image files, then assert
+        `sleap_roots_predict.discover_scans(tmp_path)` returns exactly one `ScanInput` with
+        `scan_key="scan_1"`, `error=None`, and non-None `params`
+        (`pytest.importorskip("sleap_roots_predict")` at the top of the test).
+
+## 4. RED — pure helpers (`bloomcli/tests/test_cyl_download_for_predict.py`)
+
+Each test must FAIL before `download_for_predict.py` exists.
+
+- [ ] 4.1 `scan_key_for(scan_id)` returns `f"scan_{scan_id}"` for integer and string inputs.
+- [ ] 4.2 `frame_dest_for_predict(scan_dir, image)` returns
+      `scan_dir / f"{image['frame_number']}{suffix}"` where suffix is the original extension of
+      `image['object_path']` (or `.png` when missing).
+- [ ] 4.3 `compute_checksum(frame_bytes_list)` returns a string starting with `"sha256:"` whose
+      hex suffix is the sha256 of all bytes concatenated in list order; an empty list produces a
+      well-defined checksum (sha256 of `b""`).
+- [ ] 4.4 `build_sidecar(scan, images, frame_bytes_list)` assembles the sidecar dict — all four
+      fields present (`scan_key`, `params`, `image_ids`, `images_checksum`); `image_ids` order
+      matches the input `images` list order; `scan_key` equals `scan_key_for(scan["scan_id"])`.
+- [ ] 4.5 `build_sidecar` calls `resolve_params(scan, overrides={"mode": "cylinder"})` — assert
+      the actual call, not just the output (monkeypatch/spy on `resolve_params` to capture the
+      `overrides` argument it receives), and assert it is exactly `{"mode": "cylinder"}`.
+      (Asserting only `params["mode"] == "cylinder"` is insufficient: `sleap-roots-contracts
+      >=0.1.0a4`'s `_mode_for_scan` currently ignores its `metadata` argument and unconditionally
+      returns `"cylinder"` regardless of how — or whether — `resolve_params` is called, so that
+      assertion alone can't distinguish "the override was passed" from "the oracle ignores every
+      caller.")
+- [ ] 4.5b Add `test_resolve_params_ignores_mode_on_pinned_contracts_version`: call
+      `resolve_params(SCAN)` directly (no `overrides` at all) against the pinned
+      `sleap-roots-contracts>=0.1.0a4`, and assert `result.values["mode"] == "cylinder"` anyway.
+      Documents that `overrides={"mode": "cylinder"}` in `build_sidecar` is not currently
+      load-bearing on this contracts version; if a future contracts bump makes `mode`
+      metadata-driven, this test starts failing and flags the divergence instead of it going
+      unnoticed.
+- [ ] 4.6 `write_sidecar(sidecar, path)` writes valid UTF-8 JSON to `path` (parent created if
+      absent); round-trips back to the original dict via `json.loads`.
+- [ ] 4.7 `frame_dest_for_predict` with `image["object_path"]` lacking an extension (e.g.
+      `"cyl-images/a"`) returns a path ending in `.png` (the documented default).
+- [ ] 4.8 `compute_checksum` and `build_sidecar` with an empty `images` / `frame_bytes_list`
+      produce `image_ids: []` and `images_checksum == "sha256:" + hashlib.sha256(b"").hexdigest()`
+      — documents the pure helpers are well-defined on empty input. (Note: this path is not
+      actually exercised by 5.9's CLI behavior — the command short-circuits on zero `cyl_images`
+      rows before ever calling `build_sidecar`, per spec.md's "zero cyl_images rows" scenario —
+      this task exists for the helpers' own contract, independent of that CLI-level guard.)
+
+## 5. RED — command wiring (`bloomcli/tests/test_cyl_download_for_predict.py`)
+
+- [ ] 5.1 Confirm `fetch_scan` is reused from `download.py`, not duplicated: import
+      `bloomctl.cyl.download_for_predict` and assert `download_for_predict.fetch_scan is
+      download.fetch_scan` (mirrors the intent of `test_fetch_scan_returns_single_row`, which
+      exercises `fetch_scan` itself — this task instead pins the no-duplication contract).
+- [ ] 5.2 Happy-path CLI: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
+      str(out)])` with faked `fetch_scan` → SCAN, faked `fetch_images` → two image rows, faked
+      Storage bucket, monkeypatched creds/auth → exit 0; assert:
+      - `out/scan_1/0.png` and `out/scan_1/1.png` exist;
+      - `out/scan_1/scan_1.scan_metadata.json` is valid JSON with `scan_key="scan_1"`,
+        `image_ids=[1001, 1002]`, `params.mode="cylinder"`, `images_checksum` starts with
+        `"sha256:"`.
+- [ ] 5.3 Scan not found: faked `fetch_scan` returns `None` → exit non-zero, "not found" in
+      output, no directory created.
+- [ ] 5.4 Partial frame failure: one frame download raises → exit non-zero, failure count in
+      output; assert the successfully-downloaded frame file(s) still exist on disk; assert
+      `scan_1.scan_metadata.json` is **not** written (per the design decision: a sidecar is a
+      claim that `image_ids`/`images_checksum` match what's on disk — see design.md).
+- [ ] 5.5 `fetch_scans` (experiment path) is never called in `download-for-predict` — assert via
+      monkeypatch that raises if called.
+- [ ] 5.6 `discover_scans` smoke (manual, dev-machine only — same non-CI-gate note as 3.1): after
+      the happy-path run, `sleap_roots_predict.discover_scans` on `out` finds one scan (same
+      `pytest.importorskip` guard as 3.1).
+- [ ] 5.7 Registration smoke: `CliRunner().invoke(cli, ["cyl", "--help"])` output contains
+      `"download-for-predict"`.
+- [ ] 5.8 Missing credentials → non-zero exit, "login" in output (mirror
+      `test_cli_missing_credentials_hints_login`'s pattern of monkeypatching
+      `creds.default_config_dir`, adapted to whichever of `load_credentials`/`_authed_client`
+      `download_for_predict.py`'s command actually calls).
+- [ ] 5.9 Zero-frame scan: faked `fetch_images` → `[]` → exit non-zero, "no frames found" (or
+      equivalent readable message) in output, no output directory created.
+- [ ] 5.10 `--profile` passthrough: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
+      str(out), "-p", "staging"])` with monkeypatched `load_credentials` capturing its `profile`
+      argument → assert it received `"staging"`.
+- [ ] 5.11 Checksum changes when frame content changes: run the happy-path CLI invocation twice
+      into two different output dirs with different fake bytes for the same frame; assert the two
+      resulting sidecars' `images_checksum` values differ.
+- [ ] 5.12 Storage bucket returns `None` (not raising) for one frame: assert this is treated as a
+      per-frame failure (same handling as `download.py`'s `download_images`, which raises
+      `ValueError("empty response from storage")` on a `None` response) — same non-zero exit /
+      failure-count / no-sidecar assertions as 5.4.
+- [ ] 5.13 Stale-frame reconciliation on retry (added after second review round): pre-create
+      `out/scan_1/` with an extra image file not among the current run's frames (e.g. `2.png`,
+      simulating a leftover from an earlier attempt whose `cyl_images` row was since deleted/
+      renumbered); run the happy-path CLI invocation into that same `out`; assert `2.png` no
+      longer exists after a successful run, while `0.png`/`1.png` (this run's actual frames) do.
+      Verified against `sleap_roots_predict.batch._load_scan`'s real behavior (globs every
+      image-extension file in the sidecar's directory, not just `image_ids`) — see design.md.
+
+## 6. GREEN — implementation
+
+- [ ] 6.1 Create `bloomcli/src/bloomctl/cyl/download_for_predict.py`:
+      Pure helpers (`scan_key_for`, `frame_dest_for_predict`, `compute_checksum`, `build_sidecar`,
+      `write_sidecar`) above the `# --- supabase / storage I/O ---` marker. Import and reuse
+      `fetch_scan`, `fetch_images`, `FrameResult`, `DownloadResult` from `download.py` (no
+      duplication). Add `download_frames_for_predict(client, scan, images, out_dir)` → returns
+      `(DownloadResult, list[bytes])` (result + per-frame bytes in frame_number order, for
+      checksum). On full success (before writing the sidecar), reconcile stray files: delete any
+      image-extension file in `scan_dir` that isn't one of the frame paths just written (task
+      5.13; see design.md's stray-frame-reconciliation decision). Add the
+      `@click.command(name="download-for-predict")` command.
+- [ ] 6.2 Register `download_for_predict_cmd` in `bloomcli/src/bloomctl/cyl/__init__.py`
+      (alias + `cyl.add_command`, matching the pattern for `download_cmd` and `ingest_result_cmd`).
+      Iterate until tasks 3–5 are GREEN.
+
+## 7. Docs & changelog
+
+- [ ] 7.1 Add a bullet under the *existing* `### Added` heading in `[Unreleased]` in
+      `bloomcli/CHANGELOG.md` (do not add a second `### Added` header — the section already has
+      one, from the `ingest-result` entry) for `bloomctl cyl download-for-predict`. Update
+      `bloomcli/README.md`:
+      (a) add a bullet to the top "## Commands" list, distinguishing it from `cyl download`;
+      (b) add a `## bloomctl cyl download-for-predict` section matching the `ingest-result`
+          section's shape (usage line, bullets of behavior, auth note, example) — positional
+          args, `--profile`, output layout, sidecar field names/types/one-line purpose (full
+          rationale stays in design.md, not duplicated here), and an explicit note that this
+          produces a different directory tree than `cyl download` for the same scan.
+
+## 8. Verify
+
+- [ ] 8.1 `openspec validate add-cyl-download-for-predict --strict` passes.
+- [ ] 8.2 bloomcli unit suite green using the CI invocation:
+      `cd bloomcli && uv run --extra test pytest tests/ -m "not integration" -v --tb=short`.
+      Run the release-time ruff gate manually:
+      `uvx ruff@0.9.9 check bloomcli && uvx ruff@0.9.9 format --check bloomcli`.
+      Run `pre-commit run --files` over new `.py`/`.md` files; confirm gitleaks is clean.
+- [ ] 8.3 Confirm no `TBD` or placeholder remains in `proposal.md` / `design.md`.
+- [ ] 8.4 Re-run task 2.1's installability check
+      (`uv run --no-project --with 'sleap-roots-contracts>=0.1.0a4' python -c "from
+      sleap_roots_contracts import resolve_params; print('ok')"`) as a final gate, not just a
+      one-off at the start of §2.
+- [ ] 8.5 Run `npm run contracts:check` at the repo root to confirm the re-pin (task 2.2) passes
+      the drift guard before committing.
+- [ ] 8.6 Manually run tests 3.1 and 5.6 with `sleap-roots-predict` installed locally (e.g. the
+      `sleap-roots-predict-dev` environment) and confirm they pass; paste the passing output into
+      the PR description — this is the only place these two tests are demonstrated to pass, since
+      they self-skip in CI (see §3 note).

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -245,21 +245,21 @@ important gaps. See `design.md`'s Decisions/Risks for the full rationale of each
 tests below must FAIL against the current `download_for_predict.py` before the §10 implementation
 lands.
 
-- [ ] 9.1 **BLOCKING fix — uncaught `ValueError` + reconcile-before-validation ordering:** a scan
+- [x] 9.1 **BLOCKING fix — uncaught `ValueError` + reconcile-before-validation ordering:** a scan
       with `species_name=None` (or `plant_age_days=None`) exits non-zero with a readable
       `click.ClickException` message (not a raw traceback); if `scan_dir` already existed with
       content, that content is untouched (the failure happens before any destructive action).
-- [ ] 9.2 **New pure helper `resolve_sidecar_params(scan) -> dict`:** extracted from
+- [x] 9.2 **New pure helper `resolve_sidecar_params(scan) -> dict`:** extracted from
       `build_sidecar`'s inline `resolve_params(scan, overrides={"mode": "cylinder"}).values` call
       — same behavior, now independently callable/testable. Raises `ValueError` on missing
       required params (unchanged underlying behavior).
-- [ ] 9.3 **New pure helper `validate_frame_numbers(images) -> None`:** raises `ValueError` if any
+- [x] 9.3 **New pure helper `validate_frame_numbers(images) -> None`:** raises `ValueError` if any
       `image["frame_number"]` is `None`, or if two images share the same non-`None`
       `frame_number`. No-op (returns `None`) otherwise.
-- [ ] 9.4 **CLI-level:** a scan whose `cyl_images` rows have a null or duplicate `frame_number`
+- [x] 9.4 **CLI-level:** a scan whose `cyl_images` rows have a null or duplicate `frame_number`
       exits non-zero with a readable message before any frame is downloaded or any existing
       `scan_dir` content is touched.
-- [ ] 9.5 **`build_sidecar` signature change:** now `build_sidecar(scan, images,
+- [x] 9.5 **`build_sidecar` signature change:** now `build_sidecar(scan, images,
 frame_bytes_list, params)` — accepts the already-resolved `params` dict instead of calling
       `resolve_sidecar_params` internally. Update the existing tests
       (`test_build_sidecar_assembles_all_fields_in_input_order`,
@@ -267,39 +267,39 @@ frame_bytes_list, params)` — accepts the already-resolved `params` dict instea
       `params` explicitly; `test_build_sidecar_passes_mode_override_to_resolve_params` now tests
       `resolve_sidecar_params` directly (it's the one that calls `resolve_params`) rather than
       `build_sidecar`.
-- [ ] 9.6 **Params values, not just keys:** the sidecar's `params["species"]` is exactly
+- [x] 9.6 **Params values, not just keys:** the sidecar's `params["species"]` is exactly
       `"pennycress"` and `params["age"]` is exactly `14` for the `SCAN` fixture (not just "keys
       present") — closes the spec.md "canonical values" scenario that had no real assertion behind
       it.
-- [ ] 9.7 **`clear_scan_dir(scan_dir) -> list[str]`** (replaces `reconcile_stray_frames`): if
+- [x] 9.7 **`clear_scan_dir(scan_dir) -> list[str]`** (replaces `reconcile_stray_frames`): if
       `scan_dir` exists, removes it entirely (frames + any old sidecar) and returns the list of
       removed entry names (for the CLI to echo); no-op, returns `[]`, if `scan_dir` doesn't exist.
-- [ ] 9.8 **CLI-level — stale sidecar cannot survive a retry:** run the happy-path CLI to success
+- [x] 9.8 **CLI-level — stale sidecar cannot survive a retry:** run the happy-path CLI to success
       (sidecar + frames written), then re-run for the same scan with one frame now failing —
       assert the now-non-zero-exit run's directory has **no** `scan_metadata.json` at all (not a
       stale one from the first run) and reports what it cleared before starting.
-- [ ] 9.9 **CLI-level — clear is echoed, not silent:** the happy-path re-run test above (or a
+- [x] 9.9 **CLI-level — clear is echoed, not silent:** the happy-path re-run test above (or a
       dedicated one) asserts the command's output mentions the directory was cleared/what was
       removed, closing the "silent deletion" gap.
-- [ ] 9.10 **`frame_dest_for_predict` fails loudly on a missing `object_path`:** `KeyError` (not a
+- [x] 9.10 **`frame_dest_for_predict` fails loudly on a missing `object_path`:** `KeyError` (not a
       silently-defaulted `.png`) for `{"frame_number": 3}` (no `object_path` key) — still caught
       per-frame by `download_frames_for_predict`'s existing `try/except Exception`, so this
       surfaces as a clean per-frame failure, not a crash; update
       `test_frame_dest_for_predict_defaults_to_png_when_extension_missing` (which used a row that
       _had_ `object_path` with no extension — still valid, keep it) and add a new test for the
       missing-key case.
-- [ ] 9.11 **Atomic writes:** `write_sidecar` and each frame write survive a simulated kill
+- [x] 9.11 **Atomic writes:** `write_sidecar` and each frame write survive a simulated kill
       mid-write without leaving a truncated file at the final path — assert via monkeypatching the
       write call to raise partway through, then check the final path either doesn't exist or has
       the complete prior content (never partial new content).
-- [ ] 9.12 **Auth refactor has no behavior change:** `test_cli_missing_credentials_hints_login`
+- [x] 9.12 **Auth refactor has no behavior change:** `test_cli_missing_credentials_hints_login`
       continues to pass unmodified after switching to `cli._authed_client` (same error message,
       same "run `bloomctl login`" hint) — this is the test that pins the refactor is behavior-
       preserving.
-- [ ] 9.13 **Reuse identity tests for the remaining three re-used objects** (mirrors 5.1's
+- [x] 9.13 **Reuse identity tests for the remaining three re-used objects** (mirrors 5.1's
       `fetch_scan` pattern): `dfp.fetch_images is dl.fetch_images`, `dfp.FrameResult is
 dl.FrameResult`, `dfp.DownloadResult is dl.DownloadResult`.
-- [ ] 9.14 **Oracle test — `_IMAGE_EXTENSIONS` drift guard (manual, dev-machine only, same
+- [x] 9.14 **Oracle test — `_IMAGE_EXTENSIONS` drift guard (manual, dev-machine only, same
       non-CI-gate note as §3):** add `assert dfp._IMAGE_EXTENSIONS ==
 frozenset(sleap_roots_predict.batch._IMAGE_EXTENSIONS)` to
       `test_oracle_sidecar_is_accepted_by_discover_scans`, guarded by the same
@@ -307,7 +307,7 @@ frozenset(sleap_roots_predict.batch._IMAGE_EXTENSIONS)` to
 
 ## 10. GREEN — implement the fixes
 
-- [ ] 10.1 Update `bloomcli/src/bloomctl/cyl/download_for_predict.py`:
+- [x] 10.1 Update `bloomcli/src/bloomctl/cyl/download_for_predict.py`:
       add `resolve_sidecar_params`, `validate_frame_numbers`; change `build_sidecar`'s signature;
       rename/rewrite `reconcile_stray_frames` → `clear_scan_dir`; switch
       `frame_dest_for_predict` to `image["object_path"]`; add atomic writes (temp file +
@@ -317,13 +317,13 @@ frozenset(sleap_roots_predict.batch._IMAGE_EXTENSIONS)` to
       (both wrapped in `try/except ValueError` → `ClickException`) → `clear_scan_dir` (echo what
       was removed) → download frames → failure check → `build_sidecar` (using the already-resolved
       `params`) → `write_sidecar` → success echo.
-- [ ] 10.2 Iterate until every §9 test is GREEN, and the full suite (§8.2's invocation) stays
+- [x] 10.2 Iterate until every §9 test is GREEN, and the full suite (§8.2's invocation) stays
       green with no regressions.
 
 ## 11. Re-verify
 
-- [ ] 11.1 Re-run §8.1-8.5 (validate, full suite, ruff, pre-commit, contracts guards).
-- [ ] 11.2 Re-run §8.6's manual oracle-test verification (now including the new
+- [x] 11.1 Re-run §8.1-8.5 (validate, full suite, ruff, pre-commit, contracts guards).
+- [x] 11.2 Re-run §8.6's manual oracle-test verification (now including the new
       `_IMAGE_EXTENSIONS` assertion from 9.14) — paste the passing output.
 - [ ] 11.3 Push a fixup and reply to the `/review-pr` findings on PR #458, noting what was fixed
       vs. explicitly accepted as a documented limitation (concurrent same-scan invocations).

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -21,13 +21,14 @@ unregistered command fails CLI-invocation tests outright, not silently). Landed 
 merged during implementation — the reviewer noted this split was optional, not CI-mandatory,
 since one module file + its full test suite + registration is a single coherent, already-GREEN
 unit; see round-1 git-workflow review):
+
 1. `docs(openspec): add proposal for cyl download-for-predict (#411)` — §1 (this proposal).
 2. `chore(contracts): bump sleap-roots-contracts to v0.1.0a4 (bloomcli floor + full re-pin)` —
    §2, verified installable (2.1) and re-pin diff confirmed `$id`-only (2.2) before committing.
 3. `feat(bloomctl): add cyl download-for-predict command (#411)` — §3-§6 (oracle test, pure
    helpers, command-wiring tests, implementation, and registration together).
 4. `docs(bloomcli): document cyl download-for-predict command` — §7.
-§8 (verify) is a gate applied across all commits during review, not its own commit.
+   §8 (verify) is a gate applied across all commits during review, not its own commit.
 
 ## 1. Proposal & specs (this change)
 
@@ -38,24 +39,24 @@ unit; see round-1 git-workflow review):
 
 - [x] 2.1 Bump `sleap-roots-contracts>=0.1.0a3` → `>=0.1.0a4` in `bloomcli/pyproject.toml`.
       Verify installability: `uv run --no-project --with 'sleap-roots-contracts>=0.1.0a4' python -c
-      "from sleap_roots_contracts import resolve_params; print('ok')"`. bloomcli has no `uv.lock` —
+"from sleap_roots_contracts import resolve_params; print('ok')"`. bloomcli has no `uv.lock` —
       no lock refresh needed.
 - [x] 2.2 Full contracts re-pin per contracts PR #16 instructions:
       (a) update `contracts/pin.json`: version `v0.1.0a3` → `v0.1.0a4`, `$id` and `source` URLs;
       (b) fetch updated `contracts/schema/result_envelope.schema.json` from
-          `github.com/talmolab/sleap-roots-contracts` at tag `v0.1.0a4` and **diff it against the
-          currently-vendored `a3` schema with the version string normalized out** — do not assume
-          the diff shape in advance (the prior two re-pins, `a1→a2` and `a2→a3`, were both real
-          revisions, not `$id`-only no-ops). Confirmed during review: for `a4` this diff IS
-          `$id`-only;
-      (c) regenerate `contracts/generated/result-envelope.ts` from the updated schema (`npm run
-          contracts:gen`, per `contracts/README.md`'s re-pin procedure) and run
-          `npm run contracts:check` locally to confirm it passes before committing;
+      `github.com/talmolab/sleap-roots-contracts` at tag `v0.1.0a4` and **diff it against the
+      currently-vendored `a3` schema with the version string normalized out** — do not assume
+      the diff shape in advance (the prior two re-pins, `a1→a2` and `a2→a3`, were both real
+      revisions, not `$id`-only no-ops). Confirmed during review: for `a4` this diff IS
+      `$id`-only;
+      (c) regenerate `contracts/generated/result-envelope.ts` from the updated schema
+      (`npm run contracts:gen`, per `contracts/README.md`'s re-pin procedure) and run
+      `npm run contracts:check` locally to confirm it passes before committing;
       (d) update `contracts/README.md`: bump the "Currently pinned: `v0.1.0a3`" line to
-          `v0.1.0a4`, and add a new dated "> Note on `v0.1.0a4`: ..." paragraph above the existing
-          `v0.1.0a3` note (matching that note's structure) explaining that this re-pin is an
-          `$id`-only structural no-op for the JSON Schema, and that the substantive addition
-          (`resolve_params`) is on the Python package side, not the schema.
+      `v0.1.0a4`, and add a new dated "> Note on `v0.1.0a4`: ..." paragraph above the existing
+      `v0.1.0a3` note (matching that note's structure) explaining that this re-pin is an
+      `$id`-only structural no-op for the JSON Schema, and that the substantive addition
+      (`resolve_params`) is on the Python package side, not the schema.
 
 ## 3. RED — oracle test (write FIRST; must fail before implementation)
 
@@ -73,20 +74,19 @@ CI**; run it manually on a dev machine with `sleap-roots-predict` installed (e.g
 every shape fact predict's code is documented to require, without importing predict — that suite,
 not this test, is the CI-enforced contract for this change.
 
-- [x] 3.1 **Oracle / acceptance test (manual, dev-machine only — see note above):**
-      Given the SCAN fixture row (from `test_download_metadata.py`), a list of two fake
-      `cyl_images` rows (`id=1001, frame_number=0, object_path="cyl-images/a.png"` and `id=1002,
-      frame_number=1, object_path="cyl-images/b.png"`), and fake frame bytes per image:
-      - `build_sidecar(scan, images, frame_bytes)` returns a dict whose `scan_key` equals
-        `"scan_1"` (scan_id=1 from SCAN fixture);
-      - the dict's `params` has keys `species`, `mode`, `age`; `mode` is `"cylinder"`;
-      - the dict's `image_ids` is `[1001, 1002]`;
-      - the dict's `images_checksum` starts with `"sha256:"`;
-      - **cross-repo oracle**: write the sidecar to `tmp_path/scan_1/scan_1.scan_metadata.json`
-        alongside two fake image files, then assert
-        `sleap_roots_predict.discover_scans(tmp_path)` returns exactly one `ScanInput` with
-        `scan_key="scan_1"`, `error=None`, and non-None `params`
-        (`pytest.importorskip("sleap_roots_predict")` at the top of the test).
+- [x] 3.1 **Oracle / acceptance test (manual, dev-machine only — see note above):** Given the
+      SCAN fixture row (from `test_download_metadata.py`), a list of two fake `cyl_images` rows
+      (`id=1001, frame_number=0, object_path="cyl-images/a.png"` and
+      `id=1002, frame_number=1, object_path="cyl-images/b.png"`), and fake frame bytes per image:
+  - `build_sidecar(scan, images, frame_bytes)` returns a dict whose `scan_key` equals `"scan_1"`
+    (scan_id=1 from SCAN fixture);
+  - the dict's `params` has keys `species`, `mode`, `age`; `mode` is `"cylinder"`;
+  - the dict's `image_ids` is `[1001, 1002]`;
+  - the dict's `images_checksum` starts with `"sha256:"`;
+  - **cross-repo oracle**: write the sidecar to `tmp_path/scan_1/scan_1.scan_metadata.json`
+    alongside two fake image files, then assert `sleap_roots_predict.discover_scans(tmp_path)`
+    returns exactly one `ScanInput` with `scan_key="scan_1"`, `error=None`, and non-None `params`
+    (`pytest.importorskip("sleap_roots_predict")` at the top of the test).
 
 ## 4. RED — pure helpers (`bloomcli/tests/test_cyl_download_for_predict.py`)
 
@@ -105,11 +105,10 @@ Each test must FAIL before `download_for_predict.py` exists.
 - [x] 4.5 `build_sidecar` calls `resolve_params(scan, overrides={"mode": "cylinder"})` — assert
       the actual call, not just the output (monkeypatch/spy on `resolve_params` to capture the
       `overrides` argument it receives), and assert it is exactly `{"mode": "cylinder"}`.
-      (Asserting only `params["mode"] == "cylinder"` is insufficient: `sleap-roots-contracts
-      >=0.1.0a4`'s `_mode_for_scan` currently ignores its `metadata` argument and unconditionally
-      returns `"cylinder"` regardless of how — or whether — `resolve_params` is called, so that
-      assertion alone can't distinguish "the override was passed" from "the oracle ignores every
-      caller.")
+      (Asserting only `params["mode"] == "cylinder"` is insufficient: `sleap-roots-contracts>=0.1.0a4`'s
+      `_mode_for_scan` currently ignores its `metadata` argument and unconditionally returns
+      `"cylinder"` regardless of how — or whether — `resolve_params` is called, so that assertion
+      alone can't distinguish "the override was passed" from "the oracle ignores every caller.")
 - [x] 4.5b Add `test_resolve_params_ignores_mode_on_pinned_contracts_version`: call
       `resolve_params(SCAN)` directly (no `overrides` at all) against the pinned
       `sleap-roots-contracts>=0.1.0a4`, and assert `result.values["mode"] == "cylinder"` anyway.
@@ -132,15 +131,13 @@ Each test must FAIL before `download_for_predict.py` exists.
 
 - [x] 5.1 Confirm `fetch_scan` is reused from `download.py`, not duplicated: import
       `bloomctl.cyl.download_for_predict` and assert `download_for_predict.fetch_scan is
-      download.fetch_scan` (mirrors the intent of `test_fetch_scan_returns_single_row`, which
+download.fetch_scan` (mirrors the intent of `test_fetch_scan_returns_single_row`, which
       exercises `fetch_scan` itself — this task instead pins the no-duplication contract).
 - [x] 5.2 Happy-path CLI: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
-      str(out)])` with faked `fetch_scan` → SCAN, faked `fetch_images` → two image rows, faked
-      Storage bucket, monkeypatched creds/auth → exit 0; assert:
-      - `out/scan_1/0.png` and `out/scan_1/1.png` exist;
-      - `out/scan_1/scan_1.scan_metadata.json` is valid JSON with `scan_key="scan_1"`,
-        `image_ids=[1001, 1002]`, `params.mode="cylinder"`, `images_checksum` starts with
-        `"sha256:"`.
+str(out)])` with faked `fetch_scan` → SCAN, faked `fetch_images` → two image rows, faked
+      Storage bucket, monkeypatched creds/auth → exit 0; assert: - `out/scan_1/0.png` and `out/scan_1/1.png` exist; - `out/scan_1/scan_1.scan_metadata.json` is valid JSON with `scan_key="scan_1"`,
+      `image_ids=[1001, 1002]`, `params.mode="cylinder"`, `images_checksum` starts with
+      `"sha256:"`.
 - [x] 5.3 Scan not found: faked `fetch_scan` returns `None` → exit non-zero, "not found" in
       output, no directory created.
 - [x] 5.4 Partial frame failure: one frame download raises → exit non-zero, failure count in
@@ -161,7 +158,7 @@ Each test must FAIL before `download_for_predict.py` exists.
 - [x] 5.9 Zero-frame scan: faked `fetch_images` → `[]` → exit non-zero, "no frames found" (or
       equivalent readable message) in output, no output directory created.
 - [x] 5.10 `--profile` passthrough: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
-      str(out), "-p", "staging"])` with monkeypatched `load_credentials` capturing its `profile`
+str(out), "-p", "staging"])` with monkeypatched `load_credentials` capturing its `profile`
       argument → assert it received `"staging"`.
 - [x] 5.11 Checksum changes when frame content changes: run the happy-path CLI invocation twice
       into two different output dirs with different fake bytes for the same frame; assert the two
@@ -196,16 +193,16 @@ Each test must FAIL before `download_for_predict.py` exists.
 
 ## 7. Docs & changelog
 
-- [ ] 7.1 Add a bullet under the *existing* `### Added` heading in `[Unreleased]` in
+- [x] 7.1 Add a bullet under the _existing_ `### Added` heading in `[Unreleased]` in
       `bloomcli/CHANGELOG.md` (do not add a second `### Added` header — the section already has
       one, from the `ingest-result` entry) for `bloomctl cyl download-for-predict`. Update
       `bloomcli/README.md`:
       (a) add a bullet to the top "## Commands" list, distinguishing it from `cyl download`;
       (b) add a `## bloomctl cyl download-for-predict` section matching the `ingest-result`
-          section's shape (usage line, bullets of behavior, auth note, example) — positional
-          args, `--profile`, output layout, sidecar field names/types/one-line purpose (full
-          rationale stays in design.md, not duplicated here), and an explicit note that this
-          produces a different directory tree than `cyl download` for the same scan.
+      section's shape (usage line, bullets of behavior, auth note, example) — positional
+      args, `--profile`, output layout, sidecar field names/types/one-line purpose (full
+      rationale stays in design.md, not duplicated here), and an explicit note that this
+      produces a different directory tree than `cyl download` for the same scan.
 
 ## 8. Verify
 
@@ -218,7 +215,7 @@ Each test must FAIL before `download_for_predict.py` exists.
 - [ ] 8.3 Confirm no `TBD` or placeholder remains in `proposal.md` / `design.md`.
 - [ ] 8.4 Re-run task 2.1's installability check
       (`uv run --no-project --with 'sleap-roots-contracts>=0.1.0a4' python -c "from
-      sleap_roots_contracts import resolve_params; print('ok')"`) as a final gate, not just a
+sleap_roots_contracts import resolve_params; print('ok')"`) as a final gate, not just a
       one-off at the start of §2.
 - [ ] 8.5 Run `npm run contracts:check` at the repo root to confirm the re-pin (task 2.2) passes
       the drift guard before committing.
@@ -226,8 +223,8 @@ Each test must FAIL before `download_for_predict.py` exists.
       (`test_discover_scans_smoke_after_happy_path`) with `sleap-roots-predict` installed locally
       and confirm they pass; paste the passing output into the PR description. **Attempted during
       implementation, blocked** — the local `sleap-roots-predict-dev` conda env has `sleap-nn
-      0.0.1` installed while `sleap-roots-predict`'s own `pyproject.toml` pins `sleap-nn==0.3.0`;
+0.0.1` installed while `sleap-roots-predict`'s own `pyproject.toml` pins `sleap-nn==0.3.0`;
       `import sleap_roots_predict` fails on `ImportError: cannot import name 'Predictor' from
-      'sleap_nn.inference'` before `discover_scans` is even reachable. This is a pre-existing,
+'sleap_nn.inference'` before `discover_scans` is even reachable. This is a pre-existing,
       broken environment issue in a separate repo, unrelated to this change — re-run once that
       env is fixed (worth flagging to whoever owns `sleap-roots-predict-dev`'s setup).

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -138,9 +138,12 @@ download.fetch_scan` (mirrors the intent of `test_fetch_scan_returns_single_row`
       exercises `fetch_scan` itself — this task instead pins the no-duplication contract).
 - [x] 5.2 Happy-path CLI: `CliRunner().invoke(cli, ["cyl", "download-for-predict", "1",
 str(out)])` with faked `fetch_scan` → SCAN, faked `fetch_images` → two image rows, faked
-      Storage bucket, monkeypatched creds/auth → exit 0; assert: - `out/scan_1/0.png` and `out/scan_1/1.png` exist; - `out/scan_1/scan_1.scan_metadata.json` is valid JSON with `scan_key="scan_1"`,
-      `image_ids=[1001, 1002]`, `params.mode="cylinder"`, `images_checksum` starts with
-      `"sha256:"`.
+      Storage bucket, monkeypatched creds/auth → exit 0; assert:
+
+  - `out/scan_1/0.png` and `out/scan_1/1.png` exist;
+  - `out/scan_1/scan_1.scan_metadata.json` is valid JSON with `scan_key="scan_1"`,
+    `image_ids=[1001, 1002]`, `params.mode="cylinder"`, `images_checksum` starts with `"sha256:"`.
+
 - [x] 5.3 Scan not found: faked `fetch_scan` returns `None` → exit non-zero, "not found" in
       output, no directory created.
 - [x] 5.4 Partial frame failure: one frame download raises → exit non-zero, failure count in
@@ -234,3 +237,93 @@ test pytest tests/test_cyl_download_for_predict.py -k "oracle or discover_scans_
       extra (correctly pins `sleap-nn==0.3.0` + CPU `torch`). Result:
       `2 passed, 22 deselected in 24.46s` — both oracle tests pass against the real
       `sleap_roots_predict.discover_scans`.
+
+## 9. RED — PR #458 `/review-pr` fixes (write tests FIRST; must fail before implementation)
+
+`/review-pr` on the merged PR reproduced three real bugs (not hypothetical) plus several
+important gaps. See `design.md`'s Decisions/Risks for the full rationale of each fix. All new
+tests below must FAIL against the current `download_for_predict.py` before the §10 implementation
+lands.
+
+- [ ] 9.1 **BLOCKING fix — uncaught `ValueError` + reconcile-before-validation ordering:** a scan
+      with `species_name=None` (or `plant_age_days=None`) exits non-zero with a readable
+      `click.ClickException` message (not a raw traceback); if `scan_dir` already existed with
+      content, that content is untouched (the failure happens before any destructive action).
+- [ ] 9.2 **New pure helper `resolve_sidecar_params(scan) -> dict`:** extracted from
+      `build_sidecar`'s inline `resolve_params(scan, overrides={"mode": "cylinder"}).values` call
+      — same behavior, now independently callable/testable. Raises `ValueError` on missing
+      required params (unchanged underlying behavior).
+- [ ] 9.3 **New pure helper `validate_frame_numbers(images) -> None`:** raises `ValueError` if any
+      `image["frame_number"]` is `None`, or if two images share the same non-`None`
+      `frame_number`. No-op (returns `None`) otherwise.
+- [ ] 9.4 **CLI-level:** a scan whose `cyl_images` rows have a null or duplicate `frame_number`
+      exits non-zero with a readable message before any frame is downloaded or any existing
+      `scan_dir` content is touched.
+- [ ] 9.5 **`build_sidecar` signature change:** now `build_sidecar(scan, images,
+frame_bytes_list, params)` — accepts the already-resolved `params` dict instead of calling
+      `resolve_sidecar_params` internally. Update the existing tests
+      (`test_build_sidecar_assembles_all_fields_in_input_order`,
+      `test_build_sidecar_passes_mode_override_to_resolve_params`, the oracle test) to pass
+      `params` explicitly; `test_build_sidecar_passes_mode_override_to_resolve_params` now tests
+      `resolve_sidecar_params` directly (it's the one that calls `resolve_params`) rather than
+      `build_sidecar`.
+- [ ] 9.6 **Params values, not just keys:** the sidecar's `params["species"]` is exactly
+      `"pennycress"` and `params["age"]` is exactly `14` for the `SCAN` fixture (not just "keys
+      present") — closes the spec.md "canonical values" scenario that had no real assertion behind
+      it.
+- [ ] 9.7 **`clear_scan_dir(scan_dir) -> list[str]`** (replaces `reconcile_stray_frames`): if
+      `scan_dir` exists, removes it entirely (frames + any old sidecar) and returns the list of
+      removed entry names (for the CLI to echo); no-op, returns `[]`, if `scan_dir` doesn't exist.
+- [ ] 9.8 **CLI-level — stale sidecar cannot survive a retry:** run the happy-path CLI to success
+      (sidecar + frames written), then re-run for the same scan with one frame now failing —
+      assert the now-non-zero-exit run's directory has **no** `scan_metadata.json` at all (not a
+      stale one from the first run) and reports what it cleared before starting.
+- [ ] 9.9 **CLI-level — clear is echoed, not silent:** the happy-path re-run test above (or a
+      dedicated one) asserts the command's output mentions the directory was cleared/what was
+      removed, closing the "silent deletion" gap.
+- [ ] 9.10 **`frame_dest_for_predict` fails loudly on a missing `object_path`:** `KeyError` (not a
+      silently-defaulted `.png`) for `{"frame_number": 3}` (no `object_path` key) — still caught
+      per-frame by `download_frames_for_predict`'s existing `try/except Exception`, so this
+      surfaces as a clean per-frame failure, not a crash; update
+      `test_frame_dest_for_predict_defaults_to_png_when_extension_missing` (which used a row that
+      _had_ `object_path` with no extension — still valid, keep it) and add a new test for the
+      missing-key case.
+- [ ] 9.11 **Atomic writes:** `write_sidecar` and each frame write survive a simulated kill
+      mid-write without leaving a truncated file at the final path — assert via monkeypatching the
+      write call to raise partway through, then check the final path either doesn't exist or has
+      the complete prior content (never partial new content).
+- [ ] 9.12 **Auth refactor has no behavior change:** `test_cli_missing_credentials_hints_login`
+      continues to pass unmodified after switching to `cli._authed_client` (same error message,
+      same "run `bloomctl login`" hint) — this is the test that pins the refactor is behavior-
+      preserving.
+- [ ] 9.13 **Reuse identity tests for the remaining three re-used objects** (mirrors 5.1's
+      `fetch_scan` pattern): `dfp.fetch_images is dl.fetch_images`, `dfp.FrameResult is
+dl.FrameResult`, `dfp.DownloadResult is dl.DownloadResult`.
+- [ ] 9.14 **Oracle test — `_IMAGE_EXTENSIONS` drift guard (manual, dev-machine only, same
+      non-CI-gate note as §3):** add `assert dfp._IMAGE_EXTENSIONS ==
+frozenset(sleap_roots_predict.batch._IMAGE_EXTENSIONS)` to
+      `test_oracle_sidecar_is_accepted_by_discover_scans`, guarded by the same
+      `pytest.importorskip("sleap_roots_predict")`.
+
+## 10. GREEN — implement the fixes
+
+- [ ] 10.1 Update `bloomcli/src/bloomctl/cyl/download_for_predict.py`:
+      add `resolve_sidecar_params`, `validate_frame_numbers`; change `build_sidecar`'s signature;
+      rename/rewrite `reconcile_stray_frames` → `clear_scan_dir`; switch
+      `frame_dest_for_predict` to `image["object_path"]`; add atomic writes (temp file +
+      `os.replace`) to `write_sidecar` and the per-frame write loop; switch the command to
+      `from ..cli import _authed_client`. Reorder the command body: auth → `fetch_scan` → not-found
+      check → `fetch_images` → no-images check → `validate_frame_numbers` → `resolve_sidecar_params`
+      (both wrapped in `try/except ValueError` → `ClickException`) → `clear_scan_dir` (echo what
+      was removed) → download frames → failure check → `build_sidecar` (using the already-resolved
+      `params`) → `write_sidecar` → success echo.
+- [ ] 10.2 Iterate until every §9 test is GREEN, and the full suite (§8.2's invocation) stays
+      green with no regressions.
+
+## 11. Re-verify
+
+- [ ] 11.1 Re-run §8.1-8.5 (validate, full suite, ruff, pre-commit, contracts guards).
+- [ ] 11.2 Re-run §8.6's manual oracle-test verification (now including the new
+      `_IMAGE_EXTENSIONS` assertion from 9.14) — paste the passing output.
+- [ ] 11.3 Push a fixup and reply to the `/review-pr` findings on PR #458, noting what was fixed
+      vs. explicitly accepted as a documented limitation (concurrent same-scan invocations).

--- a/openspec/changes/add-cyl-download-for-predict/tasks.md
+++ b/openspec/changes/add-cyl-download-for-predict/tasks.md
@@ -69,8 +69,11 @@ conflicts with this proposal's `>=0.1.0a4` floor — adding it as a bloomcli tes
 would break dependency resolution outright. Its own re-pin to the newer contracts version is
 in progress separately (per Elizabeth). Until that lands and `sleap-roots-predict` can be added
 as a git dependency, this test is `pytest.importorskip`-guarded and **will always self-skip in
-CI**; run it manually on a dev machine with `sleap-roots-predict` installed (e.g. via the local
-`sleap-roots-predict-dev` environment) before merge. Tasks 4.x/5.x below independently assert
+CI**; run it manually on a dev machine with `sleap-roots-predict` installed via its own `uv`
+extra (`uv run --with "sleap-roots-predict[cpu] @ file:///path/to/sleap-roots-predict" --extra
+test pytest ...` from `bloomcli/`, or `cd sleap-roots-predict && uv sync --extra cpu` for a
+standalone env) before merge — this repo's convention is `uv`, not a hand-maintained conda env.
+Tasks 4.x/5.x below independently assert
 every shape fact predict's code is documented to require, without importing predict — that suite,
 not this test, is the CI-enforced contract for this change.
 
@@ -219,12 +222,15 @@ sleap_roots_contracts import resolve_params; print('ok')"`) as a final gate, not
       one-off at the start of §2.
 - [x] 8.5 Run `npm run contracts:check` at the repo root to confirm the re-pin (task 2.2) passes
       the drift guard before committing.
-- [ ] 8.6 Manually run tests 3.1 (`test_oracle_sidecar_is_accepted_by_discover_scans`) and 5.6
+- [x] 8.6 Manually run tests 3.1 (`test_oracle_sidecar_is_accepted_by_discover_scans`) and 5.6
       (`test_discover_scans_smoke_after_happy_path`) with `sleap-roots-predict` installed locally
-      and confirm they pass; paste the passing output into the PR description. **Attempted during
-      implementation, blocked** — the local `sleap-roots-predict-dev` conda env has `sleap-nn
-0.0.1` installed while `sleap-roots-predict`'s own `pyproject.toml` pins `sleap-nn==0.3.0`;
-      `import sleap_roots_predict` fails on `ImportError: cannot import name 'Predictor' from
-'sleap_nn.inference'` before `discover_scans` is even reachable. This is a pre-existing,
-      broken environment issue in a separate repo, unrelated to this change — re-run once that
-      env is fixed (worth flagging to whoever owns `sleap-roots-predict-dev`'s setup).
+      and confirm they pass; paste the passing output into the PR description. **Done** — a
+      pre-existing local conda env (`sleap-roots-predict-dev`) turned out to have a stale
+      `sleap-nn` (`0.0.1` installed vs. the repo's own `pyproject.toml` pin of `0.3.0`) and was
+      abandoned; the correct approach is `uv`, this repo's actual convention:
+      `uv run --with "sleap-roots-predict[cpu] @ file:///C:/repos/sleap-roots-predict" --extra
+test pytest tests/test_cyl_download_for_predict.py -k "oracle or discover_scans_smoke" -v`
+      from `bloomcli/`, which builds a fresh env from `sleap-roots-predict`'s own declared `cpu`
+      extra (correctly pins `sleap-nn==0.3.0` + CPU `torch`). Result:
+      `2 passed, 22 deselected in 24.46s` — both oracle tests pass against the real
+      `sleap_roots_predict.discover_scans`.


### PR DESCRIPTION
## Summary

Adds `bloomctl cyl download-for-predict <scan-id> <out>` — stages one cylinder scan into the layout `sleap_roots_predict.discover_scans` expects (frames co-located with a `scan_metadata.json` sidecar authored from live DB metadata), for the A4 per-scan pipeline stage-in. The existing `cyl download` (legacy `images/Wave{n}/…` + `scans.csv` layout) is untouched.

- New `bloomctl cyl download-for-predict` subcommand, reusing `fetch_scan`/`fetch_images`/`FrameResult`/`DownloadResult` from `download.py` (no duplication).
- Sidecar `params` resolved via `sleap-roots-contracts`'s `resolve_params(scan, overrides={"mode": "cylinder"})` — the documented API surface for a caller who knows the assay type, not row augmentation (see design.md for a correction made during review: the contracts library's `_mode_for_scan` currently ignores its input entirely, so the override is forward-compatible defensive code, not currently load-bearing).
- No sidecar is written on partial frame-download failure (a written sidecar is a claim that `image_ids`/`images_checksum` match what's on disk).
- A successful run reconciles away any stray frame file left by an earlier failed attempt, since `discover_scans` globs every image file physically present in the sidecar's directory, not just the ones named in `image_ids` (verified against the real `sleap_roots_predict.batch._load_scan` code).
- Bumps `sleap-roots-contracts>=0.1.0a3` → `>=0.1.0a4` in `bloomcli/pyproject.toml` with the full mechanical re-pin (`pin.json`, vendored schema, regenerated TS, `contracts/README.md` note) — verified `$id`-only diff, not assumed.

This is a mechanical follow-up to contracts PR #16 bundled with its first real consumer, not a separate scope-creep addition.

## Review

Went through two rounds of adversarial `/review-openspec` (5 subagents each) before implementation, plus a fact-checking pass that executed code rather than trusting docs. Corrected: a factually-wrong claim about how `resolve_params` reads `mode` (verified by inspecting the real installed package); reframed the two cross-repo "oracle" tests as non-CI-gated (adding `sleap-roots-predict` as a dependency was considered and rejected — it's not on PyPI and its `pyproject.toml` currently exact-pins a conflicting `sleap-roots-contracts` version; its own re-pin is in progress separately); decided and implemented the no-sidecar-on-partial-failure and stray-frame-reconciliation behaviors after reading predict's actual frame-discovery code; removed a scope-mismatched spec scenario that tested a different capability's RPC.

## Test plan

- [x] `openspec validate add-cyl-download-for-predict --strict` passes
- [x] `cd bloomcli && uv run --extra test pytest tests/ -m "not integration" -v` — 109 passed, 4 skipped (the two oracle tests × their CI-skip guard — see below), 1 pre-existing unrelated failure (`test_saved_file_is_owner_only`, a POSIX-chmod assertion that fails identically on this Windows checkout with none of this PR's changes present)
- [x] The two oracle tests (`test_oracle_sidecar_is_accepted_by_discover_scans`, `test_discover_scans_smoke_after_happy_path`) manually verified against the real `sleap_roots_predict.discover_scans`, using `sleap-roots-predict`'s own `uv`-managed `cpu` extra: `uv run --with "sleap-roots-predict[cpu] @ file:///path/to/sleap-roots-predict" --extra test pytest tests/test_cyl_download_for_predict.py -k "oracle or discover_scans_smoke" -v` → `2 passed, 22 deselected in 24.46s`
- [x] `uvx ruff@0.9.9 check bloomcli && uvx ruff@0.9.9 format --check bloomcli` — clean
- [x] `pre-commit run --files <changed files>` — clean (prettier, gitleaks, etc.)
- [x] `npm run contracts:check` and `npm run contracts:test` — pass (9/9), confirming the re-pin is byte-identical apart from `$id`
- [x] Rebased onto latest `origin/staging` (no conflicts — the new staging commits touch only `bloommcp`/`langchain`, nothing in this PR's paths)

Closes #411.