### PR TITLE
feat(workflows): queued cyl-video generation (pgmq queue + worker)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -115,6 +115,34 @@ services:
       - kong
     restart: unless-stopped
 
+  # Consumes the cyl_video_generation pgmq queue and generates videos with the
+  # same code as the on-demand route. Same image as workflows; scale by replicas.
+  cyl-video-worker:
+    build:
+      context: ./services/workflows
+      dockerfile: Dockerfile
+    read_only: true
+    tmpfs:
+      - /tmp:mode=1777,size=512m
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    environment:
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      WORKFLOWS_SUPABASE_EMAIL: ${WORKFLOWS_SUPABASE_EMAIL}
+      WORKFLOWS_SUPABASE_PASSWORD: ${WORKFLOWS_SUPABASE_PASSWORD}
+    volumes:
+      - ./services/workflows:/app
+    command: ["python", "worker.py"]
+    networks:
+      - supanet
+    depends_on:
+      - db-dev
+      - kong
+    restart: unless-stopped
+
   bloommcp:
     build:
       context: ./bloommcp

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -227,6 +227,33 @@ services:
     restart: unless-stopped
     command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5100", "--workers", "2"]
 
+  # Consumes the cyl_video_generation pgmq queue and generates videos with the
+  # same code as the on-demand route. Same image as workflows; scale by replicas.
+  cyl-video-worker:
+    build:
+      context: ./services/workflows
+      dockerfile: Dockerfile
+    read_only: true
+    tmpfs:
+      - /tmp:mode=1777,size=512m
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cpus: "2.0"
+    environment:
+      SUPABASE_URL: ${SUPABASE_URL}
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      WORKFLOWS_SUPABASE_EMAIL: ${WORKFLOWS_SUPABASE_EMAIL}
+      WORKFLOWS_SUPABASE_PASSWORD: ${WORKFLOWS_SUPABASE_PASSWORD}
+    networks:
+      - supanet
+    depends_on:
+      - kong
+      - db-prod
+    restart: unless-stopped
+    command: ["python", "worker.py"]
+
   # -------------------
   # Bloom MCP Server
   # -------------------

--- a/services/workflows/README.md
+++ b/services/workflows/README.md
@@ -49,10 +49,12 @@ internal-only and not exposed through the public proxy.
 `job_id` immediately. The `cyl-video-worker` container polls the queue, runs the
 **same** `video.generate_scan_video` as the on-demand route, and updates the
 `cyl_video_jobs` status table (`queued → processing → complete`/`failed`). Poll
-that table for status (authenticated users can read it). On failure a job retries
-via the message visibility timeout and is dead-lettered (archived) after 3
-attempts. Scale throughput by running more `cyl-video-worker` replicas — pgmq's
-claim is concurrency-safe.
+that table for status (authenticated users can read it). On a reported failure a
+job retries via the message visibility timeout and is dead-lettered (archived)
+after 3 attempts; a job that hard-crashes the worker (never reporting) is
+dead-lettered by pgmq's `read_ct` after a few deliveries, so a poison message
+can't redeliver forever. Scale throughput by running more `cyl-video-worker`
+replicas — pgmq's claim is concurrency-safe.
 
 ### Video generation
 

--- a/services/workflows/README.md
+++ b/services/workflows/README.md
@@ -39,7 +39,20 @@ internal-only and not exposed through the public proxy.
 | Method | Path                                          | Auth | Purpose                                   |
 | ------ | --------------------------------------------- | ---- | ----------------------------------------- |
 | GET    | `/health`                                   | none (internal-only) | Liveness — kept for the in-container probe; **not** exposed via the public proxy |
-| POST   | `/cyl/experiments/{experiment_id}/scans/{scan_id}/video` | Supabase user JWT | Generate a scan's video, upload to Storage |
+| POST   | `/cyl/experiments/{experiment_id}/scans/{scan_id}/video` | Supabase user JWT | On-demand: generate a scan's video, upload to Storage |
+| POST   | `/cyl/experiments/{experiment_id}/scans/{scan_id}/video/queue` | Supabase user JWT | Queued: enqueue the job, return a `job_id`; a worker generates it |
+
+### Queued generation (worker)
+
+`…/video/queue` enqueues a job on the `cyl_video_generation` pgmq queue (via
+`SECURITY DEFINER` wrappers — the service holds no pgmq grants) and returns a
+`job_id` immediately. The `cyl-video-worker` container polls the queue, runs the
+**same** `video.generate_scan_video` as the on-demand route, and updates the
+`cyl_video_jobs` status table (`queued → processing → complete`/`failed`). Poll
+that table for status (authenticated users can read it). On failure a job retries
+via the message visibility timeout and is dead-lettered (archived) after 3
+attempts. Scale throughput by running more `cyl-video-worker` replicas — pgmq's
+claim is concurrency-safe.
 
 ### Video generation
 
@@ -109,6 +122,8 @@ All of the above is set up by the migration `…_create_workflows_role.sql`.
 | `WORKFLOWS_VIDEO_TABLE`        | `cyl_scan_videos`       | Record table (`scan_id -> path`)                     |
 | `WORKFLOWS_RATE_LIMIT`         | `5`                     | Max video requests per user per window, per process (429 over) |
 | `WORKFLOWS_RATE_WINDOW_SECONDS`| `60`                    | Rate-limit window                                    |
+| `WORKFLOWS_WORKER_POLL_SECONDS`| `5`                     | Worker idle sleep between empty queue polls          |
+| `WORKFLOWS_WORKER_VT_SECONDS`  | `120`                   | Per-message visibility timeout (retry window)        |
 
 > `ffmpeg` must be present in the runtime image — the Dockerfile copies a digest-pinned static `ffmpeg` binary (avoids apt's ffmpeg pulling in vulnerable GPU/TLS libraries).
 > Caller auth is delegated to Supabase (`/auth/v1/user`), so `JWT_SECRET` is **not** needed by this service.

--- a/services/workflows/main.py
+++ b/services/workflows/main.py
@@ -14,6 +14,12 @@ Endpoints:
                                                        Storage, return a signed
                                                        download URL
                                                        (requires a Supabase user JWT)
+    POST /cyl/experiments/{experiment_id}/scans/{scan_id}/video/queue
+                                                     - queued: enqueue the job and
+                                                       return a job id immediately;
+                                                       a worker generates it and
+                                                       updates cyl_video_jobs
+                                                       (requires a Supabase user JWT)
 """
 
 import os
@@ -24,6 +30,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from auth import require_supabase_user, enforce_rate_limit
 from video import generate_experiment_scan_video
+from video_queue import enqueue_experiment_scan_video
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -71,3 +78,25 @@ def cyl_experiment_scan_video(
         result["frames"],
     )
     return {"experiment_id": experiment_id, **result}
+
+
+@app.post("/cyl/experiments/{experiment_id}/scans/{scan_id}/video/queue")
+def cyl_experiment_scan_video_queue(
+    experiment_id: int,
+    scan_id: int,
+    user_id: str = Depends(require_supabase_user),
+):
+    """Queued: enqueue a cyl scan's video for the worker to generate.
+
+    Returns immediately with a job id; poll cyl_video_jobs for status. Same auth
+    (Supabase user JWT) and per-user rate limit as the on-demand route.
+    """
+    enforce_rate_limit(user_id)
+    result = enqueue_experiment_scan_video(experiment_id, scan_id)
+    logger.info(
+        "Queued video job %s for experiment %s scan %s",
+        result["job_id"],
+        experiment_id,
+        scan_id,
+    )
+    return {"experiment_id": experiment_id, "scan_id": scan_id, **result}

--- a/services/workflows/tests/test_worker.py
+++ b/services/workflows/tests/test_worker.py
@@ -1,0 +1,81 @@
+"""Unit tests for the queue worker loop (mocks the claim/generate/complete/fail
+seam, so no ffmpeg, DB, or Supabase client is needed)."""
+
+import pytest
+from fastapi import HTTPException
+
+import worker
+import video_queue
+
+
+def test_process_one_returns_false_on_empty_queue(monkeypatch):
+    monkeypatch.setattr(worker, "claim_job", lambda c: None)
+    assert worker.process_one(object()) is False
+
+
+def test_process_one_generates_and_completes(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(worker, "claim_job", lambda c: {"job_id": "j1", "scan_id": 5, "msg_id": 9})
+    monkeypatch.setattr(worker, "generate_scan_video", lambda c, s: {"path": "cyl-videos/5.mp4", "frames": 10})
+    monkeypatch.setattr(worker, "complete_job", lambda c, j, m, p: calls.update(complete=(j, m, p)))
+    monkeypatch.setattr(worker, "fail_job", lambda *a: calls.update(fail=a))
+
+    assert worker.process_one(object()) is True
+    assert calls["complete"] == ("j1", 9, "cyl-videos/5.mp4")
+    assert "fail" not in calls
+
+
+def test_process_one_fails_on_encode_error(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(worker, "claim_job", lambda c: {"job_id": "j1", "scan_id": 5, "msg_id": 9})
+
+    def boom(_c, _s):
+        raise HTTPException(status_code=500, detail="encode boom")
+
+    monkeypatch.setattr(worker, "generate_scan_video", boom)
+    monkeypatch.setattr(worker, "complete_job", lambda *a: calls.update(complete=a))
+    monkeypatch.setattr(worker, "fail_job", lambda c, j, m, e: calls.update(fail=(j, m, e)))
+
+    assert worker.process_one(object()) is True
+    assert calls["fail"][0] == "j1" and calls["fail"][1] == 9  # job_id, msg_id
+    assert "complete" not in calls  # the bad video was never recorded
+
+
+# --- enqueue helper (route side) --------------------------------------------
+
+class _RpcResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _EnqueueClient:
+    def __init__(self, job_id="job-1"):
+        self._job_id = job_id
+        self.rpc_calls = []
+
+    def rpc(self, name, params):
+        self.rpc_calls.append((name, params))
+        return self  # chainable
+
+    def execute(self):
+        return _RpcResult(self._job_id)
+
+
+def test_enqueue_404_when_scan_not_in_experiment(monkeypatch):
+    monkeypatch.setattr(video_queue, "app_client", lambda: _EnqueueClient())
+    monkeypatch.setattr(video_queue, "scan_in_experiment", lambda c, e, s: False)
+    with pytest.raises(HTTPException) as ei:
+        video_queue.enqueue_experiment_scan_video(1, 5)
+    assert ei.value.status_code == 404
+
+
+def test_enqueue_returns_job_id(monkeypatch):
+    client = _EnqueueClient(job_id="job-42")
+    monkeypatch.setattr(video_queue, "app_client", lambda: client)
+    monkeypatch.setattr(video_queue, "scan_in_experiment", lambda c, e, s: True)
+
+    result = video_queue.enqueue_experiment_scan_video(1, 5)
+
+    assert result == {"job_id": "job-42", "status": "queued"}
+    assert client.rpc_calls[0][0] == "enqueue_cyl_video"
+    assert client.rpc_calls[0][1] == {"p_scan_id": 5, "p_experiment_id": 1}

--- a/services/workflows/video_queue.py
+++ b/services/workflows/video_queue.py
@@ -1,0 +1,57 @@
+"""
+Queue helpers for the async cyl-video path.
+
+Everything goes through the public SECURITY DEFINER wrapper functions
+(enqueue_cyl_video / claim_cyl_video_job / complete_cyl_video_job /
+fail_cyl_video_job), called as the bloom_workflows app user via the Supabase
+client — so neither the API nor the worker needs a direct DB connection or pgmq
+grants. Enqueue is used by the route; claim/complete/fail by the worker.
+"""
+
+import os
+
+from fastapi import HTTPException
+
+from supabase_client import app_client
+from video import scan_in_experiment
+
+# Visibility timeout for a claimed message — longer than a worst-case encode so a
+# healthy worker finishes before the message is redelivered.
+VISIBILITY_TIMEOUT = int(os.environ.get("WORKFLOWS_WORKER_VT_SECONDS", "120"))
+
+
+def enqueue_experiment_scan_video(experiment_id: int, scan_id: int) -> dict:
+    """Validate the scan belongs to the experiment, then enqueue a video job."""
+    client = app_client()
+    if not scan_in_experiment(client, experiment_id, scan_id):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Scan {scan_id} not found in experiment {experiment_id}",
+        )
+    res = client.rpc(
+        "enqueue_cyl_video",
+        {"p_scan_id": scan_id, "p_experiment_id": experiment_id},
+    ).execute()
+    return {"job_id": res.data, "status": "queued"}
+
+
+def claim_job(client, vt: int = VISIBILITY_TIMEOUT):
+    """Claim the next queued job (or None if the queue is empty)."""
+    rows = client.rpc("claim_cyl_video_job", {"p_vt": vt}).execute().data or []
+    return rows[0] if rows else None
+
+
+def complete_job(client, job_id: str, msg_id: int, path: str) -> None:
+    """Mark the job complete and drop the message."""
+    client.rpc(
+        "complete_cyl_video_job",
+        {"p_job_id": job_id, "p_msg_id": msg_id, "p_path": path},
+    ).execute()
+
+
+def fail_job(client, job_id: str, msg_id: int, error) -> None:
+    """Record a failure (retry via vt expiry, or dead-letter after max attempts)."""
+    client.rpc(
+        "fail_cyl_video_job",
+        {"p_job_id": job_id, "p_msg_id": msg_id, "p_error": str(error)[:500]},
+    ).execute()

--- a/services/workflows/worker.py
+++ b/services/workflows/worker.py
@@ -1,0 +1,89 @@
+"""
+Queued cyl-scan video worker.
+
+Polls the pgmq 'cyl_video_generation' queue (via the claim wrapper), generates the
+video with the SAME code the on-demand route uses (video.generate_scan_video),
+records the result, and deletes or dead-letters the message. Runs as the
+least-privilege bloom_workflows app user — no direct DB connection.
+
+Deploy: a container off the workflows image with `command: python worker.py`,
+CPU-capped, scaled by replicas (pgmq's claim is concurrency-safe).
+
+Env:
+    WORKFLOWS_WORKER_POLL_SECONDS  idle sleep between empty polls (default 5)
+    WORKFLOWS_WORKER_VT_SECONDS    per-message visibility timeout (default 120)
+"""
+
+import logging
+import os
+import signal
+import time
+
+from supabase_client import app_client
+from video import generate_scan_video
+from video_queue import claim_job, complete_job, fail_job
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL = float(os.environ.get("WORKFLOWS_WORKER_POLL_SECONDS", "5"))
+
+_running = True
+
+
+def _stop(signum, _frame):
+    """SIGTERM/SIGINT → finish the in-flight job, then exit the loop."""
+    global _running
+    logger.info("worker: received signal %s, shutting down after current job", signum)
+    _running = False
+
+
+def process_one(client) -> bool:
+    """Claim and process a single job. Returns True if a job was handled."""
+    job = claim_job(client)
+    if not job:
+        return False
+
+    job_id, scan_id, msg_id = job["job_id"], job["scan_id"], job["msg_id"]
+    logger.info("worker: claimed job %s (scan %s)", job_id, scan_id)
+    try:
+        result = generate_scan_video(client, scan_id)
+        complete_job(client, job_id, msg_id, result["path"])
+        logger.info("worker: completed job %s (%s frames)", job_id, result.get("frames"))
+    except Exception as exc:
+        # generate_scan_video raises HTTPException on encode failures; anything
+        # else is unexpected. Either way, record it and let retry/dead-letter run.
+        detail = getattr(exc, "detail", exc)
+        logger.warning("worker: job %s failed: %s", job_id, detail)
+        fail_job(client, job_id, msg_id, detail)
+    return True
+
+
+def run():
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    client = app_client()
+    logger.info(
+        "cyl-video worker started (poll=%ss)", POLL_INTERVAL
+    )
+    while _running:
+        try:
+            handled = process_one(client)
+        except Exception as exc:
+            # A loop-level error (e.g. an expired session) — reconnect and retry.
+            logger.exception("worker: loop error, reconnecting: %s", exc)
+            time.sleep(POLL_INTERVAL)
+            try:
+                client = app_client()
+            except Exception:
+                pass
+            continue
+        if not handled:
+            time.sleep(POLL_INTERVAL)
+    logger.info("cyl-video worker stopped")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+    run()

--- a/supabase/migrations/20260718000000_cyl_video_queue.sql
+++ b/supabase/migrations/20260718000000_cyl_video_queue.sql
@@ -39,6 +39,10 @@ CREATE TABLE IF NOT EXISTS public.cyl_video_jobs (
 );
 CREATE INDEX IF NOT EXISTS idx_cyl_video_jobs_scan ON public.cyl_video_jobs(scan_id);
 CREATE INDEX IF NOT EXISTS idx_cyl_video_jobs_status ON public.cyl_video_jobs(status);
+-- At most one active job per scan — the DB enforces the dedupe that enqueue's
+-- check-then-insert can't guarantee under concurrent calls.
+CREATE UNIQUE INDEX IF NOT EXISTS cyl_video_jobs_one_active_per_scan
+  ON public.cyl_video_jobs(scan_id) WHERE status IN ('queued', 'processing');
 ALTER TABLE public.cyl_video_jobs ENABLE ROW LEVEL SECURITY;
 
 -- Reads: the service (bloom_workflows) and authenticated users (frontend poll).
@@ -70,9 +74,20 @@ BEGIN
     RETURN v_job_id;  -- already queued/processing
   END IF;
 
-  INSERT INTO public.cyl_video_jobs (scan_id, experiment_id, status)
-  VALUES (p_scan_id, p_experiment_id, 'queued')
-  RETURNING id INTO v_job_id;
+  -- Insert the new job. If a concurrent enqueue won the race for this scan, the
+  -- partial unique index raises unique_violation — reuse the winner's job.
+  BEGIN
+    INSERT INTO public.cyl_video_jobs (scan_id, experiment_id, status)
+    VALUES (p_scan_id, p_experiment_id, 'queued')
+    RETURNING id INTO v_job_id;
+  EXCEPTION WHEN unique_violation THEN
+    SELECT id INTO v_job_id
+    FROM public.cyl_video_jobs
+    WHERE scan_id = p_scan_id AND status IN ('queued', 'processing')
+    ORDER BY created_at DESC
+    LIMIT 1;
+    RETURN v_job_id;  -- winner already sent the message; don't enqueue a duplicate
+  END;
 
   SELECT pgmq.send(
     'cyl_video_generation',

--- a/supabase/migrations/20260718000000_cyl_video_queue.sql
+++ b/supabase/migrations/20260718000000_cyl_video_queue.sql
@@ -1,0 +1,155 @@
+-- Queued cyl-scan video generation: a pgmq queue + a status table + SECURITY
+-- DEFINER wrapper functions.
+--
+-- The workflows service (role bloom_workflows, reached via the Supabase client —
+-- no direct DB connection) cannot call pgmq directly. Instead it calls these
+-- public wrapper functions, which run as the owner and encapsulate both the
+-- queue and the status table. The enqueue route and the worker both go through
+-- them, so no pgmq grants or PostgREST schema exposure are needed.
+--
+-- Flow: enqueue -> (row 'queued' + pgmq.send) -> worker claim (pgmq.read + row
+-- 'processing') -> complete (row 'complete' + pgmq.delete) or fail (retry via vt
+-- expiry, or 'failed' + pgmq.archive as dead-letter after max attempts).
+
+BEGIN;
+
+-- 1. The queue -------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pgmq.list_queues() WHERE queue_name = 'cyl_video_generation') THEN
+    PERFORM pgmq.create('cyl_video_generation');
+  END IF;
+END
+$$;
+
+-- 2. Status table (the job viewer) -----------------------------------------
+CREATE TABLE IF NOT EXISTS public.cyl_video_jobs (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scan_id       bigint NOT NULL REFERENCES public.cyl_scans(id),
+  experiment_id bigint,
+  status        text NOT NULL DEFAULT 'queued'
+                CHECK (status IN ('queued', 'processing', 'complete', 'failed')),
+  msg_id        bigint,       -- pgmq message id (for delete/archive)
+  attempts      integer NOT NULL DEFAULT 0,
+  error         text,
+  path          text,         -- stored video path when complete
+  created_at    timestamptz DEFAULT now(),
+  started_at    timestamptz,
+  completed_at  timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_cyl_video_jobs_scan ON public.cyl_video_jobs(scan_id);
+CREATE INDEX IF NOT EXISTS idx_cyl_video_jobs_status ON public.cyl_video_jobs(status);
+ALTER TABLE public.cyl_video_jobs ENABLE ROW LEVEL SECURITY;
+
+-- Reads: the service (bloom_workflows) and authenticated users (frontend poll).
+-- All writes go through the SECURITY DEFINER functions below, so no write grants.
+GRANT SELECT ON public.cyl_video_jobs TO bloom_workflows;
+DROP POLICY IF EXISTS cyl_video_jobs_read ON public.cyl_video_jobs;
+CREATE POLICY cyl_video_jobs_read ON public.cyl_video_jobs
+  FOR SELECT TO bloom_workflows, authenticated USING (true);
+
+-- 3. Wrapper functions -----------------------------------------------------
+-- SECURITY DEFINER so they run as the owner (which can use pgmq); bloom_workflows
+-- only gets EXECUTE. search_path is pinned to avoid capture.
+
+-- enqueue: idempotent per scan — reuse an in-flight job instead of piling up.
+CREATE OR REPLACE FUNCTION public.enqueue_cyl_video(p_scan_id bigint, p_experiment_id bigint)
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public, pgmq
+AS $$
+DECLARE
+  v_job_id uuid;
+  v_msg_id bigint;
+BEGIN
+  SELECT id INTO v_job_id
+  FROM public.cyl_video_jobs
+  WHERE scan_id = p_scan_id AND status IN ('queued', 'processing')
+  ORDER BY created_at DESC
+  LIMIT 1;
+  IF v_job_id IS NOT NULL THEN
+    RETURN v_job_id;  -- already queued/processing
+  END IF;
+
+  INSERT INTO public.cyl_video_jobs (scan_id, experiment_id, status)
+  VALUES (p_scan_id, p_experiment_id, 'queued')
+  RETURNING id INTO v_job_id;
+
+  SELECT pgmq.send(
+    'cyl_video_generation',
+    jsonb_build_object('job_id', v_job_id, 'scan_id', p_scan_id, 'experiment_id', p_experiment_id)
+  ) INTO v_msg_id;
+
+  UPDATE public.cyl_video_jobs SET msg_id = v_msg_id WHERE id = v_job_id;
+  RETURN v_job_id;
+END;
+$$;
+
+-- claim: read one message (invisible for p_vt seconds), mark the job processing.
+CREATE OR REPLACE FUNCTION public.claim_cyl_video_job(p_vt integer DEFAULT 120)
+RETURNS TABLE(job_id uuid, scan_id bigint, experiment_id bigint, msg_id bigint)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public, pgmq
+AS $$
+DECLARE
+  r pgmq.message_record;
+BEGIN
+  SELECT * INTO r FROM pgmq.read('cyl_video_generation', p_vt, 1) LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN;  -- empty queue
+  END IF;
+
+  UPDATE public.cyl_video_jobs
+  SET status = 'processing', started_at = now()
+  WHERE id = (r.message->>'job_id')::uuid;
+
+  RETURN QUERY SELECT
+    (r.message->>'job_id')::uuid,
+    (r.message->>'scan_id')::bigint,
+    (r.message->>'experiment_id')::bigint,
+    r.msg_id;
+END;
+$$;
+
+-- complete: record the path, drop the message.
+CREATE OR REPLACE FUNCTION public.complete_cyl_video_job(p_job_id uuid, p_msg_id bigint, p_path text)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public, pgmq
+AS $$
+BEGIN
+  UPDATE public.cyl_video_jobs
+  SET status = 'complete', path = p_path, completed_at = now()
+  WHERE id = p_job_id;
+  PERFORM pgmq.delete('cyl_video_generation', p_msg_id);
+END;
+$$;
+
+-- fail: under max attempts, leave the message to redeliver after its vt expires
+-- (row back to 'queued'); at max attempts, dead-letter it (archive) + mark failed.
+CREATE OR REPLACE FUNCTION public.fail_cyl_video_job(
+  p_job_id uuid, p_msg_id bigint, p_error text, p_max_attempts integer DEFAULT 3
+)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public, pgmq
+AS $$
+DECLARE
+  v_attempts integer;
+BEGIN
+  UPDATE public.cyl_video_jobs
+  SET attempts = attempts + 1, error = p_error
+  WHERE id = p_job_id
+  RETURNING attempts INTO v_attempts;
+
+  IF v_attempts >= p_max_attempts THEN
+    UPDATE public.cyl_video_jobs SET status = 'failed', completed_at = now() WHERE id = p_job_id;
+    PERFORM pgmq.archive('cyl_video_generation', p_msg_id);  -- dead-letter
+  ELSE
+    UPDATE public.cyl_video_jobs SET status = 'queued' WHERE id = p_job_id;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.enqueue_cyl_video(bigint, bigint) TO bloom_workflows;
+GRANT EXECUTE ON FUNCTION public.claim_cyl_video_job(integer) TO bloom_workflows;
+GRANT EXECUTE ON FUNCTION public.complete_cyl_video_job(uuid, bigint, text) TO bloom_workflows;
+GRANT EXECUTE ON FUNCTION public.fail_cyl_video_job(uuid, bigint, text, integer) TO bloom_workflows;
+
+COMMIT;

--- a/supabase/migrations/20260718000000_cyl_video_queue.sql
+++ b/supabase/migrations/20260718000000_cyl_video_queue.sql
@@ -181,6 +181,17 @@ BEGIN
 END;
 $$;
 
+-- New functions get EXECUTE granted to PUBLIC by default. These wrappers are
+-- SECURITY DEFINER and the public schema is PostgREST-exposed, so a leftover
+-- PUBLIC grant would let any anon/authenticated caller invoke them directly via
+-- /rest/v1/rpc — bypassing the API's auth, rate limit, and scan validation (e.g.
+-- setting an arbitrary path on any job). Deny PUBLIC; grant only bloom_workflows,
+-- the sanctioned caller (matches insert_cyl_result_envelope, 20260630180000).
+REVOKE EXECUTE ON FUNCTION public.enqueue_cyl_video(bigint, bigint) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.claim_cyl_video_job(integer, integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.complete_cyl_video_job(uuid, bigint, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.fail_cyl_video_job(uuid, bigint, text, integer) FROM PUBLIC;
+
 GRANT EXECUTE ON FUNCTION public.enqueue_cyl_video(bigint, bigint) TO bloom_workflows;
 GRANT EXECUTE ON FUNCTION public.claim_cyl_video_job(integer, integer) TO bloom_workflows;
 GRANT EXECUTE ON FUNCTION public.complete_cyl_video_job(uuid, bigint, text) TO bloom_workflows;

--- a/supabase/migrations/20260718000000_cyl_video_queue.sql
+++ b/supabase/migrations/20260718000000_cyl_video_queue.sql
@@ -100,24 +100,43 @@ END;
 $$;
 
 -- claim: read one message (invisible for p_vt seconds), mark the job processing.
-CREATE OR REPLACE FUNCTION public.claim_cyl_video_job(p_vt integer DEFAULT 120)
+-- Poison-message guard: a job that hard-crashes the worker (OOM/SIGKILL) never
+-- reaches fail_cyl_video_job, so its attempts counter never advances and it would
+-- redeliver forever. pgmq's read_ct increments on every delivery regardless, so
+-- past p_max_reads we dead-letter here rather than hand it out again.
+CREATE OR REPLACE FUNCTION public.claim_cyl_video_job(
+  p_vt integer DEFAULT 120, p_max_reads integer DEFAULT 5
+)
 RETURNS TABLE(job_id uuid, scan_id bigint, experiment_id bigint, msg_id bigint)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public, pgmq
 AS $$
 DECLARE
   r pgmq.message_record;
+  v_job_id uuid;
 BEGIN
   SELECT * INTO r FROM pgmq.read('cyl_video_generation', p_vt, 1) LIMIT 1;
   IF NOT FOUND THEN
     RETURN;  -- empty queue
   END IF;
 
+  v_job_id := (r.message->>'job_id')::uuid;
+
+  IF r.read_ct > p_max_reads THEN
+    UPDATE public.cyl_video_jobs
+    SET status = 'failed',
+        error = coalesce(error, format('dead-lettered after %s deliveries', r.read_ct)),
+        completed_at = now()
+    WHERE id = v_job_id;
+    PERFORM pgmq.archive('cyl_video_generation', r.msg_id);
+    RETURN;  -- poison message — do not hand it to the worker again
+  END IF;
+
   UPDATE public.cyl_video_jobs
   SET status = 'processing', started_at = now()
-  WHERE id = (r.message->>'job_id')::uuid;
+  WHERE id = v_job_id;
 
   RETURN QUERY SELECT
-    (r.message->>'job_id')::uuid,
+    v_job_id,
     (r.message->>'scan_id')::bigint,
     (r.message->>'experiment_id')::bigint,
     r.msg_id;
@@ -163,7 +182,7 @@ END;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.enqueue_cyl_video(bigint, bigint) TO bloom_workflows;
-GRANT EXECUTE ON FUNCTION public.claim_cyl_video_job(integer) TO bloom_workflows;
+GRANT EXECUTE ON FUNCTION public.claim_cyl_video_job(integer, integer) TO bloom_workflows;
 GRANT EXECUTE ON FUNCTION public.complete_cyl_video_job(uuid, bigint, text) TO bloom_workflows;
 GRANT EXECUTE ON FUNCTION public.fail_cyl_video_job(uuid, bigint, text, integer) TO bloom_workflows;
 

--- a/supabase/migrations/20260721000000_cyl_video_queue.sql
+++ b/supabase/migrations/20260721000000_cyl_video_queue.sql
@@ -181,16 +181,17 @@ BEGIN
 END;
 $$;
 
--- New functions get EXECUTE granted to PUBLIC by default. These wrappers are
--- SECURITY DEFINER and the public schema is PostgREST-exposed, so a leftover
--- PUBLIC grant would let any anon/authenticated caller invoke them directly via
--- /rest/v1/rpc — bypassing the API's auth, rate limit, and scan validation (e.g.
--- setting an arbitrary path on any job). Deny PUBLIC; grant only bloom_workflows,
--- the sanctioned caller (matches insert_cyl_result_envelope, 20260630180000).
-REVOKE EXECUTE ON FUNCTION public.enqueue_cyl_video(bigint, bigint) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.claim_cyl_video_job(integer, integer) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.complete_cyl_video_job(uuid, bigint, text) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.fail_cyl_video_job(uuid, bigint, text, integer) FROM PUBLIC;
+-- These wrappers are SECURITY DEFINER and the public schema is PostgREST-exposed,
+-- so any client-reachable EXECUTE grant would let anon/authenticated invoke them
+-- directly via /rest/v1/rpc — bypassing the API's auth, rate limit, and scan
+-- validation (e.g. setting an arbitrary path on any job). New functions get
+-- EXECUTE granted to PUBLIC by default AND — under Supabase's default privileges —
+-- directly to anon/authenticated, so PUBLIC alone is not enough. Revoke all three;
+-- grant only bloom_workflows, the sanctioned caller.
+REVOKE EXECUTE ON FUNCTION public.enqueue_cyl_video(bigint, bigint) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.claim_cyl_video_job(integer, integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.complete_cyl_video_job(uuid, bigint, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.fail_cyl_video_job(uuid, bigint, text, integer) FROM PUBLIC, anon, authenticated;
 
 GRANT EXECUTE ON FUNCTION public.enqueue_cyl_video(bigint, bigint) TO bloom_workflows;
 GRANT EXECUTE ON FUNCTION public.claim_cyl_video_job(integer, integer) TO bloom_workflows;

--- a/tests/integration/test_cyl_video_queue.py
+++ b/tests/integration/test_cyl_video_queue.py
@@ -1,0 +1,139 @@
+"""Integration tests for the cyl-video queue wrappers against the live compose DB.
+
+Exercises the SECURITY DEFINER wrappers (enqueue/claim/complete/fail) and the
+cyl_video_jobs status table end-to-end over real pgmq — the layer the worker
+unit tests mock out. Seeds a temporary cyl_scans row, runs the queue lifecycle,
+then rolls back so nothing persists (uses `pg_conn`, connected as supabase_admin).
+"""
+
+
+def _new_scan(cur) -> int:
+    """Create a throwaway cyl_scans row (all columns nullable) and return its id."""
+    cur.execute("INSERT INTO public.cyl_scans DEFAULT VALUES RETURNING id")
+    return cur.fetchone()[0]
+
+
+def _job(cur, job_id):
+    cur.execute(
+        "SELECT status, scan_id, experiment_id, msg_id, attempts, path, error "
+        "FROM public.cyl_video_jobs WHERE id = %s",
+        (job_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    keys = ["status", "scan_id", "experiment_id", "msg_id", "attempts", "path", "error"]
+    return dict(zip(keys, row))
+
+
+def test_enqueue_creates_queued_job(pg_conn):
+    try:
+        with pg_conn.cursor() as cur:
+            scan_id = _new_scan(cur)
+            cur.execute("SELECT public.enqueue_cyl_video(%s, %s)", (scan_id, 42))
+            job_id = cur.fetchone()[0]
+
+            job = _job(cur, job_id)
+            assert job["status"] == "queued"
+            assert job["scan_id"] == scan_id
+            assert job["experiment_id"] == 42
+            assert job["msg_id"] is not None  # pgmq.send returned a message id
+    finally:
+        pg_conn.rollback()
+
+
+def test_enqueue_is_idempotent_per_scan(pg_conn):
+    # The partial unique index + fast-path must collapse repeat enqueues into one job.
+    try:
+        with pg_conn.cursor() as cur:
+            scan_id = _new_scan(cur)
+            cur.execute("SELECT public.enqueue_cyl_video(%s, %s)", (scan_id, 1))
+            first = cur.fetchone()[0]
+            cur.execute("SELECT public.enqueue_cyl_video(%s, %s)", (scan_id, 1))
+            second = cur.fetchone()[0]
+
+            assert first == second
+            cur.execute(
+                "SELECT count(*) FROM public.cyl_video_jobs WHERE scan_id = %s", (scan_id,)
+            )
+            assert cur.fetchone()[0] == 1
+    finally:
+        pg_conn.rollback()
+
+
+def test_claim_marks_processing_and_returns_job(pg_conn):
+    try:
+        with pg_conn.cursor() as cur:
+            scan_id = _new_scan(cur)
+            cur.execute("SELECT public.enqueue_cyl_video(%s, %s)", (scan_id, 7))
+            job_id = cur.fetchone()[0]
+
+            cur.execute("SELECT * FROM public.claim_cyl_video_job(120)")
+            claimed = cur.fetchone()
+            assert claimed is not None
+            c_job_id, c_scan_id, c_exp_id, c_msg_id = claimed
+            assert c_job_id == job_id
+            assert c_scan_id == scan_id
+            assert c_exp_id == 7
+            assert c_msg_id is not None
+
+            job = _job(cur, job_id)
+            assert job["status"] == "processing"
+    finally:
+        pg_conn.rollback()
+
+
+def test_complete_marks_complete_and_drops_message(pg_conn):
+    try:
+        with pg_conn.cursor() as cur:
+            scan_id = _new_scan(cur)
+            cur.execute("SELECT public.enqueue_cyl_video(%s, %s)", (scan_id, 1))
+            job_id = cur.fetchone()[0]
+            cur.execute("SELECT * FROM public.claim_cyl_video_job(120)")
+            _, _, _, msg_id = cur.fetchone()
+
+            cur.execute(
+                "SELECT public.complete_cyl_video_job(%s, %s, %s)",
+                (job_id, msg_id, f"cyl-videos/{scan_id}.mp4"),
+            )
+            job = _job(cur, job_id)
+            assert job["status"] == "complete"
+            assert job["path"] == f"cyl-videos/{scan_id}.mp4"
+
+            # Message is gone: a fresh claim finds nothing.
+            cur.execute("SELECT * FROM public.claim_cyl_video_job(120)")
+            assert cur.fetchone() is None
+    finally:
+        pg_conn.rollback()
+
+
+def test_fail_retries_then_dead_letters(pg_conn):
+    try:
+        with pg_conn.cursor() as cur:
+            scan_id = _new_scan(cur)
+            cur.execute("SELECT public.enqueue_cyl_video(%s, %s)", (scan_id, 1))
+            job_id = cur.fetchone()[0]
+            cur.execute("SELECT * FROM public.claim_cyl_video_job(120)")
+            _, _, _, msg_id = cur.fetchone()
+
+            # Under max attempts: back to 'queued' for redelivery.
+            cur.execute(
+                "SELECT public.fail_cyl_video_job(%s, %s, %s, %s)",
+                (job_id, msg_id, "boom", 3),
+            )
+            job = _job(cur, job_id)
+            assert job["status"] == "queued"
+            assert job["attempts"] == 1
+            assert job["error"] == "boom"
+
+            # Reach max attempts: dead-lettered and marked failed.
+            for _ in range(2):
+                cur.execute(
+                    "SELECT public.fail_cyl_video_job(%s, %s, %s, %s)",
+                    (job_id, msg_id, "boom", 3),
+                )
+            job = _job(cur, job_id)
+            assert job["status"] == "failed"
+            assert job["attempts"] == 3
+    finally:
+        pg_conn.rollback()

--- a/tests/integration/test_cyl_video_queue.py
+++ b/tests/integration/test_cyl_video_queue.py
@@ -137,3 +137,32 @@ def test_fail_retries_then_dead_letters(pg_conn):
             assert job["attempts"] == 3
     finally:
         pg_conn.rollback()
+
+
+def test_claim_dead_letters_poison_message(pg_conn):
+    # A job that hard-crashes the worker never calls fail_job (attempts stays 0),
+    # so dead-lettering must fall back to pgmq's read_ct. Simulate a message that
+    # has been redelivered many times and confirm claim dead-letters it.
+    try:
+        with pg_conn.cursor() as cur:
+            scan_id = _new_scan(cur)
+            cur.execute("SELECT public.enqueue_cyl_video(%s, %s)", (scan_id, 1))
+            job_id = cur.fetchone()[0]
+            cur.execute("SELECT msg_id FROM public.cyl_video_jobs WHERE id = %s", (job_id,))
+            msg_id = cur.fetchone()[0]
+
+            # Pretend the worker has already crashed on this message many times.
+            cur.execute(
+                "UPDATE pgmq.q_cyl_video_generation SET read_ct = 10 WHERE msg_id = %s",
+                (msg_id,),
+            )
+
+            # max_reads below read_ct -> dead-letter, hand nothing to the worker.
+            cur.execute("SELECT * FROM public.claim_cyl_video_job(120, 5)")
+            assert cur.fetchone() is None
+
+            job = _job(cur, job_id)
+            assert job["status"] == "failed"   # dead-lettered by read_ct...
+            assert job["attempts"] == 0        # ...even though fail_job never ran
+    finally:
+        pg_conn.rollback()

--- a/tests/integration/test_cyl_video_queue.py
+++ b/tests/integration/test_cyl_video_queue.py
@@ -139,6 +139,32 @@ def test_fail_retries_then_dead_letters(pg_conn):
         pg_conn.rollback()
 
 
+def test_wrappers_denied_to_public(pg_conn):
+    # The SECURITY DEFINER wrappers are PostgREST-exposed (public schema). EXECUTE
+    # must be revoked from PUBLIC so a direct /rest/v1/rpc call as anon/authenticated
+    # can't bypass the API's auth + rate limit. Only bloom_workflows may call them.
+    wrappers = [
+        "public.enqueue_cyl_video(bigint, bigint)",
+        "public.claim_cyl_video_job(integer, integer)",
+        "public.complete_cyl_video_job(uuid, bigint, text)",
+        "public.fail_cyl_video_job(uuid, bigint, text, integer)",
+    ]
+    try:
+        with pg_conn.cursor() as cur:
+            for sig in wrappers:
+                for role in ("anon", "authenticated"):
+                    cur.execute(
+                        "SELECT has_function_privilege(%s, %s, 'EXECUTE')", (role, sig)
+                    )
+                    assert cur.fetchone()[0] is False, f"{role} must NOT execute {sig}"
+                cur.execute(
+                    "SELECT has_function_privilege('bloom_workflows', %s, 'EXECUTE')", (sig,)
+                )
+                assert cur.fetchone()[0] is True, f"bloom_workflows must execute {sig}"
+    finally:
+        pg_conn.rollback()
+
+
 def test_claim_dead_letters_poison_message(pg_conn):
     # A job that hard-crashes the worker never calls fail_job (attempts stays 0),
     # so dead-lettering must fall back to pgmq's read_ct. Simulate a message that


### PR DESCRIPTION
## What this does

Adds the **queued** (async) way to generate a cyl-scan video, alongside the existing on-demand route.

- **On-demand** (already shipped): you call the endpoint, it generates the video during the request, and returns the URL. Fine for one video, but the caller waits.
- **Queued** (this PR): you call `.../video/queue`, it drops a job on a queue and returns a `job_id` right away. A separate worker picks the job up and generates the video in the background. Good for batches and for not making the caller wait.

## How it works

1. **Enqueue** — `POST /cyl/experiments/{id}/scans/{id}/video/queue` adds a job to a Postgres queue (pgmq) and returns a `job_id`. Same auth (Supabase user JWT) and per-user rate limit as the on-demand route.
2. **Worker** — a new `cyl-video-worker` container polls the queue, generates the video using the **same code** as the on-demand route (`video.generate_scan_video`), and updates a status table.
3. **Status** — the `cyl_video_jobs` table tracks each job: `queued → processing → complete` (or `failed`). Authenticated users can read it to poll progress.
4. **Retries** — if a job fails, it's retried automatically; after 3 attempts it's set aside (dead-lettered) and marked `failed`.

## Security model (unchanged from the on-demand route)

The service never talks to the queue directly. All queue operations go through four database wrapper functions (`SECURITY DEFINER`), and the `bloom_workflows` role only gets permission to *call* those functions — no direct queue access, no new privileges. Same least-privilege identity as the rest of the workflows service.

## Files

- **migration** `20260718000000_cyl_video_queue.sql` — the queue, the `cyl_video_jobs` status table, and the four wrapper functions.
- **`video_queue.py`** — enqueue / claim / complete / fail helpers.
- **`worker.py`** — the polling worker loop (graceful shutdown, reconnect on error).
- **`main.py`** — the new `.../video/queue` endpoint.
- **compose (dev + prod)** — the `cyl-video-worker` service (same image as the API; scale by running more replicas).
- **tests + README**.

## Scope

Cyl only. A graviscan video queue is a separate follow-up — it needs its own video-generation code first (the service can't yet make graviscan videos).

## History

This is a clean rebuild of the earlier #416 (which had drifted far behind staging). Everything already merged (auth, the on-demand video code, the pgmq-enable migration) is left out — this PR is only the net-new queue pieces. #416 can be closed as superseded.

## Draft

Opening as a draft to review the approach first.
