### PR TITLE
feat(workflows): return a publicly-reachable download_url

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -100,6 +100,9 @@ services:
       SUPABASE_ANON_KEY: ${ANON_KEY}
       WORKFLOWS_SUPABASE_EMAIL: ${WORKFLOWS_SUPABASE_EMAIL}
       WORKFLOWS_SUPABASE_PASSWORD: ${WORKFLOWS_SUPABASE_PASSWORD}
+      # Public base for rewriting signed URLs off the internal kong host so
+      # download_url is usable by outside callers.
+      WORKFLOWS_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
     volumes:
       - ./services/workflows:/app
     command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5100", "--reload"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -214,6 +214,9 @@ services:
       SUPABASE_ANON_KEY: ${ANON_KEY}
       WORKFLOWS_SUPABASE_EMAIL: ${WORKFLOWS_SUPABASE_EMAIL}
       WORKFLOWS_SUPABASE_PASSWORD: ${WORKFLOWS_SUPABASE_PASSWORD}
+      # Public base for rewriting signed URLs off the internal kong host so
+      # download_url is usable by outside callers.
+      WORKFLOWS_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
     networks:
       - supanet
     healthcheck:

--- a/services/workflows/README.md
+++ b/services/workflows/README.md
@@ -109,6 +109,7 @@ All of the above is set up by the migration `…_create_workflows_role.sql`.
 | `WORKFLOWS_VIDEO_TABLE`        | `cyl_scan_videos`       | Record table (`scan_id -> path`)                     |
 | `WORKFLOWS_RATE_LIMIT`         | `5`                     | Max video requests per user per window, per process (429 over) |
 | `WORKFLOWS_RATE_WINDOW_SECONDS`| `60`                    | Rate-limit window                                    |
+| `WORKFLOWS_PUBLIC_SUPABASE_URL`| –                        | Public base to rewrite signed URLs off the internal `kong` host, so `download_url` works for outside callers (set to `NEXT_PUBLIC_SUPABASE_URL`). Unset → the internal URL is returned unchanged. |
 
 > `ffmpeg` must be present in the runtime image — the Dockerfile copies a digest-pinned static `ffmpeg` binary (avoids apt's ffmpeg pulling in vulnerable GPU/TLS libraries).
 > Caller auth is delegated to Supabase (`/auth/v1/user`), so `JWT_SECRET` is **not** needed by this service.

--- a/services/workflows/README.md
+++ b/services/workflows/README.md
@@ -109,7 +109,7 @@ All of the above is set up by the migration `…_create_workflows_role.sql`.
 | `WORKFLOWS_VIDEO_TABLE`        | `cyl_scan_videos`       | Record table (`scan_id -> path`)                     |
 | `WORKFLOWS_RATE_LIMIT`         | `5`                     | Max video requests per user per window, per process (429 over) |
 | `WORKFLOWS_RATE_WINDOW_SECONDS`| `60`                    | Rate-limit window                                    |
-| `WORKFLOWS_PUBLIC_SUPABASE_URL`| –                        | Public base to rewrite signed URLs off the internal `kong` host, so `download_url` works for outside callers (set to `NEXT_PUBLIC_SUPABASE_URL`). Unset → the internal URL is returned unchanged. |
+| `WORKFLOWS_PUBLIC_SUPABASE_URL`| –                        | Public base that replaces the internal `SUPABASE_URL` host in signed URLs, so `download_url` works for outside callers (set to `NEXT_PUBLIC_SUPABASE_URL`). Unset → the internal URL is returned unchanged. |
 
 > `ffmpeg` must be present in the runtime image — the Dockerfile copies a digest-pinned static `ffmpeg` binary (avoids apt's ffmpeg pulling in vulnerable GPU/TLS libraries).
 > Caller auth is delegated to Supabase (`/auth/v1/user`), so `JWT_SECRET` is **not** needed by this service.

--- a/services/workflows/tests/test_public_url.py
+++ b/services/workflows/tests/test_public_url.py
@@ -1,41 +1,58 @@
-"""Unit tests for rewriting signed URLs from the internal kong host to the
+"""Unit tests for rewriting signed URLs from the internal Supabase host to the
 public base (video._to_public_url), mirroring web/lib/supabase/storage-url.ts."""
 
 import video
 
+INTERNAL = "http://kong:8000"
 PUBLIC = "https://bloom.salk.edu/api"
 SIGNED = "/storage/v1/object/sign/videos/cyl-videos/1.mp4?token=abc"
 
 
-def test_rewrites_internal_kong_host(monkeypatch):
-    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
-    assert video._to_public_url("http://kong:8000" + SIGNED) == PUBLIC + SIGNED
+def _configure(monkeypatch, internal=INTERNAL, public=PUBLIC):
+    monkeypatch.setattr(video, "SUPABASE_URL", internal)
+    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", public)
 
 
-def test_rewrites_https_kong_host(monkeypatch):
-    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
-    assert video._to_public_url("https://kong:8000" + SIGNED) == PUBLIC + SIGNED
+def test_rewrites_internal_host(monkeypatch):
+    _configure(monkeypatch)
+    assert video._to_public_url(INTERNAL + SIGNED) == PUBLIC + SIGNED
 
 
 def test_noop_when_public_base_unset(monkeypatch):
-    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", None)
-    url = "http://kong:8000" + SIGNED
-    assert video._to_public_url(url) == url
+    _configure(monkeypatch, public=None)
+    assert video._to_public_url(INTERNAL + SIGNED) == INTERNAL + SIGNED
+
+
+def test_noop_when_internal_base_unset(monkeypatch):
+    _configure(monkeypatch, internal=None)
+    assert video._to_public_url(INTERNAL + SIGNED) == INTERNAL + SIGNED
 
 
 def test_only_replaces_leading_host(monkeypatch):
-    # A kong host later in the string (e.g. a redirect query param) is untouched.
-    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
-    url = "http://kong:8000/storage/v1/x?redirect=http://kong:8000/y"
-    assert video._to_public_url(url) == PUBLIC + "/storage/v1/x?redirect=http://kong:8000/y"
+    # An internal host later in the string (e.g. a redirect query param) is untouched.
+    _configure(monkeypatch)
+    url = INTERNAL + "/storage/v1/x?redirect=" + INTERNAL + "/y"
+    assert video._to_public_url(url) == PUBLIC + "/storage/v1/x?redirect=" + INTERNAL + "/y"
 
 
-def test_leaves_non_kong_url_untouched(monkeypatch):
-    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
+def test_strips_trailing_slashes(monkeypatch):
+    # Trailing slashes on either base must not produce a double slash.
+    _configure(monkeypatch, internal=INTERNAL + "/", public=PUBLIC + "/")
+    assert video._to_public_url(INTERNAL + SIGNED) == PUBLIC + SIGNED
+
+
+def test_derives_internal_host_from_supabase_url(monkeypatch):
+    # Not hardcoded to "kong": whatever SUPABASE_URL is set to is the host swapped.
+    _configure(monkeypatch, internal="http://gateway:9000")
+    assert video._to_public_url("http://gateway:9000" + SIGNED) == PUBLIC + SIGNED
+
+
+def test_leaves_non_internal_url_untouched(monkeypatch):
+    _configure(monkeypatch)
     url = "https://already-public.example/storage/v1/x"
     assert video._to_public_url(url) == url
 
 
 def test_handles_none(monkeypatch):
-    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
+    _configure(monkeypatch)
     assert video._to_public_url(None) is None

--- a/services/workflows/tests/test_public_url.py
+++ b/services/workflows/tests/test_public_url.py
@@ -1,0 +1,41 @@
+"""Unit tests for rewriting signed URLs from the internal kong host to the
+public base (video._to_public_url), mirroring web/lib/supabase/storage-url.ts."""
+
+import video
+
+PUBLIC = "https://bloom.salk.edu/api"
+SIGNED = "/storage/v1/object/sign/videos/cyl-videos/1.mp4?token=abc"
+
+
+def test_rewrites_internal_kong_host(monkeypatch):
+    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
+    assert video._to_public_url("http://kong:8000" + SIGNED) == PUBLIC + SIGNED
+
+
+def test_rewrites_https_kong_host(monkeypatch):
+    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
+    assert video._to_public_url("https://kong:8000" + SIGNED) == PUBLIC + SIGNED
+
+
+def test_noop_when_public_base_unset(monkeypatch):
+    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", None)
+    url = "http://kong:8000" + SIGNED
+    assert video._to_public_url(url) == url
+
+
+def test_only_replaces_leading_host(monkeypatch):
+    # A kong host later in the string (e.g. a redirect query param) is untouched.
+    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
+    url = "http://kong:8000/storage/v1/x?redirect=http://kong:8000/y"
+    assert video._to_public_url(url) == PUBLIC + "/storage/v1/x?redirect=http://kong:8000/y"
+
+
+def test_leaves_non_kong_url_untouched(monkeypatch):
+    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
+    url = "https://already-public.example/storage/v1/x"
+    assert video._to_public_url(url) == url
+
+
+def test_handles_none(monkeypatch):
+    monkeypatch.setattr(video, "PUBLIC_SUPABASE_URL", PUBLIC)
+    assert video._to_public_url(None) is None

--- a/services/workflows/video.py
+++ b/services/workflows/video.py
@@ -13,7 +13,6 @@ H.264 with VideoWriter -> upload MP4 to the videos bucket -> signed URL ->
 import io
 import logging
 import os
-import re
 import tempfile
 
 import numpy as np
@@ -42,18 +41,23 @@ VIDEO_PATH_PREFIX = "cyl-videos"
 # Record table linking scan_id -> stored video path (upserted per scan).
 VIDEO_TABLE = os.environ.get("WORKFLOWS_VIDEO_TABLE", "cyl_scan_videos")
 
-# Signed URLs come back pointing at the internal gateway (http://kong:8000), which
-# an outside caller can't reach. Rewrite that host to the public base so the
-# returned download_url is usable externally — mirrors web/lib/supabase/storage-url.ts.
+# Signed URLs come back pointing at the internal gateway (SUPABASE_URL, e.g.
+# http://kong:8000), which an outside caller can't reach. Rewrite that host to the
+# public base so the returned download_url is usable externally — mirrors
+# web/lib/supabase/storage-url.ts.
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
 PUBLIC_SUPABASE_URL = os.environ.get("WORKFLOWS_PUBLIC_SUPABASE_URL")
-_INTERNAL_HOST = re.compile(r"^https?://kong:\d+")
 
 
 def _to_public_url(url: str) -> str:
-    """Swap the internal kong host for the public base; no-op if base unset."""
-    if not url or not PUBLIC_SUPABASE_URL:
+    """Swap the internal Supabase host for the public base; no-op if either is
+    unset or the URL isn't on the internal host."""
+    if not url or not PUBLIC_SUPABASE_URL or not SUPABASE_URL:
         return url
-    return _INTERNAL_HOST.sub(PUBLIC_SUPABASE_URL, url, count=1)
+    internal = SUPABASE_URL.rstrip("/")
+    if url.startswith(internal):
+        return PUBLIC_SUPABASE_URL.rstrip("/") + url[len(internal):]
+    return url
 
 
 def scan_in_experiment(client, experiment_id: int, scan_id: int) -> bool:

--- a/services/workflows/video.py
+++ b/services/workflows/video.py
@@ -13,6 +13,7 @@ H.264 with VideoWriter -> upload MP4 to the videos bucket -> signed URL ->
 import io
 import logging
 import os
+import re
 import tempfile
 
 import numpy as np
@@ -40,6 +41,19 @@ VIDEOS_BUCKET = os.environ.get("WORKFLOWS_VIDEOS_BUCKET", "videos")
 VIDEO_PATH_PREFIX = "cyl-videos"
 # Record table linking scan_id -> stored video path (upserted per scan).
 VIDEO_TABLE = os.environ.get("WORKFLOWS_VIDEO_TABLE", "cyl_scan_videos")
+
+# Signed URLs come back pointing at the internal gateway (http://kong:8000), which
+# an outside caller can't reach. Rewrite that host to the public base so the
+# returned download_url is usable externally — mirrors web/lib/supabase/storage-url.ts.
+PUBLIC_SUPABASE_URL = os.environ.get("WORKFLOWS_PUBLIC_SUPABASE_URL")
+_INTERNAL_HOST = re.compile(r"^https?://kong:\d+")
+
+
+def _to_public_url(url: str) -> str:
+    """Swap the internal kong host for the public base; no-op if base unset."""
+    if not url or not PUBLIC_SUPABASE_URL:
+        return url
+    return _INTERNAL_HOST.sub(PUBLIC_SUPABASE_URL, url, count=1)
 
 
 def scan_in_experiment(client, experiment_id: int, scan_id: int) -> bool:
@@ -91,11 +105,14 @@ def _recorded_frames(client, scan_id: int):
 
 
 def _signed_url(bucket, path: str) -> str:
-    """Best-effort extraction of the signed URL across supabase-py versions."""
+    """Best-effort extraction of the signed URL across supabase-py versions,
+    rewritten to the public host so external callers can open it."""
     res = bucket.create_signed_url(path, DOWNLOAD_URL_TTL)
     if isinstance(res, dict):
-        return res.get("signedURL") or res.get("signed_url") or res.get("signedUrl")
-    return res
+        url = res.get("signedURL") or res.get("signed_url") or res.get("signedUrl")
+    else:
+        url = res
+    return _to_public_url(url)
 
 
 def generate_scan_video(client, scan_id: int, decimate: int = DECIMATE_FACTOR) -> dict:


### PR DESCRIPTION
## What this does

The on-demand video route returns a `download_url` in its response. Today that URL points at the **internal** Supabase gateway (`http://kong:8000`), which only works from inside the cluster. An outside caller — a CLI, `curl`, or any tool on someone's laptop — can't open it.

This makes the returned `download_url` point at the **public** address instead, so it works from anywhere.

## How

The signed URL comes back from Supabase with the internal host baked in. Before returning it, we swap that internal host for the public one. This is the same thing the web app already does with its helper `web/lib/supabase/storage-url.ts` — this PR just does the equivalent in the workflows service (Python).

- **`video.py`** — a small `_to_public_url()` helper replaces a leading `http(s)://kong:<port>` with the public base, applied to the signed URL before it's returned.
- **compose (dev + prod)** — the workflows service now gets `WORKFLOWS_PUBLIC_SUPABASE_URL`, set to the existing `NEXT_PUBLIC_SUPABASE_URL` value. **No new secret** — it reuses a value that's already in the env files.
- **tests** — unit tests for the rewrite (rewrites the kong host, no-op when the base is unset, only touches the leading host, leaves already-public URLs alone).
- **README** — documents the new env var.

## Safe by default

If `WORKFLOWS_PUBLIC_SUPABASE_URL` is not set, the URL is returned unchanged — so nothing breaks anywhere the value isn't configured.

## Not affected

The Bloom web app doesn't use this `download_url` — it builds its own URL from the stored video path — so this change only affects outside/CLI callers.

## Draft

Opening as a draft to review the approach first. Locally testable on the dev stack (it rewrites `kong:8000` → `localhost:8000`).
