### PR TITLE
chore(web): temporarily disable section of Bloom

### DIFF
--- a/web/app/app/layout.tsx
+++ b/web/app/app/layout.tsx
@@ -28,7 +28,8 @@ const navSections = [
   {
     heading: "Tools",
     items: [
-      { name: "Bloom Assistant", href: "/chat" },
+      // Temporarily disabled — Bloom Assistant is a work in progress.
+      // { name: "Bloom Assistant", href: "/chat" },
       { name: "OrthoBrowser", href: "/app/orthofinder" },
       { name: "OrthoVec", href: "/app/embedtree" },
     ],

--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -1,5 +1,8 @@
-import MCPChat from "@/components/mcp-chat-client";
+import { redirect } from "next/navigation";
+// Temporarily disabled — Bloom Assistant is a work in progress.
+// import MCPChat from "@/components/mcp-chat-client";
 
 export default function ChatPage() {
-  return <MCPChat />;
+  redirect("/app");
+  // return <MCPChat />;
 }

--- a/web/components/home-hero.tsx
+++ b/web/components/home-hero.tsx
@@ -60,12 +60,14 @@ export function HomeHero({ firstName, speciesCount, dbCounts }: Props) {
               Explore phenotypes
               <span aria-hidden>→</span>
             </Link>
+            {/* Temporarily disabled — Bloom Assistant is a work in progress.
             <Link
               href="/chat"
               className="inline-flex items-center rounded-md border border-stone-300 px-4 py-2.5 text-sm font-medium text-stone-700 hover:bg-stone-50 hover:border-stone-400 transition-colors"
             >
               Ask the Bloom Assistant
             </Link>
+            */}
           </div>
         </div>
 


### PR DESCRIPTION
Summary

## 

### What changed
- **Sidebar nav** (`web/app/app/layout.tsx`) — commented out the "Bloom Assistant" nav item under Tools.
- **Home hero CTA** (`web/components/home-hero.tsx`) — commented out the "Ask the Bloom Assistant" button.
- **`/chat` route** (`web/app/chat/page.tsx`) — redirects to `/app` instead of rendering the chat client, so the page can't be reached directly.

### Scope
- No behavior change to any other feature 

-  RIP Bloom Assistant 
Here lies the Bloom Assistant UI — temporarily laid to rest, with hopes of being resurrected in the future. 🌱

This PR hides the assistant's user-facing entry points while it's still a work in progress. Nothing is deleted — the client and route code are left in place so it can rise again with a one-line revert.

### What's preserved (for the resurrection 🧬)
- The chat client (`components/mcp-chat-client`) and all route/backend code are untouched.
- Re-enabling = uncomment the three spots and drop the redirect.

### Testing
- `/chat` now redirects to `/app`.
- Bloom Assistant no longer appears in the sidebar or on the home page.
- No other nav entries or routes changed.