### PR TITLE
feat(bloomctl): concurrent image downloads in cyl download (#534)

### DIFF
--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
 
 ## [Unreleased]
 
+### Changed
+
+- `bloomctl cyl download` now downloads image frames **concurrently** via a thread
+  pool (`-n/--workers`, default 8; `1` restores sequential). Large cylinder
+  experiments (hundreds of thousands of frames) previously downloaded one frame at
+  a time over many hours; per-frame failures are still recorded and don't abort the
+  run, and output order is unchanged (#534).
+
 ## [0.1.0a2] - 2026-07-23
 
 ### Changed

--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
 ### Changed
 
 - `bloomctl cyl download` now downloads image frames **concurrently** via a thread
-  pool (`-n/--workers`, default 8; `1` restores sequential). Large cylinder
-  experiments (hundreds of thousands of frames) previously downloaded one frame at
-  a time over many hours; per-frame failures are still recorded and don't abort the
-  run, and output order is unchanged (#534).
+  pool (`-n/--workers`, default 8, range 1-64; `1` restores sequential). Large cylinder
+  experiments (hundreds of thousands of frames) previously downloaded one frame at a
+  time over many hours. Per-frame failures — and a scan whose frame list can't be
+  fetched — are recorded (not raised) so the run finishes and reports them; frames are
+  written atomically (temp + rename) so colliding destinations can't tear a file; and
+  output order is unchanged (#534).
 
 ## [0.1.0a2] - 2026-07-23
 

--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -46,7 +46,8 @@ command is tagged **[read]** or **[write]** — see [Access & roles](#access--ro
 - `bloomctl login` — bootstrap client config from the Bloom server and store
   credentials per profile.
 - **[read]** `bloomctl cyl download <out_dir> …` — download a cylinder experiment
-  or single scan (metadata `scans.csv` + per-frame images).
+  or single scan (metadata `scans.csv` + per-frame images). Images download
+  concurrently; tune with `-n/--workers` (default 8, `1` = sequential).
 - **[read]** `bloomctl cyl download-for-predict <scan-id> <out>` — stage one scan
   into the predict-ready layout (see below); produces a **different** output tree
   than `cyl download` — use this only for A4 pipeline stage-in.

--- a/bloomcli/src/bloomctl/cyl/download.py
+++ b/bloomcli/src/bloomctl/cyl/download.py
@@ -7,6 +7,8 @@ so the contract is unit-testable without a live server.
 from __future__ import annotations
 
 import csv
+import os
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -189,6 +191,12 @@ def download_frame(
     Self-contained and exception-safe: any failure (missing object, transient 5xx,
     write error) is captured on the result, never raised — so one bad frame can't
     abort a concurrent run. Safe to call from a worker thread.
+
+    The bytes are written to a temp file in the destination directory and then atomically
+    ``os.replace``-d into place. Two frames can map to the same destination path when the
+    path scheme (wave/day/qr + frame_number) doesn't distinguish two scans; the atomic
+    rename means concurrent writers can never produce a torn file — the result is one
+    complete file (last writer wins), matching the sequential behaviour.
     """
     object_path = image.get("object_path", "")
     result = FrameResult(scan.get("scan_id"), image.get("frame_number"), object_path, ok=False)
@@ -198,11 +206,40 @@ def download_frame(
             raise ValueError("empty response from storage")
         dest = image_dest(out_dir, scan, image)
         dest.parent.mkdir(parents=True, exist_ok=True)  # mkdir(exist_ok) is race-safe
-        dest.write_bytes(data)
+        fd, tmp = tempfile.mkstemp(dir=dest.parent, prefix=".dl-", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(data)
+            os.replace(tmp, dest)  # atomic: no torn file even if two workers collide
+        except BaseException:
+            _unlink_quietly(tmp)  # never leave a temp behind
+            raise
         result.ok = True
     except Exception as exc:  # per-frame: record and continue
         result.error = str(exc)
     return result
+
+
+def _unlink_quietly(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _list_scan_frames(
+    client: Any, scan: dict[str, Any]
+) -> tuple[list[dict[str, Any]], FrameResult | None]:
+    """List a scan's frames; on a listing failure return a synthetic failed FrameResult.
+
+    A failed metadata query (transient 5xx, auth expiry) becomes one recorded failure for
+    that scan instead of crashing the whole run with a traceback — so the partial-download
+    exit + download_log still apply uniformly.
+    """
+    try:
+        return fetch_images(client, scan.get("scan_id")), None
+    except Exception as exc:
+        return [], FrameResult(scan.get("scan_id"), None, "", ok=False, error=f"list images: {exc}")
 
 
 def download_images(
@@ -215,23 +252,32 @@ def download_images(
     """Download every frame for every scan from Storage bucket `images`.
 
     Frames are listed per scan (ordered), then downloaded concurrently across a thread
-    pool of ``workers`` — the per-frame HTTP round-trips are the bottleneck on large
+    pool of up to ``workers`` — the per-frame HTTP round-trips are the bottleneck on large
     experiments, and being I/O-bound they overlap well (see #534). ``workers <= 1`` runs
-    sequentially (identical to the original behaviour). Results preserve scan/frame order,
-    so the download log is deterministic. The Supabase client's underlying httpx client is
-    thread-safe, so the one bucket handle is shared across workers.
+    sequentially. Results preserve scan/frame order, so the download log is deterministic.
+    The Supabase client's underlying httpx client is thread-safe, so the one bucket handle
+    is shared across workers. A scan whose frame list can't be fetched is recorded as a
+    failure (not a crash); atomic per-frame writes tolerate colliding destination paths.
     """
     bucket = client.storage.from_("images")
-    work: list[tuple[dict[str, Any], dict[str, Any]]] = [
-        (scan, image) for scan in scans for image in fetch_images(client, scan["scan_id"])
-    ]
-    if workers <= 1:
+    work: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    listing_failures: list[FrameResult] = []
+    for scan in scans:
+        images, failure = _list_scan_frames(client, scan)
+        if failure is not None:
+            listing_failures.append(failure)
+        for image in images:
+            work.append((scan, image))
+
+    # Never spawn more threads than there's work for (or than requested).
+    n = min(workers, len(work)) if work else 0
+    if n <= 1:
         frames = [download_frame(bucket, scan, image, out_dir) for scan, image in work]
     else:
-        with ThreadPoolExecutor(max_workers=workers) as pool:
+        with ThreadPoolExecutor(max_workers=n) as pool:
             # map preserves input order → log stays in scan/frame order.
-            frames = list(pool.map(lambda si: download_frame(bucket, si[0], si[1], out_dir), work))
-    return DownloadResult(frames)
+            frames = list(pool.map(lambda p: download_frame(bucket, p[0], p[1], out_dir), work))
+    return DownloadResult(frames + listing_failures)
 
 
 def write_download_log(result: DownloadResult, path: Path) -> None:
@@ -319,10 +365,10 @@ def write_download_log(result: DownloadResult, path: Path) -> None:
 @click.option(
     "-n",
     "--workers",
-    type=int,
+    type=click.IntRange(min=1, max=64),
     default=DEFAULT_WORKERS,
     show_default=True,
-    help="Concurrent image downloads (I/O-bound). 1 = sequential.",
+    help="Concurrent image downloads (I/O-bound, 1-64). 1 = sequential.",
 )
 def download(
     out_dir: Path,
@@ -344,8 +390,6 @@ def download(
     # Exactly one of --experiment-id / --scan-id.
     if (experiment_id is None) == (scan_id is None):
         raise click.UsageError("Pass exactly one of --experiment-id or --scan-id.")
-    if workers < 1:
-        raise click.UsageError("--workers must be >= 1.")
 
     try:
         creds = load_credentials(profile)

--- a/bloomcli/src/bloomctl/cyl/download.py
+++ b/bloomcli/src/bloomctl/cyl/download.py
@@ -7,6 +7,7 @@ so the contract is unit-testable without a live server.
 from __future__ import annotations
 
 import csv
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,11 @@ from typing import Any
 import click
 
 from ..credentials import DEFAULT_PROFILE
+
+# Default concurrent image downloads. Image fetches are I/O-bound (one HTTP round-trip
+# to Storage each), so a thread pool overlaps request latency; 8 is a modest default
+# that cuts large-experiment download time without hammering the server (see #534).
+DEFAULT_WORKERS = 8
 
 # scans.csv schema: (output column, source key in a cyl_scans_extended row).
 # Order matches the legacy CLI's predict-container contract; `genotype` is
@@ -175,30 +181,56 @@ class DownloadResult:
         return len(self.frames)
 
 
-def download_images(client: Any, scans: list[dict[str, Any]], out_dir: Path) -> DownloadResult:
+def download_frame(
+    bucket: Any, scan: dict[str, Any], image: dict[str, Any], out_dir: Path
+) -> FrameResult:
+    """Download one frame to its destination, returning a FrameResult.
+
+    Self-contained and exception-safe: any failure (missing object, transient 5xx,
+    write error) is captured on the result, never raised — so one bad frame can't
+    abort a concurrent run. Safe to call from a worker thread.
+    """
+    object_path = image.get("object_path", "")
+    result = FrameResult(scan.get("scan_id"), image.get("frame_number"), object_path, ok=False)
+    try:
+        data = bucket.download(object_path)
+        if data is None:
+            raise ValueError("empty response from storage")
+        dest = image_dest(out_dir, scan, image)
+        dest.parent.mkdir(parents=True, exist_ok=True)  # mkdir(exist_ok) is race-safe
+        dest.write_bytes(data)
+        result.ok = True
+    except Exception as exc:  # per-frame: record and continue
+        result.error = str(exc)
+    return result
+
+
+def download_images(
+    client: Any,
+    scans: list[dict[str, Any]],
+    out_dir: Path,
+    *,
+    workers: int = DEFAULT_WORKERS,
+) -> DownloadResult:
     """Download every frame for every scan from Storage bucket `images`.
 
-    Each frame is downloaded independently: a failure is recorded, not raised, so
-    one bad frame (missing object, transient 5xx) can't abort the whole run.
-    Signs server-side via Supabase Storage (no MinIO secrets, no legacy Lambda).
+    Frames are listed per scan (ordered), then downloaded concurrently across a thread
+    pool of ``workers`` — the per-frame HTTP round-trips are the bottleneck on large
+    experiments, and being I/O-bound they overlap well (see #534). ``workers <= 1`` runs
+    sequentially (identical to the original behaviour). Results preserve scan/frame order,
+    so the download log is deterministic. The Supabase client's underlying httpx client is
+    thread-safe, so the one bucket handle is shared across workers.
     """
     bucket = client.storage.from_("images")
-    frames: list[FrameResult] = []
-    for scan in scans:
-        for image in fetch_images(client, scan["scan_id"]):
-            object_path = image.get("object_path", "")
-            result = FrameResult(scan.get("scan_id"), image.get("frame_number"), object_path, ok=False)
-            try:
-                data = bucket.download(object_path)
-                if data is None:
-                    raise ValueError("empty response from storage")
-                dest = image_dest(out_dir, scan, image)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                dest.write_bytes(data)
-                result.ok = True
-            except Exception as exc:  # per-frame: record and continue
-                result.error = str(exc)
-            frames.append(result)
+    work: list[tuple[dict[str, Any], dict[str, Any]]] = [
+        (scan, image) for scan in scans for image in fetch_images(client, scan["scan_id"])
+    ]
+    if workers <= 1:
+        frames = [download_frame(bucket, scan, image, out_dir) for scan, image in work]
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            # map preserves input order → log stays in scan/frame order.
+            frames = list(pool.map(lambda si: download_frame(bucket, si[0], si[1], out_dir), work))
     return DownloadResult(frames)
 
 
@@ -207,7 +239,9 @@ def write_download_log(result: DownloadResult, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = []
     for f in result.frames:
-        line = f"{'OK  ' if f.ok else 'FAIL'} scan={f.scan_id} frame={f.frame_number} {f.object_path}"
+        line = (
+            f"{'OK  ' if f.ok else 'FAIL'} scan={f.scan_id} frame={f.frame_number} {f.object_path}"
+        )
         if not f.ok:
             line += f"  error={f.error}"
         lines.append(line)
@@ -282,6 +316,14 @@ def write_download_log(result: DownloadResult, path: Path) -> None:
     show_default=True,
     help="Maximum number of scans to fetch.",
 )
+@click.option(
+    "-n",
+    "--workers",
+    type=int,
+    default=DEFAULT_WORKERS,
+    show_default=True,
+    help="Concurrent image downloads (I/O-bound). 1 = sequential.",
+)
 def download(
     out_dir: Path,
     experiment_id: int | None,
@@ -292,6 +334,7 @@ def download(
     plant_age_min: int,
     plant_age_max: int,
     limit: int,
+    workers: int,
 ) -> None:
     """Download a cylinder experiment (--experiment-id) or a single scan (--scan-id):
     metadata (scans.csv) and per-frame images."""
@@ -301,6 +344,8 @@ def download(
     # Exactly one of --experiment-id / --scan-id.
     if (experiment_id is None) == (scan_id is None):
         raise click.UsageError("Pass exactly one of --experiment-id or --scan-id.")
+    if workers < 1:
+        raise click.UsageError("--workers must be >= 1.")
 
     try:
         creds = load_credentials(profile)
@@ -336,7 +381,7 @@ def download(
     if meta_only:
         return
 
-    result = download_images(client, scans, out)
+    result = download_images(client, scans, out, workers=workers)
     log_path = out / "download_log.txt"
     write_download_log(result, log_path)
     click.echo(

--- a/bloomcli/tests/test_download_images.py
+++ b/bloomcli/tests/test_download_images.py
@@ -95,9 +95,9 @@ def test_partial_download_exits_nonzero(tmp_path, monkeypatch):
     monkeypatch.setattr(dl, "fetch_scans", lambda *a, **k: [SCAN])
     monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {42: "Spring-32"})
     monkeypatch.setattr(
-        dl, "fetch_images", lambda client, scan_id: [
-            {"frame_number": 0, "object_path": "cyl-images/boom.png"}
-        ]
+        dl,
+        "fetch_images",
+        lambda client, scan_id: [{"frame_number": 0, "object_path": "cyl-images/boom.png"}],
     )
 
     out = tmp_path / "out"
@@ -108,6 +108,100 @@ def test_partial_download_exits_nonzero(tmp_path, monkeypatch):
     assert "frames failed" in result.output
     assert (out / "scans.csv").exists()
     assert (out / "download_log.txt").exists()
+
+
+# --- concurrency (#534) -----------------------------------------------------
+
+
+def test_download_images_preserves_order_when_concurrent(tmp_path, monkeypatch):
+    # pool.map keeps input order, so the frame list (and thus the log) is deterministic
+    # regardless of which worker finishes first.
+    images = [{"frame_number": i, "object_path": f"cyl-images/{i}.png"} for i in range(10)]
+    monkeypatch.setattr(dl, "fetch_images", lambda client, scan_id: images)
+
+    result = dl.download_images(_FakeClient(), [SCAN], tmp_path, workers=4)
+
+    assert result.ok == 10 and result.failed == 0
+    assert [f.frame_number for f in result.frames] == list(range(10))
+
+
+def test_download_images_workers_one_is_sequential(tmp_path, monkeypatch):
+    images = [
+        {"frame_number": 0, "object_path": "cyl-images/a.png"},
+        {"frame_number": 1, "object_path": "cyl-images/b.png"},
+    ]
+    monkeypatch.setattr(dl, "fetch_images", lambda client, scan_id: images)
+
+    result = dl.download_images(_FakeClient(), [SCAN], tmp_path, workers=1)
+
+    assert result.ok == 2 and result.total == 2
+
+
+def test_download_images_actually_runs_in_parallel(tmp_path, monkeypatch):
+    # A barrier that only releases once `workers` downloads are in flight at once. If the
+    # pool weren't concurrent, the first .wait() times out (BrokenBarrierError) and the
+    # frame is recorded as failed — so this deterministically proves real parallelism.
+    import threading
+
+    workers = 4
+    barrier = threading.Barrier(workers, timeout=5)
+    seen: set[int] = set()
+    lock = threading.Lock()
+
+    class _BarrierBucket:
+        def download(self, object_path):
+            barrier.wait()  # needs >= `workers` threads here simultaneously
+            with lock:
+                seen.add(threading.get_ident())
+            return b"x"
+
+    class _BarrierClient:
+        storage = type("S", (), {"from_": lambda self, b: _BarrierBucket()})()
+
+    images = [{"frame_number": i, "object_path": f"p{i}.png"} for i in range(workers)]
+    monkeypatch.setattr(dl, "fetch_images", lambda client, scan_id: images)
+
+    result = dl.download_images(_BarrierClient(), [SCAN], tmp_path, workers=workers)
+
+    assert result.ok == workers, "downloads did not overlap (barrier timed out)"
+    assert len(seen) == workers  # each frame ran on a distinct worker thread
+
+
+def test_download_workers_option_passed_through(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: _FakeClient())
+    monkeypatch.setattr(dl, "fetch_scans", lambda *a, **k: [SCAN])
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {42: "Spring-32"})
+    captured = {}
+
+    def _fake_download(client, scans, out_dir, *, workers=dl.DEFAULT_WORKERS):
+        captured["workers"] = workers
+        return dl.DownloadResult([])
+
+    monkeypatch.setattr(dl, "download_images", _fake_download)
+
+    out = tmp_path / "out"
+    res = CliRunner().invoke(
+        cli, ["cyl", "download", str(out), "--experiment-id", "17957", "-n", "3"]
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["workers"] == 3
+
+
+def test_download_workers_zero_rejected(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    out = tmp_path / "out"
+    res = CliRunner().invoke(
+        cli, ["cyl", "download", str(out), "--experiment-id", "17957", "--workers", "0"]
+    )
+    assert res.exit_code != 0
+    assert "workers must be >= 1" in res.output
 
 
 def test_full_download_writes_csv_and_images(tmp_path, monkeypatch):
@@ -121,9 +215,7 @@ def test_full_download_writes_csv_and_images(tmp_path, monkeypatch):
     monkeypatch.setattr(
         dl,
         "fetch_images",
-        lambda client, scan_id: [
-            {"frame_number": 0, "object_path": "cyl-images/a.png"}
-        ],
+        lambda client, scan_id: [{"frame_number": 0, "object_path": "cyl-images/a.png"}],
     )
 
     out = tmp_path / "out"

--- a/bloomcli/tests/test_download_images.py
+++ b/bloomcli/tests/test_download_images.py
@@ -135,6 +135,62 @@ def test_download_images_workers_one_is_sequential(tmp_path, monkeypatch):
     result = dl.download_images(_FakeClient(), [SCAN], tmp_path, workers=1)
 
     assert result.ok == 2 and result.total == 2
+    assert [f.frame_number for f in result.frames] == [0, 1]  # sequential path preserves order
+
+
+SCAN2 = {**SCAN, "scan_id": 2, "qr_code": "QR-2", "plant_age_days": 21}
+
+
+def test_download_images_preserves_cross_scan_order_concurrent(tmp_path, monkeypatch):
+    # The real-world case: multiple scans, concurrent. Order must be scan1-frames then
+    # scan2-frames (input order), independent of which worker finishes first.
+    per_scan = {
+        1: [
+            {"frame_number": 0, "object_path": "a/0.png"},
+            {"frame_number": 1, "object_path": "a/1.png"},
+        ],
+        2: [
+            {"frame_number": 0, "object_path": "b/0.png"},
+            {"frame_number": 1, "object_path": "b/1.png"},
+        ],
+    }
+    monkeypatch.setattr(dl, "fetch_images", lambda client, scan_id: per_scan[scan_id])
+
+    result = dl.download_images(_FakeClient(), [SCAN, SCAN2], tmp_path, workers=8)
+
+    assert result.ok == 4
+    assert [(f.scan_id, f.frame_number) for f in result.frames] == [(1, 0), (1, 1), (2, 0), (2, 1)]
+
+
+def test_download_images_empty_scans(tmp_path):
+    result = dl.download_images(_FakeClient(), [], tmp_path, workers=8)
+    assert result.total == 0 and result.ok == 0 and result.failed == 0
+
+
+def test_download_images_list_failure_is_recorded_not_raised(tmp_path, monkeypatch):
+    # A scan whose frame listing raises becomes one recorded failure, not a crash — so
+    # the partial-download exit + log still apply.
+    def _boom_list(client, scan_id):
+        raise RuntimeError("503 listing images")
+
+    monkeypatch.setattr(dl, "fetch_images", _boom_list)
+
+    result = dl.download_images(_FakeClient(), [SCAN], tmp_path, workers=4)
+
+    assert result.total == 1 and result.failed == 1 and result.ok == 0
+    assert "503 listing images" in result.frames[0].error
+
+
+def test_download_frame_leaves_no_temp_files(tmp_path, monkeypatch):
+    # atomic write: a successful download leaves exactly the frame, no .dl-*.tmp litter.
+    images = [{"frame_number": 0, "object_path": "cyl-images/a.png"}]
+    monkeypatch.setattr(dl, "fetch_images", lambda client, scan_id: images)
+
+    dl.download_images(_FakeClient(), [SCAN], tmp_path, workers=2)
+
+    frame_dir = tmp_path / "images/Wave2/Day14_2026-05-11/QR-1"
+    assert (frame_dir / "0.png").read_bytes() == b"bytes::cyl-images/a.png"
+    assert list(frame_dir.glob(".dl-*.tmp")) == []  # no temp left behind
 
 
 def test_download_images_actually_runs_in_parallel(tmp_path, monkeypatch):
@@ -191,17 +247,19 @@ def test_download_workers_option_passed_through(tmp_path, monkeypatch):
     assert captured["workers"] == 3
 
 
-def test_download_workers_zero_rejected(tmp_path, monkeypatch):
+def test_download_workers_out_of_range_rejected(tmp_path, monkeypatch):
+    # IntRange(1, 64) rejects both 0 and >64 before any work runs.
     monkeypatch.setattr(
         "bloomctl.credentials.load_credentials",
         lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
     )
     out = tmp_path / "out"
-    res = CliRunner().invoke(
-        cli, ["cyl", "download", str(out), "--experiment-id", "17957", "--workers", "0"]
-    )
-    assert res.exit_code != 0
-    assert "workers must be >= 1" in res.output
+    for bad in ("0", "65", "-3"):
+        res = CliRunner().invoke(
+            cli, ["cyl", "download", str(out), "--experiment-id", "17957", "--workers", bad]
+        )
+        assert res.exit_code != 0, f"--workers {bad} should be rejected"
+        assert "workers" in res.output.lower() and "range" in res.output.lower()
 
 
 def test_full_download_writes_csv_and_images(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Makes `bloomctl cyl download` download image frames **concurrently** instead of one at a
time. On large cylinder experiments the sequential frame-by-frame loop was the dominant
cost — downloading a big experiment (hundreds of thousands of frames) took **hours**.
Frames are I/O-bound HTTP round-trips to Storage, so a thread pool overlaps the per-request
latency and cuts wall-clock time substantially.

Refs #534 (does not close it — leaving the issue open to track the remaining scope below).
Throughput here also compounds with the session-refresh/resume work in #525.

## What changed

- `download_images()` fans the per-frame downloads across a `ThreadPoolExecutor`.
- New **`-n/--workers`** option — default 8, **range 1–64** (`click.IntRange`); `1` restores
  the fully-sequential behaviour. The pool never spawns more threads than there is work
  (`min(workers, len(work))`).
- Extracted a thread-safe, exception-safe `download_frame()` helper. Per-frame failures are
  **recorded, not raised**, and results preserve **scan/frame order** so `download_log.txt`
  stays deterministic.

## Correctness / robustness (from an adversarial review pass)

A 5-agent review confirmed the shared-`bucket` design is genuinely thread-safe (the installed
`storage3` download path mutates no shared state; httpx's pool/cookie-jar are lock-guarded).
Three issues it surfaced are fixed here:

- **Atomic writes** — the on-disk path scheme (`wave/day/qr` + `frame_number`) doesn't include
  `scan_id`, so two scans *can* map to the same file. Frames are now written to a temp file
  and `os.replace`-d into place, so concurrent writers to a colliding path can't tear a file
  (one complete file, last-writer-wins — matching sequential).
- **Bounded workers** — `IntRange(1, 64)` + the `min(workers, len(work))` cap prevent a typo
  like `-n 100000` from launching a thread/connection storm.
- **Graceful listing** — a scan whose frame list can't be fetched is recorded as one failed
  frame instead of crashing the whole run with a traceback, so the partial-download exit +
  log apply uniformly.

## Scope / what this does NOT touch

- **Only `cyl download`.** `cyl download-for-predict` shares the per-frame pattern (and #534
  notes it likely wants the same fix), but it's a separate command owned elsewhere, so it's
  intentionally left unchanged here.
- No server/schema/RPC changes.

## Testing

- `uv run --extra test pytest tests/` — **203 passed, 4 skipped**; `ruff check` clean.
- Concurrency tests: a **barrier test that deterministically proves real parallelism** (times
  out → recorded failure rather than hanging if the pool weren't concurrent), single- and
  **cross-scan** order preservation, `--workers 1` order-equivalence, out-of-range `--workers`
  (0 / 65 / -3) rejected, list-failure recorded-not-raised, empty scans, and no temp-file litter.
- Local build verified: `uv build` → wheel + sdist; `-n/--workers` present in the CLI.
- Not yet run: a live concurrent download against a real Bloom server (needs creds + an
  experiment) — recommended manual smoke before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
