### PR TITLE
refactor(langchain/web): single-source foundational MCP tool list (#485)

### DIFF
--- a/bloommcp/docs/2026-06-29-bloom-mcp-contributor-namespacing.md
+++ b/bloommcp/docs/2026-06-29-bloom-mcp-contributor-namespacing.md
@@ -69,11 +69,17 @@ new blanket convention.
 
 ## Consequence for hand-maintained tool-name lists
 
-Two client-side lists match MCP tool names by exact string: `ALWAYS_INCLUDE_MCP_TOOLS`
-(`langchain/routes/chat.py`) and `HIDDEN_TOOLS` (`web/components/mcp-chat-client.tsx`). Section
-namespacing changes a tool's *registered* name (e.g. `list_available_experiments` becomes
-`core_list_available_experiments`), so both lists match **prefix-aware** (exact name, or
+One list matches MCP tool names by exact string: `ALWAYS_INCLUDE_MCP_TOOLS`
+(`langchain/helpers/foundational_tools.py`), consumed by `langchain/routes/chat.py` to always
+include these tools in the agent's toolset regardless of routing, and by
+`langchain/server.py`'s `GET /langchain/mcp-tools` to mark each tool `foundational: bool` in
+its response. The web client (`web/components/mcp-chat-client.tsx`) no longer keeps a second,
+independent list (the retired `HIDDEN_TOOLS`) — it filters its tool picker on that
+`foundational` field instead (see `refactor-foundational-tool-list`). Section namespacing
+changes a tool's *registered* name (e.g. `list_available_experiments` becomes
+`core_list_available_experiments`), so the list matches **prefix-aware** (exact name, or
 `<anything>_<base name>`) rather than requiring an exact literal — otherwise a namespacing
-change would silently empty a always-included/hidden set with no test failure. A drift-guard
-test in `bloommcp/tests/test_devendor_invariants.py` parses both lists' source and asserts every
-name they carry resolves to a live tool in the mounted registry.
+change would silently empty the always-included/foundational set with no test failure. A
+drift-guard test in `bloommcp/tests/test_devendor_invariants.py` parses the list's source and
+asserts every name it carries resolves to a live tool in the mounted registry, plus a
+content-based check that the web client hasn't reintroduced a hand-list of its own.

--- a/bloommcp/src/bloom_mcp/sections/core/__init__.py
+++ b/bloommcp/src/bloom_mcp/sections/core/__init__.py
@@ -4,9 +4,11 @@
 ``list_existing_analyses`` are thin shims over ``experiment_utils`` / the
 injected ports — distinct from the ``sleap_roots`` section, and always
 included in the agent's tool set regardless of namespacing (see
-``ALWAYS_INCLUDE_MCP_TOOLS`` in ``langchain/routes/chat.py`` and
-``HIDDEN_TOOLS`` in ``web/components/mcp-chat-client.tsx``, both matched
-prefix-aware so the ``core_`` namespace doesn't silently drop them).
+``ALWAYS_INCLUDE_MCP_TOOLS`` in ``langchain/helpers/foundational_tools.py``,
+matched prefix-aware so the ``core_`` namespace doesn't silently drop them).
+The web client marks these the same way, via the ``foundational`` field
+``GET /langchain/mcp-tools`` computes from that same set — it no longer
+keeps its own copy of these names.
 
 The server mounts this section into the combined ``/mcp`` surface (tools appear
 namespaced ``core_<name>``) and serves it at its own ``/core/mcp`` URL.

--- a/bloommcp/src/bloom_mcp/sections/core/list_available_experiments.py
+++ b/bloommcp/src/bloom_mcp/sections/core/list_available_experiments.py
@@ -2,7 +2,7 @@
 
 Not a ``sleap-roots-analyze`` wrapper — reads through the injected
 ``ExperimentReader`` port. Always-included in the agent's tool set (see
-``ALWAYS_INCLUDE_MCP_TOOLS`` in ``langchain/routes/chat.py``).
+``ALWAYS_INCLUDE_MCP_TOOLS`` in ``langchain/helpers/foundational_tools.py``).
 """
 
 from bloom_mcp.tools import _ports

--- a/bloommcp/tests/test_devendor_invariants.py
+++ b/bloommcp/tests/test_devendor_invariants.py
@@ -313,13 +313,18 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _parse_always_include_mcp_tools() -> set[str]:
-    """Statically parse ALWAYS_INCLUDE_MCP_TOOLS from langchain/routes/chat.py.
+    """Statically parse ALWAYS_INCLUDE_MCP_TOOLS from
+    langchain/helpers/foundational_tools.py — the single source of truth for
+    foundational tools since refactor-foundational-tool-list (previously
+    langchain/routes/chat.py defined it locally; the web client's HIDDEN_TOOLS
+    hand-list, formerly parsed here too, no longer exists — see
+    test_no_hand_listed_foundational_tool_names_in_web_client).
 
-    Parsed via AST rather than imported — chat.py lives in a different service
-    (its own venv/dependencies), so importing it here isn't viable; this reads
-    the literal set assignment directly out of the source.
+    Parsed via AST rather than imported — this module lives in a different
+    service (its own venv/dependencies), so importing it here isn't viable;
+    this reads the literal set assignment directly out of the source.
     """
-    path = _REPO_ROOT / "langchain" / "routes" / "chat.py"
+    path = _REPO_ROOT / "langchain" / "helpers" / "foundational_tools.py"
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign) and any(
@@ -332,43 +337,62 @@ def _parse_always_include_mcp_tools() -> set[str]:
     raise AssertionError(f"ALWAYS_INCLUDE_MCP_TOOLS not found in {path}")
 
 
-def _parse_hidden_tools() -> set[str]:
-    """Statically parse HIDDEN_TOOLS from web/components/mcp-chat-client.tsx."""
-    import re
-
-    path = _REPO_ROOT / "web" / "components" / "mcp-chat-client.tsx"
-    text = path.read_text(encoding="utf-8")
-    match = re.search(r"HIDDEN_TOOLS = new Set\(\[(.*?)\]\)", text, re.DOTALL)
-    if not match:
-        raise AssertionError(f"HIDDEN_TOOLS not found in {path}")
-    names = set(re.findall(r'"([^"]+)"', match.group(1)))
-    if not names:
-        raise AssertionError(f"HIDDEN_TOOLS parsed empty from {path}")
-    return names
-
-
 def test_tool_name_lists_match_live_registry():
-    """Neither hand-list names a retired tool, and every name each lists resolves
-    to a live tool in the mounted registry — catches a rename/removal desyncing
-    either list from the actual server (the DRY follow-up's backstop).
+    """The always-include hand-list names no retired tool, and every name it
+    lists resolves to a live tool in the mounted registry — catches a
+    rename/removal desyncing it from the actual server. This is now the only
+    hand-list in the codebase (see refactor-foundational-tool-list, which
+    deleted the web client's HIDDEN_TOOLS in favor of a `foundational` field
+    computed from this same set — test_no_hand_listed_foundational_tool_names_in_web_client
+    guards against that duplication reappearing).
 
     (bloommcp-tool-sections: 'Always-included selection tracks the core tools'
-    registered names' / 'The web client's hidden-tools list ... stay in sync'.)
+    registered names'.)
     """
     import asyncio
 
     always_include = _parse_always_include_mcp_tools()
-    hidden_tools = _parse_hidden_tools()
 
     assert "inspect_data_quality" not in always_include
-    assert "inspect_data_quality" not in hidden_tools
 
     live = asyncio.run(_live_tool_names())
-    for name in sorted(always_include | hidden_tools):
-        # Prefix-aware, matching the production matching logic in chat.py /
-        # mcp-chat-client.tsx: an exact name, or "<section>_<name>" post-namespacing.
+    for name in sorted(always_include):
+        # Prefix-aware, matching the production matching logic in
+        # foundational_tools.py: an exact name, or "<section>_<name>" post-namespacing.
         matched = name in live or any(t.endswith(f"_{name}") for t in live)
         assert matched, f"{name!r} is not a live tool — hand-list has drifted"
+
+
+def test_no_hand_listed_foundational_tool_names_in_web_client():
+    """Content-based guard: no array/Set/object literal in
+    mcp-chat-client.tsx hand-lists all three foundational tool names
+    together. A narrower "is there still an identifier called HIDDEN_TOOLS"
+    check would miss a rename or inlining of the same three literals under a
+    different name — this one doesn't, because it looks at literal content,
+    not an identifier name.
+
+    (refactor-foundational-tool-list: 'Web client filters on the backend's
+    field, not a local list'.)
+    """
+    import re
+
+    path = _REPO_ROOT / "web" / "components" / "mcp-chat-client.tsx"
+    text = path.read_text(encoding="utf-8")
+
+    foundational_names = {
+        "list_available_experiments",
+        "load_experiment_data",
+        "list_existing_analyses",
+    }
+    # Array/Set literals in this file don't nest (no `[...[...]...]`), so a
+    # non-nested bracket-span regex safely captures each one whole.
+    for literal in re.findall(r"\[([^\[\]]*)\]", text, re.DOTALL):
+        found = set(re.findall(r'"([^"]+)"', literal))
+        assert foundational_names - found, (
+            "mcp-chat-client.tsx hand-lists all 3 foundational tool names "
+            f"together in one literal — reintroduces the retired HIDDEN_TOOLS "
+            f"duplication: {literal[:200]!r}"
+        )
 
 
 def test_expected_tool_surface():

--- a/bloommcp/tests/test_devendor_invariants.py
+++ b/bloommcp/tests/test_devendor_invariants.py
@@ -384,6 +384,12 @@ def test_no_hand_listed_foundational_tool_names_in_web_client():
         "load_experiment_data",
         "list_existing_analyses",
     }
+    # String literals as double-quoted, single-quoted, OR backtick-quoted (a
+    # hand-list could be retyped in any of the 3 — the repo's own .prettierrc.json
+    # sets singleQuote: true, making that a very plausible restyling, not a
+    # hypothetical one). \1 backreferences the opening quote char so a
+    # `'...'` span can't be closed by a stray `"` and vice versa.
+    quoted_string = r"""(["'`])((?:(?!\1).)*)\1"""
     # Scan both array/Set literals (`[...]`) and object literals (`{...}`) —
     # a hand-list could be reintroduced as either. Innermost-span regexes
     # (no nested brackets/braces within a captured span) are enough: a
@@ -394,7 +400,7 @@ def test_no_hand_listed_foundational_tool_names_in_web_client():
         (r"\{([^{}]*)\}", "object"),
     ):
         for literal in re.findall(pattern, text, re.DOTALL):
-            found = set(re.findall(r'"([^"]+)"', literal))
+            found = {name for _quote, name in re.findall(quoted_string, literal)}
             assert foundational_names - found, (
                 f"mcp-chat-client.tsx hand-lists all 3 foundational tool names "
                 f"together in one {kind} literal — reintroduces the retired "

--- a/bloommcp/tests/test_devendor_invariants.py
+++ b/bloommcp/tests/test_devendor_invariants.py
@@ -384,15 +384,22 @@ def test_no_hand_listed_foundational_tool_names_in_web_client():
         "load_experiment_data",
         "list_existing_analyses",
     }
-    # Array/Set literals in this file don't nest (no `[...[...]...]`), so a
-    # non-nested bracket-span regex safely captures each one whole.
-    for literal in re.findall(r"\[([^\[\]]*)\]", text, re.DOTALL):
-        found = set(re.findall(r'"([^"]+)"', literal))
-        assert foundational_names - found, (
-            "mcp-chat-client.tsx hand-lists all 3 foundational tool names "
-            f"together in one literal — reintroduces the retired HIDDEN_TOOLS "
-            f"duplication: {literal[:200]!r}"
-        )
+    # Scan both array/Set literals (`[...]`) and object literals (`{...}`) —
+    # a hand-list could be reintroduced as either. Innermost-span regexes
+    # (no nested brackets/braces within a captured span) are enough: a
+    # hand-authored name list has no internal nesting, so if the three
+    # names co-occur anywhere, they co-occur within some innermost span.
+    for pattern, kind in (
+        (r"\[([^\[\]]*)\]", "array/Set"),
+        (r"\{([^{}]*)\}", "object"),
+    ):
+        for literal in re.findall(pattern, text, re.DOTALL):
+            found = set(re.findall(r'"([^"]+)"', literal))
+            assert foundational_names - found, (
+                f"mcp-chat-client.tsx hand-lists all 3 foundational tool names "
+                f"together in one {kind} literal — reintroduces the retired "
+                f"HIDDEN_TOOLS duplication: {literal[:200]!r}"
+            )
 
 
 def test_expected_tool_surface():

--- a/langchain/Dockerfile
+++ b/langchain/Dockerfile
@@ -12,15 +12,17 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv PATH="/opt/venv/bin:$PATH"
 # for all subsequent layers.
 RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js (required for stdio-based MCP servers like web-search) — runs as root
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
+# Install Node.js (required for stdio-based MCP servers like web-search) — runs as root.
+# Debian trixie's own repo already ships Node 20.x, so install straight from apt instead
+# of NodeSource's curl-piped setup script: its signing-key fetch has started 403ing in CI,
+# and on failure it silently falls through to this same apt-get install anyway. npm is a
+# suggests-only package in Debian (not pulled in by nodejs), so name it explicitly.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nodejs npm && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# NodeSource's Node 20.x package bundles global npm 10.8.2, which vendors its own
-# tar@6.2.1 (CVE-2026-59873, gzip-bomb DoS) at
-# /usr/lib/node_modules/npm/node_modules/tar — unrelated to this app's own
+# Debian's bundled npm vendors its own tar (CVE-2026-59873, gzip-bomb DoS) at
+# /usr/local/lib/node_modules/npm/node_modules/tar — unrelated to this app's own
 # dependencies. Pin npm forward to a version that vendors the fixed tar (confirmed:
 # npm@11.18.0 -> tar@7.5.19). Same fix as web/Dockerfile.bloom-web.prod's runner stage.
 RUN npm install -g npm@11.18.0

--- a/langchain/Dockerfile
+++ b/langchain/Dockerfile
@@ -1,3 +1,7 @@
+# Source of Node.js binaries only (see the COPY block below) — same pinned digest
+# web/Dockerfile.bloom-web.prod's builder stage already trusts.
+FROM node:20-bookworm@sha256:a4545fc6f4f1483384ad5f4c71d34d71781c3779da407173ec6058079a718520 AS node_source
+
 FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
 
 # Install uv from official image (pinned to version + immutable digest so rebuilds
@@ -13,16 +17,25 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv PATH="/opt/venv/bin:$PATH"
 RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js (required for stdio-based MCP servers like web-search) — runs as root.
-# Debian trixie's own repo already ships Node 20.x, so install straight from apt instead
-# of NodeSource's curl-piped setup script: its signing-key fetch has started 403ing in CI,
-# and on failure it silently falls through to this same apt-get install anyway. npm is a
-# suggests-only package in Debian (not pulled in by nodejs), so name it explicitly.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends nodejs npm && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copied from the node_source stage above, NOT apt-installed: NodeSource's curl-piped
+# setup script's signing-key fetch has started 403ing in CI, and on failure silently
+# falls through to `apt-get install nodejs`, which then resolves to Debian trixie's own
+# nodejs/node-lodash/node-undici packages — carrying unpatched CRITICAL CVEs
+# (CVE-2026-48930/4800/1525) with no fixed Debian version available. node:20-bookworm
+# ships upstream's own Node build (confirmed via a local Trivy scan: none of the three
+# CVEs are present), sidestepping both problems at once.
+#
+# npm/npx are recreated as symlinks rather than copied directly: `COPY --from` dereferences
+# a symlink source into a plain file, which breaks npm-cli.js's own `require('../lib/...')`
+# (it ends up thinking its directory is /usr/local/bin instead of the real
+# lib/node_modules/npm/bin) — confirmed by a failed local build before this was added.
+COPY --from=node_source /usr/local/bin/node /usr/local/bin/node
+COPY --from=node_source /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-# Debian's bundled npm vendors its own tar (CVE-2026-59873, gzip-bomb DoS) at
-# /usr/local/lib/node_modules/npm/node_modules/tar — unrelated to this app's own
+# node:20-bookworm's bundled global npm vendors its own tar (CVE-2026-59873, gzip-bomb
+# DoS) at /usr/local/lib/node_modules/npm/node_modules/tar — unrelated to this app's own
 # dependencies. Pin npm forward to a version that vendors the fixed tar (confirmed:
 # npm@11.18.0 -> tar@7.5.19). Same fix as web/Dockerfile.bloom-web.prod's runner stage.
 RUN npm install -g npm@11.18.0

--- a/langchain/helpers/foundational_tools.py
+++ b/langchain/helpers/foundational_tools.py
@@ -1,0 +1,24 @@
+"""Single source of truth for which MCP tools are "foundational" — always
+included in the agent's toolset regardless of tool_set/mcp_tool_names
+routing (routes/chat.py), and marked on the GET /langchain/mcp-tools
+response so the web client can filter its tool picker without keeping its
+own copy of this list (server.py).
+
+inspect_data_quality was dropped (bloom-mcp devendor-bloommcp-analysis;
+redundant with qc_inspect). Matched prefix-aware (exact name or
+"<section>_<name>") so the Phase-2 sections migration's namespacing (e.g.
+core_list_available_experiments) doesn't silently empty this set — see
+bloommcp/tests/test_devendor_invariants.py::test_tool_name_lists_match_live_registry.
+"""
+
+ALWAYS_INCLUDE_MCP_TOOLS = {
+    "list_available_experiments",
+    "load_experiment_data",
+    "list_existing_analyses",
+}
+
+
+def is_foundational_tool(tool_name: str) -> bool:
+    return tool_name in ALWAYS_INCLUDE_MCP_TOOLS or any(
+        tool_name.endswith(f"_{base}") for base in ALWAYS_INCLUDE_MCP_TOOLS
+    )

--- a/langchain/pyproject.toml
+++ b/langchain/pyproject.toml
@@ -42,3 +42,9 @@ dependencies = [
     # repo convention.
     "mcp>=1.28.1",
 ]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+]

--- a/langchain/routes/chat.py
+++ b/langchain/routes/chat.py
@@ -12,27 +12,10 @@ import deps
 from agent import AVAILABLE_MODELS
 from schemas import ChatRequest, ChatResponse
 from helpers.sse_events import tool_result_event
+from helpers.foundational_tools import is_foundational_tool
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-# Foundational MCP tools are always exposed so the agent can discover and load data.
-# inspect_data_quality was dropped (bloom-mcp devendor-bloommcp-analysis; redundant
-# with qc_inspect). Matched prefix-aware (exact name or "<section>_<name>") so the
-# Phase-2 sections migration's namespacing (e.g. core_list_available_experiments)
-# doesn't silently empty this set — see test_tool_name_lists_match_live_registry.
-ALWAYS_INCLUDE_MCP_TOOLS = {
-    "list_available_experiments",
-    "load_experiment_data",
-    "list_existing_analyses",
-}
-
-
-def _is_always_included(tool_name: str) -> bool:
-    return tool_name in ALWAYS_INCLUDE_MCP_TOOLS or any(
-        tool_name.endswith(f"_{base}") for base in ALWAYS_INCLUDE_MCP_TOOLS
-    )
-
 
 VALID_TOOL_SETS = ["all", "scrna", "cyl", "generic", "mcp"]
 
@@ -65,13 +48,13 @@ def _resolve_agent(body: ChatRequest, checkpointer) -> tuple[object, str, str]:
         filtered = [
             t
             for t in deps.mcp_tools
-            if t.name in explicit or _is_always_included(t.name)
+            if t.name in explicit or is_foundational_tool(t.name)
         ]
     elif tool_set == "mcp":
         # MCP-only mode: expose every connected MCP tool (no foundational filter).
         filtered = list(deps.mcp_tools)
     else:
-        filtered = [t for t in deps.mcp_tools if _is_always_included(t.name)]
+        filtered = [t for t in deps.mcp_tools if is_foundational_tool(t.name)]
 
     agent = deps.get_or_create_agent(
         provider=provider,

--- a/langchain/schemas.py
+++ b/langchain/schemas.py
@@ -27,3 +27,13 @@ class CreateThreadRequest(BaseModel):
 
 class ModelsResponse(BaseModel):
     models: dict[str, list[str]]
+
+
+class MCPToolInfo(BaseModel):
+    name: str
+    description: str
+    foundational: bool
+
+
+class MCPToolsResponse(BaseModel):
+    tools: list[MCPToolInfo]

--- a/langchain/server.py
+++ b/langchain/server.py
@@ -31,7 +31,8 @@ import deps
 from agent import AVAILABLE_MODELS, setup_checkpointer
 from mcp_config import MCP_SERVERS
 from routes import chat as chat_routes
-from schemas import CreateThreadRequest, ModelsResponse
+from schemas import CreateThreadRequest, ModelsResponse, MCPToolsResponse
+from helpers.foundational_tools import is_foundational_tool
 
 logger = logging.getLogger(__name__)
 
@@ -205,12 +206,18 @@ async def get_models(user_id: str = Depends(deps.get_current_user)):
     return ModelsResponse(models=AVAILABLE_MODELS)
 
 
-@app.get("/langchain/mcp-tools")
+@app.get("/langchain/mcp-tools", response_model=MCPToolsResponse)
 async def get_mcp_tools(user_id: str = Depends(deps.get_current_user)):
-    """List connected MCP tools with their names and descriptions."""
+    """List connected MCP tools with their names, descriptions, and whether
+    each is foundational (always included in the agent's toolset — see
+    helpers/foundational_tools.py)."""
     return {
         "tools": [
-            {"name": t.name, "description": t.description}
+            {
+                "name": t.name,
+                "description": t.description,
+                "foundational": is_foundational_tool(t.name),
+            }
             for t in deps.mcp_tools
         ]
     }

--- a/langchain/tests/conftest.py
+++ b/langchain/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Shared test fixtures for the langchain service.
+
+Importing `server` transitively imports `agent.py` (module-level Postgres URL
+composition + local-model auto-detection) and `config.py` (module-level
+Supabase env checks) — all of which raise at import time if their env vars
+are unset. None of these are actually *connected to* unless the FastAPI
+lifespan runs, and `TestClient` only runs lifespan when entered as a context
+manager (`with TestClient(app) as c:`); the `client` fixture below never
+does that, so no real Postgres/Supabase/vLLM network call ever happens —
+only the module-level presence checks need satisfying.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _required_env(monkeypatch, tmp_path):
+    """Set every env var required at import time by deps/config/agent/server,
+    to a fixed test value. None of these need to point at anything real —
+    see the module docstring for why. BLOOM_PLOTS_DIR must be writable:
+    server.py creates it at *import* time (`os.makedirs`), and its default
+    (`/app/data/PLOTS_DIR`) isn't writable outside a container."""
+    monkeypatch.setenv("JWT_SECRET", "test-jwt-secret")
+    monkeypatch.setenv("SUPABASE_URL", "https://example.invalid")
+    monkeypatch.setenv("BLOOM_AGENT_KEY", "test-agent-key")
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "test-local-model")
+    monkeypatch.setenv("BLOOM_PLOTS_DIR", str(tmp_path / "plots"))
+    for var in (
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_DB",
+    ):
+        monkeypatch.setenv(var, "test")
+
+
+@pytest.fixture
+def client(_required_env):
+    """A TestClient over the real app, with auth overridden and lifespan
+    (Postgres/MCP startup) never triggered — see module docstring."""
+    from fastapi.testclient import TestClient
+
+    import deps
+    import server
+
+    server.app.dependency_overrides[deps.get_current_user] = lambda: "test-user-id"
+    try:
+        yield TestClient(server.app)
+    finally:
+        server.app.dependency_overrides.clear()

--- a/langchain/tests/test_mcp_tools_endpoint.py
+++ b/langchain/tests/test_mcp_tools_endpoint.py
@@ -1,0 +1,57 @@
+"""GET /langchain/mcp-tools must mark each tool as foundational or not, per
+the single shared selection in helpers/foundational_tools.py — see the
+refactor-foundational-tool-list OpenSpec change."""
+
+from types import SimpleNamespace
+
+
+def _fake_tool(name: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name, description=f"{name} description")
+
+
+def test_foundational_field_matches_shared_selection(client, monkeypatch):
+    import deps
+
+    monkeypatch.setattr(
+        deps,
+        "mcp_tools",
+        [
+            _fake_tool("list_available_experiments"),
+            _fake_tool("load_experiment_data"),
+            _fake_tool("list_existing_analyses"),
+            _fake_tool("qc_clean"),
+            _fake_tool("pca_analysis"),
+        ],
+    )
+
+    response = client.get(
+        "/langchain/mcp-tools", headers={"Authorization": "Bearer test"}
+    )
+    assert response.status_code == 200
+
+    tools = {t["name"]: t for t in response.json()["tools"]}
+    assert tools["list_available_experiments"]["foundational"] is True
+    assert tools["load_experiment_data"]["foundational"] is True
+    assert tools["list_existing_analyses"]["foundational"] is True
+    assert tools["qc_clean"]["foundational"] is False
+    assert tools["pca_analysis"]["foundational"] is False
+
+
+def test_foundational_field_is_prefix_aware_for_namespaced_tools(client, monkeypatch):
+    import deps
+
+    monkeypatch.setattr(
+        deps,
+        "mcp_tools",
+        [
+            _fake_tool("core_list_available_experiments"),
+            _fake_tool("sleap_roots_qc_clean"),
+        ],
+    )
+
+    response = client.get(
+        "/langchain/mcp-tools", headers={"Authorization": "Bearer test"}
+    )
+    tools = {t["name"]: t for t in response.json()["tools"]}
+    assert tools["core_list_available_experiments"]["foundational"] is True
+    assert tools["sleap_roots_qc_clean"]["foundational"] is False

--- a/langchain/uv.lock
+++ b/langchain/uv.lock
@@ -100,6 +100,12 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
@@ -119,6 +125,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -127,6 +135,7 @@ requires-dist = [
     { name = "supabase", specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.32.0" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "cachetools"
@@ -666,6 +675,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1789,6 +1807,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "postgrest"
 version = "2.28.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2259,6 +2286,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/3a/0a9d837478912ce51d1583bc4352818e8933252207d05d3021e91103e084/pyroaring-1.0.4-cp314-cp314t-win32.whl", hash = "sha256:f9a111e668f026849a22a7e4cab628e41e48bb87bd2a9aea72bca75edcd7a6f2", size = 234160, upload-time = "2026-03-19T13:57:07.848Z" },
     { url = "https://files.pythonhosted.org/packages/50/9d/bcd304935f20ce5f9ecb2837df69516be657e144da350a73a1899985aa38/pyroaring-1.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:92fdad43421ad2e076639f7a0d9ee815713b98bfe07dd9107ef3ea91ff0f3b37", size = 298468, upload-time = "2026-03-19T13:57:08.94Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4d/bd52a55dcef5cde4d0dda8c80000463c6929c7faba2466d9fa58fd0d48f8/pyroaring-1.0.4-cp314-cp314t-win_arm64.whl", hash = "sha256:c291428f148450e0609d5b1201b81e8248b3262770e51fc4c89768529ee36df0", size = 234175, upload-time = "2026-03-19T13:57:10.071Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]

--- a/openspec/changes/refactor-foundational-tool-list/proposal.md
+++ b/openspec/changes/refactor-foundational-tool-list/proposal.md
@@ -1,0 +1,111 @@
+## Why
+
+Two hand-authored lists in two languages name the same 3 foundational MCP tools
+(`list_available_experiments`, `load_experiment_data`, `list_existing_analyses`), and
+nothing but a static cross-repo test keeps them from disagreeing with each other:
+
+1. `ALWAYS_INCLUDE_MCP_TOOLS` (`langchain/routes/chat.py:24-28`) — forces these tools into
+   the agent's toolset regardless of `tool_set`/`mcp_tool_names` routing, via the
+   prefix-aware `_is_always_included()` helper (`chat.py:31-34`).
+2. `HIDDEN_TOOLS` (`web/components/mcp-chat-client.tsx:266-270`) — hides the same tools from
+   the tool-picker UI, via an equivalent prefix-aware `isHidden()` helper
+   (`mcp-chat-client.tsx:271-273`).
+
+`bloommcp/tests/test_devendor_invariants.py`'s `test_tool_name_lists_match_live_registry`
+(line 350) statically parses both lists (`_parse_always_include_mcp_tools` at line 315,
+`_parse_hidden_tools` at line 335) and checks each, independently, against the live mounted
+tool registry. That guard catches either list going stale (naming a retired tool) — it does
+**not** assert the two lists are equal to each other, and (confirmed during proposal review)
+would not catch either list being renamed or its literal tool-name strings being moved into a
+new identifier — so a future edit to one (e.g. adding a newly-added foundational tool to
+`ALWAYS_INCLUDE_MCP_TOOLS` but forgetting `HIDDEN_TOOLS`) would pass CI while silently
+desyncing backend inclusion from frontend visibility.
+
+The frontend already fetches the tool list from the backend's own `GET /langchain/mcp-tools`
+endpoint (`langchain/server.py:208-216`, imported as `chat_routes` at `server.py:33`). That
+response can carry foundational status directly, making `HIDDEN_TOOLS` an unnecessary second
+copy of information the backend already computes.
+
+Per GitHub issue #485, ask #3 — rewriting `CONTEXT_MCP` (`langchain/tools/context_tools.py`)
+to stop hand-listing retired workflow/correlation tools — is **already done** on `staging`
+(confirmed while researching this proposal, and independently re-confirmed during review):
+`CONTEXT_MCP` (line 85) now reads "Every other MCP tool ... is discovered dynamically from
+the live tool registry — do not rely on a hand-listed catalog here," with no
+`run_*_workflow`, `inspect_data_quality`, or `correlation_tools`/`viz_tools` references.
+`inspect_data_quality` has also already been dropped from both `ALWAYS_INCLUDE_MCP_TOOLS` and
+`HIDDEN_TOOLS`. Ask #3 also floats a softer, optional suggestion — deriving `CONTEXT_MCP`'s
+tool descriptions from the live registry's own `description` fields instead of the
+hand-written strings that remain there today — which is **not** done and is **not** in this
+proposal's scope either; task 4.1 below tracks it as a follow-up so it isn't silently lost
+when #485 closes. This proposal's scope is issue #485's asks #1 and #2: expose a
+`foundational` field on `/langchain/mcp-tools` and delete `HIDDEN_TOOLS` in favor of it.
+
+**Sequencing note:** `devendor-bloommcp-analysis` (43/53 tasks — all C-series/P-series/P3-series
+code tasks complete; what remains is Phase 0's `0.1` (an external sign-off ping to the
+package's other maintainer) and `0.3` (a historical note whose actual fix already landed as
+`P2.0`, checked), plus the `V.1`-`V.8` validation/CI-gate checklist) already specifies and
+ships today's two-hand-list-plus-drift-guard arrangement as its intended design, in
+`bloommcp-tool-sections/spec.md`'s "Always-included selection tracks the core tools'
+registered names" and "The web client's hidden-tools list and the routing prompt stay in
+sync with namespacing" scenarios. This proposal goes further than that design — collapsing
+the second hand-list entirely rather than merely drift-guarding it — which directly revises
+behavior that change specifies. `bloommcp-tool-sections` is not yet archived into
+`openspec/specs/`, so there is no archived base to write a `MODIFIED Requirements` delta
+against yet; this proposal's delta is written as `ADDED Requirements` instead, with no
+in-spec cross-reference to the other change (that provenance note lives here, not in the
+archived requirement text). Task 4.5 makes reconciliation a **hard pre-merge gate**, not an
+advisory note: if `devendor-bloommcp-analysis` archives first, its superseded "hidden-tools"
+scenario must be manually removed/rewritten from the archived `bloommcp-tool-sections` spec
+as part of *this* change's own archive step, so the two never coexist as contradictory
+requirements in `openspec/specs/`.
+
+## What Changes
+
+- `langchain/helpers/foundational_tools.py` (**new**) becomes the single source of truth:
+  `ALWAYS_INCLUDE_MCP_TOOLS` and a public `is_foundational_tool()` move here from
+  `langchain/routes/chat.py` (same set, same prefix-matching logic, no behavior change),
+  alongside the existing `db_url.py`/`plot_renderer.py`/`sse_events.py`/
+  `trait_name_resolver.py` shared-helpers convention. `routes/chat.py` imports from it instead
+  of defining it.
+- `langchain/server.py`'s `GET /langchain/mcp-tools` handler (`get_mcp_tools`, line 209) adds
+  a `foundational: bool` field to each returned tool object, computed via
+  `is_foundational_tool()` from the new helpers module — not by reaching into another route
+  module's private internals. A small `MCPToolInfo`/`MCPToolsResponse` pair is added to
+  `langchain/schemas.py` (matching the existing `ModelsResponse` pattern) as the endpoint's
+  `response_model`, so the new field's presence/type is enforced by FastAPI itself.
+- Minimal pytest infrastructure is added to `langchain/` (currently has none): a `test` extra
+  in `langchain/pyproject.toml`, and `langchain/tests/` with a fixture-backed test proving the
+  new field's values. This is a new local-only gate (not wired into CI in this change — see
+  task 1.6).
+- `web/components/mcp-chat-client.tsx` deletes `HIDDEN_TOOLS` and `isHidden()`; the tool
+  picker's filter is extracted into a small pure function in a new
+  `web/components/mcp-chat-client.helpers.ts` (following the existing
+  `best-match-sort.ts`/`.test.ts` colocated-pure-function convention), unit-tested with
+  Vitest (already wired in `web/`, zero new dependencies). The `MCPTool` interface
+  (`mcp-chat-client.tsx:24-27`) gains `foundational: boolean`.
+- `bloommcp/tests/test_devendor_invariants.py`'s `test_tool_name_lists_match_live_registry`
+  drops `_parse_hidden_tools()` and the `hidden_tools` half of the check — `HIDDEN_TOOLS` no
+  longer exists to parse. The guard becomes single-sided: `ALWAYS_INCLUDE_MCP_TOOLS` against
+  the live registry, since it's the only hand-list left. A new, **content-based** (not just
+  identifier-name) test asserts no array/Set/object literal in `mcp-chat-client.tsx` contains
+  all three foundational tool-name strings together, so a future regression (someone
+  reintroducing the duplication under a different name) fails loudly instead of slipping past
+  a narrower "is `HIDDEN_TOOLS` still called `HIDDEN_TOOLS`" check.
+
+Out of scope (already resolved on `staging` before this proposal): rewriting `CONTEXT_MCP`'s
+prose to stop hand-listing retired tools; dropping `inspect_data_quality` from either list.
+Tracked as a follow-up, not silently dropped: deriving `CONTEXT_MCP`'s tool descriptions from
+the live registry (task 4.1).
+
+## Impact
+
+- Affected specs: `bloommcp-tool-sections` (adds a requirement that supersedes the
+  not-yet-archived "hidden-tools list ... stay in sync" scenario from
+  `devendor-bloommcp-analysis` — see Sequencing note above and the hard gate at task 4.5)
+- Affected code: `langchain/helpers/foundational_tools.py` (new), `langchain/routes/chat.py`,
+  `langchain/server.py`, `langchain/schemas.py`, `langchain/pyproject.toml`,
+  `langchain/tests/` (new), `web/components/mcp-chat-client.tsx`,
+  `web/components/mcp-chat-client.helpers.ts` (new, with its test),
+  `bloommcp/tests/test_devendor_invariants.py`
+- Confirmed during review: `web/components/mcp-chat-client.tsx:254` is the only consumer of
+  `GET /langchain/mcp-tools` in the repo — no other caller needs updating.

--- a/openspec/changes/refactor-foundational-tool-list/specs/bloommcp-tool-sections/spec.md
+++ b/openspec/changes/refactor-foundational-tool-list/specs/bloommcp-tool-sections/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Foundational MCP Tools Are Marked by the Backend, Not Duplicated in the Frontend
+
+The system SHALL expose foundational-tool status as a `foundational` field on each tool
+object returned by `GET /langchain/mcp-tools`, computed from a single shared
+`ALWAYS_INCLUDE_MCP_TOOLS` selection used to always include those tools in the agent's
+toolset regardless of `tool_set`/`mcp_tool_names` routing. The web client SHALL filter its
+tool picker using that field and SHALL NOT maintain its own hand-authored list of
+foundational tool names.
+
+#### Scenario: Backend marks foundational tools in the tool-list response
+
+- **WHEN** a client calls `GET /langchain/mcp-tools`
+- **THEN** each returned tool object includes `foundational: true` for
+  `list_available_experiments`, `load_experiment_data`, and `list_existing_analyses` — or, if
+  the section-namespacing migration is live for a given tool, its namespaced `core_*`
+  equivalent — and `foundational: false` for every other tool
+
+#### Scenario: Web client filters on the backend's field, not a local list
+
+- **WHEN** the web client fetches the tool list to populate the tool picker
+- **THEN** it hides exactly the tools with `foundational: true` using the field from the
+  response, and no array, Set, or object literal in `mcp-chat-client.tsx` hand-lists the
+  foundational tool names for this purpose
+
+#### Scenario: A renamed or newly-added foundational tool needs no frontend change
+
+- **WHEN** a tool is added to, removed from, or renamed within the shared
+  `ALWAYS_INCLUDE_MCP_TOOLS` selection
+- **THEN** the web client's tool picker reflects the change automatically on its next fetch of
+  `GET /langchain/mcp-tools`, with no edit required in `mcp-chat-client.tsx`

--- a/openspec/changes/refactor-foundational-tool-list/tasks.md
+++ b/openspec/changes/refactor-foundational-tool-list/tasks.md
@@ -43,7 +43,8 @@ task 1.2 real, not aspirational.
       This is a new, local-only gate — no CI job currently runs pytest against `langchain/`,
       and wiring one up is out of scope for this change (the same way
       `devendor-bloommcp-analysis`'s `V.3` documents its `ruff`/`black` check as local-only,
-      not CI-enforced).
+      not CI-enforced). Tracked so it doesn't sit as a bare unchecked precedent:
+      [#542](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/542).
 
 ## 2. Frontend: filter on `foundational` via a unit-tested pure function
 
@@ -110,3 +111,31 @@ task 1.2 real, not aspirational.
       `devendor-bloommcp-analysis` still shows `43/53 tasks`, not archived. No reconciliation
       needed yet; flagging the dependency to its owner before either change merges remains the
       outstanding action.
+
+## 5. PR #539 review round 2 — third stale reference + regex hardening
+
+- [x] 5.1 `bloommcp/src/bloom_mcp/sections/core/list_available_experiments.py:5` still pointed
+      at `ALWAYS_INCLUDE_MCP_TOOLS` in `langchain/routes/chat.py` — missed by task 1.3's move
+      (only `core/__init__.py`'s docstring was updated). Repointed to
+      `langchain/helpers/foundational_tools.py`. Grepped both `bloommcp/src/bloom_mcp/sections/core/`
+      and `bloommcp/docs/` afterward to confirm no third site was missed.
+- [x] 5.2 `bloommcp/docs/2026-06-29-bloom-mcp-contributor-namespacing.md`'s "Consequence for
+      hand-maintained tool-name lists" section still described the retired two-list design
+      (`ALWAYS_INCLUDE_MCP_TOOLS` + `HIDDEN_TOOLS`, both hand-maintained). Rewritten to describe
+      the single-source design and the web client's `foundational`-field filter.
+- [x] 5.3 Widened `test_no_hand_listed_foundational_tool_names_in_web_client`'s string-literal
+      regex from double-quotes-only to double/single/backtick-quoted (backreferenced so a
+      literal can't be closed by a mismatched quote char) — the repo's own `.prettierrc.json`
+      sets `singleQuote: true`, making single-quote a plausible restyling that the
+      double-quote-only regex would have missed entirely. Verified against synthetic
+      double/single/backtick/object-literal cases (all caught) and an unrelated array (not
+      falsely caught), standalone, without modifying the real `mcp-chat-client.tsx`. Full
+      `bloommcp` suite re-run green after the change (676 passed, 26 skipped, 0 failed).
+- [x] 5.4 Filed a follow-up issue tracking task 1.6's disclosed CI gap (no job runs
+      `langchain/`'s new pytest suite) so it gets a tracked decision instead of sitting as a
+      bare precedent: [#542](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/542).
+- [ ] 5.5 Task 2.5 (manual browser verification) remains undone. Discovered a live dev Docker
+      stack already running (`bloom_v2_dev-langchain-agent`, `bloom-web`, etc.) predating this
+      branch — but it's shared state (matches this session's earlier shared-checkout hazard on
+      the git working tree), so rebuilding/restarting it to test this branch's code needs the
+      user's explicit go-ahead rather than being done unilaterally.

--- a/openspec/changes/refactor-foundational-tool-list/tasks.md
+++ b/openspec/changes/refactor-foundational-tool-list/tasks.md
@@ -89,11 +89,11 @@ task 1.2 real, not aspirational.
 
 ## 4. Scope closure + validation
 
-- [ ] 4.1 File a follow-up GitHub issue tracking the still-open soft suggestion from #485's
+- [x] 4.1 File a follow-up GitHub issue tracking the still-open soft suggestion from #485's
       ask #3 — deriving `CONTEXT_MCP`'s tool descriptions from the live tool registry's own
       `description` fields, rather than the hand-written strings that remain there today — so
-      it isn't silently lost when #485 closes. **Not done** — filing a public GitHub issue is
-      an external, visible action; deferred pending explicit confirmation.
+      it isn't silently lost when #485 closes. Filed as
+      [#538](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/538).
 - [x] 4.2 `openspec validate refactor-foundational-tool-list --strict` passes.
 - [x] 4.3 `ruff check` (`ruff@0.9.9`, matching `.pre-commit-config.yaml`'s pin) and
       `black --check --target-version py311` (`black@26.3.1`, same pin) both green on every

--- a/openspec/changes/refactor-foundational-tool-list/tasks.md
+++ b/openspec/changes/refactor-foundational-tool-list/tasks.md
@@ -1,0 +1,112 @@
+## 1. Backend: single source of truth + minimal test infra for `langchain/`
+
+`langchain/` currently has zero test infrastructure (no `conftest.py`, no test dependency
+group, no CI step runs pytest against it). This section adds the minimal amount needed to make
+task 1.2 real, not aspirational.
+
+- [x] 1.1 Add a `test` extra to `langchain/pyproject.toml` (mirrors `bloommcp/pyproject.toml`'s
+      `[project.optional-dependencies].test` pattern):
+      `pytest>=8.3`, `pytest-asyncio>=0.24` (`httpx>=0.27.0`, needed for `fastapi.testclient`,
+      is already a runtime dependency). Add `langchain/tests/__init__.py` and
+      `langchain/tests/conftest.py` with a `client` fixture that: sets `JWT_SECRET` to a fixed
+      test value (via `monkeypatch.setenv`, before importing `server`/`deps`, since
+      `deps.py:22-24` raises at import time if it's unset), imports `server`, constructs
+      `fastapi.testclient.TestClient(server.app)`, and overrides
+      `app.dependency_overrides[deps.get_current_user]` to return a fixed test user id — no
+      real JWT or Supabase connection needed. (Also required, discovered while implementing:
+      `BLOOM_PLOTS_DIR` — `server.py` calls `os.makedirs(PLOTS_DIR)` at *import* time and its
+      default `/app/data/PLOTS_DIR` isn't writable outside a container; the fixture points it
+      at `tmp_path` instead. `langchain/uv.lock` re-synced; `scripts/check-uv-locks.py` green.)
+- [x] 1.2 (test first) Add `langchain/tests/test_mcp_tools_endpoint.py`: monkeypatch
+      `deps.mcp_tools` to a small fixed list of fake tool objects (name/description pairs)
+      covering all 3 foundational names and at least 2 non-foundational names; assert
+      `GET /langchain/mcp-tools` returns `foundational: true` for the foundational ones and
+      `false` for the rest. Confirmed red (`KeyError: 'foundational'`) before task 1.4 landed
+      the field.
+- [x] 1.3 Create `langchain/helpers/foundational_tools.py` (alongside the existing
+      `db_url.py` / `plot_renderer.py` / `sse_events.py` / `trait_name_resolver.py`
+      shared-helpers convention): move `ALWAYS_INCLUDE_MCP_TOOLS` and `_is_always_included`
+      here from `langchain/routes/chat.py:24-34`, renaming the latter to a public
+      `is_foundational_tool` (same set, same prefix-matching logic — no behavior change).
+      Update `routes/chat.py` to import both names from the new module instead of defining
+      them; its own `_resolve_agent` logic (lines 43-83) is otherwise untouched.
+- [x] 1.4 In `langchain/server.py`'s `get_mcp_tools` (line 209), add
+      `"foundational": is_foundational_tool(t.name)` to each tool dict, importing
+      `is_foundational_tool` from `langchain.helpers.foundational_tools` — not from
+      `routes.chat`'s internals.
+- [x] 1.5 Add a small `MCPToolInfo` (`name: str`, `description: str`, `foundational: bool`)
+      and `MCPToolsResponse` (`tools: list[MCPToolInfo]`) pair to `langchain/schemas.py`
+      (matching the existing `ModelsResponse` pattern at `schemas.py:28-29`); set it as
+      `get_mcp_tools`'s `response_model` so the new field's presence/type is enforced by
+      FastAPI itself, not only by the task 1.2 test.
+- [x] 1.6 Run green locally: `cd langchain && uv run --extra test pytest tests/ -v` — 2 passed.
+      This is a new, local-only gate — no CI job currently runs pytest against `langchain/`,
+      and wiring one up is out of scope for this change (the same way
+      `devendor-bloommcp-analysis`'s `V.3` documents its `ruff`/`black` check as local-only,
+      not CI-enforced).
+
+## 2. Frontend: filter on `foundational` via a unit-tested pure function
+
+- [x] 2.1 (test first) Create `web/components/mcp-chat-client.helpers.ts`, following the
+      `best-match-sort.ts` colocated-pure-function convention:
+      `export function filterPickerTools(tools: MCPTool[]): MCPTool[] { return tools.filter((t) => !t.foundational); }`
+      (`MCPTool` type, with the new `foundational: boolean` field, defined here and imported
+      into `mcp-chat-client.tsx`). Added `mcp-chat-client.helpers.test.ts` covering: empty
+      list, all-foundational, all-non-foundational, and a mixed list — 4 passed.
+- [x] 2.2 Add `foundational: boolean` to the `MCPTool` interface (moved into
+      `mcp-chat-client.helpers.ts`; the local interface in `mcp-chat-client.tsx:24-27` was
+      removed in favor of the import).
+- [x] 2.3 Delete `HIDDEN_TOOLS` (line 266) and `isHidden()` (lines 271-273) from
+      `mcp-chat-client.tsx`; replace the `.filter(...)` call (line 274) with
+      `filterPickerTools(data.tools || [])` from the new helpers file.
+- [x] 2.4 Run green: `cd web && npx vitest run components/mcp-chat-client.helpers.test.ts` — 4
+      passed. Also ran `npx tsc --noEmit` for the whole `web/` workspace: zero errors touching
+      either changed file (pre-existing, unrelated errors in `app/api/gitlab/*` and two
+      `*.test.ts` files under `lib/config/` are untouched by this change).
+- [ ] 2.5 Manually verify in the browser that the tool picker still hides the 3 foundational
+      tools and shows the rest, driven by the live `/langchain/mcp-tools` response (not a
+      local list). **Not done** — requires the full Docker stack (Supabase auth, langchain
+      service, web) running live; out of reach in this session. Flagging for manual
+      verification before merge.
+
+## 3. Drift-guard test: retire the dead `HIDDEN_TOOLS` parse, strengthen the regression guard
+
+- [x] 3.1 (test first) In `bloommcp/tests/test_devendor_invariants.py`, add a test asserting
+      `web/components/mcp-chat-client.tsx` contains no array/Set/object literal holding all
+      three of `"list_available_experiments"`, `"load_experiment_data"`, and
+      `"list_existing_analyses"` as string literals together — a **content-based** check, not
+      an identifier-name check. Confirmed red against the pre-change file content (via
+      `git show HEAD:...`, checked out to a scratch path and run through the same regex logic
+      standalone, without touching the working tree) and green against the fixed file.
+- [x] 3.2 Implemented tasks 2.1-2.3; the task 3.1 test is green against the current tree.
+- [x] 3.3 Deleted `_parse_hidden_tools()` and the `hidden_tools` half of
+      `test_tool_name_lists_match_live_registry` — kept the `always_include`-vs-live-registry
+      assertion. Updated `_parse_always_include_mcp_tools` to read from
+      `langchain/helpers/foundational_tools.py` (moved there per task 1.3) instead of
+      `langchain/routes/chat.py`.
+- [x] 3.4 Full `bloommcp` test suite green: `uv run --frozen --extra test pytest` — 676 passed,
+      26 skipped (live-Supabase/live-persistence smoke tests, expected), 0 failed.
+
+## 4. Scope closure + validation
+
+- [ ] 4.1 File a follow-up GitHub issue tracking the still-open soft suggestion from #485's
+      ask #3 — deriving `CONTEXT_MCP`'s tool descriptions from the live tool registry's own
+      `description` fields, rather than the hand-written strings that remain there today — so
+      it isn't silently lost when #485 closes. **Not done** — filing a public GitHub issue is
+      an external, visible action; deferred pending explicit confirmation.
+- [x] 4.2 `openspec validate refactor-foundational-tool-list --strict` passes.
+- [x] 4.3 `ruff check` (`ruff@0.9.9`, matching `.pre-commit-config.yaml`'s pin) and
+      `black --check --target-version py311` (`black@26.3.1`, same pin) both green on every
+      file this change touches. (`server.py`/`schemas.py` have pre-existing black-formatting
+      debt in lines this change doesn't touch — confirmed by diffing black's complaints
+      against the actual edit — left alone rather than folded into this diff.) `tsc --noEmit`
+      green for the `web` changes. No lint command exists for `web/` to run (no
+      `eslint.config.js`, no `lint` script in `web/package.json`) — noting rather than
+      fabricating one.
+- [x] 4.4 Other consumers of `GET /langchain/mcp-tools`: confirmed during proposal review by
+      repo-wide grep — `web/components/mcp-chat-client.tsx:254` is the only caller. No further
+      action needed.
+- [x] 4.5 **Pre-merge sequencing gate (hard, not advisory):** ran `openspec list` —
+      `devendor-bloommcp-analysis` still shows `43/53 tasks`, not archived. No reconciliation
+      needed yet; flagging the dependency to its owner before either change merges remains the
+      outstanding action.

--- a/web/components/mcp-chat-client.helpers.test.ts
+++ b/web/components/mcp-chat-client.helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { filterPickerTools, type MCPTool } from "./mcp-chat-client.helpers";
+
+const tool = (name: string, foundational: boolean): MCPTool => ({
+  name,
+  description: `${name} description`,
+  foundational,
+});
+
+describe("filterPickerTools", () => {
+  it("returns an empty list unchanged", () => {
+    expect(filterPickerTools([])).toEqual([]);
+  });
+
+  it("drops every tool when all are foundational", () => {
+    const tools = [tool("list_available_experiments", true), tool("load_experiment_data", true)];
+    expect(filterPickerTools(tools)).toEqual([]);
+  });
+
+  it("keeps every tool when none are foundational", () => {
+    const tools = [tool("qc_clean", false), tool("pca_analysis", false)];
+    expect(filterPickerTools(tools)).toEqual(tools);
+  });
+
+  it("keeps only the non-foundational tools in a mixed list", () => {
+    const tools = [
+      tool("list_available_experiments", true),
+      tool("qc_clean", false),
+      tool("list_existing_analyses", true),
+      tool("pca_analysis", false),
+    ];
+    expect(filterPickerTools(tools).map((t) => t.name)).toEqual(["qc_clean", "pca_analysis"]);
+  });
+});

--- a/web/components/mcp-chat-client.helpers.ts
+++ b/web/components/mcp-chat-client.helpers.ts
@@ -1,0 +1,18 @@
+// Pure helpers for the MCP tool picker, split out so they are unit-testable
+// without rendering the chat client component.
+
+export interface MCPTool {
+  name: string;
+  description: string;
+  foundational: boolean;
+}
+
+// Foundational tools (list_available_experiments, load_experiment_data,
+// list_existing_analyses — always available to the agent regardless of the
+// tool picker) are hidden from the picker; the backend computes
+// `foundational` from its own single source of truth
+// (langchain/helpers/foundational_tools.py), so no tool names are
+// hand-listed here.
+export function filterPickerTools(tools: MCPTool[]): MCPTool[] {
+  return tools.filter((t) => !t.foundational);
+}

--- a/web/components/mcp-chat-client.tsx
+++ b/web/components/mcp-chat-client.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { createClientSupabaseClient } from "@/lib/supabase/client";
 import styles from "./mcp-chat-client.module.css";
+import { filterPickerTools, type MCPTool } from "./mcp-chat-client.helpers";
 
 type Message = { from: "user" | "bot"; text: string };
 type Provider = "local";
@@ -20,11 +21,6 @@ type SuggestionPayload = {
 type FollowupAction = { label: string; prompt: string };
 type FollowupPayload = { tool: string; actions: FollowupAction[] };
 type ImagePayload = { tool: string; url: string; layout: string };
-
-interface MCPTool {
-  name: string;
-  description: string;
-}
 
 interface ThreadInfo {
   thread_id: string;
@@ -259,19 +255,7 @@ export default function MCPChat() {
           return;
         }
         const data = await r.json();
-        // inspect_data_quality was dropped (bloom-mcp devendor-bloommcp-analysis;
-        // redundant with qc_inspect). Matched prefix-aware (exact name or
-        // "<section>_<name>") so the Phase-2 sections migration's namespacing
-        // (e.g. core_list_available_experiments) doesn't silently stop hiding these.
-        const HIDDEN_TOOLS = new Set([
-          "list_available_experiments",
-          "load_experiment_data",
-          "list_existing_analyses",
-        ]);
-        const isHidden = (name: string) =>
-          HIDDEN_TOOLS.has(name) ||
-          Array.from(HIDDEN_TOOLS).some((base) => name.endsWith(`_${base}`));
-        setAvailableMcpTools((data.tools || []).filter((t: MCPTool) => !isHidden(t.name)));
+        setAvailableMcpTools(filterPickerTools(data.tools || []));
       } catch {
         setAvailableMcpTools([]);
       }


### PR DESCRIPTION
## Summary

Closes #485's asks #1 and #2 (ask #3 was already resolved on `staging` before this change was
scoped — confirmed during proposal review).

- `GET /langchain/mcp-tools` now returns a `foundational: bool` field per tool, computed from
  a new `langchain/helpers/foundational_tools.py` — the single remaining source of truth for
  which MCP tools are always included in the agent's toolset.
- `web/components/mcp-chat-client.tsx` no longer hand-lists the same 3 tool names in its own
  `HIDDEN_TOOLS` set; it filters on the backend's `foundational` field via a new, unit-tested
  `filterPickerTools()` helper.
- `bloommcp/tests/test_devendor_invariants.py`'s drift-guard test drops the now-dead
  `HIDDEN_TOOLS` parse and gains a content-based check that catches the duplication
  reappearing under a different identifier, not just under the same name.
- OpenSpec change: `openspec/changes/refactor-foundational-tool-list/` (reviewed via
  `/openspec-review` — 5-subagent pass, findings applied).
- Follow-up filed for the still-open soft suggestion from ask #3 (deriving `CONTEXT_MCP`'s
  descriptions from the live registry): #538.

## Sequencing note

`devendor-bloommcp-analysis` (still open, 43/53 tasks — only validation/CI-gate items remain)
already specifies today's two-hand-list-plus-drift-guard design as intentional, in
`bloommcp-tool-sections/spec.md`'s "hidden-tools list ... stay in sync" scenario. This PR goes
further and collapses that second hand-list entirely. Since that capability isn't archived
into `openspec/specs/` yet, this change's spec delta is `ADDED`, not `MODIFIED`. **Whichever of
the two changes archives second needs to reconcile the superseded scenario** — flagging this
for review before merge, not resolving it silently.

## Test plan

- [x] `cd langchain && uv run --extra test pytest tests/ -v` — 2 passed (new test infra; none
      existed before this PR)
- [x] `cd web && npx vitest run components/mcp-chat-client.helpers.test.ts` — 4 passed
- [x] `cd web && npx tsc --noEmit` — clean (pre-existing unrelated errors in `app/api/gitlab/*`
      and two `lib/config/*.test.ts` files untouched by this change)
- [x] `cd bloommcp && uv run --frozen --extra test pytest` — 676 passed, 26 skipped (expected:
      live-Supabase/live-persistence smoke tests), 0 failed
- [x] `ruff@0.9.9 check` / `black@26.3.1 --check` (repo's pinned pre-commit versions) — clean
      on every file this PR touches
- [x] `python scripts/check-uv-locks.py` — clean (`langchain/uv.lock` re-synced for the new
      `test` extra)
- [x] `openspec validate refactor-foundational-tool-list --strict` — passes
- [ ] Manual browser verification that the tool picker still hides the 3 foundational tools —
      **not done**, requires the full Docker stack running live; flagging for reviewer to
      verify before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
