### PR TITLE
ci(security): suppress CVE-2026-57433 in .trivyignore (no upstream fix)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -91,6 +91,14 @@ CVE-2026-42496
 # Reassess on next python:3.11-slim SHA bump.
 CVE-2026-8376
 
+# perl-base 5.40.1-6 (Debian 13.6 in python:3.11-slim) — affects: langchain-agent
+# Signed integer overflow in Perl's Storable module (pre-3.41) during
+# deserialization. The agent does not execute Perl or deserialize Perl Storable
+# data at runtime; perl-base is a transitive Debian base package included by
+# python:3.11-slim, never invoked by application code. No fix available
+# upstream. Reassess on next python:3.11-slim SHA bump.
+CVE-2026-57433
+
 # linux-libc-dev (Debian 13 in python:3.11-slim) — affects: langchain-agent / bloommcp
 # kernel: ksmbd signedness bug. Kernel headers are a build-time-only transitive base
 # package; the container runs no kernel and uses no in-kernel SMB server (ksmbd), so the


### PR DESCRIPTION
## Summary

- Suppresses CVE-2026-57433 (perl-base 5.40.1-6, Debian 13.6 in `python:3.11-slim`) in `.trivyignore` — a signed integer overflow in Perl's Storable module during deserialization.
- Split out as its own PR per `scripts/lint_cve_isolation.sh`'s "CVE work must ship in its own PR" rule — it was originally going to ride along in #480, but that PR touches unrelated non-Dockerfile files, which would fail the isolation check.

## Why this is safe to suppress

- No fix available upstream for this Debian package version.
- `perl-base` is a transitive dependency of `python:3.11-slim` — none of the services built on it (langchain-agent, bloommcp, workflows) execute Perl or deserialize Perl `Storable` data at runtime. The affected code path is unreachable.
- Matches the exact existing pattern for CVE-2026-13221, CVE-2026-42496, and CVE-2026-8376 — same package, same base image, same reachability argument, already accepted in this file.

## Test plan

- [x] `bash scripts/lint_cve_isolation.sh origin/staging` — passes (touches only `.trivyignore`)
- [ ] CI's `Check langchain-agent for critical CVEs` (and any other service sharing this base image) goes green once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
