### PR TITLE
fix(bloomcli): resolve ruff import-order errors blocking release-bloomcli.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: 2c8dce6094fa2b4b668e74f694ca63ceffd38614  # v0.9.9
     hooks:
       - id: ruff
-        files: ^(langchain|bloommcp|services/workflows)/
+        files: ^(langchain|bloommcp|services/workflows|bloomcli)/
         args: [--fix]
       - id: ruff-format
         files: ^(langchain|bloommcp|services/workflows)/

--- a/bloomcli/src/bloomctl/cyl/experiments.py
+++ b/bloomcli/src/bloomctl/cyl/experiments.py
@@ -79,8 +79,9 @@ def fetch_experiments(client: Any) -> list[dict[str, Any]]:
 )
 def list_experiments(as_json: bool, profile: str) -> None:
     """List cylinder experiments."""
-    from ..cli import _authed_client
     from postgrest import APIError
+
+    from ..cli import _authed_client
 
     client = _authed_client(profile)
     try:

--- a/bloomcli/tests/test_changelog_version_sync.py
+++ b/bloomcli/tests/test_changelog_version_sync.py
@@ -6,6 +6,7 @@ time.
 """
 
 from __future__ import annotations
+
 import re
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

Cutting the `bloomctl-v0.1.0a2` GitHub Release just failed at
`release-bloomcli.yml`'s `validate-release` job — `ruff check .` found 2
unsorted-import (`I001`) errors. This is the **only** place in the whole
pipeline that lints `bloomcli` (it was never in `.pre-commit-config.yaml`'s
`ruff` hook scope), so both slipped through unnoticed until an actual release
was attempted. Nothing published to PyPI — the release pipeline correctly
aborted before `build-and-publish` ran. The release/tag have been deleted and
will be re-cut once this merges.

## Changes

- `bloomcli/src/bloomctl/cyl/experiments.py` — pre-existing import-order
  issue, unrelated to any recent bloomcli work.
- `bloomcli/tests/test_changelog_version_sync.py` — introduced with the
  container-release work (#515), never linted before now.
- Both fixed via `ruff check --fix` (whitespace/import-order only, no
  functional change).
- Added `bloomcli` to `.pre-commit-config.yaml`'s `ruff` hook scope so this
  can't silently recur. `ruff-format` intentionally left untouched — it would
  reformat 10 unrelated files, a separate concern outside this fix's scope.

## Testing

- [x] `uvx ruff@0.9.9 check bloomcli/` — clean
- [x] `cd bloomcli && uv run --extra test pytest tests/ -m "not integration"` — 192 passed, 2 pre-existing unrelated failures (same as noted in #515)