### PR TITLE
chore(ci): list pinned-image CVEs below the table, not inline

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1107,18 +1107,24 @@ jobs:
           {
             echo "## Pinned Image CVE Report"
             echo ""
-            echo "| Image | Critical | High | CVEs |"
-            echo "|-------|----------|------|------|"
+            echo "| Image | Critical | High |"
+            echo "|-------|----------|------|"
+            cve_lines=""
             for file in results/trivy-pinned-*/summary.txt; do
               if [ -f "$file" ]; then
                 IFS='|' read -r img crit high cves < "$file"
+                echo "| ${img} | ${crit} | ${high} |"
                 if [ -n "$cves" ]; then
-                  echo "| ${img} | ${crit} | ${high} | ${cves} |"
-                else
-                  echo "| ${img} | ${crit} | ${high} | — |"
+                  cve_lines="${cve_lines}- **${img}**: ${cves}"$'\n'
                 fi
               fi
             done
+            if [ -n "$cve_lines" ]; then
+              echo ""
+              echo "### CVEs by image"
+              echo ""
+              printf '%s' "$cve_lines"
+            fi
           } > pinned-report.md
 
       - name: Post as PR comment


### PR DESCRIPTION
## What

Cosmetic change to the **Pinned Image CVE Report** (the sticky PR comment from the pinned-image scans): keep the summary table to `Image | Critical | High` and move the per-image CVE IDs to a **"CVEs by image"** list beneath it.

## Why

The old table had a `CVEs` column that inlined every CVE ID per row, making rows very wide and the table hard to read once an image had several CVEs. Moving the IDs below keeps the table compact and scannable while preserving all the detail.

## Behavior

- Table rows: `| image | crit | high |` — narrow, fixed width.
- Below (only when there are CVEs): a `### CVEs by image` bullet list, one line per image that has CVEs. Images with none are simply omitted from the list.

Output tested locally against mock `summary.txt` inputs.

## Scope

- One block in `.github/workflows/pr-checks.yml` (the `Generate combined report` step). No behavioral change to scanning or gating — report formatting only.
