### PR TITLE
docs: document A4 bloom_workflows cluster credential (sleap-roots-pipeline#17)

### DIFF
--- a/bloomcli/README.md
+++ b/bloomcli/README.md
@@ -190,8 +190,10 @@ one scan on the target server — the command explains that the scan's images mu
 already exist in `cyl_images` on the Bloom you're pointed at.
 
 Auth: uses your saved login profile, which must have write access
-(`bloom_writer` / `bloom_admin`). Non-interactive / scoped credentials for
-cluster/CI use are tracked separately (#398).
+(`bloom_writer` / `bloom_admin`). For non-interactive / scoped credentials for
+cluster/CI use, see
+[`docs/credentials/bloom-workflows-a4-pipeline.md`](../docs/credentials/bloom-workflows-a4-pipeline.md)
+(tracked by #398).
 
 Examples:
 

--- a/docs/credentials/bloom-workflows-a4-pipeline.md
+++ b/docs/credentials/bloom-workflows-a4-pipeline.md
@@ -1,0 +1,61 @@
+# `bloom_workflows` credential for the A4 cluster pipeline
+
+The A4 cluster pipeline (`talmolab/sleap-roots-pipeline`'s Argo `images-downloader` and
+`write-back` tasks) authenticates to Bloom as a dedicated Supabase Auth account flagged
+`is_workflows: true`, which the existing JWT hook
+(`supabase/migrations/20260703120000_add_bloom_workflows_jwt_hook_branch.sql`) routes into the
+`bloom_workflows` Postgres role. All grants that role needs already exist:
+
+- `SELECT` on `cyl_images` / `cyl_scans_extended`, and `SELECT` on the `images` Storage bucket —
+  `supabase/migrations/20260716000000_create_workflows_role.sql`.
+- `EXECUTE` on `insert_cyl_result_envelope` (the write-back RPC) —
+  `supabase/migrations/20260720000000_grant_bloom_workflows_writeback_rpc.sql`.
+- `SELECT`/`INSERT`/`UPDATE` on the `cyl-intermediates` Storage bucket (blob uploads from
+  `bloomctl cyl ingest-result --predictions-dir`) —
+  `supabase/migrations/20260722000200_create_cyl_intermediates_bucket.sql`.
+
+**This is a dedicated account, not a reuse of #391's `services/workflows` video-generation
+endpoint's account.** Both accounts share the `bloom_workflows` *role* (an accepted shared-role
+tradeoff from bloom #470's review), but each has its own Auth *credentials* — so a leaked
+cluster-pod Secret doesn't also compromise the video endpoint, and vice versa.
+
+## Consumption shape
+
+`bloomctl` reads credentials from a plain dotenv file — see
+`bloomcli/src/bloomctl/credentials.py`'s `load_credentials`. No service-role-key path and no
+env-var-only path exist; this is the only mechanism:
+
+- Path: `~/.bloom/credentials.txt` (the default `prod` profile).
+- Format: dotenv, four required keys —
+
+  ```
+  BLOOM_API_URL=https://bloom.salk.edu
+  BLOOM_ANON_KEY=<anon key>
+  BLOOM_EMAIL=bloom-pipeline-workflows@salk.edu
+  BLOOM_PASSWORD=<password>
+  ```
+- Permissions: `0600`.
+
+**This means a Kubernetes Secret volume-mounted at `~/.bloom/credentials.txt` inside the
+`images-downloader` and `write-back` task containers works today, with zero `bloomctl` code
+changes.** `bloomctl` doesn't need to know it's running non-interactively — it just reads the file
+that's already there, exactly as `bloomctl login` would have written it interactively.
+
+## Handing off the credential values
+
+Once the account exists (email `bloom-pipeline-workflows@salk.edu`, password in the account
+owner's password manager, plus the `BLOOM_API_URL`/`BLOOM_ANON_KEY` pair from
+`https://bloom.salk.edu/api/client-info`), those four values must reach whoever wires the
+cluster-side Kubernetes Secret **over a secure channel — never plaintext Slack or email** (same
+rule used for the `bloom-pipeline-serviceaccount.yaml` token handoff). The exact channel isn't
+pinned down here because the consumer-side Secret doesn't exist yet; decide it when
+`sleap-roots-pipeline`'s Argo wiring (see the `wire-a4-batch-stage-write-back` branch, or its
+successor) is ready to receive it.
+
+## Related
+
+- [talmolab/sleap-roots-pipeline#17](https://github.com/talmolab/sleap-roots-pipeline/issues/17) —
+  tracks this credential's provisioning end-to-end.
+- [bloom #398](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/398) — originally
+  scoped for non-interactive `bloomctl` auth; the file-mount approach above already satisfies that
+  need with no `bloomctl` code changes.

--- a/docs/credentials/bloom-workflows-a4-pipeline.md
+++ b/docs/credentials/bloom-workflows-a4-pipeline.md
@@ -13,6 +13,9 @@ The A4 cluster pipeline (`talmolab/sleap-roots-pipeline`'s Argo `images-download
 - `SELECT`/`INSERT`/`UPDATE` on the `cyl-intermediates` Storage bucket (blob uploads from
   `bloomctl cyl ingest-result --predictions-dir`) —
   `supabase/migrations/20260722000200_create_cyl_intermediates_bucket.sql`.
+- `GRANT USAGE ON SCHEMA storage TO bloom_workflows` (schema grants are a `supabase db push`
+  no-op, so this one lives outside the migrations, in `supabase/grants/schema_grants.sql`
+  instead) — a prerequisite for the storage grants above.
 
 **This is a dedicated account, not a reuse of #391's `services/workflows` video-generation
 endpoint's account.** Both accounts share the `bloom_workflows` *role* (an accepted shared-role
@@ -23,18 +26,25 @@ cluster-pod Secret doesn't also compromise the video endpoint, and vice versa.
 
 `bloomctl` reads credentials from a plain dotenv file — see
 `bloomcli/src/bloomctl/credentials.py`'s `load_credentials`. No service-role-key path and no
-env-var-only path exist; this is the only mechanism:
+env-var-only path exist; this is the only mechanism for how `bloomctl` *reads* credentials.
+(`bloomctl login --email ... --password ... --api-url ... --anon-key ...` is a second, fully
+non-interactive way to *produce* the same file — it just runs the same write path a human
+running `bloomctl login` interactively would. Either approach is valid; the file-mount approach
+documented below needs no code changes and no login step.)
 
 - Path: `~/.bloom/credentials.txt` (the default `prod` profile).
 - Format: dotenv, four required keys —
 
   ```
-  BLOOM_API_URL=https://bloom.salk.edu
+  BLOOM_API_URL=https://bloom.salk.edu/api
   BLOOM_ANON_KEY=<anon key>
   BLOOM_EMAIL=bloom-pipeline-workflows@salk.edu
   BLOOM_PASSWORD=<password>
   ```
-- Permissions: `0600`.
+- Permissions: as hygiene, set `defaultMode: 0600` on the Secret volume — `bloomctl` doesn't
+  check the file's mode when reading it (only `save_credentials`, the interactive `bloomctl
+  login` write path, calls `chmod(0o600)`), so a Kubernetes Secret volume mount defaulting to
+  `0644` would still work, but `0600` is good practice for a file holding a password.
 
 **This means a Kubernetes Secret volume-mounted at `~/.bloom/credentials.txt` inside the
 `images-downloader` and `write-back` task containers works today, with zero `bloomctl` code
@@ -47,7 +57,8 @@ Once the account exists (email `bloom-pipeline-workflows@salk.edu`, password in 
 owner's password manager, plus the `BLOOM_API_URL`/`BLOOM_ANON_KEY` pair from
 `https://bloom.salk.edu/api/client-info`), those four values must reach whoever wires the
 cluster-side Kubernetes Secret **over a secure channel — never plaintext Slack or email** (same
-rule used for the `bloom-pipeline-serviceaccount.yaml` token handoff). The exact channel isn't
+rule used for the `talmolab/sleap-roots-pipeline` repo's `bloom-pipeline-serviceaccount.yaml`
+token handoff). The exact channel isn't
 pinned down here because the consumer-side Secret doesn't exist yet; decide it when
 `sleap-roots-pipeline`'s Argo wiring (see the `wire-a4-batch-stage-write-back` branch, or its
 successor) is ready to receive it.
@@ -59,3 +70,5 @@ successor) is ready to receive it.
 - [bloom #398](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/398) — originally
   scoped for non-interactive `bloomctl` auth; the file-mount approach above already satisfies that
   need with no `bloomctl` code changes.
+- `docs/superpowers/specs/2026-07-28-a4-workflows-credential-design.md` — the fuller design doc
+  with the reasoning behind the decisions summarized here.

--- a/docs/superpowers/plans/2026-07-28-a4-workflows-credential-doc.md
+++ b/docs/superpowers/plans/2026-07-28-a4-workflows-credential-doc.md
@@ -1,0 +1,303 @@
+# A4 `bloom_workflows` Credential Doc Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document how the A4 cluster pipeline consumes a dedicated `bloom_workflows` Supabase
+credential, and point the existing `bloomcli` README stub + bloom #398 at that documentation —
+closing the documentation half of `sleap-roots-pipeline#17`.
+
+**Architecture:** Pure documentation change. One new doc under `docs/credentials/`, a one-line edit
+to an existing `bloomcli/README.md` stub, and a drafted (not posted) GitHub comment. No code,
+tests, or migrations — every DB grant this credential needs already exists (verified directly
+against `supabase/migrations/20260716000000_create_workflows_role.sql`,
+`20260720000000_grant_bloom_workflows_writeback_rpc.sql`,
+`20260722000200_create_cyl_intermediates_bucket.sql`), and the consumption mechanism
+(`bloomcli/src/bloomctl/credentials.py`'s `load_credentials`) already works via a plain file mount
+with zero code changes.
+
+**Tech Stack:** Markdown docs only, in the `salk-bloom` repo (branch
+`eberrigan/a4-workflows-credential-doc`, based on `origin/staging`).
+
+## Global Constraints
+
+- No code, test, or migration changes in this plan — documentation only.
+- Never post a GitHub comment without Elizabeth's explicit sign-off on the exact text (standing
+  rule) — Task 3 produces a draft for her review; posting happens only after she approves it,
+  outside this plan's automated steps.
+- Do not specify a concrete secret-transmission mechanism (e.g. a specific secrets manager or
+  channel) — the consumer-side Kubernetes Secret doesn't exist yet
+  (`wire-a4-batch-stage-write-back` in `sleap-roots-pipeline` has zero diff from `main` as of this
+  writing). State the constraint ("secure channel, never plaintext Slack/email"), not a mechanism.
+- Match the dotenv format exactly as implemented in `bloomcli/src/bloomctl/credentials.py`:
+  keys `BLOOM_API_URL`, `BLOOM_ANON_KEY`, `BLOOM_EMAIL`, `BLOOM_PASSWORD`; file
+  `~/.bloom/credentials.txt` for the default `prod` profile; file mode `0600`.
+
+---
+
+## Task 1: Write the new credential-consumption doc
+
+**Files:**
+- Create: `docs/credentials/bloom-workflows-a4-pipeline.md`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: the doc path `docs/credentials/bloom-workflows-a4-pipeline.md`, which Task 2 links to.
+
+- [ ] **Step 1: Create the `docs/credentials/` directory and write the doc**
+
+Write this exact content to `docs/credentials/bloom-workflows-a4-pipeline.md`:
+
+```markdown
+# `bloom_workflows` credential for the A4 cluster pipeline
+
+The A4 cluster pipeline (`talmolab/sleap-roots-pipeline`'s Argo `images-downloader` and
+`write-back` tasks) authenticates to Bloom as a dedicated Supabase Auth account flagged
+`is_workflows: true`, which the existing JWT hook
+(`supabase/migrations/20260703120000_add_bloom_workflows_jwt_hook_branch.sql`) routes into the
+`bloom_workflows` Postgres role. All grants that role needs already exist:
+
+- `SELECT` on `cyl_images` / `cyl_scans_extended`, and `SELECT` on the `images` Storage bucket —
+  `supabase/migrations/20260716000000_create_workflows_role.sql`.
+- `EXECUTE` on `insert_cyl_result_envelope` (the write-back RPC) —
+  `supabase/migrations/20260720000000_grant_bloom_workflows_writeback_rpc.sql`.
+- `SELECT`/`INSERT`/`UPDATE` on the `cyl-intermediates` Storage bucket (blob uploads from
+  `bloomctl cyl ingest-result --predictions-dir`) —
+  `supabase/migrations/20260722000200_create_cyl_intermediates_bucket.sql`.
+
+**This is a dedicated account, not a reuse of #391's `services/workflows` video-generation
+endpoint's account.** Both accounts share the `bloom_workflows` *role* (an accepted shared-role
+tradeoff from bloom #470's review), but each has its own Auth *credentials* — so a leaked
+cluster-pod Secret doesn't also compromise the video endpoint, and vice versa.
+
+## Consumption shape
+
+`bloomctl` reads credentials from a plain dotenv file — see
+`bloomcli/src/bloomctl/credentials.py`'s `load_credentials`. No service-role-key path and no
+env-var-only path exist; this is the only mechanism:
+
+- Path: `~/.bloom/credentials.txt` (the default `prod` profile).
+- Format: dotenv, four required keys —
+
+  ```
+  BLOOM_API_URL=https://bloom.salk.edu
+  BLOOM_ANON_KEY=<anon key>
+  BLOOM_EMAIL=bloom-pipeline-workflows@salk.edu
+  BLOOM_PASSWORD=<password>
+  ```
+- Permissions: `0600`.
+
+**This means a Kubernetes Secret volume-mounted at `~/.bloom/credentials.txt` inside the
+`images-downloader` and `write-back` task containers works today, with zero `bloomctl` code
+changes.** `bloomctl` doesn't need to know it's running non-interactively — it just reads the file
+that's already there, exactly as `bloomctl login` would have written it interactively.
+
+## Handing off the credential values
+
+Once the account exists (email `bloom-pipeline-workflows@salk.edu`, password in the account
+owner's password manager, plus the `BLOOM_API_URL`/`BLOOM_ANON_KEY` pair from
+`https://bloom.salk.edu/api/client-info`), those four values must reach whoever wires the
+cluster-side Kubernetes Secret **over a secure channel — never plaintext Slack or email** (same
+rule used for the `bloom-pipeline-serviceaccount.yaml` token handoff). The exact channel isn't
+pinned down here because the consumer-side Secret doesn't exist yet; decide it when
+`sleap-roots-pipeline`'s Argo wiring (see the `wire-a4-batch-stage-write-back` branch, or its
+successor) is ready to receive it.
+
+## Related
+
+- [talmolab/sleap-roots-pipeline#17](https://github.com/talmolab/sleap-roots-pipeline/issues/17) —
+  tracks this credential's provisioning end-to-end.
+- [bloom #398](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/398) — originally
+  scoped for non-interactive `bloomctl` auth; the file-mount approach above already satisfies that
+  need with no `bloomctl` code changes.
+```
+
+- [ ] **Step 2: Verify the doc's factual claims against the live source**
+
+Run these to confirm nothing has drifted since this plan was written:
+
+```bash
+git -C c:/repos/salk-bloom show HEAD:supabase/migrations/20260716000000_create_workflows_role.sql | grep -c "bloom_workflows"
+git -C c:/repos/salk-bloom show HEAD:supabase/migrations/20260720000000_grant_bloom_workflows_writeback_rpc.sql | grep -c "insert_cyl_result_envelope"
+git -C c:/repos/salk-bloom show HEAD:bloomcli/src/bloomctl/credentials.py | grep -n "BLOOM_API_URL\|BLOOM_ANON_KEY\|BLOOM_EMAIL\|BLOOM_PASSWORD\|0o600\|credentials.txt"
+```
+
+Expected: each grep returns matches (non-zero counts / non-empty output). If anything is empty,
+the doc's claims are stale — fix the doc's text before continuing, don't fix the grep.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/credentials/bloom-workflows-a4-pipeline.md
+git commit -m "docs(credentials): document A4 bloom_workflows cluster credential"
+```
+
+---
+
+## Task 2: Link the new doc from `bloomcli/README.md`
+
+**Files:**
+- Modify: `bloomcli/README.md:192-194`
+
+**Interfaces:**
+- Consumes: the doc path produced by Task 1
+  (`docs/credentials/bloom-workflows-a4-pipeline.md`, relative to repo root; from `bloomcli/`
+  that's `../docs/credentials/bloom-workflows-a4-pipeline.md`).
+- Produces: nothing further downstream.
+
+- [ ] **Step 1: Read the current stub to confirm line numbers haven't shifted**
+
+Run: `grep -n "Non-interactive / scoped credentials" bloomcli/README.md`
+
+Expected output (line number may vary slightly, text must match):
+```
+193:(`bloom_writer` / `bloom_admin`). Non-interactive / scoped credentials for
+```
+
+- [ ] **Step 2: Replace the stub**
+
+Find this exact text in `bloomcli/README.md` (currently spanning two lines):
+
+```
+Auth: uses your saved login profile, which must have write access
+(`bloom_writer` / `bloom_admin`). Non-interactive / scoped credentials for
+cluster/CI use are tracked separately (#398).
+```
+
+Replace with:
+
+```
+Auth: uses your saved login profile, which must have write access
+(`bloom_writer` / `bloom_admin`). For non-interactive / scoped credentials for
+cluster/CI use, see
+[`docs/credentials/bloom-workflows-a4-pipeline.md`](../docs/credentials/bloom-workflows-a4-pipeline.md)
+(tracked by #398).
+```
+
+- [ ] **Step 3: Verify the replacement**
+
+Run: `grep -n "bloom-workflows-a4-pipeline" bloomcli/README.md`
+Expected: one match, on the line just edited.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bloomcli/README.md
+git commit -m "docs(bloomcli): link README's #398 stub to the new credential doc"
+```
+
+---
+
+## Task 3: Draft the bloom #398 comment for Elizabeth's review
+
+**Files:**
+- Create: `docs/credentials/398-comment-draft.md` (temporary — deleted in Step 4 of this task,
+  never committed)
+
+**Interfaces:**
+- Consumes: the doc path from Task 1.
+- Produces: nothing — this task's output is a message shown to Elizabeth in-conversation, not a
+  file that ships in the PR.
+
+- [ ] **Step 1: Write the draft comment to a scratch file**
+
+Write this exact content to `docs/credentials/398-comment-draft.md`:
+
+```markdown
+While provisioning A4's cluster credential (sleap-roots-pipeline#17), found that this issue's
+original scope may be narrower than written: `bloomctl` already reads credentials from a plain
+dotenv file (`~/.bloom/credentials.txt`, see `bloomcli/src/bloomctl/credentials.py`) with no
+service-role-key path and no interactive-only requirement. A Kubernetes Secret volume-mounted at
+that path works today, with **zero `bloomctl` code changes** — `bloomctl` doesn't need to know
+it's running non-interactively, it just reads whatever file is already there.
+
+Documented the full consumption shape + the dedicated-account decision at
+`docs/credentials/bloom-workflows-a4-pipeline.md`.
+
+Not closing this — leaving the call on whether to re-scope, narrow, or close #398 to whoever's
+driving it. Flagging so the remaining scope (if any) is considered against what's already covered
+by the file-mount approach.
+```
+
+- [ ] **Step 2: Show the draft to Elizabeth for approval**
+
+Print the contents of `docs/credentials/398-comment-draft.md` in the conversation and ask
+explicitly: "Here's the draft comment for bloom #398 — post it as-is, edit it, or hold off?" Do
+not post to GitHub until she gives explicit approval of this specific action.
+
+- [ ] **Step 3: Post the comment (only after explicit approval)**
+
+Once approved, post via:
+
+```bash
+gh api repos/Salk-Harnessing-Plants-Initiative/bloom/issues/398/comments -f body="$(cat docs/credentials/398-comment-draft.md)"
+```
+
+- [ ] **Step 4: Delete the scratch draft file (it must not ship in the PR)**
+
+```bash
+rm docs/credentials/398-comment-draft.md
+```
+
+Confirm it's gone: `git status docs/credentials/398-comment-draft.md` should show nothing (file
+was never staged/committed, so nothing to unstage).
+
+---
+
+## Task 4: Open the pull request
+
+**Files:** none (this task only pushes the branch and opens a PR; Tasks 1–2 are the code content).
+
+**Interfaces:**
+- Consumes: commits from Tasks 1 and 2 (Task 3's file is deleted, not part of the PR).
+
+- [ ] **Step 1: Confirm the working tree is clean and only intended commits are present**
+
+```bash
+git status
+git log --oneline origin/staging..HEAD
+```
+
+Expected: clean working tree; exactly two commits ahead of `origin/staging` (Task 1's and Task
+2's), no `398-comment-draft.md` present anywhere (tracked or untracked).
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin eberrigan/a4-workflows-credential-doc
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --base staging --title "docs: document A4 bloom_workflows cluster credential (sleap-roots-pipeline#17)" --body "$(cat <<'EOF'
+## Summary
+- Documents how the A4 cluster pipeline's dedicated `bloom_workflows` credential is consumed (`docs/credentials/bloom-workflows-a4-pipeline.md`) — all DB grants already exist (#391/#470/#407's migrations), so this is documentation only, no code/migration change.
+- Links `bloomcli/README.md`'s existing #398 stub to the new doc.
+
+## Context
+Closes the documentation half of [talmolab/sleap-roots-pipeline#17](https://github.com/talmolab/sleap-roots-pipeline/issues/17). The actual Supabase Auth account (`bloom-pipeline-workflows@salk.edu`, dedicated — not reused from #391's video endpoint) is provisioned directly in the Supabase dashboard, outside this PR. See `docs/superpowers/specs/2026-07-28-a4-workflows-credential-design.md` for the full design/brainstorm.
+
+## Test plan
+- [ ] Doc's factual claims re-verified against current `supabase/migrations/**` and `bloomcli/src/bloomctl/credentials.py` (see Task 1, Step 2 of the implementation plan)
+- [ ] README link renders correctly and points at the right relative path
+EOF
+)"
+```
+
+- [ ] **Step 4: Report the PR URL back to Elizabeth**
+
+The `gh pr create` output includes the PR URL — share it directly, don't fetch or re-derive it.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** design doc's three deliverables (new credential doc, README stub link, #398
+  comment draft) each map to Task 1, Task 2, and Task 3 respectively. The design doc's explicit
+  "out of scope" items (Supabase account creation, Secret transmission, bloomctl code, OpenSpec)
+  have no corresponding task, matching the spec.
+- **No placeholders:** every task step includes literal file content or exact commands; no "add
+  appropriate docs" or "TBD" language.
+- **Consistency:** the doc path (`docs/credentials/bloom-workflows-a4-pipeline.md`) and the account
+  email (`bloom-pipeline-workflows@salk.edu`) are identical across Tasks 1–3, matching the design
+  doc.

--- a/docs/superpowers/specs/2026-07-28-a4-workflows-credential-design.md
+++ b/docs/superpowers/specs/2026-07-28-a4-workflows-credential-design.md
@@ -1,0 +1,105 @@
+# A4 `bloom_workflows` Cluster Credential — Provisioning + Documentation
+
+## Purpose
+
+Close [talmolab/sleap-roots-pipeline#17](https://github.com/talmolab/sleap-roots-pipeline/issues/17)
+("A4 infra: provision scoped Supabase credential for cluster stage-in + write-back") — the last
+blocker for A4's Argo `images-downloader`/`write-back` tasks to call `bloomctl` unattended from a
+cluster pod.
+
+## Background
+
+A4's cluster pipeline (in `talmolab/sleap-roots-pipeline`) runs `bloomctl cyl
+batch-download-for-predict` / `batch-ingest-result` (merged
+[bloom #532](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/532)) from Argo
+Workflow pods, and needs a Supabase credential to authenticate as. The issue's framing ("provision
+a scoped credential") suggested new DB grants might be needed, but reading the migrations directly
+shows otherwise:
+
+- `supabase/migrations/20260716000000_create_workflows_role.sql` +
+  `20260703120000_add_bloom_workflows_jwt_hook_branch.sql` — the `bloom_workflows` role, its
+  Storage-read grant on the `images` bucket, and the `is_workflows` JWT-hook branch that routes an
+  Auth user into that role all already exist and are live in production (backing #391's
+  `services/workflows` video-generation endpoint since 2026-07-17).
+- `20260720000000_grant_bloom_workflows_writeback_rpc.sql` — `EXECUTE` on
+  `insert_cyl_result_envelope` is already granted to `bloom_workflows` (merged via bloom #470,
+  2026-07-20).
+- `20260722000200_create_cyl_intermediates_bucket.sql` — the blob-upload bucket grants
+  (`cyl-intermediates`) are already in place too, per that migration's own comment anticipating this
+  exact gap.
+
+So **every DB-side grant `bloom_workflows` needs for A4 already exists.** What's actually missing is
+narrower than the issue title implies:
+
+1. An Auth *account* for the cluster pipeline to sign in as.
+2. Documentation of the credential's consumption shape, for whoever wires the cluster-side
+   Kubernetes Secret (the `sleap-roots-pipeline` side, branch `wire-a4-batch-stage-write-back` —
+   currently zero diff from `main`, i.e. not yet built).
+
+`bloomcli/src/bloomctl/{auth,credentials}.py` confirm the consumption side is already simple: a
+dotenv file at `~/.bloom/credentials.txt` (`BLOOM_EMAIL`/`BLOOM_PASSWORD`/`BLOOM_API_URL`/
+`BLOOM_ANON_KEY`, mode `0600`), read via `dotenv_values` and authenticated via plain
+`sign_in_with_password` — no service-role-key path, no env-var-only path. A Kubernetes Secret
+volume-mounted at that path works **today, with zero `bloomctl` code changes.**
+
+## Decisions
+
+**Dedicated account, not reuse.** `bloom_workflows` is a shared *role* — bloom #470's review already
+had Benfica (@blm3886, who owns the role and the `services/workflows` video endpoint) accept it as
+non-A4-dedicated at the grants level. But the *Auth account* is a separate trust boundary: reusing
+#391's video-endpoint account would mean a leaked cluster-pod Secret also compromises video
+generation, and vice versa. Decision: provision a **second, dedicated** Supabase Auth account,
+flagged `is_workflows: true` (so it inherits the same `bloom_workflows` role via the existing JWT
+hook), used only by the A4 cluster pipeline.
+
+- **Email:** `bloom-pipeline-workflows@salk.edu` — distinguishes it from #391's account by naming
+  its specific consumer.
+- **Password:** generated and stored by Elizabeth in her own password manager — never enters this
+  session/transcript.
+- **Who provisions it:** Elizabeth, directly in the Supabase dashboard (has admin access).
+
+**No migration, no `bloomctl` code change.** All grants exist; the consumption path already works
+via file mount. This is an ops action (create one Auth account) + documentation, not a feature —
+per this repo's "tiny changes skip OpenSpec but still state intent" convention, this stays a design
+note rather than a full OpenSpec proposal.
+
+**Documentation location:** a new doc, `docs/credentials/bloom-workflows-a4-pipeline.md` (this repo
+has no existing `docs/ops/` or `docs/credentials/` convention to match, so this is a new small
+directory). Covers:
+- The dotenv shape and file path/permissions the K8s Secret mount must produce.
+- That this works via a plain file mount with no `bloomctl` code changes required.
+- That handing the 4 credential values to whoever wires the cluster Secret must go over a secure
+  channel (never plaintext Slack/email) — same standing rule as the
+  `bloom-pipeline-serviceaccount.yaml` token handoff. The exact transmission mechanism is left
+  unspecified here since the consumer-side Secret doesn't exist yet (`wire-a4-batch-stage-write-back`
+  has no commits) — pick it when that side is ready to receive it.
+- A pointer back to `sleap-roots-pipeline#17` and this design doc for context.
+
+Also update the existing stub in `bloomcli/README.md` (currently: "Non-interactive / scoped
+credentials for cluster/CI use are tracked separately (#398)") to link the new doc.
+
+**Bloom #398:** still open, but scoped assuming a code change was needed — it isn't; the file-mount
+approach already satisfies non-interactive cluster auth with zero `bloomctl` changes. Post a comment
+on #398 noting this (narrows its remaining scope) without closing or re-scoping it unilaterally —
+that call belongs to whoever's driving that issue.
+
+## Scope
+
+**In scope (this change):**
+- `docs/credentials/bloom-workflows-a4-pipeline.md` (new)
+- `bloomcli/README.md` — update the #398 stub to link the new doc
+- A drafted (not yet posted) comment for bloom #398
+
+**Out of scope:**
+- Creating the actual Supabase Auth account — an ops action Elizabeth performs directly in the
+  Supabase dashboard, not a code change tracked by this PR.
+- Transmitting the credential to the cluster-side Secret — deferred until
+  `wire-a4-batch-stage-write-back` (or its successor) actually defines the Secret.
+- Any `bloomctl` code change — none needed.
+- Re-scoping or closing bloom #398 — a comment only.
+
+## Testing
+
+Documentation-only change; no automated tests apply. Verification is a self-review read-through
+confirming the doc accurately describes `credentials.py`'s actual dotenv format and permissions
+(already verified against the live source during this design's background research).


### PR DESCRIPTION
## Summary
- Documents how the A4 cluster pipeline's dedicated `bloom_workflows` credential is consumed (`docs/credentials/bloom-workflows-a4-pipeline.md`) — all DB grants already exist (#391/#470/#407's migrations), so this is documentation only, no code/migration change.
- Links `bloomcli/README.md`'s existing #398 stub to the new doc.

## Context
Closes the documentation half of [talmolab/sleap-roots-pipeline#17](https://github.com/talmolab/sleap-roots-pipeline/issues/17). The actual Supabase Auth account (`bloom-pipeline-workflows@salk.edu`, dedicated — not reused from #391's video endpoint) is provisioned directly in the Supabase dashboard, outside this PR. See `docs/superpowers/specs/2026-07-28-a4-workflows-credential-design.md` for the full design/brainstorm.

Also posted a comment on [bloom #398](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/398) noting the file-mount approach documented here already satisfies non-interactive cluster auth with zero `bloomctl` code changes, narrowing that issue's remaining scope.

## Test plan
- [ ] Doc's factual claims re-verified against current `supabase/migrations/**` and `bloomcli/src/bloomctl/credentials.py` (already verified during implementation — see task reports)
- [ ] README link renders correctly and points at the right relative path