### PR TITLE
ci(security): suppress CVE-2026-59873 (node-tar vendored in Next.js, not runtime-reachable)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -121,3 +121,14 @@ CVE-2026-53260
 # upstream. Reassess on the next python:3.11-slim SHA bump.
 # Upstream: https://nvd.nist.gov/vuln/detail/CVE-2026-11940
 CVE-2026-11940
+
+# tar / node-tar (bloom-web) — CVE-2026-59873, gzip-bomb DoS.
+# Two copies exist in the bloom-web runtime image: npm's bundled tar (build
+# tooling; already forwarded to fixed 7.5.19 via `npm install -g npm@11.18.0`
+# in the runner stage) and next/dist/compiled/tar, a copy vendored INSIDE
+# Next.js (16.2.0). Neither is reachable: the Next production server
+# (`next start`) does not extract untrusted, attacker-supplied gzip'd tar
+# archives, so the gzip-bomb precondition never holds at runtime. Next's
+# vendored copy has no fix short of a Next upgrade that re-vendors tar >=7.5.19.
+# Reassess when Next ships a build with the patched vendored tar.
+CVE-2026-59873


### PR DESCRIPTION
## What

Suppress **CVE-2026-59873** (node-tar gzip-bomb DoS) in `.trivyignore`, clearing the required `bloom-web` critical-CVE gate that currently blocks the merge queue on `staging` and every open PR.

## Why suppression (not another bump)

The `bloom-web` runtime image carries **two** copies of `tar`:

| Copy | Version | Status |
| --- | --- | --- |
| `/usr/local/lib/node_modules/npm/node_modules/tar` | 7.5.19 | ✅ already fixed — the runner pins `npm@11.18.0` (merged to staging in `3b6516b`) |
| `/app/node_modules/next/dist/compiled/tar` | 6.2.1 | ❌ vendored **inside Next.js 16.2.0** — no in-tree fix |

The npm pin only patches npm's copy. The remaining flagged copy is vendored inside Next.js itself, so it cannot be bumped via `package-lock.json`/`overrides`; the only "real" fix would be a Next.js upgrade that happens to re-vendor a patched tar (uncertain, and a runtime dependency shift).

## Exploitability

The gzip-bomb DoS requires the process to **extract an untrusted, attacker-supplied gzip'd tar archive**. The Next production server (`next start`) does not do this — the vendored tar is internal Next build machinery, not reachable from request handling. So the runtime risk is nil; this is the scanner flagging a vendored copy.

## Scope

- One entry in `.trivyignore` (with justification), nothing else. Passes the CVE-isolation lint.

## Notes

Confirmed empirically by inventorying every `tar/package.json` in the built image. Reassess and drop this suppression when Next.js ships a build vendoring tar ≥ 7.5.19.
