### PR TITLE
docs(bloommcp): OpenSpec proposal — retire TRAITS_DIR read bypasses (#476)

### DIFF
--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/design.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/design.md
@@ -3,11 +3,11 @@
 Issue #476 asks to audit two `BLOOM_TRAITS_DIR` read bypasses and either (a) route them
 through `ExperimentReader`, or (b) delete them if provably unreachable.
 
-- **Site (a), `qc_inspect.py:503`**, is cheap and safe: `_ports.raw_source_for` already
-  exists and is already the pattern `qc_clean.py`/`_ports.start_run` use for the identical
-  provenance-sourcing problem. #479's PR review independently found and fixed this same
-  line (for a different reason — fully-local-mode provenance), but that branch is
-  unmerged, so `staging` still has the bare `TRAITS_DIR` read today.
+- **Site (a), `qc_inspect.py:503`**, is already resolved — not this change's scope. #479's
+  PR review independently found and fixed this same line (for a different reason —
+  fully-local-mode provenance), and that work merged into `staging` as
+  [PR #526](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/526). See the
+  Reconciliation note below for how this was caught.
 - **Site (b), `supabase_reader.py`'s raw-tier fallback**, is not a simple bypass to route
   or delete — it is the *only* thing serving raw experiment reads on the default
   (Supabase) backend today. `bloommcp/docs/data-access-roadmap.md`'s Live-state facts
@@ -26,8 +26,6 @@ through `ExperimentReader`, or (b) delete them if provably unreachable.
 ## Goals / Non-Goals
 
 - Goals:
-  - Fix site (a) now — it's genuinely independent, low-risk, and already validated by
-    #479's implementation.
   - Fix `supabase_reader.py`'s two distinct doc problems: the module docstring citing the
     closed bucket-migration plan as the removal trigger (the same belief that already
     produced two wrong-direction PRs), and `_LOCAL_RAW_DEPRECATION`'s "promoted, not
@@ -35,6 +33,8 @@ through `ExperimentReader`, or (b) delete them if provably unreachable.
     fallback has a tracked retirement path. These are two separate sentences with two
     separate problems, not one blanket "stop citing the bucket" edit.
 - Non-Goals:
+  - Re-implementing `qc_inspect.py`'s provenance-source fix — already shipped by
+    #479/PR #526; nothing to do here.
   - Implementing `data-access-roadmap.md`'s Tier 1/2 (DB-direct rewrite).
   - Changing `SupabaseReader`'s raw-tier read behavior, return values, or `RawSourced`
     contract.
@@ -70,13 +70,21 @@ through `ExperimentReader`, or (b) delete them if provably unreachable.
   anything."** Mitigation: the value is specifically preventing a third wrong-direction
   attempt at the bucket-wiring fix (two already closed) — that's a real, if narrow,
   outcome, not busywork.
+- **Keeping the fallback alive indefinitely assumes `BLOOM_TRAITS_DIR` is complete.**
+  Treating the local-disk raw-tier read as a stable "load-bearing interim adapter" (rather
+  than wiring it to the empty bucket) is the right call given #368/#413's closures, but it
+  leaves an unstated assumption: a Supabase-backend deployment's `BLOOM_TRAITS_DIR`
+  actually contains every experiment a user might request a raw read for. If it doesn't,
+  those reads 404 silently, indefinitely — `data-access-roadmap.md` Tier 2 isn't filed yet
+  and has no timeline. Mitigation: state this explicitly in `proposal.md`'s Scope section
+  rather than leave it implicit; this change does not resolve the risk, only stops
+  documenting past it.
 
 ## Migration Plan
 
-None — no data or schema migration. The `qc_inspect.py` change only alters the resolved
-`source_csv` path when a non-default input root is configured (e.g. a custom
-`BLOOM_EXPERIMENT_LOCAL_ROOT`); on the default Supabase backend with no such override, the
-resolved path is unchanged.
+None — no data or schema migration, and no runtime behavior change at all in this
+revision (doc/warning-text only, `qc_inspect.py` having dropped out of scope per the
+Reconciliation note below).
 
 ## Open Questions
 
@@ -84,3 +92,32 @@ resolved path is unchanged.
   `data-access-roadmap.md` Tier 2, or split into a new tracking issue for the
   `SupabaseReader` DB-direct rewrite specifically? This proposal assumes "kept open,
   re-scoped" as the default — recommend Evelyn/Elizabeth confirm at review time.
+
+## Follow-ups (not this change)
+
+- `bloommcp/tests/test_persistence_import_guard.py`'s AST-based import guard currently
+  forbids only `{"supabase", "AnalysisDir"}`, not `TRAITS_DIR` — it would not catch a
+  future PR silently reintroducing a `TRAITS_DIR`-based bypass elsewhere (the same class
+  of bug #476 itself is about). Worth extending in a follow-up; out of scope here since
+  this change makes no code changes to guard.
+
+## Reconciliation note (5-agent review, 2026-07-24)
+
+A 5-subagent review (Code Quality / Testing / Scientific Rigor / Security / Behavioural
+Correctness) independently converged on the same blocking finding: the first two
+revisions of this proposal targeted `qc_inspect.py:503` as work still to do, but by the
+time PR #530 was opened, [PR #526](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/526)
+(#479's implementation) had already merged into `staging` — fixing that exact line for an
+unrelated reason (fully-local-mode provenance) — 34 seconds before this PR opened, per the
+review's own timestamp check. The proposal's citations (line 64's import, line 421's
+comment, a "failing test to write") no longer matched the file at all: the import was
+already gone, the comment already documented the fix, and the regression test
+(`test_source_csv_honors_local_root_only_mode`) already existed.
+
+**Resolved:** rebased this branch onto the current `staging` tip (which now includes
+#526), dropped the `qc_inspect.py` site from scope entirely rather than rescoping it to a
+confirmation step (per the review's own Suggestion — there is nothing left to confirm
+that the merged test doesn't already cover), and reworded `proposal.md`/`design.md`'s
+"Why"/Context to state the site is resolved via #526, citing the PR number the way #368/
+#413 already were. This is exactly the kind of drift the roadmap docs' own reconciliation
+logs exist to catch — recorded here for the same reason.

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/design.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/design.md
@@ -28,9 +28,12 @@ through `ExperimentReader`, or (b) delete them if provably unreachable.
 - Goals:
   - Fix site (a) now — it's genuinely independent, low-risk, and already validated by
     #479's implementation.
-  - Stop `supabase_reader.py`'s own documentation from pointing at a closed migration plan
-    as the reason the fallback will disappear, since that's precisely the belief that
-    already produced two wrong-direction PRs.
+  - Fix `supabase_reader.py`'s two distinct doc problems: the module docstring citing the
+    closed bucket-migration plan as the removal trigger (the same belief that already
+    produced two wrong-direction PRs), and `_LOCAL_RAW_DEPRECATION`'s "promoted, not
+    slated for removal" framing, which contradicts this proposal's own decision that the
+    fallback has a tracked retirement path. These are two separate sentences with two
+    separate problems, not one blanket "stop citing the bucket" edit.
 - Non-Goals:
   - Implementing `data-access-roadmap.md`'s Tier 1/2 (DB-direct rewrite).
   - Changing `SupabaseReader`'s raw-tier read behavior, return values, or `RawSourced`

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/design.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/design.md
@@ -1,0 +1,83 @@
+## Context
+
+Issue #476 asks to audit two `BLOOM_TRAITS_DIR` read bypasses and either (a) route them
+through `ExperimentReader`, or (b) delete them if provably unreachable.
+
+- **Site (a), `qc_inspect.py:503`**, is cheap and safe: `_ports.raw_source_for` already
+  exists and is already the pattern `qc_clean.py`/`_ports.start_run` use for the identical
+  provenance-sourcing problem. #479's PR review independently found and fixed this same
+  line (for a different reason — fully-local-mode provenance), but that branch is
+  unmerged, so `staging` still has the bare `TRAITS_DIR` read today.
+- **Site (b), `supabase_reader.py`'s raw-tier fallback**, is not a simple bypass to route
+  or delete — it is the *only* thing serving raw experiment reads on the default
+  (Supabase) backend today. `bloommcp/docs/data-access-roadmap.md`'s Live-state facts
+  traced the full write path for the `bloommcp_input/` Storage bucket and confirmed it has
+  **no producer anywhere in the repo**. Two PRs already tried to fix this exact site the
+  "obvious" way and were closed for that reason:
+  - PR #368 — read `bloommcp_input/<name>` directly. Closed 2026-07-23: "since prod has no
+    input data, switching the raw source is non-breaking" — i.e. it would just always 404.
+  - PR #413 — add an upload endpoint that writes to `bloommcp_input/` first, so #368's read
+    would have something to find. Closed the same day — the upload path isn't being
+    pursued.
+  - The roadmap's actual plan (Tier 2) is to rewrite the raw tier to query Bloom's
+    Postgres directly by `experiment_id`, which needs a new bulk-read RPC (Tier 1, not yet
+    filed, gated on Benfica's review) — a materially bigger, separate piece of work.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Fix site (a) now — it's genuinely independent, low-risk, and already validated by
+    #479's implementation.
+  - Stop `supabase_reader.py`'s own documentation from pointing at a closed migration plan
+    as the reason the fallback will disappear, since that's precisely the belief that
+    already produced two wrong-direction PRs.
+- Non-Goals:
+  - Implementing `data-access-roadmap.md`'s Tier 1/2 (DB-direct rewrite).
+  - Changing `SupabaseReader`'s raw-tier read behavior, return values, or `RawSourced`
+    contract.
+  - Touching `LocalReader` / `BLOOM_STORAGE_BACKEND=local`.
+
+## Decisions
+
+- **Decision:** Treat `SupabaseReader`'s local-disk raw-tier read as an intentional,
+  load-bearing interim adapter — document it as such (pointing at
+  `data-access-roadmap.md` Tier 2 as the tracked retirement path) rather than attempting a
+  partial fix.
+  - Alternative considered — wire the raw tier to `supabase_client.read_input_csv`
+    (`bloommcp_input/`), per the issue's literal option (a). Rejected: this is PR #368's
+    exact approach, already attempted and closed because the bucket has no producer; it
+    would silently break raw reads (a real regression) in every environment today.
+  - Alternative considered — delete the fallback outright, per the issue's option (b)
+    ("if provably unreachable"). Rejected: it is not unreachable. It is the only path
+    serving raw reads on the default backend today; deleting it without a replacement
+    breaks `qc_clean`/`qc_inspect`/every tool that reads an uncleaned experiment.
+  - Alternative considered — implement `data-access-roadmap.md` Tier 1/2 as part of this
+    change. Rejected as out of scope: that program is DRAFT, gated on a Postgres migration
+    Benfica hasn't reviewed yet, and is a materially larger, separate piece of work than
+    what issue #476 itself scopes.
+
+## Risks / Trade-offs
+
+- **This does not fully close #476.** The issue's underlying architectural ask —
+  retiring `BLOOM_TRAITS_DIR` from the default read path — is genuinely `data-access-
+  roadmap.md` Tier 2's job, not something this change can do safely on its own. Mitigation:
+  say so explicitly in the proposal rather than claim full closure; recommend #476 stay
+  open and re-scoped to track that roadmap dependency.
+- **Documentation-only changes to `supabase_reader.py` could look like "not really fixing
+  anything."** Mitigation: the value is specifically preventing a third wrong-direction
+  attempt at the bucket-wiring fix (two already closed) — that's a real, if narrow,
+  outcome, not busywork.
+
+## Migration Plan
+
+None — no data or schema migration. The `qc_inspect.py` change only alters the resolved
+`source_csv` path when a non-default input root is configured (e.g. a custom
+`BLOOM_EXPERIMENT_LOCAL_ROOT`); on the default Supabase backend with no such override, the
+resolved path is unchanged.
+
+## Open Questions
+
+- Should #476 be closed by this change, kept open and re-scoped to depend on
+  `data-access-roadmap.md` Tier 2, or split into a new tracking issue for the
+  `SupabaseReader` DB-direct rewrite specifically? This proposal assumes "kept open,
+  re-scoped" as the default — recommend Evelyn/Elizabeth confirm at review time.

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/proposal.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/proposal.md
@@ -2,14 +2,23 @@
 
 [#476](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/476) — `bloommcp/docs/roadmap.md` Tier 2 called for consolidating the read path onto
 Supabase Storage (`bloommcp_input/`) via the `ExperimentReader` port and retiring the
-legacy local `BLOOM_TRAITS_DIR` disk-read path. Two call sites still bypass the port:
+legacy local `BLOOM_TRAITS_DIR` disk-read path. The issue named two call sites still
+bypassing the port:
 
-- `qc_inspect.py:503` — `local_src = TRAITS_DIR / params.experiment`, building the
-  provenance `source_csv` from a hard-coded `TRAITS_DIR` global instead of the active
-  reader, exactly the bug #479's PR review independently found and fixed on its own
-  (unmerged) branch for a different reason (fully-local-mode provenance). This proposal
-  re-does that one-line fix on `staging` directly so it isn't hostage to #479's merge
-  order.
+- `qc_inspect.py:503` (`local_src = TRAITS_DIR / params.experiment`) — **already resolved,
+  not part of this change.** #479's PR review independently found and fixed this exact
+  line (for a different reason — fully-local-mode provenance), and that work merged into
+  `staging` as [PR #526](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/526)
+  before this proposal was opened. Verified directly against current `staging`
+  (`29edec9`, #526's merge commit): `qc_inspect.py` already reads
+  `source_csv=_ports.raw_source_for(params.experiment)`, the stale `TRAITS_DIR` import is
+  already gone, and a regression test
+  (`test_source_csv_honors_local_root_only_mode`,
+  `bloommcp/tests/tools/test_qc_inspect_tool.py`) already covers it. An earlier draft of
+  this proposal targeted this site as new work — a review round (5 independent agents)
+  caught that the draft had gone stale after #526 merged out from under it; this revision
+  drops that scope rather than re-doing already-merged work. See `design.md`'s
+  Reconciliation note.
 - `bloommcp/src/bloom_mcp/data_access/supabase_reader.py` — `SupabaseReader`'s raw-tier
   read still comes from local `BLOOM_TRAITS_DIR`. Two of its three doc sites are stale in
   different ways, not the same way: the **module docstring** (lines 1-9) explicitly says
@@ -45,12 +54,7 @@ tracked retirement path (Tier 2).
 
 ## What Changes
 
-- **`qc_inspect.py`** — replace the hard-coded `local_src = TRAITS_DIR / params.experiment`
-  / `source_csv=local_src if local_src.exists() else None` with
-  `source_csv=_ports.raw_source_for(params.experiment)` (mirrors `_ports.start_run`,
-  already the pattern `qc_clean.py` uses). Drop the now-unused
-  `from bloom_mcp.experiment_utils import TRAITS_DIR` import and update the stale
-  `# ... flows into TRAITS_DIR / experiment` comment at line 421.
+- **`qc_inspect.py`** — no change; already fixed by #479/PR #526 (see Why).
 - **`supabase_reader.py`** — two distinct, per-site doc fixes (not one blanket edit):
   - The **module docstring** (lines 1-9): stop citing the closed bucket-upload plan as
     the removal trigger; name `data-access-roadmap.md`'s Tier 2 DB-direct rewrite instead.
@@ -68,8 +72,9 @@ tracked retirement path (Tier 2).
   - `ExperimentReader Port`: its "consumers go through the port" scenarios still name
     `qc_tools.py`/`storage_tools.py`/`correlation_tools`/`tools/workflows/*` — all retired
     by `devendor-bloommcp-analysis` (confirmed gone from `bloommcp/src/`). Reconciled to
-    the current `sections/sleap_roots/analysis/*` locations, and added a scenario for the
-    `qc_inspect.py` provenance fix above.
+    the current `sections/sleap_roots/analysis/*` locations, and to state that
+    `qc_inspect.py`'s provenance already routes through `_ports.raw_source_for` (shipped
+    by #479/PR #526, not this change).
   - `SupabaseReader Adapter`: updated to describe the raw-tier fallback as an intentional
     interim adapter (not a bug awaiting an imminent fix) and to match the corrected
     deprecation-signal wording.
@@ -78,14 +83,16 @@ tracked retirement path (Tier 2).
 
 - **Affected specs:** `bloommcp-experiment-read` (MODIFIED only — no ADDED/REMOVED).
 - **Affected code:**
-  - `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/qc_inspect.py`
-  - `bloommcp/src/bloom_mcp/data_access/supabase_reader.py`
+  - `bloommcp/src/bloom_mcp/data_access/supabase_reader.py` (doc/warning text only)
 - **Affected tests:**
-  - `bloommcp/tests/tools/test_qc_inspect_tool.py` — new regression test for the
-    provenance source-path fix.
-  - `bloommcp/tests/data_access/test_supabase_reader.py` — new test on the corrected
-    message text; the existing `pytest.warns(DeprecationWarning)` test
-    (line ~25) is a named regression checkpoint and must stay green unmodified.
+  - `bloommcp/tests/data_access/test_supabase_reader.py` — new tests on the corrected
+    doc/message text (one per site — see `tasks.md`); the existing
+    `pytest.warns(DeprecationWarning)` test (line ~25) is a named regression checkpoint
+    and must stay green unmodified.
+  - `bloommcp/tests/tools/test_qc_inspect_tool.py` — **no new test needed**; the
+    provenance-routing coverage this proposal would have asked for
+    (`test_source_csv_honors_local_root_only_mode`) already exists, shipped by #479/PR
+    #526.
 
 ## Scope / Non-Goals
 
@@ -97,9 +104,16 @@ tracked retirement path (Tier 2).
 - **Does not change `SupabaseReader`'s read behavior, return values, or resolution
   order** — only its documentation/warning text changes. The raw-tier local-disk read
   itself is unchanged.
-- **Does not fully close #476's architectural ask.** This proposal resolves the one
-  bypass that's safely, independently fixable today (`qc_inspect.py`) and stops the other
-  (`supabase_reader.py`) from misdocumenting its own future — it does not retire
+- **Does not fully close #476's architectural ask.** Of the issue's two named bypasses,
+  `qc_inspect.py`'s is already resolved (via #479/PR #526, not this change); this proposal
+  only stops `supabase_reader.py` from misdocumenting its own future. It does not retire
   `BLOOM_TRAITS_DIR` from the default read path, which is `data-access-roadmap.md` Tier
   2's job. Recommend #476 stay open, re-scoped to track that roadmap's Tier 2, rather than
   closed by this change — see `design.md` Open Questions.
+- **Residual risk, stated explicitly (not left implicit in "load-bearing interim
+  adapter"):** keeping the local-disk raw-tier fallback alive indefinitely assumes a
+  Supabase-backend deployment's `BLOOM_TRAITS_DIR` actually contains every experiment a
+  user might request a raw read for. If it doesn't, those reads 404 silently, and will
+  keep doing so indefinitely — `data-access-roadmap.md` Tier 2 (the real fix) isn't filed
+  yet and has no timeline. This proposal does not resolve that risk; it only stops the
+  docs from claiming a fix is imminent when it isn't.

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/proposal.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+[#476](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/476) — `bloommcp/docs/roadmap.md` Tier 2 called for consolidating the read path onto
+Supabase Storage (`bloommcp_input/`) via the `ExperimentReader` port and retiring the
+legacy local `BLOOM_TRAITS_DIR` disk-read path. Two call sites still bypass the port:
+
+- `qc_inspect.py:503` — `local_src = TRAITS_DIR / params.experiment`, building the
+  provenance `source_csv` from a hard-coded `TRAITS_DIR` global instead of the active
+  reader, exactly the bug #479's PR review independently found and fixed on its own
+  (unmerged) branch for a different reason (fully-local-mode provenance). This proposal
+  re-does that one-line fix on `staging` directly so it isn't hostage to #479's merge
+  order.
+- `bloommcp/src/bloom_mcp/data_access/supabase_reader.py` — `SupabaseReader`'s raw-tier
+  read still comes from local `BLOOM_TRAITS_DIR` and says so in its own docstring
+  (**"deprecated"**, `_LOCAL_RAW_DEPRECATION`, `raw_source_path`, lines 1-9/31-35/76-92).
+
+Investigating this second site surfaced that it's not simply "unfinished cleanup":
+`bloommcp/docs/data-access-roadmap.md` (DRAFT, Live-state facts) already traced the full
+write path and confirmed **`bloommcp_input/` has no producer anywhere in the repo** —
+nothing in `bloomcli/`, `web/`, or `supabase_client.py`'s public surface writes to that
+bucket prefix. Two PRs attempting to fix this raw tier by wiring it to the bucket were
+opened and then closed for exactly this reason: bloom PR #368 (read `bloommcp_input/`
+directly) and PR #413 (add an upload path that writes there first). The roadmap's actual
+plan (Tier 2, not yet filed/started, gated on a Postgres migration + Benfica's RPC-shape
+review) is to rewrite `SupabaseReader`'s raw tier to query Bloom's Postgres directly by
+`experiment_id` instead — at which point this local-disk fallback becomes moot on its own.
+That same roadmap doc already cross-references #476 and recommends sequencing it
+"alongside or after Tier 2," not as fully independent cleanup.
+
+So `SupabaseReader`'s local-disk raw-tier read is genuinely load-bearing on the default
+(Supabase) backend today — it is the only thing serving raw reads, not dead code —
+and its own documentation is now stale: it still describes the closed bucket-migration
+plan as the reason it'll go away. Left as-is, that stale docstring risks a third attempt
+at the same rejected fix.
+
+## What Changes
+
+- **`qc_inspect.py`** — replace the hard-coded `local_src = TRAITS_DIR / params.experiment`
+  / `source_csv=local_src if local_src.exists() else None` with
+  `source_csv=_ports.raw_source_for(params.experiment)` (mirrors `_ports.start_run`,
+  already the pattern `qc_clean.py` uses). Drop the now-unused
+  `from bloom_mcp.experiment_utils import TRAITS_DIR` import and update the stale
+  `# ... flows into TRAITS_DIR / experiment` comment at line 421.
+- **`supabase_reader.py`** — correct the module docstring, `_LOCAL_RAW_DEPRECATION`
+  message, and `raw_source_path`'s docstring so they name the actual tracked retirement
+  path (`data-access-roadmap.md`'s Tier 2 DB-direct rewrite) instead of the closed
+  bucket-upload plan. **No behavior change**: the `DeprecationWarning` still fires under
+  the same condition (`source_label == "raw"`), and the raw-tier read still resolves from
+  `BLOOM_TRAITS_DIR` exactly as today — wiring it to `read_input_csv`/`bloommcp_input/`
+  instead would make raw reads 404 in every environment today (bucket confirmed empty),
+  repeating #368/#413's mistake.
+- **`bloommcp-experiment-read` spec** — MODIFIED, two requirements:
+  - `ExperimentReader Port`: its "consumers go through the port" scenarios still name
+    `qc_tools.py`/`storage_tools.py`/`correlation_tools`/`tools/workflows/*` — all retired
+    by `devendor-bloommcp-analysis` (confirmed gone from `bloommcp/src/`). Reconciled to
+    the current `sections/sleap_roots/analysis/*` locations, and added a scenario for the
+    `qc_inspect.py` provenance fix above.
+  - `SupabaseReader Adapter`: updated to describe the raw-tier fallback as an intentional
+    interim adapter (not a bug awaiting an imminent fix) and to match the corrected
+    deprecation-signal wording.
+
+## Impact
+
+- **Affected specs:** `bloommcp-experiment-read` (MODIFIED only — no ADDED/REMOVED).
+- **Affected code:**
+  - `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/qc_inspect.py`
+  - `bloommcp/src/bloom_mcp/data_access/supabase_reader.py`
+- **Affected tests:**
+  - `bloommcp/tests/tools/test_qc_inspect_tool.py` — new regression test for the
+    provenance source-path fix.
+  - `bloommcp/tests/data_access/test_supabase_reader.py` — new test on the corrected
+    message text; the existing `pytest.warns(DeprecationWarning)` test
+    (line ~25) is a named regression checkpoint and must stay green unmodified.
+
+## Scope / Non-Goals
+
+- **Does not implement the DB-direct rewrite** (`data-access-roadmap.md` Tiers 1-3) — that
+  program is separate, larger, DRAFT (pending Elizabeth approval), and gated on a Postgres
+  migration + Benfica's RPC-shape review that hasn't started.
+- **Does not touch `LocalReader` / `BLOOM_STORAGE_BACKEND=local`** — explicitly out of
+  scope per the issue; that path stays exactly as-is.
+- **Does not change `SupabaseReader`'s read behavior, return values, or resolution
+  order** — only its documentation/warning text changes. The raw-tier local-disk read
+  itself is unchanged.
+- **Does not fully close #476's architectural ask.** This proposal resolves the one
+  bypass that's safely, independently fixable today (`qc_inspect.py`) and stops the other
+  (`supabase_reader.py`) from misdocumenting its own future — it does not retire
+  `BLOOM_TRAITS_DIR` from the default read path, which is `data-access-roadmap.md` Tier
+  2's job. Recommend #476 stay open, re-scoped to track that roadmap's Tier 2, rather than
+  closed by this change — see `design.md` Open Questions.

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/proposal.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/proposal.md
@@ -11,8 +11,16 @@ legacy local `BLOOM_TRAITS_DIR` disk-read path. Two call sites still bypass the 
   re-does that one-line fix on `staging` directly so it isn't hostage to #479's merge
   order.
 - `bloommcp/src/bloom_mcp/data_access/supabase_reader.py` — `SupabaseReader`'s raw-tier
-  read still comes from local `BLOOM_TRAITS_DIR` and says so in its own docstring
-  (**"deprecated"**, `_LOCAL_RAW_DEPRECATION`, `raw_source_path`, lines 1-9/31-35/76-92).
+  read still comes from local `BLOOM_TRAITS_DIR`. Two of its three doc sites are stale in
+  different ways, not the same way: the **module docstring** (lines 1-9) explicitly says
+  the `DeprecationWarning` exists "so the follow-up that migrates inputs into
+  `bloommcp_input/` can remove it" — citing the specific bucket-migration plan that's since
+  been closed (see below). `_LOCAL_RAW_DEPRECATION` (lines 31-35), the message actually
+  raised at runtime, doesn't mention the bucket at all — it says "the path is promoted,
+  not slated for removal," which is a *different* problem: that framing contradicts this
+  proposal's own decision to treat the fallback as having a tracked Tier 2 retirement path.
+  `raw_source_path`'s docstring (lines 76-92) is pure path-traversal-security documentation
+  (guards `../secrets.csv`-style escapes) — unrelated to either issue, no change needed.
 
 Investigating this second site surfaced that it's not simply "unfinished cleanup":
 `bloommcp/docs/data-access-roadmap.md` (DRAFT, Live-state facts) already traced the full
@@ -28,10 +36,12 @@ That same roadmap doc already cross-references #476 and recommends sequencing it
 "alongside or after Tier 2," not as fully independent cleanup.
 
 So `SupabaseReader`'s local-disk raw-tier read is genuinely load-bearing on the default
-(Supabase) backend today — it is the only thing serving raw reads, not dead code —
-and its own documentation is now stale: it still describes the closed bucket-migration
-plan as the reason it'll go away. Left as-is, that stale docstring risks a third attempt
-at the same rejected fix.
+(Supabase) backend today — it is the only thing serving raw reads, not dead code — and
+its documentation has two distinct problems: the module docstring still describes the
+closed bucket-migration plan as the reason it'll go away (risking a third attempt at the
+same rejected fix), and the runtime deprecation message's "not slated for removal"
+framing simply doesn't match this proposal's decision that the fallback does have a
+tracked retirement path (Tier 2).
 
 ## What Changes
 
@@ -41,14 +51,19 @@ at the same rejected fix.
   already the pattern `qc_clean.py` uses). Drop the now-unused
   `from bloom_mcp.experiment_utils import TRAITS_DIR` import and update the stale
   `# ... flows into TRAITS_DIR / experiment` comment at line 421.
-- **`supabase_reader.py`** — correct the module docstring, `_LOCAL_RAW_DEPRECATION`
-  message, and `raw_source_path`'s docstring so they name the actual tracked retirement
-  path (`data-access-roadmap.md`'s Tier 2 DB-direct rewrite) instead of the closed
-  bucket-upload plan. **No behavior change**: the `DeprecationWarning` still fires under
-  the same condition (`source_label == "raw"`), and the raw-tier read still resolves from
-  `BLOOM_TRAITS_DIR` exactly as today — wiring it to `read_input_csv`/`bloommcp_input/`
-  instead would make raw reads 404 in every environment today (bucket confirmed empty),
-  repeating #368/#413's mistake.
+- **`supabase_reader.py`** — two distinct, per-site doc fixes (not one blanket edit):
+  - The **module docstring** (lines 1-9): stop citing the closed bucket-upload plan as
+    the removal trigger; name `data-access-roadmap.md`'s Tier 2 DB-direct rewrite instead.
+  - **`_LOCAL_RAW_DEPRECATION`** (lines 31-35): drop the "promoted, not slated for
+    removal" framing — it contradicts the fallback having a tracked retirement path — and
+    name Tier 2 there too.
+  - `raw_source_path`'s docstring (lines 76-92) is unrelated (path-traversal security) and
+    is **not** touched by this change.
+  **No behavior change**: the `DeprecationWarning` still fires under the same condition
+  (`source_label == "raw"`), and the raw-tier read still resolves from `BLOOM_TRAITS_DIR`
+  exactly as today — wiring it to `read_input_csv`/`bloommcp_input/` instead would make
+  raw reads 404 in every environment today (bucket confirmed empty), repeating #368/#413's
+  mistake.
 - **`bloommcp-experiment-read` spec** — MODIFIED, two requirements:
   - `ExperimentReader Port`: its "consumers go through the port" scenarios still name
     `qc_tools.py`/`storage_tools.py`/`correlation_tools`/`tools/workflows/*` — all retired

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/specs/bloommcp-experiment-read/spec.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/specs/bloommcp-experiment-read/spec.md
@@ -61,12 +61,17 @@ The system SHALL provide a `SupabaseReader` adapter implementing `ExperimentRead
 #### Scenario: Falls back to the local raw input with a deprecation signal
 
 - **WHEN** `SupabaseReader.load_experiment(name)` is called for an experiment with no cleaned output, and only a raw CSV under `BLOOM_TRAITS_DIR` exists
-- **THEN** it returns the raw frame and emits a deprecation signal naming `data-access-roadmap.md`'s Tier 2 DB-direct rewrite as the tracked retirement path — not a bucket-upload migration
+- **THEN** it returns the raw frame and emits a `DeprecationWarning`
 
-#### Scenario: Deprecation signal does not cite a superseded migration plan
+#### Scenario: Module docstring does not cite the superseded bucket-migration plan
 
-- **WHEN** the deprecation warning/docstring text is inspected
-- **THEN** it does not claim removal is pending "the follow-up that migrates inputs into `bloommcp_input/`" — that plan (bloom PR #368) is closed — and instead points at the currently tracked plan (`data-access-roadmap.md` Tier 2)
+- **WHEN** `supabase_reader.py`'s module docstring is inspected
+- **THEN** it does not claim the `DeprecationWarning` exists "so the follow-up that migrates inputs into `bloommcp_input/` can remove it" — that plan (bloom PR #368) is closed — and instead names `data-access-roadmap.md`'s Tier 2 DB-direct rewrite as the tracked retirement path
+
+#### Scenario: Deprecation message states a tracked retirement path, not an open-ended promotion
+
+- **WHEN** the runtime `DeprecationWarning` message (`_LOCAL_RAW_DEPRECATION`) is inspected
+- **THEN** it does not describe the local raw-tier read as merely "promoted, not slated for removal" — a framing that never cited the bucket plan but contradicts this adapter having a tracked retirement path at all — and instead names `data-access-roadmap.md`'s Tier 2 DB-direct rewrite as that path
 
 #### Scenario: Adapter tests do not touch the network
 

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/specs/bloommcp-experiment-read/spec.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/specs/bloommcp-experiment-read/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: ExperimentReader Port
+
+The system SHALL define a backend-agnostic `ExperimentReader` port exposing `load_experiment(name, version, require_clean)` and `list_experiments()`, where `load_experiment` returns an `ExperimentFrame` carrying the experiment frame, **adapter-declared** column roles (trait vs metadata columns), and a source label. Column roles SHALL be declared by the adapter, not re-inferred by callers, so a future adapter sourcing tidy/long rows can satisfy the contract without reproducing dtype-based detection. Consumers SHALL depend only on this port — never on `supabase`, `experiment_utils`, or `storage/` primitives directly — for reading experiment data.
+
+#### Scenario: Load an experiment returns a frame with declared roles
+
+- **WHEN** a consumer calls `load_experiment(name)` (default `version="latest"`) for a known experiment
+- **THEN** it returns an `ExperimentFrame` whose frame holds the experiment data, whose trait and metadata column roles are populated, and whose source label identifies what was resolved (e.g. `raw`, `legacy_cleaned`, or a versioned cleaned output)
+
+#### Scenario: Version selection resolves in the deployed order
+
+- **WHEN** `load_experiment(name, version="latest")` is called and a versioned `qc_<stem>` manifest with a `latest` cleaned output exists
+- **THEN** the reader resolves outputs in the deployed order — versioned-manifest `latest` cleaned CSV, then the legacy un-versioned `qc_<stem>/<stem>_cleaned.csv`, then the raw input — returning the first that resolves
+
+#### Scenario: Explicit version miss is a hard error
+
+- **WHEN** `load_experiment(name, version="v9")` is called for a version that does not exist
+- **THEN** the reader signals a not-found condition for that explicit version rather than silently falling back to another tier
+
+#### Scenario: Clean-required load
+
+- **WHEN** `load_experiment(name, require_clean=True)` is called and no cleaned output exists
+- **THEN** the reader signals that a cleaned version is required and absent, rather than returning the raw frame
+
+#### Scenario: Unknown experiment is reported through the contract
+
+- **WHEN** `load_experiment(name)` is called for a name the reader cannot resolve in any tier
+- **THEN** the reader surfaces a structured not-found condition with no raw Supabase or filesystem traceback, bucket name, or connection string leaked to the caller
+
+#### Scenario: List experiments enumerates available inputs
+
+- **WHEN** a consumer calls `list_experiments()`
+- **THEN** it returns the available experiments (each identified by name) and returns an empty list — not an error — when none are available
+
+#### Scenario: Single-experiment read consumers go through the port
+
+- **WHEN** `qc_clean.py` and `qc_inspect.py` (`bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/`) are inspected
+- **THEN** neither imports `supabase` or a storage-writer class directly, nor builds a raw-input path from a hard-coded `TRAITS_DIR` constant; each obtains data through an injected `ExperimentReader`, and any provenance source-path lookup routes through `_ports.raw_source_for` (mirroring `_ports.start_run`) rather than reading the `TRAITS_DIR` module global directly
+
+#### Scenario: qc_inspect's provenance source path honors the active reader's input root
+
+- **WHEN** `qc_inspect` persists a report run
+- **THEN** the recorded `source_csv` is resolved via `_ports.raw_source_for(experiment)` — the active reader's declared raw-input path — not a hard-coded `TRAITS_DIR / experiment` build, so a non-default input root (e.g. a custom `BLOOM_EXPERIMENT_LOCAL_ROOT`) is honored the same way `_ports.start_run`'s callers already are
+
+#### Scenario: No consumer imports the storage writer or Supabase directly
+
+- **WHEN** the discovery and analysis tools (`list_available_experiments.py`, `list_existing_analyses.py`, and the `sections/sleap_roots/analysis/*` tools) are inspected
+- **THEN** none imports `supabase`, `AnalysisWriter`, or `AnalysisDir` directly; the `correlation_tools`/`tools/workflows/*` modules this scenario previously carved out for the deprecated `BLOOM_TRAITS_DIR` path no longer exist (retired by `devendor-bloommcp-analysis`) — the only remaining local-disk raw-input read is `SupabaseReader`'s own raw-tier fallback (see the `SupabaseReader Adapter` requirement), which is intentional infrastructure inside the port's Supabase adapter, not a consumer bypassing the port
+
+### Requirement: SupabaseReader Adapter
+
+The system SHALL provide a `SupabaseReader` adapter implementing `ExperimentReader` that preserves the deployed read behaviour: raw inputs from the local `BLOOM_TRAITS_DIR` and versioned-cleaned outputs from Supabase Storage under `bloommcp_output/` as `bloom_agent`. The local raw-input read is **retained as an intentional interim adapter** — it is the only thing serving raw reads on the default (Supabase) backend today, since the `bloommcp_input/` Storage bucket has no producer anywhere in the codebase (confirmed by `bloommcp/docs/data-access-roadmap.md`'s Live-state facts). It SHALL emit a deprecation signal naming the actual tracked retirement path — `bloommcp/docs/data-access-roadmap.md`'s Tier 2 rewrite of this raw tier to query Bloom's Postgres directly by `experiment_id` — not a bucket-upload migration, which was attempted and closed (bloom PR #368, PR #413) because the bucket has no producer.
+
+#### Scenario: Resolves the latest versioned cleaned output from Supabase
+
+- **WHEN** `SupabaseReader.load_experiment(name)` is called and a versioned `qc_<stem>` manifest with a `latest` cleaned output exists
+- **THEN** it downloads and returns that cleaned CSV from Supabase Storage, with a source label identifying the version
+
+#### Scenario: Falls back to the local raw input with a deprecation signal
+
+- **WHEN** `SupabaseReader.load_experiment(name)` is called for an experiment with no cleaned output, and only a raw CSV under `BLOOM_TRAITS_DIR` exists
+- **THEN** it returns the raw frame and emits a deprecation signal naming `data-access-roadmap.md`'s Tier 2 DB-direct rewrite as the tracked retirement path — not a bucket-upload migration
+
+#### Scenario: Deprecation signal does not cite a superseded migration plan
+
+- **WHEN** the deprecation warning/docstring text is inspected
+- **THEN** it does not claim removal is pending "the follow-up that migrates inputs into `bloommcp_input/`" — that plan (bloom PR #368) is closed — and instead points at the currently tracked plan (`data-access-roadmap.md` Tier 2)
+
+#### Scenario: Adapter tests do not touch the network
+
+- **WHEN** the `SupabaseReader` test suite runs
+- **THEN** it exercises the adapter against a monkeypatched `supabase_client` boundary (no `supabase.create_client` call) and passes with no `SUPABASE_URL`/`BLOOM_AGENT_KEY` configured

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
@@ -15,16 +15,27 @@
 
 ## 2. `supabase_reader.py` documentation/warning accuracy
 
-- [ ] 2.1a Write a failing test asserting the `DeprecationWarning` message text (and/or the
-      module docstring) no longer claims removal is pending "the follow-up that migrates
-      inputs into `bloommcp_input/`" — that plan (bloom PR #368) is closed — and instead
-      references the actual tracked plan (`data-access-roadmap.md`'s Tier 2 DB-direct
-      rewrite of the raw tier).
-- [ ] 2.1b Implement: rewrite `supabase_reader.py`'s module docstring (lines 1-9), the
-      `_LOCAL_RAW_DEPRECATION` message (lines 31-35), and `raw_source_path`'s docstring
-      (lines 76-92) to name the correct plan. Keep the `DeprecationWarning` category and
-      trigger condition (`source_label == "raw"`) unchanged.
-- [ ] 2.2 Confirm the existing deprecation test
+- [ ] 2.1a Write a failing test asserting `supabase_reader.py`'s **module docstring**
+      names `data-access-roadmap.md`'s Tier 2 DB-direct rewrite as the retirement path and
+      no longer claims removal is pending "the follow-up that migrates inputs into
+      `bloommcp_input/`" (bloom PR #368, closed). Assert what the corrected text should
+      say, not just the absence of the old phrase — a test that only checks
+      `"bloommcp_input" not in docstring` would pass trivially without the Tier 2 mention
+      actually being added.
+- [ ] 2.1b Implement: rewrite the module docstring (lines 1-9) per 2.1a.
+- [ ] 2.2a Write a failing test asserting the runtime **`_LOCAL_RAW_DEPRECATION`** message
+      (lines 31-35) — the string actually passed to `warnings.warn` — names Tier 2 as the
+      tracked retirement path and no longer describes the fallback as "promoted, not
+      slated for removal" (that framing predates this proposal and contradicts having a
+      tracked retirement path at all; it never mentioned the bucket, so this is a distinct
+      fix from 2.1a, not the same edit applied twice).
+- [ ] 2.2b Implement: rewrite `_LOCAL_RAW_DEPRECATION` per 2.2a. Keep the
+      `DeprecationWarning` category and trigger condition (`source_label == "raw"`)
+      unchanged.
+- [ ] 2.3 No change to `raw_source_path`'s docstring (lines 76-92) — confirmed unrelated
+      (path-traversal-security documentation, not a migration-plan citation). Leave as-is;
+      do not touch it under this task.
+- [ ] 2.4 Confirm the existing deprecation test
       (`bloommcp/tests/data_access/test_supabase_reader.py:~25`,
       `pytest.warns(DeprecationWarning)`) still passes unmodified — a named regression
       checkpoint proving the trigger condition didn't change, only the message.
@@ -39,9 +50,11 @@
       `sections/sleap_roots/analysis/*` locations, and add a scenario for the
       `qc_inspect.py` provenance fix (Task 1).
 - [ ] 3.2 Write the MODIFIED `SupabaseReader Adapter` requirement: update its intro and
-      deprecation-signal scenario to match the corrected message/plan reference (Task 2),
-      and add a scenario asserting the deprecation signal doesn't cite the superseded
-      bucket-migration plan.
+      deprecation-signal scenario to match the corrected message/plan reference, and add
+      two distinct scenarios matching Task 2's two separate fixes — one for the module
+      docstring no longer citing the closed bucket-migration plan, one for
+      `_LOCAL_RAW_DEPRECATION` no longer using the "promoted, not slated for removal"
+      framing.
 
 ## 4. Verification
 

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
@@ -59,8 +59,9 @@
 
 ## 4. Follow-up (process — no code commit)
 
-- [ ] 4.1 Post a comment on #476 (from this PR) linking `data-access-roadmap.md` Tier 2
+- [x] 4.1 Post a comment on #476 (from this PR) linking `data-access-roadmap.md` Tier 2
       and this change, explicitly recommending #476 stay **open**, re-scoped to depend on
       that tier, rather than being closed when this PR merges — a concrete, checkable
       artifact instead of a free-floating "confirm at review time" reminder. See
-      `design.md` Open Questions for the reasoning.
+      `design.md` Open Questions for the reasoning. Done:
+      https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/476#issuecomment-5075068236

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
@@ -1,73 +1,66 @@
-## 1. `qc_inspect.py` provenance fix
+## 1. `supabase_reader.py` documentation/warning accuracy
 
-- [ ] 1.1a Write a failing regression test asserting `qc_inspect`'s persisted run
-      `source_csv` resolves via the active reader (`_ports.raw_source_for`) rather than a
-      hard-coded `TRAITS_DIR` path — e.g. inject a `FakeReader`/monkeypatched reader with a
-      distinct input root (or set `BLOOM_EXPERIMENT_LOCAL_ROOT`) and assert the recorded
-      `source_csv` follows it instead of `TRAITS_DIR`.
-- [ ] 1.1b Implement: in `qc_inspect.py`, replace
-      `local_src = TRAITS_DIR / params.experiment` /
-      `source_csv=local_src if local_src.exists() else None` with
-      `source_csv=_ports.raw_source_for(params.experiment)`; drop the now-unused
-      `from bloom_mcp.experiment_utils import TRAITS_DIR` import (line 64); update the
-      stale `# ... flows into TRAITS_DIR / experiment` comment (line 421) to describe the
-      reader-routed guard instead.
-
-## 2. `supabase_reader.py` documentation/warning accuracy
-
-- [ ] 2.1a Write a failing test asserting `supabase_reader.py`'s **module docstring**
+- [ ] 1.1a Write a failing test asserting `supabase_reader.py`'s **module docstring**
       names `data-access-roadmap.md`'s Tier 2 DB-direct rewrite as the retirement path and
       no longer claims removal is pending "the follow-up that migrates inputs into
       `bloommcp_input/`" (bloom PR #368, closed). Assert what the corrected text should
       say, not just the absence of the old phrase — a test that only checks
       `"bloommcp_input" not in docstring` would pass trivially without the Tier 2 mention
       actually being added.
-- [ ] 2.1b Implement: rewrite the module docstring (lines 1-9) per 2.1a.
-- [ ] 2.2a Write a failing test asserting the runtime **`_LOCAL_RAW_DEPRECATION`** message
+- [ ] 1.1b Implement: rewrite the module docstring (lines 1-9) per 1.1a.
+- [ ] 1.2a Write a failing test asserting the runtime **`_LOCAL_RAW_DEPRECATION`** message
       (lines 31-35) — the string actually passed to `warnings.warn` — names Tier 2 as the
       tracked retirement path and no longer describes the fallback as "promoted, not
       slated for removal" (that framing predates this proposal and contradicts having a
       tracked retirement path at all; it never mentioned the bucket, so this is a distinct
-      fix from 2.1a, not the same edit applied twice).
-- [ ] 2.2b Implement: rewrite `_LOCAL_RAW_DEPRECATION` per 2.2a. Keep the
+      fix from 1.1a, not the same edit applied twice). As with 1.1a, assert what the
+      corrected text should say (names Tier 2), not just the absence of the old phrase —
+      a test that only checks `"not slated for removal" not in message` would pass
+      trivially without the Tier 2 mention actually being added.
+- [ ] 1.2b Implement: rewrite `_LOCAL_RAW_DEPRECATION` per 1.2a. Keep the
       `DeprecationWarning` category and trigger condition (`source_label == "raw"`)
       unchanged.
-- [ ] 2.3 No change to `raw_source_path`'s docstring (lines 76-92) — confirmed unrelated
+- [ ] 1.3 No change to `raw_source_path`'s docstring (lines 76-92) — confirmed unrelated
       (path-traversal-security documentation, not a migration-plan citation). Leave as-is;
       do not touch it under this task.
-- [ ] 2.4 Confirm the existing deprecation test
+- [ ] 1.4 Confirm the existing deprecation test
       (`bloommcp/tests/data_access/test_supabase_reader.py:~25`,
       `pytest.warns(DeprecationWarning)`) still passes unmodified — a named regression
       checkpoint proving the trigger condition didn't change, only the message.
 
-## 3. Spec reconciliation (`bloommcp-experiment-read`)
+## 2. Spec reconciliation (`bloommcp-experiment-read`)
 
-- [ ] 3.1 Write the MODIFIED `ExperimentReader Port` requirement: correct the
+- [ ] 2.1 Write the MODIFIED `ExperimentReader Port` requirement: correct the
       "Single-experiment read consumers go through the port" and "No consumer imports the
       storage writer or Supabase directly" scenarios' stale module names
       (`qc_tools.py`/`storage_tools.py`/`correlation_tools`/`tools/workflows/*`, all
       retired by `devendor-bloommcp-analysis`) to the current
-      `sections/sleap_roots/analysis/*` locations, and add a scenario for the
-      `qc_inspect.py` provenance fix (Task 1).
-- [ ] 3.2 Write the MODIFIED `SupabaseReader Adapter` requirement: update its intro and
+      `sections/sleap_roots/analysis/*` locations, and state that `qc_inspect.py`'s
+      provenance already routes through `_ports.raw_source_for` — shipped by #479/PR
+      #526, not this change (no new scenario/test needed here; it's already covered by
+      `test_source_csv_honors_local_root_only_mode`).
+- [ ] 2.2 Write the MODIFIED `SupabaseReader Adapter` requirement: update its intro and
       deprecation-signal scenario to match the corrected message/plan reference, and add
-      two distinct scenarios matching Task 2's two separate fixes — one for the module
+      two distinct scenarios matching Task 1's two separate fixes — one for the module
       docstring no longer citing the closed bucket-migration plan, one for
       `_LOCAL_RAW_DEPRECATION` no longer using the "promoted, not slated for removal"
       framing.
 
-## 4. Verification
+## 3. Verification
 
-- [ ] 4.1 `cd bloommcp && uv run --frozen --extra test pytest tests/ -m "not integration"`
-      — full suite green.
-- [ ] 4.2 `ruff check` (pinned per `.pre-commit-config.yaml`), `ruff format --check`, and
+- [ ] 3.1 `cd bloommcp && uv run --frozen --extra test pytest tests/ -m "not integration and not live_smoke"`
+      — matches `.github/workflows/pr-checks.yml`'s CI invocation exactly (the
+      `live_smoke`-marked tests under `tests/smoke/` need a live Docker Compose +
+      Supabase + MinIO stack and must not be run as a stand-in for the CI gate). Full
+      suite green.
+- [ ] 3.2 `ruff check` (pinned per `.pre-commit-config.yaml`), `ruff format --check`, and
       `black --check` clean on all changed files.
-- [ ] 4.3 `openspec validate retire-bloommcp-traits-dir-bypass --strict` passes.
+- [ ] 3.3 `openspec validate retire-bloommcp-traits-dir-bypass --strict` passes.
 
-## 5. Follow-up (process — no code commit)
+## 4. Follow-up (process — no code commit)
 
-- [ ] 5.1 At review, confirm with Evelyn/Elizabeth whether #476 should stay open
-      (re-scoped to depend on `data-access-roadmap.md` Tier 2) or be split into a new
-      tracking issue for the `SupabaseReader` DB-direct rewrite — see `design.md` Open
-      Questions. Do not close #476 outright when this change merges without that
-      confirmation.
+- [ ] 4.1 Post a comment on #476 (from this PR) linking `data-access-roadmap.md` Tier 2
+      and this change, explicitly recommending #476 stay **open**, re-scoped to depend on
+      that tier, rather than being closed when this PR merges — a concrete, checkable
+      artifact instead of a free-floating "confirm at review time" reminder. See
+      `design.md` Open Questions for the reasoning.

--- a/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
+++ b/openspec/changes/retire-bloommcp-traits-dir-bypass/tasks.md
@@ -1,0 +1,60 @@
+## 1. `qc_inspect.py` provenance fix
+
+- [ ] 1.1a Write a failing regression test asserting `qc_inspect`'s persisted run
+      `source_csv` resolves via the active reader (`_ports.raw_source_for`) rather than a
+      hard-coded `TRAITS_DIR` path — e.g. inject a `FakeReader`/monkeypatched reader with a
+      distinct input root (or set `BLOOM_EXPERIMENT_LOCAL_ROOT`) and assert the recorded
+      `source_csv` follows it instead of `TRAITS_DIR`.
+- [ ] 1.1b Implement: in `qc_inspect.py`, replace
+      `local_src = TRAITS_DIR / params.experiment` /
+      `source_csv=local_src if local_src.exists() else None` with
+      `source_csv=_ports.raw_source_for(params.experiment)`; drop the now-unused
+      `from bloom_mcp.experiment_utils import TRAITS_DIR` import (line 64); update the
+      stale `# ... flows into TRAITS_DIR / experiment` comment (line 421) to describe the
+      reader-routed guard instead.
+
+## 2. `supabase_reader.py` documentation/warning accuracy
+
+- [ ] 2.1a Write a failing test asserting the `DeprecationWarning` message text (and/or the
+      module docstring) no longer claims removal is pending "the follow-up that migrates
+      inputs into `bloommcp_input/`" — that plan (bloom PR #368) is closed — and instead
+      references the actual tracked plan (`data-access-roadmap.md`'s Tier 2 DB-direct
+      rewrite of the raw tier).
+- [ ] 2.1b Implement: rewrite `supabase_reader.py`'s module docstring (lines 1-9), the
+      `_LOCAL_RAW_DEPRECATION` message (lines 31-35), and `raw_source_path`'s docstring
+      (lines 76-92) to name the correct plan. Keep the `DeprecationWarning` category and
+      trigger condition (`source_label == "raw"`) unchanged.
+- [ ] 2.2 Confirm the existing deprecation test
+      (`bloommcp/tests/data_access/test_supabase_reader.py:~25`,
+      `pytest.warns(DeprecationWarning)`) still passes unmodified — a named regression
+      checkpoint proving the trigger condition didn't change, only the message.
+
+## 3. Spec reconciliation (`bloommcp-experiment-read`)
+
+- [ ] 3.1 Write the MODIFIED `ExperimentReader Port` requirement: correct the
+      "Single-experiment read consumers go through the port" and "No consumer imports the
+      storage writer or Supabase directly" scenarios' stale module names
+      (`qc_tools.py`/`storage_tools.py`/`correlation_tools`/`tools/workflows/*`, all
+      retired by `devendor-bloommcp-analysis`) to the current
+      `sections/sleap_roots/analysis/*` locations, and add a scenario for the
+      `qc_inspect.py` provenance fix (Task 1).
+- [ ] 3.2 Write the MODIFIED `SupabaseReader Adapter` requirement: update its intro and
+      deprecation-signal scenario to match the corrected message/plan reference (Task 2),
+      and add a scenario asserting the deprecation signal doesn't cite the superseded
+      bucket-migration plan.
+
+## 4. Verification
+
+- [ ] 4.1 `cd bloommcp && uv run --frozen --extra test pytest tests/ -m "not integration"`
+      — full suite green.
+- [ ] 4.2 `ruff check` (pinned per `.pre-commit-config.yaml`), `ruff format --check`, and
+      `black --check` clean on all changed files.
+- [ ] 4.3 `openspec validate retire-bloommcp-traits-dir-bypass --strict` passes.
+
+## 5. Follow-up (process — no code commit)
+
+- [ ] 5.1 At review, confirm with Evelyn/Elizabeth whether #476 should stay open
+      (re-scoped to depend on `data-access-roadmap.md` Tier 2) or be split into a new
+      tracking issue for the `SupabaseReader` DB-direct rewrite — see `design.md` Open
+      Questions. Do not close #476 outright when this change merges without that
+      confirmation.


### PR DESCRIPTION
## What

An OpenSpec proposal (`openspec/changes/retire-bloommcp-traits-dir-bypass/`) for #476 — this is a **plan only (docs-only diff)**, no implementation yet.

## Why

#476 asks to audit two remaining `BLOOM_TRAITS_DIR` read bypasses left over from the roadmap's Tier 2 (consolidate the read path onto the `ExperimentReader` port):

- `qc_inspect.py:503` — builds its provenance `source_csv` from a hard-coded `TRAITS_DIR` global instead of the active reader.
- `supabase_reader.py`'s raw-tier fallback, which still reads local `BLOOM_TRAITS_DIR` and documents itself as deprecated.

Investigating the second site surfaced that it isn't simple unfinished cleanup: `bloommcp/docs/data-access-roadmap.md` already traced the write path for the `bloommcp_input/` Storage bucket and confirmed it has **no producer anywhere in the repo** — two prior PRs (#368, #413) tried to wire this exact fallback to the bucket and were both closed for that reason. The real fix is that roadmap's Tier 2 (rewrite the raw tier to query Bloom's Postgres directly), which is DRAFT, not yet started, and gated on a migration + Benfica's review.

## Scope

- **In scope:** re-does the `qc_inspect.py` fix independently of #479 (whose unmerged branch happens to fix the same line for a different reason), and corrects `supabase_reader.py`'s stale docstring/warning so it stops citing the closed bucket-migration plan as the reason the fallback will go away — no behavior change there.
- **Out of scope:** the DB-direct rewrite itself (`data-access-roadmap.md` Tiers 1-3), and `LocalReader`/`BLOOM_STORAGE_BACKEND=local` (explicitly excluded by #476).
- **Does not fully close #476** — see `design.md`'s Open Questions; recommends #476 stay open, re-scoped to depend on the roadmap's Tier 2, rather than closed by this change.

## Ask

@eberrigan / @egao28 — review the scoping direction (especially the decision *not* to wire `supabase_reader.py`'s raw tier to `read_input_csv`, given the empty-bucket finding) before implementation starts.

## Test plan

- [x] `openspec validate retire-bloommcp-traits-dir-bypass --strict` passes
- [ ] No code changes yet — implementation follows proposal approval per `tasks.md`