### PR TITLE
feat(web): multi-field + batch barcode search for cylinder plants

### DIFF
--- a/supabase/migrations/20260723000000_add_cyl_plant_search_view.sql
+++ b/supabase/migrations/20260723000000_add_cyl_plant_search_view.sql
@@ -1,0 +1,35 @@
+-- Flattened, searchable plant row backing the cylinder search bar (barcode /
+-- accession name / species). One row per plant with its barcode, accession name,
+-- species, and experiment, so the UI can match a free-text term across all of them
+-- with a single query (and resolve a pasted barcode list in one call).
+--
+-- security_invoker = on so it runs under the caller's RLS. LEFT joins so a plant
+-- with no wave/experiment/accession still appears (any barcode findable before the
+-- view stays findable); soft-deleted experiments are excluded — with the LEFT join,
+-- `e.deleted_at IS NULL` is true both for a plant with no experiment and for a plant
+-- whose experiment is live, and false only when the experiment is soft-deleted.
+--
+-- Supabase's default privileges auto-grant SELECT to anon on new public views, so
+-- revoke it explicitly (omitting anon from the grant is not enough).
+
+create or replace view public.cyl_plant_search
+with (security_invoker = on) as
+select
+  p.id           as plant_id,
+  p.qr_code,
+  p.accession_id,
+  a.name         as accession_name,
+  e.id           as experiment_id,
+  e.name         as experiment_name,
+  sp.id          as species_id,
+  sp.common_name as species_name
+from cyl_plants p
+left join cyl_waves       w  on w.id  = p.wave_id
+left join cyl_experiments e  on e.id  = w.experiment_id
+left join accessions      a  on a.id  = p.accession_id
+left join species         sp on sp.id = e.species_id
+where e.deleted_at is null;
+
+grant select on public.cyl_plant_search
+  to authenticated, bloom_user, bloom_admin, bloom_agent;
+revoke all on public.cyl_plant_search from anon;

--- a/tests/integration/test_cyl_plant_search_view.py
+++ b/tests/integration/test_cyl_plant_search_view.py
@@ -63,8 +63,9 @@ def test_plant_search_matches_accession_and_species(pg_conn):
 
 def test_plant_search_excludes_soft_deleted_experiments(pg_conn):
     with pg_conn.cursor() as cur:
-        _seed_plant(cur, qr="Q-live")
-        _seed_plant(cur, qr="Q-deleted", deleted=True)
+        # distinct accession names — accessions.name is UNIQUE
+        _seed_plant(cur, qr="Q-live", accession="Acc-live", exp="Exp-live")
+        _seed_plant(cur, qr="Q-deleted", accession="Acc-del", exp="Exp-del", deleted=True)
         cur.execute("SELECT qr_code FROM cyl_plant_search WHERE qr_code IN ('Q-live', 'Q-deleted')")
         got = {r[0] for r in cur.fetchall()}
         assert got == {"Q-live"}  # the deleted-experiment plant is excluded

--- a/tests/integration/test_cyl_plant_search_view.py
+++ b/tests/integration/test_cyl_plant_search_view.py
@@ -63,9 +63,12 @@ def test_plant_search_matches_accession_and_species(pg_conn):
 
 def test_plant_search_excludes_soft_deleted_experiments(pg_conn):
     with pg_conn.cursor() as cur:
-        # distinct accession names — accessions.name is UNIQUE
-        _seed_plant(cur, qr="Q-live", accession="Acc-live", exp="Exp-live")
-        _seed_plant(cur, qr="Q-deleted", accession="Acc-del", exp="Exp-del", deleted=True)
+        # distinct accession + species names — both accessions.name and
+        # species.common_name are UNIQUE
+        _seed_plant(cur, qr="Q-live", accession="Acc-live", species="Sp-live", exp="Exp-live")
+        _seed_plant(
+            cur, qr="Q-deleted", accession="Acc-del", species="Sp-del", exp="Exp-del", deleted=True
+        )
         cur.execute("SELECT qr_code FROM cyl_plant_search WHERE qr_code IN ('Q-live', 'Q-deleted')")
         got = {r[0] for r in cur.fetchall()}
         assert got == {"Q-live"}  # the deleted-experiment plant is excluded

--- a/tests/integration/test_cyl_plant_search_view.py
+++ b/tests/integration/test_cyl_plant_search_view.py
@@ -1,0 +1,89 @@
+"""cyl_plant_search view — flattened, searchable plant rows (barcode/accession/species).
+
+LOCAL ONLY: the `pg_conn` fixture (see conftest) connects as `supabase_admin`
+(BYPASSRLS); every test rolls back. Grants are exercised with `has_table_privilege`.
+"""
+
+
+def _seed_plant(cur, *, qr, accession="Acc-1", species="Rice", exp="Exp-1", deleted=False):
+    cur.execute("INSERT INTO species (common_name) VALUES (%s) RETURNING id", (species,))
+    species_id = cur.fetchone()[0]
+    if deleted:
+        cur.execute(
+            "INSERT INTO cyl_experiments (name, species_id, deleted_at) "
+            "VALUES (%s, %s, now()) RETURNING id",
+            (exp, species_id),
+        )
+    else:
+        cur.execute(
+            "INSERT INTO cyl_experiments (name, species_id) VALUES (%s, %s) RETURNING id",
+            (exp, species_id),
+        )
+    exp_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO cyl_waves (experiment_id, number) VALUES (%s, 1) RETURNING id", (exp_id,)
+    )
+    wave_id = cur.fetchone()[0]
+    accession_id = None
+    if accession is not None:
+        cur.execute("INSERT INTO accessions (name) VALUES (%s) RETURNING id", (accession,))
+        accession_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO cyl_plants (wave_id, accession_id, qr_code) VALUES (%s, %s, %s) RETURNING id",
+        (wave_id, accession_id, qr),
+    )
+    return cur.fetchone()[0]
+
+
+def test_plant_search_flattens_fields(pg_conn):
+    with pg_conn.cursor() as cur:
+        _seed_plant(cur, qr="Q-100", accession="Williams82", species="Soybean", exp="GDM Screen")
+        cur.execute(
+            "SELECT qr_code, accession_name, species_name, experiment_name "
+            "FROM cyl_plant_search WHERE qr_code = %s",
+            ("Q-100",),
+        )
+        row = cur.fetchone()
+        assert row == ("Q-100", "Williams82", "Soybean", "GDM Screen")
+    pg_conn.rollback()
+
+
+def test_plant_search_matches_accession_and_species(pg_conn):
+    # the view is what backs the multi-field search: accession + species are queryable columns
+    with pg_conn.cursor() as cur:
+        _seed_plant(cur, qr="Q-1", accession="Bay-0", species="Canola")
+        cur.execute(
+            "SELECT count(*) FROM cyl_plant_search "
+            "WHERE accession_name ILIKE %s OR species_name ILIKE %s",
+            ("%bay%", "%canola%"),
+        )
+        assert cur.fetchone()[0] == 1
+    pg_conn.rollback()
+
+
+def test_plant_search_excludes_soft_deleted_experiments(pg_conn):
+    with pg_conn.cursor() as cur:
+        _seed_plant(cur, qr="Q-live")
+        _seed_plant(cur, qr="Q-deleted", deleted=True)
+        cur.execute("SELECT qr_code FROM cyl_plant_search WHERE qr_code IN ('Q-live', 'Q-deleted')")
+        got = {r[0] for r in cur.fetchall()}
+        assert got == {"Q-live"}  # the deleted-experiment plant is excluded
+    pg_conn.rollback()
+
+
+def test_plant_search_keeps_plant_without_accession(pg_conn):
+    # a plant with no accession must still be findable by barcode (accession_name NULL)
+    with pg_conn.cursor() as cur:
+        _seed_plant(cur, qr="Q-noacc", accession=None)
+        cur.execute(
+            "SELECT qr_code, accession_name FROM cyl_plant_search WHERE qr_code = %s", ("Q-noacc",)
+        )
+        assert cur.fetchone() == ("Q-noacc", None)
+    pg_conn.rollback()
+
+
+def test_plant_search_not_granted_to_anon(pg_conn):
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT has_table_privilege('anon', 'public.cyl_plant_search', 'SELECT')")
+        assert cur.fetchone()[0] is False, "anon must NOT have SELECT on cyl_plant_search"
+    pg_conn.rollback()

--- a/web/components/searchPage.tsx
+++ b/web/components/searchPage.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { useState, useEffect } from 'react';
-import { TextField, Box, CircularProgress, List, ListItem, ListItemText } from '@mui/material';
+import { TextField, Box, CircularProgress, List } from '@mui/material';
 import { createClientSupabaseClient } from "@/lib/supabase/client";
-import { Database } from "@/lib/database.types";
 import { Divider } from '@mui/material';
 
 export default function SearchComponent() {
@@ -26,26 +25,21 @@ export default function SearchComponent() {
   const fetchResults = async (query: string) => {
     setLoading(true);
 
-    const { data, error } = await supabase
-      .from('cyl_plants')
-        .select(`
-          *,
-          wave_id (
-            *,
-            experiment_id (
-              *,
-              species_id (
-                common_name
-              )
-            )
-          ),
-          accession:accession_id (
-            name
-          )
-        `)
-      .ilike('qr_code', `%${query}%`);
+    // A comma- or newline-separated list of barcodes → resolve them all at once.
+    // A single free-text term → match it against barcode, accession, or species.
+    const tokens = query
+      .split(/[\n,]+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
 
-    console.log(data)
+    const base = supabase.from('cyl_plant_search').select('*');
+    const term = tokens[0] ?? query.trim();
+    const { data, error } =
+      tokens.length > 1
+        ? await base.in('qr_code', tokens)
+        : await base.or(
+            `qr_code.ilike.%${term}%,accession_name.ilike.%${term}%,species_name.ilike.%${term}%`
+          );
 
     if (error) {
       console.error('Query error:', error.message);
@@ -61,31 +55,33 @@ export default function SearchComponent() {
     <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', mt: 4, mb: 4 }}>
       <TextField
         fullWidth
-        label="Search Barcodes"
+        multiline
+        minRows={1}
+        label="Search by barcode, accession, or species — or paste a list of barcodes"
         variant="outlined"
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
       />
 
+      {loading && <CircularProgress sx={{ mt: 2 }} />}
+
       { results.length > 0 && <Box
         sx={{
-          height: 300,         
-          overflowY: 'auto',  
+          maxHeight: 300,
+          overflowY: 'auto',
           border: '1px solid #ccc',
           borderRadius: 2,
           p: 2,
           mt: 2,
         }}
       >
-
-      {loading && <CircularProgress sx={{ mt: 2 }} />}
       <List>
-          {results.map((item,index )=> (
-            <div key={item.id}>
+          {results.map((item, index) => (
+            <div key={item.plant_id ?? index}>
               <h1><b>Barcode: </b>{item.qr_code}</h1>
-              <h1><b>Experiment: </b>{item.wave_id?.experiment_id?.name}</h1>
-              <h1><b>Species: </b>{item.wave_id?.experiment_id?.species_id?.common_name}</h1>
-              <h1><b>Accession: </b>{item.accession?.name}</h1>
+              <h1><b>Experiment: </b>{item.experiment_name}</h1>
+              <h1><b>Species: </b>{item.species_name}</h1>
+              <h1><b>Accession: </b>{item.accession_name}</h1>
               {index < results.length - 1 && <Divider sx={{ my: 2 }} />}
             </div>
           ))}

--- a/web/lib/database.types.ts
+++ b/web/lib/database.types.ts
@@ -2239,6 +2239,19 @@ export type Database = {
       }
     }
     Views: {
+      cyl_plant_search: {
+        Row: {
+          accession_id: number | null
+          accession_name: string | null
+          experiment_id: number | null
+          experiment_name: string | null
+          plant_id: number | null
+          qr_code: string | null
+          species_id: number | null
+          species_name: string | null
+        }
+        Relationships: []
+      }
       cyl_plants_extended: {
         Row: {
           accession_id: number | null


### PR DESCRIPTION
## What

Extends the cylinder search bar from **barcode-only, one-at-a-time** to **multi-field** and **batch** search:

- Match a free-text term against **barcode, accession name, or species** (not just barcode).
- Paste a **list of barcodes** (comma/newline-separated) → all resolved in one query.

Addresses researcher feedback that barcode-only search is limiting and one-at-a-time.

## How

- New `security_invoker` view **`cyl_plant_search`** flattens each plant with its barcode, accession name, species, and experiment. LEFT joins so any barcode findable before stays findable; soft-deleted experiments excluded; grants + explicit `REVOKE ... FROM anon`.
- `searchPage.tsx` queries the view: `.or(...)` across barcode/accession/species for a single term, `.in('qr_code', [...])` for a pasted list.
- Added the view to the web app's generated DB types.

So barcode, accession/PI, species, rep-ID, and pasted barcode lists are all handled here.

## Tests

Integration tests for the view: flattened fields, accession/species queryable, soft-deleted experiments excluded, plant-without-accession still findable by barcode, `anon` denied SELECT.

## Related

- Part of #482 (flexible search / bulk selection for Cylinder Phenotypes).
- Closes #501 (replicate-ID search — the rep ID lives in the barcode, so the barcode search covers it).

