### PR TITLE
fix(workflows): deliver bloom_workflows storage grants + reload Caddy on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,6 +162,7 @@ jobs:
           "
 
       - name: Pull latest code
+        id: pull_prod
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             cd ${{ secrets.PROD_DEPLOY_PATH }}
@@ -176,9 +177,15 @@ jobs:
               echo 'Previous deployment remains running.'
               exit 1
             fi
+            BEFORE=\$(git rev-parse HEAD)
             git fetch origin main
             git reset --hard origin/main
-          "
+            AFTER=\$(git rev-parse HEAD)
+            git diff --quiet \"\$BEFORE\" \"\$AFTER\" -- caddy/Caddyfile \
+              && echo 'CADDYFILE_CHANGED=false' || echo 'CADDYFILE_CHANGED=true'
+          " | tee /tmp/pull_prod.out
+          changed=$(grep '^CADDYFILE_CHANGED=' /tmp/pull_prod.out | tail -1 | cut -d= -f2)
+          echo "caddyfile_changed=${changed:-true}" >> "$GITHUB_OUTPUT"
 
       - name: Verify Docker Compose version (>= 2.17 required for --wait-timeout)
         run: |
@@ -258,6 +265,18 @@ jobs:
           "
         env:
           PROD_DEPLOY_PATH: ${{ secrets.PROD_DEPLOY_PATH }}
+
+      # Reload Caddy so bind-mounted Caddyfile changes take effect — `up -d` won't
+      # recreate caddy when its image is unchanged, so config edits are otherwise ignored.
+      - name: Reload Caddy config (production)
+        if: steps.pull_prod.outputs.caddyfile_changed == 'true'
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
+            set -euo pipefail
+            cd ${{ secrets.PROD_DEPLOY_PATH }}
+            docker compose -f docker-compose.prod.yml --env-file .env.prod exec -T caddy \
+              caddy reload --config /etc/caddy/Caddyfile
+          "
 
       # Layer 3 — Crash-loop detection. Caddyfile parse errors and missing
       # modules send caddy into a restart loop; each restart is another
@@ -501,6 +520,20 @@ jobs:
             exit 1
           }
 
+      # Apply bloom_* schema-USAGE grants (supabase/grants/schema_grants.sql) as
+      # supabase_admin — schema grants no-op under `supabase db push`. Mirrors CI/make.
+      - name: Apply schema-USAGE grants (production)
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
+            set -euo pipefail
+            cd ${{ secrets.PROD_DEPLOY_PATH }}
+            PG_PASSWORD=\$(grep '^POSTGRES_PASSWORD=' .env.prod | cut -d= -f2-)
+            docker compose -f docker-compose.prod.yml --env-file .env.prod exec -T \
+              -e PGPASSWORD=\"\$PG_PASSWORD\" db-prod \
+              psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1 \
+              < supabase/grants/schema_grants.sql
+          "
+
       # Layer B: diagnostic on any failure upstream. Lists applied vs pending
       # so on-call can see which migration broke without scrolling logs.
       - name: Show migration status on failure (production)
@@ -680,6 +713,7 @@ jobs:
           "
 
       - name: Pull latest code
+        id: pull_staging
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
             cd ${{ secrets.STAGING_DEPLOY_PATH }}
@@ -694,9 +728,15 @@ jobs:
               echo 'Previous deployment remains running.'
               exit 1
             fi
+            BEFORE=\$(git rev-parse HEAD)
             git fetch origin staging
             git reset --hard origin/staging
-          "
+            AFTER=\$(git rev-parse HEAD)
+            git diff --quiet \"\$BEFORE\" \"\$AFTER\" -- caddy/Caddyfile \
+              && echo 'CADDYFILE_CHANGED=false' || echo 'CADDYFILE_CHANGED=true'
+          " | tee /tmp/pull_staging.out
+          changed=$(grep '^CADDYFILE_CHANGED=' /tmp/pull_staging.out | tail -1 | cut -d= -f2)
+          echo "caddyfile_changed=${changed:-true}" >> "$GITHUB_OUTPUT"
 
       - name: Verify Docker Compose version (>= 2.17 required for --wait-timeout)
         run: |
@@ -762,6 +802,18 @@ jobs:
           "
         env:
           STAGING_DEPLOY_PATH: ${{ secrets.STAGING_DEPLOY_PATH }}
+
+      # Reload Caddy so bind-mounted Caddyfile changes take effect — `up -d` won't
+      # recreate caddy when its image is unchanged, so config edits are otherwise ignored.
+      - name: Reload Caddy config (staging)
+        if: steps.pull_staging.outputs.caddyfile_changed == 'true'
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
+            set -euo pipefail
+            cd ${{ secrets.STAGING_DEPLOY_PATH }}
+            docker compose -p bloom_v2_staging -f docker-compose.prod.yml --env-file .env.staging exec -T caddy \
+              caddy reload --config /etc/caddy/Caddyfile
+          "
 
       # Layer 3 — Crash-loop detection. See deploy-production's equivalent
       # step for rationale.
@@ -978,6 +1030,20 @@ jobs:
             echo '::error title=Migration failed (staging)::See the Migration summary at top of run and the Show-migration-status step for applied vs pending state.'
             exit 1
           }
+
+      # Apply bloom_* schema-USAGE grants (supabase/grants/schema_grants.sql) as
+      # supabase_admin — schema grants no-op under `supabase db push`. Mirrors CI/make.
+      - name: Apply schema-USAGE grants (staging)
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
+            set -euo pipefail
+            cd ${{ secrets.STAGING_DEPLOY_PATH }}
+            PG_PASSWORD=\$(grep '^POSTGRES_PASSWORD=' .env.staging | cut -d= -f2-)
+            docker compose -p bloom_v2_staging -f docker-compose.prod.yml --env-file .env.staging exec -T \
+              -e PGPASSWORD=\"\$PG_PASSWORD\" db-prod \
+              psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1 \
+              < supabase/grants/schema_grants.sql
+          "
 
       - name: Show migration status on failure (staging)
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -500,6 +500,7 @@ jobs:
       # rather than letting `supabase db push` fail later with a cryptic URL
       # parse / auth error.
       - name: Apply database migrations (production)
+        id: migrate_prod
         if: steps.check_migrations_prod.outputs.pending != '0'
         env:
           EXPECTED_CLI_VERSION: ${{ env.SUPABASE_VERSION }}
@@ -532,12 +533,15 @@ jobs:
               -e PGPASSWORD=\"\$PG_PASSWORD\" db-prod \
               psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1 \
               < supabase/grants/schema_grants.sql
-          "
+          " || {
+            echo '::error title=Schema grants failed (production)::supabase/grants/schema_grants.sql could not be applied — see this step log for the psql error.'
+            exit 1
+          }
 
       # Layer B: diagnostic on any failure upstream. Lists applied vs pending
       # so on-call can see which migration broke without scrolling logs.
       - name: Show migration status on failure (production)
-        if: failure()
+        if: failure() && steps.migrate_prod.outcome == 'failure'
         run: |
           echo "::add-mask::${{ secrets.PROD_POSTGRES_PASSWORD }}"
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
@@ -1011,6 +1015,7 @@ jobs:
           fi
 
       - name: Apply database migrations (staging)
+        id: migrate_staging
         if: steps.check_migrations_staging.outputs.pending != '0'
         env:
           EXPECTED_CLI_VERSION: ${{ env.SUPABASE_VERSION }}
@@ -1043,10 +1048,13 @@ jobs:
               -e PGPASSWORD=\"\$PG_PASSWORD\" db-prod \
               psql -U supabase_admin -d postgres -v ON_ERROR_STOP=1 \
               < supabase/grants/schema_grants.sql
-          "
+          " || {
+            echo '::error title=Schema grants failed (staging)::supabase/grants/schema_grants.sql could not be applied — see this step log for the psql error.'
+            exit 1
+          }
 
       - name: Show migration status on failure (staging)
-        if: failure()
+        if: failure() && steps.migrate_staging.outcome == 'failure'
         run: |
           echo "::add-mask::${{ secrets.STAGING_POSTGRES_PASSWORD }}"
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "

--- a/supabase/migrations/20260717000000_workflows_read_videos_policy.sql
+++ b/supabase/migrations/20260717000000_workflows_read_videos_policy.sql
@@ -1,0 +1,6 @@
+-- bloom_workflows needs SELECT on the videos bucket: the on-demand video route
+-- uploads with upsert (storage-api reads the object back), which RLS blocked when
+-- create_workflows_role granted videos write + images read but not videos read.
+DROP POLICY IF EXISTS workflows_read_videos_bucket ON storage.objects;
+CREATE POLICY workflows_read_videos_bucket ON storage.objects
+  FOR SELECT TO bloom_workflows USING (bucket_id = 'videos');


### PR DESCRIPTION
## What this fixes

The on-demand cyl-scan video route (#391) works in CI and locally, but it does not work on a fresh staging/prod deploy. 

Three things were missing. We found and fixed all three manually on staging (a video now generates end to end), and this PR bakes those fixes into the migration and the deploy so they happen automatically.

## The three problems and fixes

**1. The video upload was blocked (missing read permission).**
The route uploads the video with "upsert", which means storage reads the file back after writing it. The `bloom_workflows` role could write to the videos bucket and read the images bucket, but it could not *read* the videos bucket — so the upload failed with a 403 "row-level security" error.
Fix: a new migration adds a read policy for the videos bucket (`workflows_read_videos_bucket`).

**2. The role could not see storage. (grant not applied on deploy).**
The `bloom_workflows` role needs "USAGE" on the storage schema. That grant lives in `supabase/grants/schema_grants.sql` . But that file is only applied automatically by local dev and CI — **not by the deploy**. So on staging/prod the grant was never applied, and every storage read failed with a confusing "database schema is out of sync" error.
Fix: the deploy now applies `schema_grants.sql` after migrations (both staging and prod), the same way CI already does.

**3. Caddy did not pick up config changes on deploy.**
The Caddyfile is mounted into the Caddy container, and Caddy only reads it at startup. The deploy does not restart Caddy when its image is unchanged, so Caddyfile edits (like the new `/workflows/*` routes) silently never took effect.
Fix: the deploy now reloads Caddy — but **only when the Caddyfile actually changed** in that deploy. The reload is graceful (no downtime, no dropped connections), and the step is skipped entirely on deploys that did not touch the Caddyfile.

## Files changed

- `supabase/migrations/20260717000000_workflows_read_videos_policy.sql` (new) — the videos read policy.
- `.github/workflows/deploy.yml` — apply schema grants after migrations, and reload Caddy only when the Caddyfile changed (staging + prod).

## Not in this PR

The URL the API returns points at an internal address, so it only works inside the cluster, not from an outside caller (like a CLI). That is a separate follow-up (it needs a new public-URL setting). The web app is not affected — it builds its own URL from the stored video path.
