### PR TITLE
feat(bloomctl): batch barcode/accession selectors for cyl download

### DIFF
--- a/bloomcli/CHANGELOG.md
+++ b/bloomcli/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project uses [PEP 440](https://peps.python.org/pep-0440/) versioning
 
 ## [Unreleased]
 
+### Added
+
+- `bloomctl cyl download` batch selectors — subset an experiment to a chosen set of
+  plants by barcode or accession: `--barcode` (repeatable; alias `--plant-qr-code`),
+  `--barcodes-file` for a long list (one per line, or comma/space separated, `#`
+  comments ignored), and `--accession-id` (repeatable). Long barcode/accession lists
+  are chunked across requests so the `IN()` filter never exceeds request-URL limits.
+
 ### Changed
 
 - `bloomctl cyl download` now downloads image frames **concurrently** via a thread

--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -47,7 +47,10 @@ command is tagged **[read]** or **[write]** — see [Access & roles](#access--ro
   credentials per profile.
 - **[read]** `bloomctl cyl download <out_dir> …` — download a cylinder experiment
   or single scan (metadata `scans.csv` + per-frame images). Images download
-  concurrently; tune with `-n/--workers` (default 8, `1` = sequential).
+  concurrently; tune with `-n/--workers` (default 8, `1` = sequential). Subset a
+  batch of plants by barcode — `--barcode` (repeatable; alias `--plant-qr-code`) or
+  `--barcodes-file` for a long list — or by `--accession-id` (repeatable). Long lists
+  are chunked across requests so they never exceed URL limits.
 - **[read]** `bloomctl cyl download-for-predict <scan-id> <out>` — stage one scan
   into the predict-ready layout (see below); produces a **different** output tree
   than `cyl download` — use this only for A4 pipeline stage-in.

--- a/bloomcli/src/bloomctl/cyl/download.py
+++ b/bloomcli/src/bloomctl/cyl/download.py
@@ -12,7 +12,7 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import click
 
@@ -90,28 +90,83 @@ def image_dest(out_dir: Path, scan: dict[str, Any], image: dict[str, Any]) -> Pa
 # --- supabase / storage I/O -------------------------------------------------
 
 
+# Max values per IN() filter. A barcode/accession list is sent inside the PostgREST
+# request URL, which proxies (Kong/nginx) cap at a few KB — so a large --barcodes-file
+# is split across several requests and the rows are merged. 100 keeps each URL small.
+_IN_CHUNK = 100
+
+
+def _chunked(values: Sequence[Any], size: int = _IN_CHUNK) -> list[list[Any]]:
+    """Split into chunks of at most `size` (whole list as one chunk when small)."""
+    values = list(values)
+    return [values[i : i + size] for i in range(0, len(values), size)] or [[]]
+
+
 def fetch_scans(
     client: Any,
     experiment_id: int,
     *,
-    plant_qr_code: str | None = None,
+    plant_qr_codes: Sequence[str] | None = None,
+    accession_ids: Sequence[int] | None = None,
     plant_age_min: int = 0,
     plant_age_max: int = 1000,
     limit: int = 100000,
 ) -> list[dict[str, Any]]:
-    """Query cyl_scans_extended for an experiment (legacy filter semantics)."""
-    query = (
-        client.table("cyl_scans_extended")
-        .select("*")
-        .eq("experiment_id", experiment_id)
-    )
-    if plant_qr_code:
-        query = query.eq("qr_code", plant_qr_code)
-    else:
-        query = query.gte("plant_age_days", plant_age_min).lte(
-            "plant_age_days", plant_age_max
+    """Query cyl_scans_extended for an experiment, optionally subsetting a batch.
+
+    Batch selectors are additive: a list of ``plant_qr_codes`` (barcodes) and/or
+    ``accession_ids`` narrows the experiment to just those plants (server-side ``IN``).
+    A long barcode list is split into chunks (see ``_IN_CHUNK``) so no single request
+    URL exceeds proxy limits; the chunks' rows are merged and de-duplicated by scan_id.
+    The plant-age window always applies (its 0..1000 default is a no-op unless narrowed).
+    """
+
+    def base():
+        return (
+            client.table("cyl_scans_extended")
+            .select("*")
+            .eq("experiment_id", experiment_id)
+            .gte("plant_age_days", plant_age_min)
+            .lte("plant_age_days", plant_age_max)
         )
-    return query.limit(limit).execute().data or []
+
+    # No batch selectors → a single whole-experiment query (unchanged behaviour).
+    if not plant_qr_codes and not accession_ids:
+        return base().limit(limit).execute().data or []
+
+    # Chunk the larger selector (barcodes if present) to keep each request URL small;
+    # apply the other selector in full on every chunk. Merge/de-dup by scan_id.
+    seen: dict[Any, dict[str, Any]] = {}
+    if plant_qr_codes:
+        for chunk in _chunked(plant_qr_codes):
+            query = base().in_("qr_code", chunk)
+            if accession_ids:
+                query = query.in_("accession_id", list(accession_ids))
+            for row in query.limit(limit).execute().data or []:
+                seen[row.get("scan_id")] = row
+    else:
+        for chunk in _chunked(accession_ids):
+            for row in base().in_("accession_id", chunk).limit(limit).execute().data or []:
+                seen[row.get("scan_id")] = row
+    return list(seen.values())
+
+
+def read_barcodes_file(path: Path) -> list[str]:
+    """Read a barcode list from a file: one per line, or comma/whitespace separated.
+
+    Blank lines and ``#`` comments are ignored; order is preserved and duplicates dropped,
+    so a user can paste a messy list and get a clean batch.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    out: list[str] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        line = line.split("#", 1)[0]
+        for token in line.replace(",", " ").split():
+            if token and token not in seen:
+                seen.add(token)
+                out.append(token)
+    return out
 
 
 def fetch_scan(client: Any, scan_id: Any) -> dict[str, Any] | None:
@@ -331,11 +386,29 @@ def write_download_log(result: DownloadResult, path: Path) -> None:
     help="Write scans.csv only; skip image download.",
 )
 @click.option(
+    "--barcode",
     "--plant-qr-code",
     "--plant_qr_code",
-    "plant_qr_code",
+    "plant_qr_codes",
+    multiple=True,
+    help="Plant barcode (a.k.a. QR code — the qr_code column). Repeatable; "
+    "or pass many at once with --barcodes-file.",
+)
+@click.option(
+    "--barcodes-file",
+    "--barcodes_file",
+    "barcodes_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
     default=None,
-    help="Restrict to a single plant QR code.",
+    help="File of barcodes (same as --barcode, in bulk): one per line, or comma/space separated.",
+)
+@click.option(
+    "--accession-id",
+    "--accession_id",
+    "accession_ids",
+    type=int,
+    multiple=True,
+    help="Restrict to these accession ids (repeatable). See `cyl accessions list`.",
 )
 @click.option(
     "--plant-age-min",
@@ -376,20 +449,37 @@ def download(
     scan_id: int | None,
     profile: str,
     meta_only: bool,
-    plant_qr_code: str | None,
+    plant_qr_codes: tuple[str, ...],
+    barcodes_file: Path | None,
+    accession_ids: tuple[int, ...],
     plant_age_min: int,
     plant_age_max: int,
     limit: int,
     workers: int,
 ) -> None:
     """Download a cylinder experiment (--experiment-id) or a single scan (--scan-id):
-    metadata (scans.csv) and per-frame images."""
+    metadata (scans.csv) and per-frame images.
+
+    Batch selectors (--barcode/--barcodes-file, --accession-id) subset an
+    experiment to a chosen set of plants, fetched in one round-trip.
+    """
     from .. import auth
     from ..credentials import load_credentials
 
     # Exactly one of --experiment-id / --scan-id.
     if (experiment_id is None) == (scan_id is None):
         raise click.UsageError("Pass exactly one of --experiment-id or --scan-id.")
+
+    # Barcodes come from --plant-qr-code and/or a file; merge, de-dup, keep order.
+    barcodes = list(plant_qr_codes)
+    if barcodes_file is not None:
+        barcodes.extend(read_barcodes_file(barcodes_file))
+    barcodes = list(dict.fromkeys(barcodes))
+    if scan_id is not None and (barcodes or accession_ids):
+        raise click.UsageError(
+            "Batch selectors (--plant-qr-code / --barcodes-file / --accession-id) "
+            "apply to --experiment-id, not --scan-id."
+        )
 
     try:
         creds = load_credentials(profile)
@@ -409,7 +499,8 @@ def download(
         scans = fetch_scans(
             client,
             experiment_id,
-            plant_qr_code=plant_qr_code,
+            plant_qr_codes=barcodes or None,
+            accession_ids=list(accession_ids) or None,
             plant_age_min=plant_age_min,
             plant_age_max=plant_age_max,
             limit=limit,

--- a/bloomcli/tests/test_cyl_download_batch.py
+++ b/bloomcli/tests/test_cyl_download_batch.py
@@ -1,0 +1,306 @@
+"""`bloomctl cyl download` batch selectors: --plant-qr-code (repeatable),
+--barcodes-file, --accession-id. Query-shape + CLI wiring with monkeypatch fakes."""
+
+from click.testing import CliRunner
+from test_download_metadata import SCAN
+
+import bloomctl.auth as auth
+import bloomctl.cyl.download as dl
+from bloomctl.cli import cli
+from bloomctl.credentials import Credentials
+
+# --- read_barcodes_file (pure) ---------------------------------------------
+
+
+def test_read_barcodes_file_mixed_delimiters_and_comments(tmp_path):
+    p = tmp_path / "bc.txt"
+    p.write_text("QR-1, QR-2\nQR-3  QR-1\n# a comment\n\nQR-4 # trailing\n")
+    assert dl.read_barcodes_file(p) == ["QR-1", "QR-2", "QR-3", "QR-4"]
+
+
+def test_read_barcodes_file_empty(tmp_path):
+    p = tmp_path / "bc.txt"
+    p.write_text("\n#only a comment\n   \n")
+    assert dl.read_barcodes_file(p) == []
+
+
+# --- fetch_scans query shape ------------------------------------------------
+
+
+class _CaptureQuery:
+    def __init__(self, captured):
+        self._c = captured
+        self._c.setdefault("in_", [])
+
+    def select(self, *a):
+        return self
+
+    def eq(self, col, val):
+        self._c[("eq", col)] = val
+        return self
+
+    def in_(self, col, vals):
+        self._c["in_"].append((col, list(vals)))
+        return self
+
+    def gte(self, col, val):
+        self._c[("gte", col)] = val
+        return self
+
+    def lte(self, col, val):
+        self._c[("lte", col)] = val
+        return self
+
+    def limit(self, n):
+        self._c["limit"] = n
+        return self
+
+    def execute(self):
+        return type("R", (), {"data": [SCAN]})()
+
+
+def _capture_client(captured):
+    class _Client:
+        def table(self, name):
+            captured["table"] = name
+            return _CaptureQuery(captured)
+
+    return _Client()
+
+
+def test_fetch_scans_barcodes_use_in():
+    cap = {}
+    dl.fetch_scans(_capture_client(cap), 17957, plant_qr_codes=["A1", "A2"])
+    assert cap["table"] == "cyl_scans_extended"
+    assert ("qr_code", ["A1", "A2"]) in cap["in_"]
+
+
+def test_fetch_scans_accession_ids_use_in():
+    cap = {}
+    dl.fetch_scans(_capture_client(cap), 17957, accession_ids=[42, 43])
+    assert ("accession_id", [42, 43]) in cap["in_"]
+
+
+def test_fetch_scans_both_selectors_and_age_window():
+    cap = {}
+    dl.fetch_scans(
+        _capture_client(cap),
+        17957,
+        plant_qr_codes=["A1"],
+        accession_ids=[42],
+        plant_age_min=7,
+        plant_age_max=14,
+    )
+    cols = [c for c, _ in cap["in_"]]
+    assert "qr_code" in cols and "accession_id" in cols
+    assert cap[("gte", "plant_age_days")] == 7 and cap[("lte", "plant_age_days")] == 14
+
+
+def test_fetch_scans_no_selectors_omits_in():
+    cap = {}
+    dl.fetch_scans(_capture_client(cap), 17957)
+    assert cap["in_"] == []  # no batch selectors → no IN() filter
+
+
+# --- chunking: large IN() lists are split so no request URL exceeds proxy limits ---
+
+
+class _ChunkRecorder:
+    """Records each qr_code IN() chunk and returns one row per barcode in the chunk."""
+
+    def __init__(self, seen_chunks):
+        self._chunks = seen_chunks
+        self._codes = None
+
+    def select(self, *a):
+        return self
+
+    def eq(self, *a):
+        return self
+
+    def gte(self, *a):
+        return self
+
+    def lte(self, *a):
+        return self
+
+    def in_(self, col, vals):
+        if col == "qr_code":
+            self._codes = list(vals)
+            self._chunks.append(list(vals))
+        return self
+
+    def limit(self, n):
+        return self
+
+    def execute(self):
+        rows = [{"scan_id": code, "qr_code": code} for code in (self._codes or [])]
+        return type("R", (), {"data": rows})()
+
+
+def test_fetch_scans_chunks_large_barcode_list():
+    seen_chunks: list[list[str]] = []
+
+    class _Client:
+        def table(self, name):
+            return _ChunkRecorder(seen_chunks)
+
+    codes = [f"BC{i}" for i in range(250)]  # 250 > _IN_CHUNK (100) → 3 chunks
+    rows = dl.fetch_scans(_Client(), 17957, plant_qr_codes=codes)
+
+    assert len(seen_chunks) == 3
+    assert [len(c) for c in seen_chunks] == [100, 100, 50]
+    assert max(len(c) for c in seen_chunks) <= dl._IN_CHUNK
+    # every barcode's row is merged into the result (de-duped by scan_id)
+    assert {r["scan_id"] for r in rows} == set(codes)
+
+
+def test_fetch_scans_chunks_accession_ids_when_no_barcodes():
+    seen: list[list[int]] = []
+
+    class _Q:
+        def select(self, *a):
+            return self
+
+        def eq(self, *a):
+            return self
+
+        def gte(self, *a):
+            return self
+
+        def lte(self, *a):
+            return self
+
+        def in_(self, col, vals):
+            seen.append(list(vals))
+            self._vals = list(vals)
+            return self
+
+        def limit(self, n):
+            return self
+
+        def execute(self):
+            return type("R", (), {"data": [{"scan_id": v} for v in self._vals]})()
+
+    class _Client:
+        def table(self, name):
+            return _Q()
+
+    ids = list(range(150))  # 150 > 100 → 2 chunks
+    rows = dl.fetch_scans(_Client(), 17957, accession_ids=ids)
+    assert [len(c) for c in seen] == [100, 50]
+    assert {r["scan_id"] for r in rows} == set(ids)
+
+
+def test_barcode_alias_reaches_fetch(tmp_path, monkeypatch):
+    # --barcode is an alias of --plant-qr-code (same qr_code column).
+    _login(monkeypatch)
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {})
+    captured = {}
+
+    def _fake_fetch(client, experiment_id, *, plant_qr_codes=None, accession_ids=None, **k):
+        captured["qr"] = plant_qr_codes
+        return [SCAN]
+
+    monkeypatch.setattr(dl, "fetch_scans", _fake_fetch)
+    monkeypatch.setattr(dl, "download_images", lambda *a, **k: dl.DownloadResult([]))
+
+    out = tmp_path / "out"
+    res = CliRunner().invoke(
+        cli,
+        ["cyl", "download", str(out), "--experiment-id", "1", "--meta-only", "--barcode", "QR-9"],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["qr"] == ["QR-9"]
+
+
+# --- CLI wiring -------------------------------------------------------------
+
+
+def _login(monkeypatch):
+    monkeypatch.setattr(
+        "bloomctl.credentials.load_credentials",
+        lambda *a, **k: Credentials("https://x/api", "KEY", "u@s.edu", "pw"),
+    )
+    monkeypatch.setattr(auth, "make_authed_client", lambda creds: object())
+
+
+def test_barcodes_option_and_file_merge_deduped(tmp_path, monkeypatch):
+    _login(monkeypatch)
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {})
+    captured = {}
+
+    def _fake_fetch(client, experiment_id, *, plant_qr_codes=None, accession_ids=None, **k):
+        captured["qr"] = plant_qr_codes
+        captured["acc"] = accession_ids
+        return [SCAN]
+
+    monkeypatch.setattr(dl, "fetch_scans", _fake_fetch)
+    monkeypatch.setattr(dl, "download_images", lambda *a, **k: dl.DownloadResult([]))
+
+    bc = tmp_path / "bc.txt"
+    bc.write_text("QR-2\nQR-3\nQR-1\n")  # QR-1 also passed via option → de-duped
+    out = tmp_path / "out"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "cyl",
+            "download",
+            str(out),
+            "--experiment-id",
+            "17957",
+            "--meta-only",
+            "--plant-qr-code",
+            "QR-1",
+            "--barcodes-file",
+            str(bc),
+            "--accession-id",
+            "42",
+            "--accession-id",
+            "43",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["qr"] == ["QR-1", "QR-2", "QR-3"]  # option first, then file, de-duped
+    assert captured["acc"] == [42, 43]
+
+
+def test_no_selectors_passes_none(tmp_path, monkeypatch):
+    _login(monkeypatch)
+    monkeypatch.setattr(dl, "fetch_genotypes", lambda c, ids: {})
+    captured = {}
+
+    def _fake_fetch(client, experiment_id, *, plant_qr_codes=None, accession_ids=None, **k):
+        captured["qr"] = plant_qr_codes
+        captured["acc"] = accession_ids
+        return [SCAN]
+
+    monkeypatch.setattr(dl, "fetch_scans", _fake_fetch)
+    monkeypatch.setattr(dl, "download_images", lambda *a, **k: dl.DownloadResult([]))
+
+    out = tmp_path / "out"
+    res = CliRunner().invoke(
+        cli, ["cyl", "download", str(out), "--experiment-id", "17957", "--meta-only"]
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["qr"] is None and captured["acc"] is None
+
+
+def test_batch_selector_rejected_with_scan_id(tmp_path, monkeypatch):
+    _login(monkeypatch)
+    out = tmp_path / "out"
+    res = CliRunner().invoke(
+        cli, ["cyl", "download", str(out), "--scan-id", "5", "--plant-qr-code", "QR-1"]
+    )
+    assert res.exit_code != 0
+    assert "Batch selectors" in res.output
+
+
+def test_accession_id_rejected_with_scan_id(tmp_path, monkeypatch):
+    _login(monkeypatch)
+    out = tmp_path / "out"
+    res = CliRunner().invoke(
+        cli, ["cyl", "download", str(out), "--scan-id", "5", "--accession-id", "42"]
+    )
+    assert res.exit_code != 0
+    assert "Batch selectors" in res.output


### PR DESCRIPTION
## Summary

Adds **batch selection** to `bloomctl cyl download` so users can pull a chosen subset
of plants in one go, instead of one barcode at a time. Directly addresses user feedback
("take a list of barcodes and find them all at once", and searching by accession).

Stacked on #536 (the concurrency change) — review/merge that first; this branch targets
it, and its diff shows only the batch-selection change on top.

## What changed

- **`--barcode`** (repeatable; alias **`--plant-qr-code`** for back-compat) — inline
  barcodes. A "barcode" *is* the plant QR code (the `qr_code` column); it's one aliased
  option, not two concepts.
- **`--barcodes-file`** — the same thing in bulk: one barcode per line, or comma/space
  separated; blank lines and `#` comments ignored. Merged with `--barcode`, de-duped,
  order preserved.
- **`--accession-id`** (repeatable) — narrow to whole accessions.
- Batch selectors require `--experiment-id`; combining them with `--scan-id` is a
  usage error.

## Robustness: chunked IN()

A barcode/accession list is sent inside the PostgREST request URL, which proxies
(Kong/nginx) cap at a few KB — so a large `--barcodes-file` would overflow a single
query. `fetch_scans` splits the list into chunks of 100, runs a request per chunk, and
merges/de-dupes rows by `scan_id`. Arbitrarily long lists are safe.

## Scope

- Only `cyl download` (yours). No server/schema changes — reads the existing
  `cyl_scans_extended` view.

## Testing

- `uv run --extra test pytest tests/` — **212 passed, 4 skipped**; `ruff check` clean.
- New tests: barcode-file parsing (delimiters/comments/dedup), `IN()` query shape for
  barcodes + accessions + age window, **chunking of a 250-barcode list into 100/100/50
  with rows merged**, accession-id chunking, option+file merge/de-dup, `--barcode` alias,
  and batch-selector-with-`--scan-id` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
