### PR TITLE
feat(bloommcp): add cross_experiment_correlations tool (#489)

### DIFF
--- a/bloommcp/scripts/gen_cross_experiment_correlation_golden.py
+++ b/bloommcp/scripts/gen_cross_experiment_correlation_golden.py
@@ -1,0 +1,135 @@
+"""Regenerate ``tests/fixtures/turface_cylinder_cross_experiment_correlation_golden.json``
+(#489).
+
+A characterization snapshot pinning both the correlation math AND the confirmed upstream
+``min_samples`` no-op this tool works around (design.md D8,
+talmolab/sleap-roots-analyze#205): every literal is emitted here from
+``sleap_roots_analyze.calculate_genotype_means`` /
+``calculate_cross_experiment_correlations`` on the real turface_19 / cylinder fixtures
+(19 shared genotypes), so the fixture is regenerable and no number is transcribed by hand.
+
+Records BOTH the unfiltered call (min_samples=1, all 19 genotypes participate — the
+correlation math oracle) and the min_samples=3 comparison: calling the upstream delegate
+directly with min_samples=3 still returns all 19 genotypes (the confirmed no-op — cylinder's
+GH_7371 has only 2 samples and should have been excluded), while bloommcp's pre-filter
+workaround (drop genotype rows with n_samples < min_samples from both means tables before
+delegating) correctly excludes it, yielding 18 genotypes and a different correlation value.
+This is the drift gate for ``test_min_samples_prefilter_actually_excludes_under_replicated_genotypes``.
+
+Run:  cd bloommcp && uv run --frozen python scripts/gen_cross_experiment_correlation_golden.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import sleap_roots_analyze as sra
+from sleap_roots_analyze import (
+    calculate_cross_experiment_correlations,
+    calculate_genotype_means,
+)
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "tests" / "fixtures"
+_TURFACE = _FIXTURES / "turface_19_final_data.csv"
+_CYLINDER = _FIXTURES / "cylinder_final_data.csv"
+_OUT = _FIXTURES / "turface_cylinder_cross_experiment_correlation_golden.json"
+
+_TRAIT_1 = "Total Root Length (mm)"  # turface_19
+_TRAIT_2 = "Network Length Mean"  # cylinder
+_GENOTYPE_COL = "Genotype"
+
+
+def build() -> dict:
+    turface = pd.read_csv(_TURFACE)
+    cylinder = pd.read_csv(_CYLINDER)
+
+    gm1 = calculate_genotype_means(turface, [_TRAIT_1], genotype_col=_GENOTYPE_COL)
+    gm2 = calculate_genotype_means(cylinder, [_TRAIT_2], genotype_col=_GENOTYPE_COL)
+
+    unfiltered = calculate_cross_experiment_correlations(
+        gm1, gm2, [_TRAIT_1], [_TRAIT_2], min_samples=1
+    )
+    row_u = unfiltered.iloc[0]
+
+    # Confirms the upstream no-op directly on this fixture: passing min_samples=3 to the
+    # delegate WITHOUT a bloommcp-side pre-filter still uses all 19 genotypes (cylinder's
+    # GH_7371, n_samples=2, is never excluded).
+    buggy = calculate_cross_experiment_correlations(
+        gm1, gm2, [_TRAIT_1], [_TRAIT_2], min_samples=3
+    )
+    row_buggy = buggy.iloc[0]
+
+    # bloommcp's pre-filter workaround (design.md D8): drop genotype rows below
+    # min_samples from BOTH means tables before delegating.
+    gm1_f = gm1[gm1["n_samples"] >= 3]
+    gm2_f = gm2[gm2["n_samples"] >= 3]
+    prefiltered = calculate_cross_experiment_correlations(
+        gm1_f, gm2_f, [_TRAIT_1], [_TRAIT_2], min_samples=3
+    )
+    row_f = prefiltered.iloc[0]
+
+    return {
+        "_comment": (
+            "Characterization snapshot of sleap-roots-analyze cross-experiment "
+            "correlation on the real turface_19 (153 samples, 19 genotypes) / cylinder "
+            "(123 samples, 19 genotypes, fully overlapping) fixture pair. Used as a DRIFT "
+            "GATE + regression fixture for the confirmed min_samples no-op workaround "
+            "(design.md D8) through the cross_experiment_correlations MCP tool."
+        ),
+        "_source": (
+            "Re-derived by bloommcp/scripts/gen_cross_experiment_correlation_golden.py "
+            f"from calculate_genotype_means / calculate_cross_experiment_correlations=="
+            f"{sra.__version__}. No number here is hand-transcribed."
+        ),
+        "_reproduced_by_sleap_roots_analyze_version": sra.__version__,
+        "experiment_1": "turface_19.csv",
+        "experiment_2": "cylinder.csv",
+        "genotype_col": _GENOTYPE_COL,
+        "trait_1": _TRAIT_1,
+        "trait_2": _TRAIT_2,
+        "unfiltered": {
+            "_comment": "min_samples=1 -> all 19 shared genotypes participate.",
+            "min_samples": 1,
+            "n_genotypes": int(row_u["n_genotypes"]),
+            "correlation": float(row_u["correlation"]),
+            "p_value": float(row_u["p_value"]),
+            "significant": bool(row_u["significant"]),
+        },
+        "min_samples_3_upstream_no_op": {
+            "_comment": (
+                "Calling the upstream delegate directly with min_samples=3 (no bloommcp "
+                "pre-filter) — confirms the no-op: n_genotypes is unchanged from the "
+                "unfiltered call (still 19), even though cylinder's GH_7371 has only 2 "
+                "samples. See talmolab/sleap-roots-analyze#205."
+            ),
+            "min_samples": 3,
+            "n_genotypes": int(row_buggy["n_genotypes"]),
+            "correlation": float(row_buggy["correlation"]),
+            "p_value": float(row_buggy["p_value"]),
+        },
+        "min_samples_3_bloommcp_prefiltered": {
+            "_comment": (
+                "bloommcp's pre-filter workaround (design.md D8) applied before "
+                "delegating: genotype rows with n_samples < 3 dropped from both means "
+                "tables first. GH_7371 (cylinder n_samples=2) is correctly excluded, "
+                "n_genotypes drops to 18, and the correlation value changes."
+            ),
+            "min_samples": 3,
+            "n_genotypes": int(row_f["n_genotypes"]),
+            "correlation": float(row_f["correlation"]),
+            "p_value": float(row_f["p_value"]),
+            "excluded_genotype": "GH_7371",
+        },
+    }
+
+
+def main() -> None:
+    payload = build()
+    _OUT.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    print(f"wrote {_OUT.relative_to(_FIXTURES.parents[1])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py
+++ b/bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py
@@ -9,10 +9,11 @@ one package it happens to populate today. See
 rationale (D3 in this change's ``design.md``).
 
 Two subgroups:
-  - ``analysis/`` — the 7 granular ``sleap-roots-analyze`` consumers
+  - ``analysis/`` — the 8 granular ``sleap-roots-analyze`` consumers
     (``pca_analysis``, ``qc_clean``, ``qc_inspect``, ``remove_outliers``,
-    ``clustering``, ``umap_analysis``, ``descriptive_stats``) + the 5 surviving
-    plotting tools. Populated here.
+    ``clustering``, ``umap_analysis``, ``descriptive_stats``,
+    ``cross_experiment_correlations``) + the 5 surviving plotting tools.
+    Populated here.
   - ``extraction/`` — reserved for future ``sleap-roots`` trait-extraction
     tools. Empty; not built in this change.
 
@@ -28,6 +29,7 @@ from bloom_mcp.contract import register
 
 from .analysis import (
     clustering,
+    cross_experiment_correlations,
     descriptive_stats,
     pca_analysis,
     plot_correlation_matrix,
@@ -53,6 +55,7 @@ register(
     clustering.clustering,
     umap_analysis.umap_analysis,
     descriptive_stats.descriptive_stats,
+    cross_experiment_correlations.cross_experiment_correlations,
     plot_trait_histograms.plot_trait_histograms,
     plot_trait_boxplots.plot_trait_boxplots,
     plot_correlation_matrix.plot_correlation_matrix,

--- a/bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py
+++ b/bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py
@@ -1,0 +1,424 @@
+"""cross_experiment_correlations — genotype-mean trait correlation across two experiments,
+delegating to sleap-roots-analyze.
+
+The first granular consumer with a **two-experiment input** (#489): every prior consumer
+(``qc_clean``, ``pca_analysis``, ``remove_outliers``, ``clustering``, ``umap_analysis``,
+``descriptive_stats``) takes one ``experiment`` filename. This tool reads both
+``experiment_1`` and ``experiment_2`` through the :class:`ExperimentReader` port with
+``require_clean=True`` — "consume, don't re-clean" — and delegates **all** correlation math
+to ``sleap_roots_analyze.cross_experiment_analysis``: ``calculate_genotype_means``,
+``calculate_cross_experiment_correlations``, ``identify_significant_correlations``, and
+``summarize_correlation_results``. It never calls ``load_and_align_experiments`` (which
+reads CSVs directly off paths, bypassing the read port) and never re-implements genotype
+aggregation via a bespoke ``groupby``/``mean``.
+
+**Re-adds a capability ``devendor-bloommcp-analysis`` (PR #438) deleted rather than
+rewired**, because upstream's ``cross_experiment_analysis`` module shares function names
+with the vendored one it replaced but has a genuinely different contract. This is the
+fresh design against that actual (richer) upstream contract.
+
+**A confirmed upstream no-op, worked around (design.md D8, talmolab/sleap-roots-analyze#205).**
+``calculate_cross_experiment_correlations``'s own ``min_samples`` filtering is dead code —
+it computes a correctly-filtered genotype list, prints it, then never references it again;
+the per-trait-pair loop hardcodes ``min_samples=0`` in its internal alignment call. So this
+tool enforces ``min_samples`` itself: both genotype-means tables are filtered to
+``n_samples >= min_samples`` *before* being handed to the delegate. ``min_samples`` is still
+forwarded to the delegate call unchanged (harmless — it stays inert there today), so the
+call remains correct and idempotent if upstream fixes the internal filter later.
+
+**Required genotype role on both sides.** Correlation here is computed at the
+genotype-mean level, so — unlike ``pca_analysis``/``clustering`` (which treat
+``frame.genotype_col`` as optional, used only for plot coloring) — a missing genotype
+column on either experiment means no meaningful result can be produced at all; both are
+checked non-``None`` before any computation.
+
+**Two-experiment persistence without touching shared ports (design.md D1).**
+``ResultStore``/``Provenance`` are single-experiment-shaped (`experiment: str`,
+``based_on_version: str``, one ``source_csv``). Rather than extending those shared types
+for what is so far bloommcp's only dual-input consumer, both experiments are encoded into
+the existing fields: a composite ``experiment`` key (both filenames' stems joined by
+``__x__``), a composite ``based_on_version`` (``exp@version|exp@version``), and a single
+combined ``source_csv`` snapshot (both selections concatenated, labeled by a leading
+``_experiment`` column) so ``input_sha256`` content-addresses both inputs. ``@``/``|`` are
+therefore reserved in ``experiment_1``/``experiment_2`` and rejected up front. Persisted
+under the reused ``correlation`` tool class (design.md D9) — reserved since the pre-#438
+legacy correlation tools were retired, exactly as ``descriptive_stats`` reactivated the
+reserved ``stats`` slot — so ``list_existing_analyses`` requires no changes.
+
+**Traceability (design.md D12).** Upstream itself discards which specific genotypes fed a
+given trait pair's correlation (an internal alignment result assigned to ``_``), so this
+tool persists both experiments' full genotype-means tables (with per-genotype
+``n_samples``, post ``min_samples`` filter) alongside the correlation matrix, so a
+scientist auditing a surprising correlation has enough to manually cross-reference.
+
+**Degenerate vs. empty-but-valid (design.md D6).** Zero rows out of
+``calculate_cross_experiment_correlations`` (no trait pair reached ``min_samples`` aligned
+genotypes) is degenerate input — rejected, nothing persisted. Zero rows surviving
+``identify_significant_correlations`` (correlations exist, none clear
+``r_threshold``/``p_threshold``) is a normal outcome — persisted with a fixed-header empty
+``significant.csv``, not upstream's columnless empty frame.
+
+Deterministic — no ``random_state`` anywhere in the delegation chain, so no ``seed``
+parameter is declared and ``Provenance`` records ``seed = None`` (matching
+``pca_analysis``'s convention).
+
+Out of scope for this tool (see proposal.md's deferred list): ``calculate_per_trait_correlations``
+(a different, sample-level granularity), ``calculate_cross_experiment_correlations_extended``
+(multi-statistic combinations), ``calculate_correlation_confidence_intervals`` (deferred —
+a second, related upstream inconsistency, also reported in #205), all plotting, power
+analysis, and redundant-trait clustering.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, Field
+from sleap_roots_analyze import (
+    calculate_cross_experiment_correlations,
+    calculate_genotype_means,
+    identify_significant_correlations,
+    summarize_correlation_results,
+)
+from sleap_roots_analyze.data_utils import convert_to_json_serializable
+
+from bloom_mcp.contract import BloomMCPError, Provenance, RunLinks, as_mcp_tool
+from bloom_mcp.data_access import (
+    CleanedVersionRequiredError,
+    ExperimentFrame,
+    ExperimentReadError,
+)
+from bloom_mcp.tools import _ports
+from bloom_mcp.tools._consumer_utils import snapshot_frame
+from bloom_mcp.tools._qc_shared import _validate_trait_subset
+
+_TOOL_CLASS = "correlation"  # reused reserved slot (design.md D9), not a new one
+_CORRELATIONS_NAME = "correlations.csv"
+_SIGNIFICANT_NAME = "significant.csv"
+_GENOTYPE_MEANS_1_NAME = "genotype_means_1.csv"
+_GENOTYPE_MEANS_2_NAME = "genotype_means_2.csv"
+_SUMMARY_NAME = "summary.json"
+
+# Columns identify_significant_correlations' result carries beyond calculate_cross_experiment_
+# correlations' own columns — used to normalize its columnless empty-DataFrame return (design.md D6).
+_SIGNIFICANT_EXTRA_COLS = ("p_value_corrected", "significant_fdr")
+
+_FDR_FAMILY_CAVEAT = (
+    "FDR correction (when use_fdr=True) is computed over the full family of trait pairs "
+    "in THIS call (trait_columns_1 x trait_columns_2); re-running with a narrower subset "
+    "changes the correction family, so p_value_corrected values are not comparable across "
+    "differently-scoped calls."
+)
+
+
+class CrossExperimentCorrelationsParams(BaseModel):
+    """Inputs for ``cross_experiment_correlations``. No ``seed`` — deterministic."""
+
+    experiment_1: str = Field(
+        ...,
+        description="First experiment (CSV filename). Must have a cleaned version "
+        "produced by qc_clean; cross_experiment_correlations consumes it (require_clean). "
+        "Must not contain '@' or '|' (reserved for this tool's persisted-run encoding).",
+    )
+    experiment_2: str = Field(
+        ...,
+        description="Second experiment (CSV filename). Same requirements as experiment_1.",
+    )
+    trait_columns_1: list[str] | None = Field(
+        default=None,
+        description="Subset of experiment_1's certified-clean trait columns to correlate; "
+        "omit to use all of them. Validated independently of trait_columns_2. "
+        + _FDR_FAMILY_CAVEAT,
+    )
+    trait_columns_2: list[str] | None = Field(
+        default=None,
+        description="Subset of experiment_2's certified-clean trait columns to correlate; "
+        "omit to use all of them. Validated independently of trait_columns_1. "
+        + _FDR_FAMILY_CAVEAT,
+    )
+    min_samples: int = Field(
+        default=3,
+        ge=1,
+        description="Minimum replicates a genotype must have in BOTH experiments to "
+        "participate. Enforced by a bloommcp-side pre-filter on both genotype-means "
+        "tables before delegating — the upstream delegate's own min_samples filtering is "
+        "a confirmed no-op (talmolab/sleap-roots-analyze#205); this tool does not rely on it.",
+    )
+    p_threshold: float = Field(
+        default=0.05,
+        ge=0.0,
+        le=1.0,
+        description="P-value threshold for significance (forwarded to "
+        "identify_significant_correlations).",
+    )
+    r_threshold: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Minimum absolute correlation threshold for significance (forwarded "
+        "to identify_significant_correlations).",
+    )
+    use_fdr: bool = Field(
+        default=True,
+        description="Apply Benjamini-Hochberg FDR correction for multiple testing "
+        "(forwarded to identify_significant_correlations).",
+    )
+    user_label: str | None = Field(
+        default=None,
+        description="Optional slug appended to the version directory name.",
+    )
+
+
+class CrossExperimentCorrelationsResult(RunLinks):
+    """Summary counts + links to the persisted run — never the full correlation matrix."""
+
+    experiment_1: str
+    experiment_2: str
+    source_1: str
+    source_2: str
+    n_traits_1: int
+    n_traits_2: int
+    n_correlations: int
+    n_significant: int
+    n_highly_significant: int = Field(
+        description="Count of trait pairs with raw p_value < 0.01 over the full "
+        "correlation set (calculate_cross_experiment_correlations' own 'highly_significant' "
+        "flag) — independent of r_threshold/FDR filtering, unlike n_significant."
+    )
+
+
+def _reject_reserved_encoding_characters(experiment_1: str, experiment_2: str) -> None:
+    """Reject '@'/'|' in either experiment name (design.md D1's composite-string guard)."""
+    for label, name in (("experiment_1", experiment_1), ("experiment_2", experiment_2)):
+        if "@" in name or "|" in name:
+            raise BloomMCPError(
+                code="invalid_input",
+                message=(
+                    f"{label} ({name!r}) contains '@' or '|', reserved characters used to "
+                    "encode this tool's two-experiment persisted run."
+                ),
+                remedy="Rename the experiment file to avoid '@' and '|' characters.",
+            )
+
+
+def _load_cleaned(reader, name: str, label: str) -> ExperimentFrame:
+    """Load ``name`` with require_clean=True, naming ``label`` in a tool_error remedy."""
+    try:
+        return reader.load_experiment(name, require_clean=True)
+    except CleanedVersionRequiredError:
+        raise BloomMCPError(
+            code="tool_error",
+            message=(
+                f"No cleaned version of {name!r} ({label}) exists; "
+                f"cross_experiment_correlations requires a cleaned input for both experiments."
+            ),
+            remedy=f"Run qc_clean on {name!r} first, then retry cross_experiment_correlations.",
+        ) from None
+
+
+def _require_genotype_col(frame: ExperimentFrame, name: str, label: str) -> str:
+    """Return frame.genotype_col, or raise naming ``label`` if it is None (design.md D5)."""
+    if frame.genotype_col is None:
+        raise BloomMCPError(
+            code="assumption_violated",
+            message=f"{label} ({name!r}) has no resolvable genotype column.",
+            remedy=(
+                f"Re-run qc_clean on {name!r} with an explicit genotype_column override, "
+                "then retry cross_experiment_correlations."
+            ),
+        )
+    return frame.genotype_col
+
+
+def _resolve_trait_cols(
+    frame: ExperimentFrame, requested: list[str] | None, name: str
+) -> list[str]:
+    """Default to the full certified set, or validate a caller-supplied subset."""
+    if requested is None:
+        return list(frame.trait_cols)
+    _validate_trait_subset(frame, requested, name, require_certified=True)
+    return list(requested)
+
+
+def _require_finite(
+    frame: ExperimentFrame, trait_cols: list[str], name: str, label: str
+):
+    """Raise assumption_violated naming ``label`` if any selected trait is non-finite."""
+    selected = frame.df[trait_cols]
+    if not np.isfinite(selected.to_numpy(dtype=float)).all():
+        raise BloomMCPError(
+            code="assumption_violated",
+            message=(
+                f"{label} ({name!r}) carries a non-finite value (NaN or +/-inf) in its "
+                "certified trait columns."
+            ),
+            remedy=f"Re-run qc_clean on {name!r} to produce a finite-valued cleaned version, "
+            "then retry.",
+        )
+    return selected
+
+
+def _genotype_means_prefiltered(
+    df: pd.DataFrame, trait_cols: list[str], genotype_col: str, min_samples: int
+) -> pd.DataFrame:
+    """calculate_genotype_means, then drop genotype rows below min_samples (design.md D8)."""
+    means = calculate_genotype_means(df, trait_cols, genotype_col=genotype_col)
+    return means[means["n_samples"] >= min_samples]
+
+
+def _normalized_significant(
+    sig_df: pd.DataFrame, corr_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Normalize identify_significant_correlations' columnless empty return (design.md D6)."""
+    if sig_df.empty and len(sig_df.columns) == 0:
+        return pd.DataFrame(
+            columns=list(corr_df.columns) + list(_SIGNIFICANT_EXTRA_COLS)
+        )
+    return sig_df
+
+
+def _combined_snapshot(
+    selected_1: pd.DataFrame, selected_2: pd.DataFrame
+) -> pd.DataFrame:
+    """Both selections concatenated with a leading _experiment label (design.md D1)."""
+    combined = pd.concat(
+        [selected_1.assign(_experiment=1), selected_2.assign(_experiment=2)],
+        ignore_index=True,
+    )
+    cols = ["_experiment"] + [c for c in combined.columns if c != "_experiment"]
+    return combined[cols]
+
+
+@as_mcp_tool(
+    input_model=CrossExperimentCorrelationsParams,
+    output_model=CrossExperimentCorrelationsResult,
+    errors=(ExperimentReadError,),
+)
+def cross_experiment_correlations(
+    params: CrossExperimentCorrelationsParams, *, provenance: Provenance
+) -> CrossExperimentCorrelationsResult:
+    """Correlate genotype-mean traits between two cleaned experiments and persist the run."""
+    _reject_reserved_encoding_characters(params.experiment_1, params.experiment_2)
+
+    reader = _ports.reader()
+    store = _ports.store()
+
+    frame1 = _load_cleaned(reader, params.experiment_1, "experiment_1")
+    frame2 = _load_cleaned(reader, params.experiment_2, "experiment_2")
+
+    genotype_col_1 = _require_genotype_col(frame1, params.experiment_1, "experiment_1")
+    genotype_col_2 = _require_genotype_col(frame2, params.experiment_2, "experiment_2")
+
+    trait_cols_1 = _resolve_trait_cols(
+        frame1, params.trait_columns_1, params.experiment_1
+    )
+    trait_cols_2 = _resolve_trait_cols(
+        frame2, params.trait_columns_2, params.experiment_2
+    )
+
+    selected_1 = _require_finite(
+        frame1, trait_cols_1, params.experiment_1, "experiment_1"
+    )
+    selected_2 = _require_finite(
+        frame2, trait_cols_2, params.experiment_2, "experiment_2"
+    )
+
+    # Delegate genotype-mean aggregation (D2), then enforce min_samples ourselves (D8) —
+    # the upstream delegate's own min_samples filtering is a confirmed no-op.
+    genotype_means_1 = _genotype_means_prefiltered(
+        frame1.df, trait_cols_1, genotype_col_1, params.min_samples
+    )
+    genotype_means_2 = _genotype_means_prefiltered(
+        frame2.df, trait_cols_2, genotype_col_2, params.min_samples
+    )
+
+    corr_df = calculate_cross_experiment_correlations(
+        genotype_means_1,
+        genotype_means_2,
+        trait_cols_1,
+        trait_cols_2,
+        min_samples=params.min_samples,
+    )
+
+    if corr_df.empty:
+        raise BloomMCPError(
+            code="assumption_violated",
+            message=(
+                f"No trait pair between {params.experiment_1!r} and "
+                f"{params.experiment_2!r} reached min_samples={params.min_samples} "
+                "aligned genotypes."
+            ),
+            remedy=(
+                "Lower min_samples, or check that the two experiments share enough "
+                "genotypes with sufficient replication."
+            ),
+        )
+
+    sig_df = _normalized_significant(
+        identify_significant_correlations(
+            corr_df,
+            p_threshold=params.p_threshold,
+            r_threshold=params.r_threshold,
+            use_fdr=params.use_fdr,
+        ),
+        corr_df,
+    )
+
+    summary = convert_to_json_serializable(
+        summarize_correlation_results(
+            corr_df, exp1_name=params.experiment_1, exp2_name=params.experiment_2
+        )
+    )
+
+    composite_experiment = (
+        f"{Path(params.experiment_1).stem}__x__{Path(params.experiment_2).stem}"
+    )
+    based_on_version = (
+        f"{params.experiment_1}@{frame1.source}|{params.experiment_2}@{frame2.source}"
+    )
+    prov = provenance.model_copy(update={"based_on_version": based_on_version})
+
+    n_highly_significant = int(corr_df["highly_significant"].sum())
+
+    with snapshot_frame(_combined_snapshot(selected_1, selected_2)) as source_snapshot:
+        run = store.create_run(
+            experiment=composite_experiment,
+            tool_class=_TOOL_CLASS,
+            provenance=prov,
+            user_label=params.user_label,
+            source_csv=source_snapshot,
+        )
+        corr_df.to_csv(run.staging_dir / _CORRELATIONS_NAME, index=False)
+        sig_df.to_csv(run.staging_dir / _SIGNIFICANT_NAME, index=False)
+        genotype_means_1.to_csv(run.staging_dir / _GENOTYPE_MEANS_1_NAME, index=True)
+        genotype_means_2.to_csv(run.staging_dir / _GENOTYPE_MEANS_2_NAME, index=True)
+        (run.staging_dir / _SUMMARY_NAME).write_text(json.dumps(summary))
+        stored = store.commit(
+            run,
+            {
+                _CORRELATIONS_NAME: _CORRELATIONS_NAME,
+                _SIGNIFICANT_NAME: _SIGNIFICANT_NAME,
+                _GENOTYPE_MEANS_1_NAME: _GENOTYPE_MEANS_1_NAME,
+                _GENOTYPE_MEANS_2_NAME: _GENOTYPE_MEANS_2_NAME,
+                _SUMMARY_NAME: _SUMMARY_NAME,
+            },
+        )
+
+    return CrossExperimentCorrelationsResult(
+        experiment_1=params.experiment_1,
+        experiment_2=params.experiment_2,
+        source_1=frame1.source,
+        source_2=frame2.source,
+        n_traits_1=len(trait_cols_1),
+        n_traits_2=len(trait_cols_2),
+        n_correlations=len(corr_df),
+        n_significant=len(sig_df),
+        n_highly_significant=n_highly_significant,
+        run_ref=stored.run_ref,
+        version_dir=stored.version_dir,
+        manifest_path=stored.manifest_path,
+        outputs=dict(stored.output_keys),
+    )

--- a/bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py
+++ b/bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py
@@ -36,14 +36,20 @@ checked non-``None`` before any computation.
 ``ResultStore``/``Provenance`` are single-experiment-shaped (`experiment: str`,
 ``based_on_version: str``, one ``source_csv``). Rather than extending those shared types
 for what is so far bloommcp's only dual-input consumer, both experiments are encoded into
-the existing fields: a composite ``experiment`` key (both filenames' stems joined by
-``__x__``), a composite ``based_on_version`` (``exp@version|exp@version``), and a single
-combined ``source_csv`` snapshot (both selections concatenated, labeled by a leading
+the existing fields: a composite ``experiment`` key (both filenames' *dot-sanitized* stems
+joined by ``__x__`` — see :func:`_storage_safe_stem`; a naive un-sanitized join is silently
+truncated by ``AnalysisDir``'s own re-applied ``Path(...).stem``, found in review), a
+composite ``based_on_version`` (``exp@version|exp@version``), and a single combined
+``source_csv`` snapshot (both selections concatenated, labeled by a leading
 ``_experiment`` column) so ``input_sha256`` content-addresses both inputs. ``@``/``|`` are
-therefore reserved in ``experiment_1``/``experiment_2`` and rejected up front. Persisted
+therefore reserved in ``experiment_1``/``experiment_2`` and rejected up front, as is
+``experiment_1 == experiment_2`` (self-correlation) and any path-unsafe name. Persisted
 under the reused ``correlation`` tool class (design.md D9) — reserved since the pre-#438
 legacy correlation tools were retired, exactly as ``descriptive_stats`` reactivated the
-reserved ``stats`` slot — so ``list_existing_analyses`` requires no changes.
+reserved ``stats`` slot — so ``list_existing_analyses`` requires no changes. Argument
+order is significant and undoes no normalization: ``(A, B)`` and ``(B, A)`` persist as two
+distinct, un-cross-referenced runs (an open question in design.md, called out in each
+experiment field's own description so a caller can discover it from the schema).
 
 **Traceability (design.md D12).** Upstream itself discards which specific genotypes fed a
 given trait pair's correlation (an internal alignment result assigned to ``_``), so this
@@ -93,7 +99,7 @@ from bloom_mcp.data_access import (
 )
 from bloom_mcp.tools import _ports
 from bloom_mcp.tools._consumer_utils import snapshot_frame
-from bloom_mcp.tools._qc_shared import _validate_trait_subset
+from bloom_mcp.tools._qc_shared import _validate_experiment_name, _validate_trait_subset
 
 _TOOL_CLASS = "correlation"  # reused reserved slot (design.md D9), not a new one
 _CORRELATIONS_NAME = "correlations.csv"
@@ -101,6 +107,11 @@ _SIGNIFICANT_NAME = "significant.csv"
 _GENOTYPE_MEANS_1_NAME = "genotype_means_1.csv"
 _GENOTYPE_MEANS_2_NAME = "genotype_means_2.csv"
 _SUMMARY_NAME = "summary.json"
+
+# Reserved for the composite `experiment=`/`based_on_version=` string encoding (D1) —
+# centralized here (not repeated as bare literals) so the guard and the builder can't drift.
+_RESERVED_ENCODING_CHARS = ("@", "|")
+_COMPOSITE_SEPARATOR = "__x__"
 
 # Columns identify_significant_correlations' result carries beyond calculate_cross_experiment_
 # correlations' own columns — used to normalize its columnless empty-DataFrame return (design.md D6).
@@ -121,7 +132,10 @@ class CrossExperimentCorrelationsParams(BaseModel):
         ...,
         description="First experiment (CSV filename). Must have a cleaned version "
         "produced by qc_clean; cross_experiment_correlations consumes it (require_clean). "
-        "Must not contain '@' or '|' (reserved for this tool's persisted-run encoding).",
+        "Must not contain '@' or '|' (reserved for this tool's persisted-run encoding), "
+        "and must differ from experiment_2 (self-correlation is rejected). Argument "
+        "order is significant: swapping experiment_1/experiment_2 produces a different "
+        "persisted run (a distinct storage key) — the two calls are not cross-referenced.",
     )
     experiment_2: str = Field(
         ...,
@@ -145,7 +159,10 @@ class CrossExperimentCorrelationsParams(BaseModel):
         description="Minimum replicates a genotype must have in BOTH experiments to "
         "participate. Enforced by a bloommcp-side pre-filter on both genotype-means "
         "tables before delegating — the upstream delegate's own min_samples filtering is "
-        "a confirmed no-op (talmolab/sleap-roots-analyze#205); this tool does not rely on it.",
+        "a confirmed no-op (talmolab/sleap-roots-analyze#205); this tool does not rely on it. "
+        "The ge=1 floor only rejects a non-positive value; it does not by itself protect "
+        "against single-replicate noise — a separate, always-enforced floor requires at "
+        "least 3 aligned genotypes total regardless of this setting.",
     )
     p_threshold: float = Field(
         default=0.05,
@@ -173,7 +190,15 @@ class CrossExperimentCorrelationsParams(BaseModel):
 
 
 class CrossExperimentCorrelationsResult(RunLinks):
-    """Summary counts + links to the persisted run — never the full correlation matrix."""
+    """Summary counts + links to the persisted run — never the full correlation matrix.
+
+    Traceability note (design.md D12): the persisted ``genotype_means_1.csv``/
+    ``genotype_means_2.csv`` record each experiment's full per-genotype trait means and
+    ``n_samples``, but not the exact per-trait-pair NaN-aligned genotype subset behind a
+    specific correlation — upstream discards that identity internally
+    (``_prepare_aligned_values``). Cross-reference the two genotype-means tables by hand
+    for a specific trait pair if a finer audit trail is needed.
+    """
 
     experiment_1: str
     experiment_2: str
@@ -190,18 +215,72 @@ class CrossExperimentCorrelationsResult(RunLinks):
     )
 
 
+def _reject_path_unsafe_names(experiment_1: str, experiment_2: str) -> None:
+    """Explicit path-traversal guard for both experiment names (defense-in-depth).
+
+    Neither this tool's own composite-key construction nor
+    ``ExperimentReader.load_experiment`` guarantees this today — both happen to key off
+    ``Path(name).stem``/``.name`` rather than raising, so relying on that would be
+    incidental safety, not an explicit check (flagged in review). ``pca_analysis``/
+    ``clustering`` share the same gap; fixing it there too is a follow-up, out of scope
+    for this tool.
+    """
+    _validate_experiment_name(experiment_1)
+    _validate_experiment_name(experiment_2)
+
+
 def _reject_reserved_encoding_characters(experiment_1: str, experiment_2: str) -> None:
     """Reject '@'/'|' in either experiment name (design.md D1's composite-string guard)."""
     for label, name in (("experiment_1", experiment_1), ("experiment_2", experiment_2)):
-        if "@" in name or "|" in name:
+        if any(ch in name for ch in _RESERVED_ENCODING_CHARS):
             raise BloomMCPError(
                 code="invalid_input",
                 message=(
-                    f"{label} ({name!r}) contains '@' or '|', reserved characters used to "
-                    "encode this tool's two-experiment persisted run."
+                    f"{label} ({name!r}) contains one of the reserved characters "
+                    f"{list(_RESERVED_ENCODING_CHARS)!r}, used to encode this tool's "
+                    "two-experiment persisted run."
                 ),
-                remedy="Rename the experiment file to avoid '@' and '|' characters.",
+                remedy=(
+                    "Rename the experiment file to avoid these characters: "
+                    f"{list(_RESERVED_ENCODING_CHARS)!r}."
+                ),
             )
+
+
+def _reject_self_correlation(experiment_1: str, experiment_2: str) -> None:
+    """Reject experiment_1 == experiment_2.
+
+    A plausible copy-paste mistake that would otherwise silently compute and persist a
+    meaningless self-vs-self correlation matrix under a "foo__x__foo" storage key
+    instead of a clear, fixable error (flagged in review).
+    """
+    if experiment_1 == experiment_2:
+        raise BloomMCPError(
+            code="invalid_input",
+            message=(
+                f"experiment_1 and experiment_2 are both {experiment_1!r} — "
+                "cross_experiment_correlations compares two different experiments."
+            ),
+            remedy="Pass two distinct experiment filenames.",
+        )
+
+
+def _storage_safe_stem(filename: str) -> str:
+    """``filename``'s stem with internal dots replaced — immune to re-stemming.
+
+    ``AnalysisDir`` (the real backend's storage-prefix builder,
+    ``bloommcp/src/bloom_mcp/manifest/analysis_dir.py:33``) re-applies ``Path(...).stem``
+    to whatever ``experiment=`` string this tool passes it. A naive
+    ``f"{Path(e1).stem}{SEP}{Path(e2).stem}"`` composite is vulnerable: if either
+    original stem itself contains a dot (e.g. ``"my.experiment.v2.csv"`` -> stem
+    ``"my.experiment.v2"``), ``Path(composite).stem`` re-strips at the LAST dot in the
+    *composite* string, silently truncating everything after it — losing the second
+    experiment's name entirely and risking a storage-key collision between unrelated
+    runs (found in review, reproduced directly against the real code). Replacing dots
+    with underscores in each stem before joining makes the composite string itself
+    dot-free, so ``AnalysisDir``'s re-applied ``.stem`` is a no-op on it.
+    """
+    return Path(filename).stem.replace(".", "_")
 
 
 def _load_cleaned(reader, name: str, label: str) -> ExperimentFrame:
@@ -272,8 +351,12 @@ def _genotype_means_prefiltered(
 def _normalized_significant(
     sig_df: pd.DataFrame, corr_df: pd.DataFrame
 ) -> pd.DataFrame:
-    """Normalize identify_significant_correlations' columnless empty return (design.md D6)."""
-    if sig_df.empty and len(sig_df.columns) == 0:
+    """Normalize identify_significant_correlations' columnless empty return (design.md D6).
+
+    A 0-column DataFrame is always ``.empty`` too, so checking column count alone is
+    sufficient (a prior ``sig_df.empty and`` clause here was redundant).
+    """
+    if len(sig_df.columns) == 0:
         return pd.DataFrame(
             columns=list(corr_df.columns) + list(_SIGNIFICANT_EXTRA_COLS)
         )
@@ -301,7 +384,9 @@ def cross_experiment_correlations(
     params: CrossExperimentCorrelationsParams, *, provenance: Provenance
 ) -> CrossExperimentCorrelationsResult:
     """Correlate genotype-mean traits between two cleaned experiments and persist the run."""
+    _reject_path_unsafe_names(params.experiment_1, params.experiment_2)
     _reject_reserved_encoding_characters(params.experiment_1, params.experiment_2)
+    _reject_self_correlation(params.experiment_1, params.experiment_2)
 
     reader = _ports.reader()
     store = _ports.store()
@@ -374,7 +459,8 @@ def cross_experiment_correlations(
     )
 
     composite_experiment = (
-        f"{Path(params.experiment_1).stem}__x__{Path(params.experiment_2).stem}"
+        f"{_storage_safe_stem(params.experiment_1)}{_COMPOSITE_SEPARATOR}"
+        f"{_storage_safe_stem(params.experiment_2)}"
     )
     based_on_version = (
         f"{params.experiment_1}@{frame1.source}|{params.experiment_2}@{frame2.source}"

--- a/bloommcp/src/bloom_mcp/tools/_qc_shared.py
+++ b/bloommcp/src/bloom_mcp/tools/_qc_shared.py
@@ -113,7 +113,7 @@ def _validate_trait_subset(
         if not requested:
             raise BloomMCPError(
                 code="invalid_input",
-                message="trait_columns was given as an empty list.",
+                message=f"trait_columns for {experiment!r} was given as an empty list.",
                 remedy=(
                     "Omit trait_columns to analyze all certified-clean traits, or name at "
                     "least one certified trait column."
@@ -123,7 +123,10 @@ def _validate_trait_subset(
         if duplicates:
             raise BloomMCPError(
                 code="invalid_input",
-                message=f"trait_columns contains duplicate columns: {duplicates}.",
+                message=(
+                    f"trait_columns for {experiment!r} contains duplicate columns: "
+                    f"{duplicates}."
+                ),
                 remedy="List each trait column at most once.",
             )
         certified = set(frame.trait_cols)
@@ -146,7 +149,10 @@ def _validate_trait_subset(
         if non_numeric:
             raise BloomMCPError(
                 code="invalid_input",
-                message=f"trait_columns includes non-numeric columns: {non_numeric}.",
+                message=(
+                    f"trait_columns for {experiment!r} includes non-numeric columns: "
+                    f"{non_numeric}."
+                ),
                 remedy="Pass only numeric trait columns; identifiers/metadata cannot be analyzed.",
             )
         return

--- a/bloommcp/tests/fixtures/turface_cylinder_cross_experiment_correlation_golden.json
+++ b/bloommcp/tests/fixtures/turface_cylinder_cross_experiment_correlation_golden.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Characterization snapshot of sleap-roots-analyze cross-experiment correlation on the real turface_19 (153 samples, 19 genotypes) / cylinder (123 samples, 19 genotypes, fully overlapping) fixture pair. Used as a DRIFT GATE + regression fixture for the confirmed min_samples no-op workaround (design.md D8) through the cross_experiment_correlations MCP tool.",
+  "_source": "Re-derived by bloommcp/scripts/gen_cross_experiment_correlation_golden.py from calculate_genotype_means / calculate_cross_experiment_correlations==0.1.0a5. No number here is hand-transcribed.",
+  "_reproduced_by_sleap_roots_analyze_version": "0.1.0a5",
+  "experiment_1": "turface_19.csv",
+  "experiment_2": "cylinder.csv",
+  "genotype_col": "Genotype",
+  "trait_1": "Total Root Length (mm)",
+  "trait_2": "Network Length Mean",
+  "unfiltered": {
+    "_comment": "min_samples=1 -> all 19 shared genotypes participate.",
+    "min_samples": 1,
+    "n_genotypes": 19,
+    "correlation": -0.18437072204140167,
+    "p_value": 0.44988442773882453,
+    "significant": false
+  },
+  "min_samples_3_upstream_no_op": {
+    "_comment": "Calling the upstream delegate directly with min_samples=3 (no bloommcp pre-filter) — confirms the no-op: n_genotypes is unchanged from the unfiltered call (still 19), even though cylinder's GH_7371 has only 2 samples. See talmolab/sleap-roots-analyze#205.",
+    "min_samples": 3,
+    "n_genotypes": 19,
+    "correlation": -0.18437072204140167,
+    "p_value": 0.44988442773882453
+  },
+  "min_samples_3_bloommcp_prefiltered": {
+    "_comment": "bloommcp's pre-filter workaround (design.md D8) applied before delegating: genotype rows with n_samples < 3 dropped from both means tables first. GH_7371 (cylinder n_samples=2) is correctly excluded, n_genotypes drops to 18, and the correlation value changes.",
+    "min_samples": 3,
+    "n_genotypes": 18,
+    "correlation": -0.19177005230148392,
+    "p_value": 0.44586980157467243,
+    "excluded_genotype": "GH_7371"
+  }
+}

--- a/bloommcp/tests/smoke/conftest.py
+++ b/bloommcp/tests/smoke/conftest.py
@@ -85,13 +85,28 @@ def _call_tool_sync(tool_name: str, params: dict) -> Any:
     MCP-serialized input schema nests the whole payload under one ``params`` argument
     -- confirmed empirically against the running server, not assumed. Returns the
     tool's structured result normalized to a plain dict.
+
+    Reads ``result.structured_content`` (the raw JSON the server sent), NOT
+    ``result.data`` (fastmcp's client-side reconstruction of that JSON into a dynamic
+    type derived from the tool's output schema). Found via #489's cross-experiment-
+    correlations smoke test failing in CI with every ``RunLinks.outputs`` (a
+    ``dict[str, str]`` field) field coming back an empty ``{}``: fastmcp's
+    ``json_schema_to_type`` names every untitled nested ``object``-typed schema
+    ``Root``, and a compound result schema with two such untitled object shapes (the
+    top-level result and the nested ``outputs`` dict) collide on that name, silently
+    reusing the top-level's (fieldless) generated type for the nested dict instead of
+    ``dict[str, str]`` -- confirmed directly against the live container for the
+    long-shipped ``pca_analysis`` tool too, so this was a latent bug in every
+    ``RunLinks``-based tool's smoke coverage, not something introduced by #489.
+    ``structured_content`` is the server's actual JSON payload with no such
+    reconstruction step, so it does not carry this risk for any field shape.
     """
     url, api_key = mcp_url_and_key()
 
     async def _call():
         async with Client(url, auth=api_key, timeout=120, init_timeout=15) as client:
             result = await client.call_tool(tool_name, {"params": params})
-            return result.data
+            return result.structured_content
 
     return _asdict(asyncio.run(_call()))
 

--- a/bloommcp/tests/smoke/test_cross_experiment_correlations_smoke.py
+++ b/bloommcp/tests/smoke/test_cross_experiment_correlations_smoke.py
@@ -1,0 +1,69 @@
+"""Live smoke: ``cross_experiment_correlations`` through the real running dev stack (#489).
+
+Real MCP-transport call seeding BOTH oracle fixtures (turface_19 + cylinder)
+simultaneously -- unlike every other smoke test in this package, this tool needs two
+experiments at once, so it does not use the parametrized ``seeded_experiment`` fixture
+(which seeds exactly one per test). ``cross_experiment_correlations`` requires a cleaned
+version on both sides, so this calls ``qc_clean`` on each first, proving the
+qc_clean(x2) -> cross_experiment_correlations(require_clean=True) composition resolves
+against the real Supabase-backed ports -- including the composite ``experiment``/
+``based_on_version`` encoding (design.md D1) round-tripping through a real manifest.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.live_smoke
+
+# Mirrors conftest.py's own constants (not imported across modules -- pytest does not
+# treat this directory as a package, so a relative `from .conftest import ...` fails
+# collection; every other file here relies on injected fixtures instead, but this tool
+# needs TWO experiments seeded at once, which the single-experiment `seeded_experiment`
+# fixture can't do).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_FIXTURES_DIR = _REPO_ROOT / "bloommcp" / "tests" / "fixtures"
+_TRAITS_DIR = _REPO_ROOT / "bloommcp" / "data" / "TRAITS_DIR"
+_FIXTURE_FILES = {
+    "turface_19": "turface_19_raw_data.csv",
+    "cylinder": "cylinder_raw_data.csv",
+}
+
+
+def test_cross_experiment_correlations_smoke(call_tool) -> None:
+    _TRAITS_DIR.mkdir(parents=True, exist_ok=True)
+    turface_file = _FIXTURE_FILES["turface_19"]
+    cylinder_file = _FIXTURE_FILES["cylinder"]
+    shutil.copy(_FIXTURES_DIR / turface_file, _TRAITS_DIR / turface_file)
+    shutil.copy(_FIXTURES_DIR / cylinder_file, _TRAITS_DIR / cylinder_file)
+
+    call_tool("sleap_roots_qc_clean", {"experiment": turface_file})
+    call_tool("sleap_roots_qc_clean", {"experiment": cylinder_file})
+
+    result = call_tool(
+        "sleap_roots_cross_experiment_correlations",
+        {
+            "experiment_1": turface_file,
+            "experiment_2": cylinder_file,
+            "min_samples": 3,
+        },
+    )
+
+    assert result["experiment_1"] == turface_file
+    assert result["experiment_2"] == cylinder_file
+    # Both sides consumed a committed cleaned version, not raw (require_clean=True).
+    assert result["source_1"].endswith("_cleaned")
+    assert result["source_2"].endswith("_cleaned")
+    assert result["n_correlations"] > 0
+    assert result["run_ref"]
+    assert result["manifest_path"]
+    assert set(result["outputs"]) == {
+        "correlations.csv",
+        "significant.csv",
+        "genotype_means_1.csv",
+        "genotype_means_2.csv",
+        "summary.json",
+    }

--- a/bloommcp/tests/test_devendor_invariants.py
+++ b/bloommcp/tests/test_devendor_invariants.py
@@ -431,6 +431,7 @@ def test_expected_tool_surface():
         "sleap_roots_clustering",
         "sleap_roots_umap_analysis",
         "sleap_roots_descriptive_stats",
+        "sleap_roots_cross_experiment_correlations",
         # sleap_roots: the 5 surviving plots
         "sleap_roots_plot_trait_histograms",
         "sleap_roots_plot_trait_boxplots",

--- a/bloommcp/tests/tools/test_cross_experiment_correlations_tool.py
+++ b/bloommcp/tests/tools/test_cross_experiment_correlations_tool.py
@@ -1,0 +1,601 @@
+"""Contract + oracle tests for the granular ``cross_experiment_correlations`` tool (#489).
+
+bloommcp's first two-experiment-input consumer. Around the 5 standard contract patterns
+(schema round-trip, no-leak, require_clean, persistence, deterministic-no-seed) this file
+covers what's specific to a dual-input tool: independent per-experiment validation
+(cleaned version, genotype column, trait selection, finiteness), the composite
+``experiment``/``based_on_version`` encoding (design.md D1), the reserved-`correlation`
+tool_class reuse (design.md D9), and — the north-star oracle — the confirmed upstream
+``min_samples`` no-op and bloommcp's pre-filter workaround (design.md D8,
+talmolab/sleap-roots-analyze#205), reproduced against the real turface_19/cylinder
+fixture pair via the recorded golden.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bloom_mcp.contract import BloomMCPError
+from bloom_mcp.data_access import FakeReader, SupabaseReader
+from bloom_mcp.result_store import FakeResultStore, SupabaseResultStore
+from bloom_mcp.tools import _ports
+from bloom_mcp.sections.sleap_roots.analysis import (
+    cross_experiment_correlations as xcorr_tool,
+)
+from bloom_mcp.sections.sleap_roots.analysis.cross_experiment_correlations import (
+    CrossExperimentCorrelationsParams,
+    CrossExperimentCorrelationsResult,
+    cross_experiment_correlations,
+)
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GOLDEN = json.loads(
+    (_FIXTURES / "turface_cylinder_cross_experiment_correlation_golden.json").read_text(
+        encoding="utf-8"
+    )
+)
+_TOL = 1e-6
+
+_EXP_1 = "expA.csv"
+_EXP_2 = "expB.csv"
+
+
+def _correlated_pair() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Two small, strongly-correlated experiments: 3 shared genotypes, 3 reps each."""
+    df1 = pd.DataFrame(
+        {
+            "Genotype": ["G1", "G1", "G1", "G2", "G2", "G2", "G3", "G3", "G3"],
+            "Barcode": [f"A{i}" for i in range(9)],
+            "TraitA1": [1.0, 1.1, 0.9, 2.0, 2.1, 1.9, 3.0, 3.1, 2.9],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "Genotype": ["G1", "G1", "G1", "G2", "G2", "G2", "G3", "G3", "G3"],
+            "Barcode": [f"B{i}" for i in range(9)],
+            "TraitB1": [100.0, 102.0, 98.0, 200.0, 205.0, 195.0, 300.0, 295.0, 305.0],
+        }
+    )
+    return df1, df2
+
+
+def _uncorrelated_pair() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Genotype-mean traits with real variance but only a weak (r~0.33) relationship —
+    for the zero-significant case. Deliberately not near-constant (a near-constant
+    genotype mean triggers scipy's ConstantInputWarning / an undefined correlation)."""
+    df1 = pd.DataFrame(
+        {
+            "Genotype": ["G1", "G1", "G1", "G2", "G2", "G2", "G3", "G3", "G3"],
+            "TraitA1": [4.0, 5.0, 6.0, 8.0, 9.0, 10.0, 6.0, 7.0, 8.0],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "Genotype": ["G1", "G1", "G1", "G2", "G2", "G2", "G3", "G3", "G3"],
+            "TraitB1": [9.0, 3.0, 15.0, 2.0, 20.0, 6.0, 11.0, 1.0, 18.0],
+        }
+    )
+    return df1, df2
+
+
+@pytest.fixture
+def injected_ports():
+    reader = FakeReader()
+    store = FakeResultStore()
+    df1, df2 = _correlated_pair()
+    reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        yield reader, store
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def _run(**overrides) -> CrossExperimentCorrelationsResult:
+    params = {
+        "experiment_1": _EXP_1,
+        "experiment_2": _EXP_2,
+        "trait_columns_1": ["TraitA1"],
+        "trait_columns_2": ["TraitB1"],
+        **overrides,
+    }
+    return cross_experiment_correlations(CrossExperimentCorrelationsParams(**params))
+
+
+# ── 2.1 delegation, no reimplementation ──────────────────────────────────────
+
+
+def test_delegates_to_upstream_correlation_chain(injected_ports, monkeypatch):
+    calls: dict[str, int] = {}
+
+    def _wrap(name, real):
+        def _spy(*a, **k):
+            calls[name] = calls.get(name, 0) + 1
+            return real(*a, **k)
+
+        return _spy
+
+    monkeypatch.setattr(
+        xcorr_tool,
+        "calculate_genotype_means",
+        _wrap("means", xcorr_tool.calculate_genotype_means),
+    )
+    monkeypatch.setattr(
+        xcorr_tool,
+        "calculate_cross_experiment_correlations",
+        _wrap("corr", xcorr_tool.calculate_cross_experiment_correlations),
+    )
+    monkeypatch.setattr(
+        xcorr_tool,
+        "identify_significant_correlations",
+        _wrap("sig", xcorr_tool.identify_significant_correlations),
+    )
+    monkeypatch.setattr(
+        xcorr_tool,
+        "summarize_correlation_results",
+        _wrap("summary", xcorr_tool.summarize_correlation_results),
+    )
+    _run()
+    assert calls["means"] == 2  # once per experiment
+    assert calls["corr"] == 1
+    assert calls["sig"] == 1
+    assert calls["summary"] == 1
+
+
+def test_load_and_align_experiments_never_called(injected_ports, monkeypatch):
+    import sleap_roots_analyze
+
+    def _boom(*a, **k):  # pragma: no cover - must not run
+        raise AssertionError("load_and_align_experiments must never be called")
+
+    monkeypatch.setattr(sleap_roots_analyze, "load_and_align_experiments", _boom)
+    _run()  # must not raise
+
+
+# ── 2.2 min_samples pre-filter (north-star oracle: the confirmed upstream bug) ──
+
+
+def _captured_outputs(store, monkeypatch, run_fn) -> dict[str, str]:
+    """Run once, returning every committed output's staged text keyed by filename.
+
+    ``FakeResultStore.commit`` tears down the staging dir on success (mirroring the
+    real adapter's ephemeral local staging), so outputs must be captured at commit
+    time — mirrors ``test_clustering_tool.py``'s ``_labels_of`` helper.
+    """
+    holder: dict[str, str] = {}
+    real_commit = store.commit
+
+    def _commit(run, outputs):
+        for name in outputs:
+            holder[name] = (run.staging_dir / name).read_text(encoding="utf-8")
+        return real_commit(run, outputs)
+
+    monkeypatch.setattr(store, "commit", _commit)
+    run_fn()
+    return holder
+
+
+def test_min_samples_prefilter_actually_excludes_under_replicated_genotypes(
+    monkeypatch,
+):
+    """Reproduces the confirmed upstream no-op (talmolab/sleap-roots-analyze#205) and
+    proves bloommcp's pre-filter workaround (design.md D8) actually excludes the
+    under-replicated genotype, on the real turface_19/cylinder fixture pair."""
+    reader = FakeReader()
+    store = FakeResultStore()
+    turface = pd.read_csv(_FIXTURES / "turface_19_final_data.csv")
+    cylinder = pd.read_csv(_FIXTURES / "cylinder_final_data.csv")
+    reader.add_cleaned_version("turface_19.csv", "v1", turface, make_latest=True)
+    reader.add_cleaned_version("cylinder.csv", "v1", cylinder, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+
+        def _call():
+            return cross_experiment_correlations(
+                CrossExperimentCorrelationsParams(
+                    experiment_1="turface_19.csv",
+                    experiment_2="cylinder.csv",
+                    trait_columns_1=[_GOLDEN["trait_1"]],
+                    trait_columns_2=[_GOLDEN["trait_2"]],
+                    min_samples=3,
+                    r_threshold=0.0,
+                )
+            )
+
+        outputs = _captured_outputs(store, monkeypatch, _call)
+        g = _GOLDEN["min_samples_3_bloommcp_prefiltered"]
+        corr_csv = pd.read_csv(io.StringIO(outputs["correlations.csv"]))
+        assert int(corr_csv["n_genotypes"].iloc[0]) == g["n_genotypes"]
+        assert corr_csv["correlation"].iloc[0] == pytest.approx(
+            g["correlation"], abs=_TOL
+        )
+        # excluded genotype must not appear in either persisted genotype-means table
+        gm2 = pd.read_csv(io.StringIO(outputs["genotype_means_2.csv"]))
+        assert g["excluded_genotype"] not in gm2["Genotype"].tolist()
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+# ── 2.3 require cleaned input on both sides ──────────────────────────────────
+
+
+def test_requires_cleaned_version_both_experiments():
+    reader = FakeReader()
+    store = FakeResultStore()
+    df1, df2 = _correlated_pair()
+    reader.add_experiment(_EXP_1, df1)  # raw only, no cleaned version
+    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        with pytest.raises(BloomMCPError) as exc:
+            _run()
+        assert exc.value.code == "tool_error"
+        assert _EXP_1 in exc.value.message
+        assert "qc_clean" in exc.value.remedy
+
+        # symmetric: experiment_2 missing instead
+        reader2 = FakeReader()
+        reader2.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+        reader2.add_experiment(_EXP_2, df2)
+        _ports.configure(reader=reader2, store=store)
+        with pytest.raises(BloomMCPError) as exc2:
+            _run()
+        assert exc2.value.code == "tool_error"
+        assert _EXP_2 in exc2.value.message
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def test_two_cleaned_experiments_consumed_reports_sources(injected_ports):
+    result = _run()
+    assert result.source_1 == "v1_cleaned"
+    assert result.source_2 == "v1_cleaned"
+
+
+# ── 2.4 required genotype column on both sides ───────────────────────────────
+
+
+def test_missing_genotype_role_either_side_rejected():
+    reader = FakeReader()
+    store = FakeResultStore()
+    df1, df2 = _correlated_pair()
+    no_geno = df1.drop(columns=["Genotype"])
+    reader.add_cleaned_version(_EXP_1, "v1", no_geno, make_latest=True)
+    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        with pytest.raises(BloomMCPError) as exc:
+            cross_experiment_correlations(
+                CrossExperimentCorrelationsParams(
+                    experiment_1=_EXP_1, experiment_2=_EXP_2
+                )
+            )
+        assert exc.value.code == "assumption_violated"
+        assert _EXP_1 in exc.value.message
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+# ── 2.5 finite-value defense-in-depth ─────────────────────────────────────────
+
+
+def test_non_finite_value_either_side_rejected():
+    reader = FakeReader()
+    store = FakeResultStore()
+    df1, df2 = _correlated_pair()
+    df1.loc[0, "TraitA1"] = float("inf")
+    reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        with pytest.raises(BloomMCPError) as exc:
+            _run()
+        assert exc.value.code == "assumption_violated"
+        assert _EXP_1 in exc.value.message
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+# ── 2.8 degenerate vs. empty-but-valid ────────────────────────────────────────
+
+
+def test_zero_correlations_is_degenerate_input():
+    reader = FakeReader()
+    store = FakeResultStore()
+    df1, df2 = _correlated_pair()
+    df2 = df2.copy()
+    df2["Genotype"] = ["H1", "H1", "H1", "H2", "H2", "H2", "H3", "H3", "H3"]
+    reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        with pytest.raises(BloomMCPError) as exc:
+            _run()
+        assert exc.value.code == "assumption_violated"
+        assert store.list_runs("expA__x__expB", "correlation") == []
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def test_zero_significant_is_not_an_error():
+    reader = FakeReader()
+    store = FakeResultStore()
+    df1, df2 = _uncorrelated_pair()
+    reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        result = cross_experiment_correlations(
+            CrossExperimentCorrelationsParams(
+                experiment_1=_EXP_1,
+                experiment_2=_EXP_2,
+                trait_columns_1=["TraitA1"],
+                trait_columns_2=["TraitB1"],
+                r_threshold=0.9,
+            )
+        )
+        assert result.n_significant == 0
+        assert result.n_correlations == 1
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+# ── 2.10/2.11 trait selection ─────────────────────────────────────────────────
+
+
+def test_default_trait_selection_uses_full_certified_set_both_sides(injected_ports):
+    reader, _store = injected_ports
+    frame1 = reader.load_experiment(_EXP_1, require_clean=True)
+    frame2 = reader.load_experiment(_EXP_2, require_clean=True)
+    result = cross_experiment_correlations(
+        CrossExperimentCorrelationsParams(experiment_1=_EXP_1, experiment_2=_EXP_2)
+    )
+    assert result.n_traits_1 == len(frame1.trait_cols)
+    assert result.n_traits_2 == len(frame2.trait_cols)
+
+
+def test_trait_columns_validated_independently(injected_ports):
+    for kwargs, needle in [
+        ({"trait_columns_1": ["NoSuchTrait"]}, "NoSuchTrait"),
+        ({"trait_columns_2": ["NoSuchTrait"]}, "NoSuchTrait"),
+        ({"trait_columns_1": []}, _EXP_1),
+        ({"trait_columns_2": []}, _EXP_2),
+        ({"trait_columns_1": ["TraitA1", "TraitA1"]}, "TraitA1"),
+        ({"trait_columns_2": ["TraitB1", "TraitB1"]}, "TraitB1"),
+    ]:
+        with pytest.raises(BloomMCPError) as exc:
+            _run(**kwargs)
+        assert exc.value.code == "invalid_input"
+        assert needle in exc.value.message
+
+
+def test_non_numeric_trait_column_names_experiment(injected_ports):
+    with pytest.raises(BloomMCPError) as exc:
+        _run(trait_columns_1=["Barcode"])
+    assert exc.value.code == "invalid_input"
+    assert _EXP_1 in exc.value.message
+
+
+# ── 2.12 deterministic, no seed ───────────────────────────────────────────────
+
+
+def test_seed_recorded_as_none(injected_ports):
+    _reader, store = injected_ports
+    _run()
+    stored = store.get_run("expA__x__expB", "correlation", "latest")
+    assert stored.seed is None
+
+
+def test_repeated_runs_identical(injected_ports):
+    first = _run()
+    second = _run()
+    assert first.n_correlations == second.n_correlations
+    assert first.n_significant == second.n_significant
+    assert first.n_highly_significant == second.n_highly_significant
+
+
+# ── 2.14/2.15 composite experiment/based_on_version + reserved-character guard ──
+
+
+def test_run_persisted_with_composite_experiment_and_based_on_version(
+    injected_ports, monkeypatch
+):
+    _reader, store = injected_ports
+    captured: dict[str, object] = {}
+    real_create = store.create_run
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        return real_create(**kwargs)
+
+    monkeypatch.setattr(store, "create_run", _spy)
+    _run()
+    assert captured["experiment"] == "expA__x__expB"
+    assert (
+        captured["provenance"].based_on_version
+        == f"{_EXP_1}@v1_cleaned|{_EXP_2}@v1_cleaned"
+    )
+
+
+@pytest.mark.parametrize("bad_field", ["experiment_1", "experiment_2"])
+def test_reserved_encoding_character_in_filename_rejected(injected_ports, bad_field):
+    kwargs = {
+        "experiment_1": _EXP_1,
+        "experiment_2": _EXP_2,
+        "trait_columns_1": ["TraitA1"],
+        "trait_columns_2": ["TraitB1"],
+    }
+    kwargs[bad_field] = kwargs[bad_field].replace(".csv", "@bad|.csv")
+    with pytest.raises(BloomMCPError) as exc:
+        cross_experiment_correlations(CrossExperimentCorrelationsParams(**kwargs))
+    assert exc.value.code == "invalid_input"
+    assert bad_field in exc.value.message
+
+
+# ── 2.16/2.17 content-addressing + genotype-means artifacts ──────────────────
+
+
+def test_source_csv_content_addresses_both_inputs(injected_ports):
+    _reader, store = injected_ports
+    hashes = []
+    for trait_val in (1.0, 999.0):
+        reader = FakeReader()
+        df1, df2 = _correlated_pair()
+        df2.loc[0, "TraitB1"] = trait_val
+        reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+        reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+        _ports.configure(reader=reader, store=store)
+        _run()
+        stored = store.get_run("expA__x__expB", "correlation", "latest")
+        hashes.append(stored.output_sha256["correlations.csv"])
+    assert hashes[0] != hashes[1]
+
+
+def test_genotype_means_artifacts_persisted(injected_ports):
+    _reader, store = injected_ports
+    _run()
+    stored = store.get_run("expA__x__expB", "correlation", "latest")
+    assert "genotype_means_1.csv" in stored.output_keys
+    assert "genotype_means_2.csv" in stored.output_keys
+
+
+# ── 2.18/2.19 summary serializable, no full matrix inline ────────────────────
+
+
+def test_summary_json_serializable_no_numpy_leaks(injected_ports, monkeypatch):
+    _reader, store = injected_ports
+    captured: dict[str, str] = {}
+    real_commit = store.commit
+
+    def _commit(run, outputs):
+        captured["summary"] = (run.staging_dir / "summary.json").read_text(
+            encoding="utf-8"
+        )
+        return real_commit(run, outputs)
+
+    monkeypatch.setattr(store, "commit", _commit)
+    _run()
+    parsed = json.loads(captured["summary"])  # must not raise
+    assert isinstance(parsed["total_correlations"], int)
+
+
+def test_result_never_inlines_full_correlation_matrix(injected_ports):
+    result = _run()
+    dumped = result.model_dump()
+    assert not any(isinstance(v, list) and len(v) > 20 for v in dumped.values())
+
+
+# ── 2.20 discoverable via list_existing_analyses (reused correlation slot) ────
+
+
+def test_discoverable_via_list_existing_analyses(injected_ports):
+    from bloom_mcp.sections.core.list_existing_analyses import (
+        TOOL_CLASSES,
+        list_existing_analyses,
+    )
+
+    assert "correlation" in TOOL_CLASSES
+    _run()
+    response = json.loads(list_existing_analyses("expA__x__expB"))
+    assert "correlation" in response["analyses"]
+
+
+# ── 2.21/2.22 schema round-trip + out-of-range params ─────────────────────────
+
+
+def test_schema_round_trip(injected_ports):
+    result = _run()
+    again = CrossExperimentCorrelationsResult.model_validate(
+        json.loads(result.model_dump_json())
+    )
+    assert again.n_correlations == result.n_correlations
+
+
+@pytest.mark.parametrize(
+    "bad_kwargs",
+    [
+        {"min_samples": 0},
+        {"p_threshold": 1.5},
+        {"p_threshold": -0.1},
+        {"r_threshold": 1.5},
+        {"r_threshold": -0.1},
+    ],
+)
+def test_out_of_range_parameters_rejected(injected_ports, bad_kwargs):
+    with pytest.raises(BloomMCPError) as exc:
+        cross_experiment_correlations(
+            {
+                "experiment_1": _EXP_1,
+                "experiment_2": _EXP_2,
+                "trait_columns_1": ["TraitA1"],
+                "trait_columns_2": ["TraitB1"],
+                **bad_kwargs,
+            }
+        )
+    assert exc.value.code == "invalid_input"
+
+
+# ── 2.23 no leaked internals ──────────────────────────────────────────────────
+
+
+def test_no_error_leaks_backend_internals(injected_ports, monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("secret path /var/secrets/key and host db.internal")
+
+    monkeypatch.setattr(xcorr_tool, "calculate_genotype_means", _boom)
+    with pytest.raises(BloomMCPError) as exc:
+        _run()
+    msg = f"{exc.value.message} {exc.value.remedy}"
+    assert "/var" not in msg and "db.internal" not in msg
+
+
+# ── tools/list presence ───────────────────────────────────────────────────────
+
+
+def test_cross_experiment_correlations_in_tools_list():
+    import asyncio
+    from fastmcp import Client
+    from bloom_mcp import server
+
+    async def _list():
+        async with Client(server.mcp) as client:
+            return await client.list_tools()
+
+    tools = {t.name: t for t in asyncio.run(_list())}
+    assert "sleap_roots_cross_experiment_correlations" in tools
+    assert tools["sleap_roots_cross_experiment_correlations"].inputSchema is not None
+
+
+# ── 2.24 numeric oracle against the real turface_19/cylinder golden ──────────
+
+
+def test_reproduces_golden_correlation_unfiltered():
+    reader = FakeReader()
+    store = FakeResultStore()
+    turface = pd.read_csv(_FIXTURES / "turface_19_final_data.csv")
+    cylinder = pd.read_csv(_FIXTURES / "cylinder_final_data.csv")
+    reader.add_cleaned_version("turface_19.csv", "v1", turface, make_latest=True)
+    reader.add_cleaned_version("cylinder.csv", "v1", cylinder, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        result = cross_experiment_correlations(
+            CrossExperimentCorrelationsParams(
+                experiment_1="turface_19.csv",
+                experiment_2="cylinder.csv",
+                trait_columns_1=[_GOLDEN["trait_1"]],
+                trait_columns_2=[_GOLDEN["trait_2"]],
+                min_samples=1,
+                r_threshold=0.0,
+            )
+        )
+        g = _GOLDEN["unfiltered"]
+        assert result.n_correlations == 1
+        assert result.n_significant == (1 if g["significant"] else 0)
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())

--- a/bloommcp/tests/tools/test_cross_experiment_correlations_tool.py
+++ b/bloommcp/tests/tools/test_cross_experiment_correlations_tool.py
@@ -4,7 +4,8 @@ bloommcp's first two-experiment-input consumer. Around the 5 standard contract p
 (schema round-trip, no-leak, require_clean, persistence, deterministic-no-seed) this file
 covers what's specific to a dual-input tool: independent per-experiment validation
 (cleaned version, genotype column, trait selection, finiteness), the composite
-``experiment``/``based_on_version`` encoding (design.md D1), the reserved-`correlation`
+``experiment``/``based_on_version`` encoding (design.md D1) — including the dot-safe
+storage key fix for a truncation bug found in review — the reserved-`correlation`
 tool_class reuse (design.md D9), and — the north-star oracle — the confirmed upstream
 ``min_samples`` no-op and bloommcp's pre-filter workaround (design.md D8,
 talmolab/sleap-roots-analyze#205), reproduced against the real turface_19/cylinder
@@ -30,6 +31,8 @@ from bloom_mcp.sections.sleap_roots.analysis import (
 from bloom_mcp.sections.sleap_roots.analysis.cross_experiment_correlations import (
     CrossExperimentCorrelationsParams,
     CrossExperimentCorrelationsResult,
+    _COMPOSITE_SEPARATOR,
+    _storage_safe_stem,
     cross_experiment_correlations,
 )
 
@@ -67,7 +70,9 @@ def _correlated_pair() -> tuple[pd.DataFrame, pd.DataFrame]:
 def _uncorrelated_pair() -> tuple[pd.DataFrame, pd.DataFrame]:
     """Genotype-mean traits with real variance but only a weak (r~0.33) relationship —
     for the zero-significant case. Deliberately not near-constant (a near-constant
-    genotype mean triggers scipy's ConstantInputWarning / an undefined correlation)."""
+    genotype mean triggers scipy's ConstantInputWarning / an undefined correlation —
+    see test_constant_genotype_mean_trait_yields_nan_correlation_not_a_crash for that
+    case exercised deliberately)."""
     df1 = pd.DataFrame(
         {
             "Genotype": ["G1", "G1", "G1", "G2", "G2", "G2", "G3", "G3", "G3"],
@@ -108,7 +113,27 @@ def _run(**overrides) -> CrossExperimentCorrelationsResult:
     return cross_experiment_correlations(CrossExperimentCorrelationsParams(**params))
 
 
-# ── 2.1 delegation, no reimplementation ──────────────────────────────────────
+def _captured_outputs(store, monkeypatch, run_fn) -> dict[str, str]:
+    """Run once, returning every committed output's staged text keyed by filename.
+
+    ``FakeResultStore.commit`` tears down the staging dir on success (mirroring the
+    real adapter's ephemeral local staging), so outputs must be captured at commit
+    time — mirrors ``test_clustering_tool.py``'s ``_labels_of`` helper.
+    """
+    holder: dict[str, str] = {}
+    real_commit = store.commit
+
+    def _commit(run, outputs):
+        for name in outputs:
+            holder[name] = (run.staging_dir / name).read_text(encoding="utf-8")
+        return real_commit(run, outputs)
+
+    monkeypatch.setattr(store, "commit", _commit)
+    run_fn()
+    return holder
+
+
+# ── delegation, no reimplementation ──────────────────────────────────────────
 
 
 def test_delegates_to_upstream_correlation_chain(injected_ports, monkeypatch):
@@ -158,27 +183,32 @@ def test_load_and_align_experiments_never_called(injected_ports, monkeypatch):
     _run()  # must not raise
 
 
-# ── 2.2 min_samples pre-filter (north-star oracle: the confirmed upstream bug) ──
+def test_upstream_min_samples_no_op_still_present():
+    """Regression pin for design.md D8 / talmolab/sleap-roots-analyze#205: calls the
+    RAW upstream delegate directly (bypassing bloommcp entirely) and asserts the
+    no-op is still present. If upstream ever fixes it, this test fails LOUDLY,
+    signaling that bloommcp's pre-filter workaround should be reconsidered/removed
+    rather than silently going stale alongside a fixed dependency."""
+    from sleap_roots_analyze import calculate_cross_experiment_correlations
+
+    exp1_means = pd.DataFrame(
+        {"t1": [1.0, 2.0, 3.0], "n_samples": [10, 10, 1]}, index=["G1", "G2", "G3"]
+    )
+    exp2_means = pd.DataFrame(
+        {"t2": [1.0, 2.0, 3.0], "n_samples": [10, 10, 1]}, index=["G1", "G2", "G3"]
+    )
+    # G3 has only 1 sample; min_samples=5 SHOULD exclude it if actually enforced.
+    result = calculate_cross_experiment_correlations(
+        exp1_means, exp2_means, ["t1"], ["t2"], min_samples=5
+    )
+    assert int(result["n_genotypes"].iloc[0]) == 3, (
+        "upstream's min_samples filtering appears to have been fixed in "
+        "sleap_roots_analyze -- re-evaluate design.md D8's bloommcp-side pre-filter "
+        "workaround (talmolab/sleap-roots-analyze#205); it may now be redundant"
+    )
 
 
-def _captured_outputs(store, monkeypatch, run_fn) -> dict[str, str]:
-    """Run once, returning every committed output's staged text keyed by filename.
-
-    ``FakeResultStore.commit`` tears down the staging dir on success (mirroring the
-    real adapter's ephemeral local staging), so outputs must be captured at commit
-    time — mirrors ``test_clustering_tool.py``'s ``_labels_of`` helper.
-    """
-    holder: dict[str, str] = {}
-    real_commit = store.commit
-
-    def _commit(run, outputs):
-        for name in outputs:
-            holder[name] = (run.staging_dir / name).read_text(encoding="utf-8")
-        return real_commit(run, outputs)
-
-    monkeypatch.setattr(store, "commit", _commit)
-    run_fn()
-    return holder
+# ── min_samples pre-filter (north-star oracle: the confirmed upstream bug) ──────
 
 
 def test_min_samples_prefilter_actually_excludes_under_replicated_genotypes(
@@ -222,7 +252,7 @@ def test_min_samples_prefilter_actually_excludes_under_replicated_genotypes(
         _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
 
 
-# ── 2.3 require cleaned input on both sides ──────────────────────────────────
+# ── require cleaned input on both sides ──────────────────────────────────────
 
 
 def test_requires_cleaned_version_both_experiments():
@@ -258,51 +288,113 @@ def test_two_cleaned_experiments_consumed_reports_sources(injected_ports):
     assert result.source_2 == "v1_cleaned"
 
 
-# ── 2.4 required genotype column on both sides ───────────────────────────────
+# ── required genotype column on both sides (genuinely symmetric) ────────────────
 
 
 def test_missing_genotype_role_either_side_rejected():
-    reader = FakeReader()
-    store = FakeResultStore()
     df1, df2 = _correlated_pair()
-    no_geno = df1.drop(columns=["Genotype"])
-    reader.add_cleaned_version(_EXP_1, "v1", no_geno, make_latest=True)
-    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
-    _ports.configure(reader=reader, store=store)
-    try:
-        with pytest.raises(BloomMCPError) as exc:
-            cross_experiment_correlations(
-                CrossExperimentCorrelationsParams(
-                    experiment_1=_EXP_1, experiment_2=_EXP_2
+    no_geno_1 = df1.drop(columns=["Genotype"])
+    no_geno_2 = df2.drop(columns=["Genotype"])
+
+    for bad_df1, bad_df2, offending in (
+        (no_geno_1, df2, _EXP_1),
+        (df1, no_geno_2, _EXP_2),
+    ):
+        reader = FakeReader()
+        store = FakeResultStore()
+        reader.add_cleaned_version(_EXP_1, "v1", bad_df1, make_latest=True)
+        reader.add_cleaned_version(_EXP_2, "v1", bad_df2, make_latest=True)
+        _ports.configure(reader=reader, store=store)
+        try:
+            with pytest.raises(BloomMCPError) as exc:
+                cross_experiment_correlations(
+                    CrossExperimentCorrelationsParams(
+                        experiment_1=_EXP_1, experiment_2=_EXP_2
+                    )
                 )
-            )
-        assert exc.value.code == "assumption_violated"
-        assert _EXP_1 in exc.value.message
-    finally:
-        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+            assert exc.value.code == "assumption_violated"
+            assert offending in exc.value.message
+        finally:
+            _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
 
 
-# ── 2.5 finite-value defense-in-depth ─────────────────────────────────────────
+# ── finite-value defense-in-depth (genuinely symmetric) ─────────────────────────
 
 
 def test_non_finite_value_either_side_rejected():
+    for offending, mutate in (
+        (
+            _EXP_1,
+            lambda d1, d2: d1.__setitem__(
+                "TraitA1", [float("inf")] + list(d1["TraitA1"][1:])
+            ),
+        ),
+        (
+            _EXP_2,
+            lambda d1, d2: d2.__setitem__(
+                "TraitB1", [float("inf")] + list(d2["TraitB1"][1:])
+            ),
+        ),
+    ):
+        df1, df2 = _correlated_pair()
+        mutate(df1, df2)
+        reader = FakeReader()
+        store = FakeResultStore()
+        reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+        reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+        _ports.configure(reader=reader, store=store)
+        try:
+            with pytest.raises(BloomMCPError) as exc:
+                _run()
+            assert exc.value.code == "assumption_violated"
+            assert offending in exc.value.message
+        finally:
+            _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+@pytest.mark.filterwarnings("ignore:.*constant.*:UserWarning")
+def test_constant_genotype_mean_trait_yields_nan_correlation_not_a_crash():
+    """design.md's Risks section accepts that a constant (zero-variance) genotype-mean
+    trait can yield a NaN correlation row that passes through into correlations.csv
+    rather than being rejected. This proves that acceptance path is actually exercised
+    (not just theorized) and that the NaN row is correctly excluded from
+    n_significant/n_highly_significant (NaN comparisons are always False in pandas),
+    not silently corrupting either count."""
     reader = FakeReader()
     store = FakeResultStore()
-    df1, df2 = _correlated_pair()
-    df1.loc[0, "TraitA1"] = float("inf")
+    df1 = pd.DataFrame(
+        {
+            "Genotype": ["G1", "G1", "G1", "G2", "G2", "G2", "G3", "G3", "G3"],
+            "TraitA1": [5.0] * 9,  # constant -> constant genotype means -> NaN r
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "Genotype": ["G1", "G1", "G1", "G2", "G2", "G2", "G3", "G3", "G3"],
+            "TraitB1": [100.0, 102.0, 98.0, 200.0, 205.0, 195.0, 300.0, 295.0, 305.0],
+        }
+    )
     reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
     reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
     _ports.configure(reader=reader, store=store)
     try:
-        with pytest.raises(BloomMCPError) as exc:
-            _run()
-        assert exc.value.code == "assumption_violated"
-        assert _EXP_1 in exc.value.message
+        result = cross_experiment_correlations(
+            CrossExperimentCorrelationsParams(
+                experiment_1=_EXP_1,
+                experiment_2=_EXP_2,
+                trait_columns_1=["TraitA1"],
+                trait_columns_2=["TraitB1"],
+                r_threshold=0.0,
+            )
+        )
+        assert result.n_correlations == 1
+        assert result.n_significant == 0
+        assert result.n_highly_significant == 0
     finally:
         _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
 
 
-# ── 2.8 degenerate vs. empty-but-valid ────────────────────────────────────────
+# ── degenerate vs. empty-but-valid ───────────────────────────────────────────
 
 
 def test_zero_correlations_is_degenerate_input():
@@ -319,6 +411,33 @@ def test_zero_correlations_is_degenerate_input():
             _run()
         assert exc.value.code == "assumption_violated"
         assert store.list_runs("expA__x__expB", "correlation") == []
+    finally:
+        _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
+
+
+def test_exactly_one_shared_genotype_is_degenerate():
+    """Correlation is mathematically undefined at n=1; the delegate's own hardcoded
+    <3-genotype floor makes this indistinguishable from zero shared genotypes, so the
+    same assumption_violated path fires."""
+    reader = FakeReader()
+    store = FakeResultStore()
+    df1 = pd.DataFrame({"Genotype": ["G1", "G1", "G1"], "TraitA1": [1.0, 2.0, 3.0]})
+    df2 = pd.DataFrame({"Genotype": ["G1", "G1", "G1"], "TraitB1": [10.0, 20.0, 30.0]})
+    reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
+    reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
+    _ports.configure(reader=reader, store=store)
+    try:
+        with pytest.raises(BloomMCPError) as exc:
+            cross_experiment_correlations(
+                CrossExperimentCorrelationsParams(
+                    experiment_1=_EXP_1,
+                    experiment_2=_EXP_2,
+                    trait_columns_1=["TraitA1"],
+                    trait_columns_2=["TraitB1"],
+                    min_samples=1,
+                )
+            )
+        assert exc.value.code == "assumption_violated"
     finally:
         _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
 
@@ -346,7 +465,7 @@ def test_zero_significant_is_not_an_error():
         _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())
 
 
-# ── 2.10/2.11 trait selection ─────────────────────────────────────────────────
+# ── trait selection ───────────────────────────────────────────────────────────
 
 
 def test_default_trait_selection_uses_full_certified_set_both_sides(injected_ports):
@@ -360,19 +479,22 @@ def test_default_trait_selection_uses_full_certified_set_both_sides(injected_por
     assert result.n_traits_2 == len(frame2.trait_cols)
 
 
-def test_trait_columns_validated_independently(injected_ports):
-    for kwargs, needle in [
+@pytest.mark.parametrize(
+    "kwargs,needle",
+    [
         ({"trait_columns_1": ["NoSuchTrait"]}, "NoSuchTrait"),
         ({"trait_columns_2": ["NoSuchTrait"]}, "NoSuchTrait"),
         ({"trait_columns_1": []}, _EXP_1),
         ({"trait_columns_2": []}, _EXP_2),
         ({"trait_columns_1": ["TraitA1", "TraitA1"]}, "TraitA1"),
         ({"trait_columns_2": ["TraitB1", "TraitB1"]}, "TraitB1"),
-    ]:
-        with pytest.raises(BloomMCPError) as exc:
-            _run(**kwargs)
-        assert exc.value.code == "invalid_input"
-        assert needle in exc.value.message
+    ],
+)
+def test_trait_columns_validated_independently(injected_ports, kwargs, needle):
+    with pytest.raises(BloomMCPError) as exc:
+        _run(**kwargs)
+    assert exc.value.code == "invalid_input"
+    assert needle in exc.value.message
 
 
 def test_non_numeric_trait_column_names_experiment(injected_ports):
@@ -382,7 +504,7 @@ def test_non_numeric_trait_column_names_experiment(injected_ports):
     assert _EXP_1 in exc.value.message
 
 
-# ── 2.12 deterministic, no seed ───────────────────────────────────────────────
+# ── deterministic, no seed ────────────────────────────────────────────────────
 
 
 def test_seed_recorded_as_none(injected_ports):
@@ -400,7 +522,7 @@ def test_repeated_runs_identical(injected_ports):
     assert first.n_highly_significant == second.n_highly_significant
 
 
-# ── 2.14/2.15 composite experiment/based_on_version + reserved-character guard ──
+# ── composite experiment/based_on_version + reserved-character/self/path guards ──
 
 
 def test_run_persisted_with_composite_experiment_and_based_on_version(
@@ -438,23 +560,93 @@ def test_reserved_encoding_character_in_filename_rejected(injected_ports, bad_fi
     assert bad_field in exc.value.message
 
 
-# ── 2.16/2.17 content-addressing + genotype-means artifacts ──────────────────
+def test_self_correlation_rejected():
+    """experiment_1 == experiment_2 is rejected up front, not silently computed as a
+    meaningless self-vs-self correlation matrix (found in review)."""
+    with pytest.raises(BloomMCPError) as exc:
+        cross_experiment_correlations(
+            CrossExperimentCorrelationsParams(experiment_1=_EXP_1, experiment_2=_EXP_1)
+        )
+    assert exc.value.code == "invalid_input"
+    assert _EXP_1 in exc.value.message
+
+
+@pytest.mark.parametrize("bad_field", ["experiment_1", "experiment_2"])
+def test_path_unsafe_experiment_name_rejected(bad_field):
+    """Explicit path-traversal guard (defense-in-depth, found in review — this tool's
+    safety was previously incidental, not an explicit check)."""
+    kwargs = {"experiment_1": _EXP_1, "experiment_2": _EXP_2}
+    kwargs[bad_field] = "../secrets/passwd.csv"
+    with pytest.raises(BloomMCPError) as exc:
+        cross_experiment_correlations(CrossExperimentCorrelationsParams(**kwargs))
+    assert exc.value.code == "invalid_input"
+
+
+def test_storage_safe_stem_immune_to_restemming():
+    """Regression test for the composite-key truncation bug found in review: a naive
+    f"{Path(e1).stem}__x__{Path(e2).stem}" composite is vulnerable to AnalysisDir's own
+    re-applied Path(...).stem whenever either original stem contains a dot (e.g.
+    "my.experiment.v2.csv" -> stem "my.experiment.v2"), silently truncating the second
+    experiment's name and risking a storage collision. This proves the fix removes
+    that vulnerability for arbitrary dotted filenames, not just the tested fixtures."""
+    for e1, e2 in [
+        ("my.experiment.v2.csv", "cylinder.csv"),
+        ("a.b.c.csv", "d.e.f.csv"),
+        ("plain.csv", "plain2.csv"),
+    ]:
+        composite = (
+            f"{_storage_safe_stem(e1)}{_COMPOSITE_SEPARATOR}{_storage_safe_stem(e2)}"
+        )
+        assert (
+            Path(composite).stem == composite
+        ), f"composite key {composite!r} is still vulnerable to re-stemming"
+        assert _storage_safe_stem(e1) in composite
+        assert _storage_safe_stem(e2) in composite
+
+
+def test_analysis_dir_does_not_truncate_dotted_composite_key():
+    """Directly exercises the REAL AnalysisDir (not FakeResultStore, whose simplified
+    stem helper cannot reproduce this bug — see design.md D1) against this tool's
+    actual composite-key construction, for the exact kind of filename the review's
+    reproduction used."""
+    from bloom_mcp.manifest.analysis_dir import AnalysisDir
+
+    e1, e2 = "my.experiment.v2.csv", "cylinder.csv"
+    composite = (
+        f"{_storage_safe_stem(e1)}{_COMPOSITE_SEPARATOR}{_storage_safe_stem(e2)}"
+    )
+    adir = AnalysisDir("bloommcp_output", composite, "correlation")
+    assert adir.stem == composite
+    assert "cylinder" in adir.stem
+
+
+# ── content-addressing + genotype-means artifacts ────────────────────────────
 
 
 def test_source_csv_content_addresses_both_inputs(injected_ports):
     _reader, store = injected_ports
-    hashes = []
-    for trait_val in (1.0, 999.0):
+
+    def _hash_for(vary_exp1: float | None, vary_exp2: float | None) -> str:
         reader = FakeReader()
         df1, df2 = _correlated_pair()
-        df2.loc[0, "TraitB1"] = trait_val
+        if vary_exp1 is not None:
+            df1.loc[0, "TraitA1"] = vary_exp1
+        if vary_exp2 is not None:
+            df2.loc[0, "TraitB1"] = vary_exp2
         reader.add_cleaned_version(_EXP_1, "v1", df1, make_latest=True)
         reader.add_cleaned_version(_EXP_2, "v1", df2, make_latest=True)
         _ports.configure(reader=reader, store=store)
         _run()
         stored = store.get_run("expA__x__expB", "correlation", "latest")
-        hashes.append(stored.output_sha256["correlations.csv"])
-    assert hashes[0] != hashes[1]
+        return stored.output_sha256["correlations.csv"]
+
+    baseline = _hash_for(None, None)
+    assert (
+        _hash_for(999.0, None) != baseline
+    ), "experiment_1 alone should change the hash"
+    assert (
+        _hash_for(None, 999.0) != baseline
+    ), "experiment_2 alone should change the hash"
 
 
 def test_genotype_means_artifacts_persisted(injected_ports):
@@ -465,7 +657,7 @@ def test_genotype_means_artifacts_persisted(injected_ports):
     assert "genotype_means_2.csv" in stored.output_keys
 
 
-# ── 2.18/2.19 summary serializable, no full matrix inline ────────────────────
+# ── summary serializable, no full matrix inline ──────────────────────────────
 
 
 def test_summary_json_serializable_no_numpy_leaks(injected_ports, monkeypatch):
@@ -491,7 +683,7 @@ def test_result_never_inlines_full_correlation_matrix(injected_ports):
     assert not any(isinstance(v, list) and len(v) > 20 for v in dumped.values())
 
 
-# ── 2.20 discoverable via list_existing_analyses (reused correlation slot) ────
+# ── discoverable via list_existing_analyses (reused correlation slot) ────────
 
 
 def test_discoverable_via_list_existing_analyses(injected_ports):
@@ -506,7 +698,7 @@ def test_discoverable_via_list_existing_analyses(injected_ports):
     assert "correlation" in response["analyses"]
 
 
-# ── 2.21/2.22 schema round-trip + out-of-range params ─────────────────────────
+# ── schema round-trip + out-of-range params ──────────────────────────────────
 
 
 def test_schema_round_trip(injected_ports):
@@ -541,7 +733,7 @@ def test_out_of_range_parameters_rejected(injected_ports, bad_kwargs):
     assert exc.value.code == "invalid_input"
 
 
-# ── 2.23 no leaked internals ──────────────────────────────────────────────────
+# ── no leaked internals ───────────────────────────────────────────────────────
 
 
 def test_no_error_leaks_backend_internals(injected_ports, monkeypatch):
@@ -572,10 +764,10 @@ def test_cross_experiment_correlations_in_tools_list():
     assert tools["sleap_roots_cross_experiment_correlations"].inputSchema is not None
 
 
-# ── 2.24 numeric oracle against the real turface_19/cylinder golden ──────────
+# ── numeric oracle against the real turface_19/cylinder golden ──────────────
 
 
-def test_reproduces_golden_correlation_unfiltered():
+def test_reproduces_golden_correlation_unfiltered(monkeypatch):
     reader = FakeReader()
     store = FakeResultStore()
     turface = pd.read_csv(_FIXTURES / "turface_19_final_data.csv")
@@ -584,18 +776,27 @@ def test_reproduces_golden_correlation_unfiltered():
     reader.add_cleaned_version("cylinder.csv", "v1", cylinder, make_latest=True)
     _ports.configure(reader=reader, store=store)
     try:
-        result = cross_experiment_correlations(
-            CrossExperimentCorrelationsParams(
-                experiment_1="turface_19.csv",
-                experiment_2="cylinder.csv",
-                trait_columns_1=[_GOLDEN["trait_1"]],
-                trait_columns_2=[_GOLDEN["trait_2"]],
-                min_samples=1,
-                r_threshold=0.0,
+
+        def _call():
+            return cross_experiment_correlations(
+                CrossExperimentCorrelationsParams(
+                    experiment_1="turface_19.csv",
+                    experiment_2="cylinder.csv",
+                    trait_columns_1=[_GOLDEN["trait_1"]],
+                    trait_columns_2=[_GOLDEN["trait_2"]],
+                    min_samples=1,
+                    r_threshold=0.0,
+                )
             )
-        )
+
+        outputs = _captured_outputs(store, monkeypatch, _call)
         g = _GOLDEN["unfiltered"]
-        assert result.n_correlations == 1
-        assert result.n_significant == (1 if g["significant"] else 0)
+        corr_csv = pd.read_csv(io.StringIO(outputs["correlations.csv"]))
+        assert int(corr_csv["n_genotypes"].iloc[0]) == g["n_genotypes"]
+        assert corr_csv["correlation"].iloc[0] == pytest.approx(
+            g["correlation"], abs=_TOL
+        )
+        assert corr_csv["p_value"].iloc[0] == pytest.approx(g["p_value"], abs=_TOL)
+        assert bool(corr_csv["significant"].iloc[0]) == g["significant"]
     finally:
         _ports.configure(reader=SupabaseReader(), store=SupabaseResultStore())

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/design.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/design.md
@@ -15,7 +15,15 @@ Issue #489 explicitly names this as one of the two real contract mismatches: "Ev
 current bloommcp granular tool ... takes one `filename`. A cross-experiment tool needs
 two — a genuinely new interface shape." This design resolves that mismatch, plus
 confirms the correct upstream delegation surface (the issue's own suggested
-implementation sketch has one factual gap, corrected below).
+implementation sketch has one factual gap, corrected below) and a second, more
+consequential upstream defect discovered while verifying `min_samples`' actual
+behavior (D8).
+
+This revision incorporates a 5-lens adversarial review (spec quality, code/architecture
+feasibility, GitHub issue alignment, TDD/testing, scientific rigor) conducted before
+implementation. Every BLOCKING and IMPORTANT finding from that review is resolved
+below (D8–D13); SUGGESTION-tier findings are folded into the affected sections
+directly (spec scenarios, tasks).
 
 ## Goals / Non-Goals
 
@@ -36,9 +44,36 @@ implementation sketch has one factual gap, corrected below).
   if a second dual-experiment tool appears.
 - `calculate_per_trait_correlations`, `calculate_cross_experiment_correlations_extended`,
   `calculate_correlation_confidence_intervals`, any plotting function, power analysis,
-  or redundant-trait clustering — see proposal.md's deferred list.
+  or redundant-trait clustering — see proposal.md's deferred list and the scope
+  decision immediately below.
 - Re-deriving `pc_correlations`/`cross_platform_prediction` — issue #489's own
   exclusion, unchanged here.
+
+### Scope decision: one tool, not a "small tool family"
+
+Issue #489's Ask explicitly offers either "a granular cross-experiment-correlation
+tool (**or small tool family**)". This proposal chooses **one tool**, covering
+genotype-mean-level correlation + FDR significance + summary, and defers three
+upstream-backed capabilities the issue also names: `calculate_per_trait_correlations`
+(a different granularity — individual-sample-level, single trait pair, not
+genotype-mean-level), `calculate_cross_experiment_correlations_extended` (multi-statistic
+mean/median/std combinations, needs `calculate_genotype_statistics` first), and
+`calculate_correlation_confidence_intervals` (deferred for a substantive reason — D9,
+not scope discipline).
+
+Rationale for choosing one tool now rather than a family: the three deferred
+capabilities are each a distinct, independently-shippable unit of work (different
+granularity, different upstream inputs, or blocked on an unresolved upstream question)
+— bundling them into this proposal would couple their review and merge timing to this
+one's, and this one already carries the two-experiment architectural question (D1)
+that needs to land and prove itself before more surface builds on top of it. This
+mirrors how `pca_analysis` shipped without plots first, with `include_plots` landing
+in a later, separately-reviewed PR (#426) rather than in the same change.
+
+This is a scope decision, not silent scope-cutting: each deferred capability is named
+explicitly (here and in proposal.md) rather than left implicit, so it is not lost.
+Reviewer input welcome on whether any of the three should be pulled into this same
+change instead of following it.
 
 ## Decisions
 
@@ -48,24 +83,32 @@ The `experiment`/`based_on_version`/`source_csv` fields stay single-string/singl
 as declared on the port; this tool encodes both experiments into them rather than
 changing the shared types:
 
-- `experiment=` — a synthetic composite key,
+- `experiment=` — a synthetic composite key, exactly
   `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`, passed to
   `create_run`. `AnalysisDir` only ever uses this value as `Path(...).stem` for a
   storage-prefix string (`bloommcp/src/bloom_mcp/manifest/analysis_dir.py:33`) — it is
   never validated against a real raw filename, so a synthetic key produces a normal,
-  readable prefix (`cross_experiment_correlation_cylinder_traits__x__turface_traits/`)
+  readable prefix (`correlation_cylinder_traits__x__turface_traits/` — see D9 for why
+  the tool-class segment reads `correlation`, not `cross_experiment_correlation`)
   with zero port changes.
 - `based_on_version=` — a composite string recording both consumed cleaned-version
-  labels, `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"` (e.g.
-  `cylinder_traits.csv@v3_cleaned|turface_traits.csv@v2_cleaned`). Documented as a
-  deliberate encoding of a single-string field, not a data-model change; filenames and
-  version labels never contain `@`/`|`, so this round-trips unambiguously for a human
-  reader (it is not meant to be machine-parsed by any existing consumer of
-  `based_on_version`).
+  labels, exactly `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
+  (e.g. `cylinder_traits.csv@v3_cleaned|turface_traits.csv@v2_cleaned`). Documented as
+  a deliberate encoding of a single-string field, not a data-model change; it is not
+  meant to be machine-parsed by any existing consumer of `based_on_version`.
 - `source_csv=` — both consumed frames' selected trait columns, concatenated with a
   leading `_experiment` label column (`1`/`2`) into one temporary combined CSV, so
   `AnalysisDir.input_sha256` content-addresses **both** inputs' bytes in a single hash
   rather than covering only one side.
+- **Guard (added on review):** the encoding above assumed filenames/version labels
+  never contain `@` or `|`, but the existing experiment-name guard
+  (`_qc_shared._validate_experiment_name`) only rejects path separators and `..` — not
+  `@`/`|`. A real filename containing either character would silently corrupt the
+  composite round-trip. The tool therefore explicitly rejects `experiment_1`/
+  `experiment_2` containing `@` or `|` with `BloomMCPError(invalid_input)` before
+  building either composite string — a small, tool-local check (not a change to the
+  shared `_validate_experiment_name`, since this constraint is specific to this
+  tool's encoding scheme, not a general experiment-name rule every tool should hold).
 
 **Alternative considered and rejected:** extend `Provenance.based_on_version` and
 `StoredRun`/`create_run(experiment=...)` to accept a list of experiment/version pairs.
@@ -78,17 +121,19 @@ with two real call sites to design against instead of one speculative one.
 
 **Requires reviewer sign-off** — this is a deliberate string-encoding trade-off on a
 shared field's meaning, in the same spirit as D3 in `devendor-bloommcp-analysis/design.md`
-(a naming-convention bend that required explicit sign-off before landing).
+(a naming-convention bend that required explicit sign-off before landing). The exact
+formats above are now pinned verbatim in `spec.md`'s persistence requirement (not left
+to a paraphrase), so what is being signed off on is unambiguous.
 
 ### D2 — Genotype-means via upstream `calculate_genotype_means`, not a bespoke `.groupby().mean()`
 
 Issue #489 suggests computing genotype-means "locally (`.groupby(genotype_col)[trait_cols].mean()`
 — a simple pandas operation, no upstream dependency needed for this step)". That undercounts
 the actual contract: `calculate_cross_experiment_correlations` reads
-`exp1_means.loc[g, "n_samples"]` / `exp2_means.loc[g, "n_samples"]` internally to apply
-its own `min_samples` filter (`cross_experiment_analysis.py:1013-1019`). A bare
-`.groupby().mean()` has no `n_samples` column, so calling the delegate on it would raise
-a `KeyError` inside upstream code — an opaque failure, not a clean `assumption_violated`.
+`exp1_means.loc[g, "n_samples"]` / `exp2_means.loc[g, "n_samples"]` internally
+(`cross_experiment_analysis.py:1013-1019`). A bare `.groupby().mean()` has no
+`n_samples` column, so calling the delegate on it would raise a `KeyError` inside
+upstream code — an opaque failure, not a clean `assumption_violated`.
 
 Upstream already provides exactly the right shape:
 `calculate_genotype_means(df, trait_cols, genotype_col) -> DataFrame` groups, means, and
@@ -97,7 +142,9 @@ also not in the issue's excluded list (only `load_and_align_experiments` is excl
 Using it keeps the "delegate all math to upstream, no reimplementation" invariant every
 other granular tool holds (see `pca_analysis`'s and `clustering`'s docstrings) and avoids
 a bespoke aggregation whose column contract could silently drift from what the delegate
-expects.
+expects. (Verified during review: this correction is legitimate, not a missed reading —
+issue #489's own "confirmed public" function list never mentions
+`calculate_genotype_means`.)
 
 ### D3 — `calculate_correlation_confidence_intervals` deferred, not worked around
 
@@ -108,10 +155,7 @@ applies one scalar `n_genotypes` to **every row** via `.apply(lambda r: calculat
 trait pair does its own NaN-alignment inside `_prepare_aligned_values`, so the number of
 genotypes actually paired can legitimately differ row to row. Passing one global scalar
 to a Fisher-z confidence-interval computation for every row would silently produce a
-wrong CI width for any row whose real aligned N differs from the passed value — the same
-class of bug bloommcp already found and documented in `clustering.py`'s
-`_gmm_selected_scores` (upstream returning the wrong candidate's BIC/AIC on GMM
-auto-select).
+wrong CI width for any row whose real aligned N differs from the passed value.
 
 Two options: (a) call it once per distinct `n_genotypes` value present in the row and
 merge — plausible but adds real complexity for a function this proposal is not
@@ -122,6 +166,10 @@ ambiguous upstream signature now — before confirming with upstream whether the
 behavior is intentional — risks the same "silently changes numbers" failure mode #489
 itself was raised to avoid. Filed as a natural follow-up once resolved (either upstream
 fixes/clarifies the signature, or bloommcp deliberately implements option (a)).
+Verified during review (via `git show 1ef181a^:...correlation_tools.py`): the retired
+`run_cross_experiment_correlations` tool didn't compute CIs either — only Pearson r/p,
+FDR-correction, and a summary — so deferring this is not a regression against the tool
+being replaced, only against the fuller upstream surface.
 
 ### D4 — Deterministic tool, no seed
 
@@ -144,10 +192,12 @@ genotype column, with a remedy pointing at `qc_clean`'s `genotype_column` overri
 ### D6 — Degenerate vs. empty-but-valid results
 
 - `calculate_cross_experiment_correlations` returning zero rows (no trait pair reached
-  `min_samples` aligned genotypes) is treated as **degenerate input** —
-  `BloomMCPError(code="assumption_violated")` with a remedy to lower `min_samples` or
-  check genotype overlap between the two experiments, no run persisted. This mirrors
-  `pca_analysis`/`clustering`'s treatment of a delegate-signaled degenerate fit.
+  `min_samples` aligned genotypes, post-D8 pre-filter) is treated as **degenerate
+  input** — `BloomMCPError(code="assumption_violated")` with a remedy to lower
+  `min_samples` or check genotype overlap between the two experiments, no run
+  persisted. This mirrors `pca_analysis`/`clustering`'s treatment of a
+  delegate-signaled degenerate fit. (Before D8's fix, "lower `min_samples`" would have
+  been a misleading remedy — see D8.)
 - `identify_significant_correlations` returning zero rows (correlations exist, none
   clear `r_threshold`/`p_threshold`) is a **normal, non-error outcome** — the tool
   reports `n_significant = 0` and still persists an (empty-but-schema-consistent)
@@ -166,27 +216,178 @@ submodule path, not `__all__`) — for `convert_to_json_serializable`'s existing
 This tool reuses the identical import path and pattern rather than writing a new numpy
 JSON encoder.
 
+### D8 — `min_samples` is a confirmed no-op in the delegate; bloommcp pre-filters before delegating
+
+**Found during review, independently re-verified against the installed upstream
+source (`sleap_roots_analyze==0.1.0a5`).** `calculate_cross_experiment_correlations`
+computes a `min_samples`-filtered `valid_genotypes` list and even prints it
+(`cross_experiment_analysis.py:1011-1020`) — but the per-trait-pair loop immediately
+below calls `_prepare_aligned_values(exp1_means, exp2_means, trait1, trait2,
+min_samples=0)` with a **hardcoded `0`** (line 1028), never referencing
+`valid_genotypes` again. The only genotype floor that actually applies is
+`_prepare_aligned_values`'s own hardcoded `< 3` check (line 76). So passing
+`min_samples=10` to the delegate today has **zero effect** on which genotypes
+participate — a genotype with a single replicate is treated identically to one with
+twenty. D2's citation of these exact lines (justifying why `n_samples` must be built
+via `calculate_genotype_means`) never itself noticed the filter built from that column
+is discarded downstream — this is the same class of "trust but verify the delegate"
+lesson bloommcp already learned once, documented in `clustering.py`'s
+`_gmm_selected_scores` (upstream returning the wrong candidate's BIC/AIC on GMM
+auto-select).
+
+**Consequence if unaddressed:** the tool's own documented remedy for a degenerate
+result ("lower `min_samples`", D6) would be scientifically misleading — lowering it
+changes nothing, since it was never enforced in the first place.
+
+**Fix:** bloommcp pre-filters both genotype-means tables to `n_samples >=
+params.min_samples` **before** calling the delegate:
+
+```python
+exp1_means = calculate_genotype_means(frame1.df, trait_cols_1, frame1.genotype_col)
+exp2_means = calculate_genotype_means(frame2.df, trait_cols_2, frame2.genotype_col)
+exp1_means = exp1_means[exp1_means["n_samples"] >= params.min_samples]
+exp2_means = exp2_means[exp2_means["n_samples"] >= params.min_samples]
+corr_df = calculate_cross_experiment_correlations(
+    exp1_means, exp2_means, trait_cols_1, trait_cols_2, min_samples=params.min_samples
+)
+```
+
+`min_samples` is still forwarded to the delegate call unchanged (harmless — it stays
+inert there) rather than passing a magic `0`, so the call remains correct and
+idempotent even if upstream later fixes the internal filter (both filters would then
+agree; today only bloommcp's pre-filter does any work). This is a genuine,
+call-site-level workaround, not a documentation-only caveat — matching the bar D3
+already sets ("document, or work around — don't silently trust") rather than a lower
+one. **Filed upstream** as
+[talmolab/sleap-roots-analyze#205](https://github.com/talmolab/sleap-roots-analyze/issues/205)
+(tracked separately from this OpenSpec change; that report also raises D3's
+`calculate_correlation_confidence_intervals` question in the same thread).
+
+### D9 — Reuse the reserved `correlation` tool_class slot; no discovery-list changes needed
+
+**Found during review**, and resolved for free: `manifest.CANONICAL_TOOL_CLASSES`
+(`bloommcp/src/bloom_mcp/manifest/__init__.py:26-36`) and
+`list_existing_analyses.TOOL_CLASSES`
+(`bloommcp/src/bloom_mcp/sections/core/list_existing_analyses.py:16-24`) **both
+already contain `"correlation"`**, reserved and kept intact since the pre-#438 legacy
+correlation tools were retired, specifically so historical runs would still read back
+(see that file's "do NOT prune retired classes" comment). This tool reuses that slot
+as its `tool_class` rather than inventing a new `"cross_experiment_correlation"` entry
+— exactly the precedent `descriptive_stats` already set for the retired `"stats"`
+slot (`descriptive_stats.py:53-60`, "reused, not new"). Consequence: **no changes to
+either discovery list are needed** — runs persist under `tool_class="correlation"` and
+are immediately visible via `list_existing_analyses` with zero registration work,
+closing what would otherwise have been a silent discoverability gap (a synthetic
+composite `experiment` key is never a real `list_experiments()` entry, so an
+unregistered tool_class would have been invisible with no error).
+
+The MCP tool's *name* stays `cross_experiment_correlations` (plural, matching the
+module/function name and the issue's own naming) — only the persisted `tool_class`
+segment is `correlation` (matching the storage-prefix convention every other tool
+already uses: short, not the full tool name — `pca`, `qc`, `umap`, `stats`).
+
+### D10 — `_validate_trait_subset` patched to name the experiment in every branch
+
+**Found during review.** `_validate_trait_subset` (`bloommcp/src/bloom_mcp/tools/_qc_shared.py`)
+already takes an `experiment: str` parameter and interpolates it into the "outside
+certified set" error message (line 136), but **not** into the empty-list (line 116),
+duplicate (line 126), or non-numeric (line 149) messages. Calling it twice — once per
+experiment, as this tool does — would produce identically-worded errors for those
+three failure modes regardless of which experiment triggered them, which is not
+"naming the offending experiment" as this proposal's own acceptance test requires.
+
+**Fix:** a small, backward-compatible patch to `_qc_shared.py` — interpolate
+`{experiment!r}` into the empty-list, duplicate, and non-numeric messages too (message
+text only; no signature change, since `experiment` is already a required positional
+parameter every existing call site already passes). This is a shared helper also used
+by `pca_analysis`, `clustering`, and `descriptive_stats` — the improvement benefits all
+of them (clearer error messages), not just the new tool, and carries no behavior change
+(same exception type, same code, same remedy — only the message string gains an
+experiment identifier in three more branches).
+
+### D11 — Finite-value defense-in-depth before genotype-mean aggregation
+
+**Found during review.** `pca_analysis.py:252-264` and `clustering.py:328-340` both add
+an explicit `np.isfinite()` check on selected trait columns before delegating,
+specifically because `require_clean=True` alone isn't trusted as a guarantee. This
+proposal's original draft omitted the equivalent check before `calculate_genotype_means`
+— `.mean()` silently skips NaN (understating the true per-genotype replicate count
+against what's reported as `n_samples`) and silently propagates `±inf` into a genotype
+mean, poisoning the correlation math without ever raising. Fix: add the same
+`np.isfinite(selected.to_numpy(dtype=float)).all()` check on each experiment's selected
+trait columns, independently, before calling `calculate_genotype_means` — a non-finite
+value on either side raises `BloomMCPError(code="assumption_violated")` naming which
+experiment, with the same "re-run qc_clean" remedy `pca_analysis`/`clustering` use.
+
+### D12 — Persist both genotype-means tables for traceability
+
+**Found during review.** Upstream itself discards per-trait-pair genotype identity —
+`_prepare_aligned_values` returns the aligned genotype list but the call site inside
+`calculate_cross_experiment_correlations` assigns it to `_` (line 1032) and never
+surfaces it. So even in principle, no wrapper can recover *which specific genotypes*
+fed a given trait pair's correlation without reimplementing that private, underscore-
+prefixed alignment function — which conflicts with this tool's entire "delegate, don't
+reimplement" premise, and `_prepare_aligned_values`'s leading underscore is itself a
+"do not depend on this" signal from upstream.
+
+The proportionate middle ground: persist both experiments' full genotype-means tables
+(`genotype_means_1.csv`, `genotype_means_2.csv` — each carrying every certified trait's
+per-genotype mean **and** the `n_samples` column `calculate_genotype_means` produces,
+post-D8-filter) as additional artifacts alongside `correlations.csv`/`significant.csv`/
+`summary.json`. This doesn't reconstruct the *exact* per-pair NaN-filtered subset, but
+gives a scientist auditing a surprising correlation enough to manually cross-reference
+which genotypes, and with how many replicates, were available for either trait —
+materially better than the count-only traceability the original draft offered, without
+reimplementing upstream's internal alignment.
+
+### D13 — FDR multiplicity-family caveat is a documentation obligation, not a runtime behavior
+
+**Found during review.** Benjamini-Hochberg FDR correction (delegated to
+`identify_significant_correlations`) is only valid over the family of tests it was
+actually computed across. If a caller reruns the tool with a narrower
+`trait_columns_1`/`trait_columns_2` subset, the test family shrinks and the
+FDR-corrected `p_value_corrected` values for the surviving pairs will **not** match
+their values from a full run — a caller could reasonably (and wrongly) expect a
+"subset" rerun to reproduce the full run's corrected p-values for the pairs it shares.
+There is no runtime fix for this (the tool has no way to know a caller's cross-call
+expectations) — it is a documentation obligation: the `trait_columns_1`/
+`trait_columns_2` Pydantic field descriptions must state this caveat explicitly (see
+tasks.md 3.1), so it is visible in the tool's schema wherever an agent or human reads
+parameter docs, not buried only in this design doc.
+
 ## Risks / Trade-offs
 
 - **String-encoded composite fields are a readability/parseability trade-off**, not a
-  type-safe one — mitigated by D1's "human-readable, not machine-parsed" framing and
-  by not being the first bloommcp precedent for bending a single-string field's literal
-  meaning (D3 of `devendor-bloommcp-analysis` already bent a naming convention with
-  documented sign-off).
+  type-safe one — mitigated by D1's "human-readable, not machine-parsed" framing, the
+  explicit `@`/`|` guard, and by not being the first bloommcp precedent for bending a
+  single-string field's literal meaning (D3 of `devendor-bloommcp-analysis` already bent
+  a naming convention with documented sign-off).
 - **A second two-experiment tool would strain D1's encoding further** — mitigated by
   scoping D1 explicitly to "revisit with two real call sites," not designing an
   abstraction now against one.
+- **A confirmed upstream `min_samples` no-op (D8)** — mitigated by a bloommcp-side
+  pre-filter and an upstream bug report; the workaround is idempotent against a future
+  upstream fix.
 - **Deferring `calculate_correlation_confidence_intervals` (D3) leaves a capability gap**
-  relative to the old `run_cross_experiment_correlations` tool, which did not compute CIs
-  either (only Pearson r/p, FDR-correction, and a summary) — so this is not a regression
-  against the tool being replaced, only against the full upstream surface.
+  relative to the full upstream surface, but not relative to the tool being replaced
+  (verified: it didn't compute CIs either).
+- **A constant (zero-variance) genotype-mean trait may produce a `NaN` correlation row**
+  that survives into `correlations.csv` rather than being filtered or raising — this
+  matches upstream's own documented behavior for its public `calculate_correlations`
+  helper (returns `(NaN, NaN)` for zero-variance input) and is accepted as a
+  pass-through here rather than a bloommcp-side rejection, since the row is
+  transparently NaN (not silently dropped or misrepresented) and a stricter guard
+  would diverge from what the delegate itself considers valid output.
 
 ## Migration / Rollout
 
 No data migration — a new tool, additive registration. No existing tool's behavior,
-schema, or persisted-run shape changes. `test_devendor_invariants.py`'s retired-tool
-list and drift guards are unaffected (this is a new tool, not a repoint of a retired
-one).
+schema, or persisted-run shape changes. Reusing the `correlation` tool_class (D9) means
+`list_existing_analyses` already lists that slot today (for historical, pre-#438 runs,
+currently always empty in a fresh environment) — this tool simply makes it a live write
+target again, exactly as `descriptive_stats` already did for `stats`.
+`test_devendor_invariants.py`'s retired-tool list and drift guards are unaffected (this
+is a new tool, not a repoint of a retired one).
 
 ## Open Questions
 
@@ -199,4 +400,8 @@ one).
   rather than deciding unilaterally.
 - D1's reviewer sign-off — who signs off on the composite-string persistence encoding
   (mirrors the `devendor-bloommcp-analysis` D3 precedent of requiring an explicit
-  approver for a convention bend)?
+  approver for a convention bend)? The exact format is now pinned in spec.md, so this
+  is a concrete artifact to review, not an open-ended one.
+- ~~Should D3's deferred `calculate_correlation_confidence_intervals` question be raised
+  with upstream alongside the D8 bug report?~~ Resolved: both raised in the same thread,
+  [talmolab/sleap-roots-analyze#205](https://github.com/talmolab/sleap-roots-analyze/issues/205).

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/design.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/design.md
@@ -1,0 +1,202 @@
+## Context
+
+Every granular consumer shipped so far (`pca_analysis` #308, `clustering` #309/#422,
+`remove_outliers` #378, `umap_analysis` #425) takes exactly one `experiment` filename
+and consumes it through `ExperimentReader.load_experiment(require_clean=True)`. The
+shared persistence primitives are shaped around that single-experiment call:
+
+- `ResultStore.create_run(*, experiment: str, tool_class: str, provenance, user_label=None, source_csv: Optional[Path]=None)`
+- `Provenance.based_on_version: str` — one consumed source version
+- `AnalysisDir(output_root, experiment_filename, tool_class)` — derives its storage
+  prefix as `Path(experiment_filename).stem`, and content-addresses exactly one
+  `source_csv` via `input_sha256`
+
+Issue #489 explicitly names this as one of the two real contract mismatches: "Every
+current bloommcp granular tool ... takes one `filename`. A cross-experiment tool needs
+two — a genuinely new interface shape." This design resolves that mismatch, plus
+confirms the correct upstream delegation surface (the issue's own suggested
+implementation sketch has one factual gap, corrected below).
+
+## Goals / Non-Goals
+
+**Goals:**
+- One new tool, `cross_experiment_correlations`, delegating all correlation math to
+  tested `sleap_roots_analyze.cross_experiment_analysis` entry points.
+- Both experiments consumed through the existing `ExperimentReader` port
+  (`require_clean=True`) — no direct `pd.read_csv`, no bypass of Supabase-backed
+  reads.
+- A versioned, traceable persisted run despite the two-experiment input, without
+  changing `ResultStore`, `Provenance`, or the manifest schema.
+
+**Non-Goals:**
+- Extending `Provenance`/`StoredRun`/`ResultStore` to a first-class multi-experiment
+  shape. One dual-input consumer does not justify a schema change touching every
+  existing tool's provenance record (OpenSpec's own complexity-trigger guidance:
+  add structure only with "multiple proven use cases requiring abstraction"). Revisit
+  if a second dual-experiment tool appears.
+- `calculate_per_trait_correlations`, `calculate_cross_experiment_correlations_extended`,
+  `calculate_correlation_confidence_intervals`, any plotting function, power analysis,
+  or redundant-trait clustering — see proposal.md's deferred list.
+- Re-deriving `pc_correlations`/`cross_platform_prediction` — issue #489's own
+  exclusion, unchanged here.
+
+## Decisions
+
+### D1 — Two experiments, one single-experiment-shaped persisted run
+
+The `experiment`/`based_on_version`/`source_csv` fields stay single-string/single-path
+as declared on the port; this tool encodes both experiments into them rather than
+changing the shared types:
+
+- `experiment=` — a synthetic composite key,
+  `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`, passed to
+  `create_run`. `AnalysisDir` only ever uses this value as `Path(...).stem` for a
+  storage-prefix string (`bloommcp/src/bloom_mcp/manifest/analysis_dir.py:33`) — it is
+  never validated against a real raw filename, so a synthetic key produces a normal,
+  readable prefix (`cross_experiment_correlation_cylinder_traits__x__turface_traits/`)
+  with zero port changes.
+- `based_on_version=` — a composite string recording both consumed cleaned-version
+  labels, `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"` (e.g.
+  `cylinder_traits.csv@v3_cleaned|turface_traits.csv@v2_cleaned`). Documented as a
+  deliberate encoding of a single-string field, not a data-model change; filenames and
+  version labels never contain `@`/`|`, so this round-trips unambiguously for a human
+  reader (it is not meant to be machine-parsed by any existing consumer of
+  `based_on_version`).
+- `source_csv=` — both consumed frames' selected trait columns, concatenated with a
+  leading `_experiment` label column (`1`/`2`) into one temporary combined CSV, so
+  `AnalysisDir.input_sha256` content-addresses **both** inputs' bytes in a single hash
+  rather than covering only one side.
+
+**Alternative considered and rejected:** extend `Provenance.based_on_version` and
+`StoredRun`/`create_run(experiment=...)` to accept a list of experiment/version pairs.
+This is the more "correct" long-term shape, but it touches the contract layer every
+other tool depends on, for a single consumer — high blast radius for a capability that
+does not yet have a second use case. `devendor-bloommcp-analysis` itself declared
+"changing the contract layer, ports, or storage" a Non-Goal; this proposal holds that
+line. If a second two-experiment tool is proposed later, revisit this decision then
+with two real call sites to design against instead of one speculative one.
+
+**Requires reviewer sign-off** — this is a deliberate string-encoding trade-off on a
+shared field's meaning, in the same spirit as D3 in `devendor-bloommcp-analysis/design.md`
+(a naming-convention bend that required explicit sign-off before landing).
+
+### D2 — Genotype-means via upstream `calculate_genotype_means`, not a bespoke `.groupby().mean()`
+
+Issue #489 suggests computing genotype-means "locally (`.groupby(genotype_col)[trait_cols].mean()`
+— a simple pandas operation, no upstream dependency needed for this step)". That undercounts
+the actual contract: `calculate_cross_experiment_correlations` reads
+`exp1_means.loc[g, "n_samples"]` / `exp2_means.loc[g, "n_samples"]` internally to apply
+its own `min_samples` filter (`cross_experiment_analysis.py:1013-1019`). A bare
+`.groupby().mean()` has no `n_samples` column, so calling the delegate on it would raise
+a `KeyError` inside upstream code — an opaque failure, not a clean `assumption_violated`.
+
+Upstream already provides exactly the right shape:
+`calculate_genotype_means(df, trait_cols, genotype_col) -> DataFrame` groups, means, and
+appends `n_samples` in one call (`cross_experiment_analysis.py:702-721`) — also public,
+also not in the issue's excluded list (only `load_and_align_experiments` is excluded).
+Using it keeps the "delegate all math to upstream, no reimplementation" invariant every
+other granular tool holds (see `pca_analysis`'s and `clustering`'s docstrings) and avoids
+a bespoke aggregation whose column contract could silently drift from what the delegate
+expects.
+
+### D3 — `calculate_correlation_confidence_intervals` deferred, not worked around
+
+`calculate_correlation_confidence_intervals(correlation_df, n_genotypes, confidence=0.95)`
+applies one scalar `n_genotypes` to **every row** via `.apply(lambda r: calculate_correlation_ci(r, n_genotypes, confidence))`
+(`cross_experiment_analysis.py:1596-1638`). But `correlation_df` already carries a
+**per-row** `n_genotypes` column from `calculate_cross_experiment_correlations` — each
+trait pair does its own NaN-alignment inside `_prepare_aligned_values`, so the number of
+genotypes actually paired can legitimately differ row to row. Passing one global scalar
+to a Fisher-z confidence-interval computation for every row would silently produce a
+wrong CI width for any row whose real aligned N differs from the passed value — the same
+class of bug bloommcp already found and documented in `clustering.py`'s
+`_gmm_selected_scores` (upstream returning the wrong candidate's BIC/AIC on GMM
+auto-select).
+
+Two options: (a) call it once per distinct `n_genotypes` value present in the row and
+merge — plausible but adds real complexity for a function this proposal is not
+otherwise obligated to ship; (b) defer it entirely. Choosing **(b)**: confidence
+intervals are not part of the issue's minimum ask ("delegate the actual correlation
+math + significance testing"), and baking in an interpretation of a genuinely
+ambiguous upstream signature now — before confirming with upstream whether the flat-`n`
+behavior is intentional — risks the same "silently changes numbers" failure mode #489
+itself was raised to avoid. Filed as a natural follow-up once resolved (either upstream
+fixes/clarifies the signature, or bloommcp deliberately implements option (a)).
+
+### D4 — Deterministic tool, no seed
+
+The delegation chain (`calculate_genotype_means` → `calculate_cross_experiment_correlations`
+→ `identify_significant_correlations` → `summarize_correlation_results`) is Pearson
+correlation + Benjamini-Hochberg FDR — no `random_state` anywhere in the chain. The tool
+declares no `seed` parameter and records `seed = None` in `Provenance`, matching
+`pca_analysis`'s convention (not `clustering`'s stochastic kmeans/gmm convention).
+
+### D5 — Required genotype role on both sides
+
+`pca_analysis`/`clustering` treat `frame.genotype_col` as optional (used only for plot
+coloring where present). This tool's correlation is computed **at the genotype-mean
+level**, so a missing genotype role on either experiment means the tool cannot produce
+a meaningful result at all — not a degraded one. Both `frame.genotype_col` values are
+checked non-`None` before any computation; a `None` on either side raises
+`BloomMCPError(code="assumption_violated")` naming which experiment lacks a resolvable
+genotype column, with a remedy pointing at `qc_clean`'s `genotype_column` override.
+
+### D6 — Degenerate vs. empty-but-valid results
+
+- `calculate_cross_experiment_correlations` returning zero rows (no trait pair reached
+  `min_samples` aligned genotypes) is treated as **degenerate input** —
+  `BloomMCPError(code="assumption_violated")` with a remedy to lower `min_samples` or
+  check genotype overlap between the two experiments, no run persisted. This mirrors
+  `pca_analysis`/`clustering`'s treatment of a delegate-signaled degenerate fit.
+- `identify_significant_correlations` returning zero rows (correlations exist, none
+  clear `r_threshold`/`p_threshold`) is a **normal, non-error outcome** — the tool
+  reports `n_significant = 0` and still persists an (empty-but-schema-consistent)
+  `significant.csv`. Note upstream returns a bare `pd.DataFrame()` with **no columns**
+  in this case (`cross_experiment_analysis.py:1571`), so the tool writes a fixed-header
+  empty frame rather than the columnless one, keeping `significant.csv`'s shape
+  consistent across calls regardless of how many rows survive.
+
+### D7 — `summarize_correlation_results` through the existing JSON-serialization seam
+
+`summarize_correlation_results` returns numpy scalar types (`.sum()`/`.max()`/`.nunique()`
+results) and nested Python containers with numpy leaves. `devendor-bloommcp-analysis`
+D1 already established the call-site pattern for this exact situation —
+`sleap_roots_analyze.data_utils.convert_to_json_serializable` (imported via the
+submodule path, not `__all__`) — for `convert_to_json_serializable`'s existing callers.
+This tool reuses the identical import path and pattern rather than writing a new numpy
+JSON encoder.
+
+## Risks / Trade-offs
+
+- **String-encoded composite fields are a readability/parseability trade-off**, not a
+  type-safe one — mitigated by D1's "human-readable, not machine-parsed" framing and
+  by not being the first bloommcp precedent for bending a single-string field's literal
+  meaning (D3 of `devendor-bloommcp-analysis` already bent a naming convention with
+  documented sign-off).
+- **A second two-experiment tool would strain D1's encoding further** — mitigated by
+  scoping D1 explicitly to "revisit with two real call sites," not designing an
+  abstraction now against one.
+- **Deferring `calculate_correlation_confidence_intervals` (D3) leaves a capability gap**
+  relative to the old `run_cross_experiment_correlations` tool, which did not compute CIs
+  either (only Pearson r/p, FDR-correction, and a summary) — so this is not a regression
+  against the tool being replaced, only against the full upstream surface.
+
+## Migration / Rollout
+
+No data migration — a new tool, additive registration. No existing tool's behavior,
+schema, or persisted-run shape changes. `test_devendor_invariants.py`'s retired-tool
+list and drift guards are unaffected (this is a new tool, not a repoint of a retired
+one).
+
+## Open Questions
+
+- Should `experiment_1`/`experiment_2` order be normalized (e.g. lexicographic) before
+  building the composite `experiment=` key, so `(A, B)` and `(B, A)` land in the same
+  storage prefix? Leaning **no** for v1 — `exp1_trait`/`exp2_trait` column naming in the
+  persisted `correlations.csv` is order-dependent (asymmetric: exp1's traits are rows,
+  exp2's are columns in spirit), so normalizing the storage key while leaving the
+  content order-sensitive would be its own inconsistency. Flagging for reviewer input
+  rather than deciding unilaterally.
+- D1's reviewer sign-off — who signs off on the composite-string persistence encoding
+  (mirrors the `devendor-bloommcp-analysis` D3 precedent of requiring an explicit
+  approver for a convention bend)?

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/design.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/design.md
@@ -25,6 +25,17 @@ implementation. Every BLOCKING and IMPORTANT finding from that review is resolve
 below (D8–D13); SUGGESTION-tier findings are folded into the affected sections
 directly (spec scenarios, tasks).
 
+**Second revision, post-PR code review.** After implementation, two independent
+5-agent PR reviews (posted within a second of each other) each verified the code
+against real infrastructure rather than trusting prose, and found two genuine
+BLOCKING defects the pre-implementation review couldn't have caught (one only
+observable in live CI, one requiring a specific input the test fixtures never
+exercised): the PR's own live smoke test was failing (D-fix below), and the
+composite-key scheme from D1 silently truncated for any dotted experiment filename
+(D1 updated below). Every BLOCKING/IMPORTANT finding from both reviews is resolved
+in this revision — see D1's update, D14, and the "Testing infrastructure fix" note
+under Migration/Rollout.
+
 ## Goals / Non-Goals
 
 **Goals:**
@@ -83,14 +94,13 @@ The `experiment`/`based_on_version`/`source_csv` fields stay single-string/singl
 as declared on the port; this tool encodes both experiments into them rather than
 changing the shared types:
 
-- `experiment=` — a synthetic composite key, exactly
-  `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`, passed to
-  `create_run`. `AnalysisDir` only ever uses this value as `Path(...).stem` for a
-  storage-prefix string (`bloommcp/src/bloom_mcp/manifest/analysis_dir.py:33`) — it is
-  never validated against a real raw filename, so a synthetic key produces a normal,
-  readable prefix (`correlation_cylinder_traits__x__turface_traits/` — see D9 for why
-  the tool-class segment reads `correlation`, not `cross_experiment_correlation`)
-  with zero port changes.
+- `experiment=` — a synthetic composite key, built by `_storage_safe_stem(experiment_1)
+  + "__x__" + _storage_safe_stem(experiment_2)`, passed to `create_run`. `AnalysisDir`
+  only ever uses this value as `Path(...).stem` for a storage-prefix string
+  (`bloommcp/src/bloom_mcp/manifest/analysis_dir.py:33`) — it is never validated
+  against a real raw filename, so a synthetic key produces a normal, readable prefix
+  (`correlation_cylinder__x__turface/` — see D9 for why the tool-class segment reads
+  `correlation`, not `cross_experiment_correlation`) with zero port changes.
 - `based_on_version=` — a composite string recording both consumed cleaned-version
   labels, exactly `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
   (e.g. `cylinder_traits.csv@v3_cleaned|turface_traits.csv@v2_cleaned`). Documented as
@@ -100,8 +110,8 @@ changing the shared types:
   leading `_experiment` label column (`1`/`2`) into one temporary combined CSV, so
   `AnalysisDir.input_sha256` content-addresses **both** inputs' bytes in a single hash
   rather than covering only one side.
-- **Guard (added on review):** the encoding above assumed filenames/version labels
-  never contain `@` or `|`, but the existing experiment-name guard
+- **Guard (added on the first review pass):** the encoding above assumed filenames/
+  version labels never contain `@` or `|`, but the existing experiment-name guard
   (`_qc_shared._validate_experiment_name`) only rejects path separators and `..` — not
   `@`/`|`. A real filename containing either character would silently corrupt the
   composite round-trip. The tool therefore explicitly rejects `experiment_1`/
@@ -109,6 +119,46 @@ changing the shared types:
   building either composite string — a small, tool-local check (not a change to the
   shared `_validate_experiment_name`, since this constraint is specific to this
   tool's encoding scheme, not a general experiment-name rule every tool should hold).
+- **Second, more serious guard needed (found in PR review, confirmed by
+  reproduction): the `@`/`|` guard alone was not sufficient.** The originally-shipped
+  composite key, `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`, is
+  vulnerable to `AnalysisDir`'s own re-applied `Path(...).stem` whenever *either
+  original stem itself* contains a dot — a case the `@`/`|` guard does nothing about,
+  and no test fixture used a dotted stem, so it shipped unnoticed. Reproduced directly:
+  `experiment_1="my.experiment.v2.csv"` has `Path(...).stem == "my.experiment.v2"`;
+  joining with `experiment_2="cylinder.csv"`'s stem gives the composite
+  `"my.experiment.v2__x__cylinder"`; `AnalysisDir` then re-applies
+  `Path("my.experiment.v2__x__cylinder").stem`, which strips at the *last* dot in that
+  composite string — `"my.experiment"` — silently discarding `experiment_2`'s name and
+  the `__x__` separator entirely. Two different `(experiment_1, experiment_2)` pairs
+  that happen to produce the same truncated prefix would then collide in the same
+  storage directory — silent data mixing between unrelated runs, not a crash.
+  `FakeResultStore`'s own simplified stem helper (`name[:-4] if name.endswith(".csv")
+  else name`) does not reproduce `AnalysisDir`'s real `Path.stem` re-truncation
+  behavior, so no unit test running only against the fake store could have caught
+  this — confirmed by adding a test that exercises the real `AnalysisDir` class
+  directly (`test_analysis_dir_does_not_truncate_dotted_composite_key`).
+
+  **Fix:** each stem is passed through `_storage_safe_stem(name) ->
+  Path(name).stem.replace(".", "_")` before joining. Since the resulting composite
+  string is then guaranteed dot-free, `AnalysisDir`'s re-applied `Path(...).stem` is a
+  no-op on it regardless of what either original filename's stem contained — this
+  closes the vulnerability for *any* dotted filename, not just the one reproduction
+  case, which a narrower fix (e.g. rejecting dots in `experiment_1`/`experiment_2`
+  outright) would not have needed to reason about as carefully. `based_on_version`
+  needed no equivalent fix — it is never re-processed through `AnalysisDir.stem`,
+  only `experiment=` is.
+- **Self-correlation guard (found in PR review):** `experiment_1 == experiment_2` was
+  neither rejected nor tested — a plausible copy-paste mistake that would otherwise
+  silently compute and persist a meaningless self-vs-self correlation matrix under a
+  `"foo__x__foo"` storage key. Now rejected with `BloomMCPError(invalid_input)` before
+  any I/O.
+- **Argument-order sensitivity is now surfaced in the schema (found in PR review):**
+  `(experiment_1=A, experiment_2=B)` and `(experiment_1=B, experiment_2=A)` produce two
+  distinct composite keys and two independent, un-cross-referenced persisted runs —
+  already an accepted Open Question below, but previously undiscoverable from the
+  tool's own schema. Both `experiment_1`/`experiment_2` field descriptions now state
+  this explicitly.
 
 **Alternative considered and rejected:** extend `Provenance.based_on_version` and
 `StoredRun`/`create_run(experiment=...)` to accept a list of experiment/version pairs.
@@ -123,7 +173,12 @@ with two real call sites to design against instead of one speculative one.
 shared field's meaning, in the same spirit as D3 in `devendor-bloommcp-analysis/design.md`
 (a naming-convention bend that required explicit sign-off before landing). The exact
 formats above are now pinned verbatim in `spec.md`'s persistence requirement (not left
-to a paraphrase), so what is being signed off on is unambiguous.
+to a paraphrase), so what is being signed off on is unambiguous. The scheme's most
+serious known risk — silent truncation/collision for a dotted experiment filename — is
+now closed by `_storage_safe_stem` (above) and covered by two tests exercising the
+real `AnalysisDir` class, not just the fake store; this substantively de-risks what a
+human reviewer is being asked to approve, though the sign-off itself is still
+outstanding (tasks.md 1.3).
 
 ### D2 — Genotype-means via upstream `calculate_genotype_means`, not a bespoke `.groupby().mean()`
 
@@ -355,6 +410,19 @@ expectations) — it is a documentation obligation: the `trait_columns_1`/
 tasks.md 3.1), so it is visible in the tool's schema wherever an agent or human reads
 parameter docs, not buried only in this design doc.
 
+### D14 — Explicit path-traversal guard, not incidental safety
+
+**Found during PR review.** This tool never called the existing
+`_qc_shared._validate_experiment_name` guard; safety was incidental — it happened to
+hold only because the tool always calls `load_experiment(..., require_clean=True)`,
+whose real resolution path keys off `Path(filename).stem`/`.name` rather than the raw
+string, not because anything raised on a path-unsafe input. `pca_analysis`/`clustering`
+share this exact gap (pre-existing, not introduced here — out of scope to fix in this
+PR, a candidate follow-up to centralize). Given this tool doubles the untrusted-filename
+surface (two names instead of one), it now calls `_validate_experiment_name` explicitly
+on both `experiment_1` and `experiment_2` as defense-in-depth, rather than relying on
+the incidental protection alone.
+
 ## Risks / Trade-offs
 
 - **String-encoded composite fields are a readability/parseability trade-off**, not a
@@ -373,11 +441,18 @@ parameter docs, not buried only in this design doc.
   (verified: it didn't compute CIs either).
 - **A constant (zero-variance) genotype-mean trait may produce a `NaN` correlation row**
   that survives into `correlations.csv` rather than being filtered or raising — this
-  matches upstream's own documented behavior for its public `calculate_correlations`
-  helper (returns `(NaN, NaN)` for zero-variance input) and is accepted as a
-  pass-through here rather than a bloommcp-side rejection, since the row is
-  transparently NaN (not silently dropped or misrepresented) and a stricter guard
-  would diverge from what the delegate itself considers valid output.
+  matches the actual call path's behavior (the private `_calculate_correlations`
+  helper `calculate_cross_experiment_correlations` uses internally calls raw
+  `scipy.stats.pearsonr`/`spearmanr` with no zero-variance guard, emitting
+  `ConstantInputWarning` and returning `NaN`; corrected citation — an earlier draft of
+  this doc pointed at the public `calculate_correlations` wrapper, which has its own
+  explicit zero-variance check and is not actually on this tool's call path) and is
+  accepted as a pass-through here rather than a bloommcp-side rejection, since the row
+  is transparently NaN (not silently dropped or misrepresented) and a stricter guard
+  would diverge from what the delegate itself considers valid output. Exercised by
+  `test_constant_genotype_mean_trait_yields_nan_correlation_not_a_crash` — the NaN row
+  is confirmed excluded from `n_significant`/`n_highly_significant` (NaN comparisons
+  are always `False`), not silently corrupting either count.
 
 ## Migration / Rollout
 
@@ -388,6 +463,25 @@ currently always empty in a fresh environment) — this tool simply makes it a l
 target again, exactly as `descriptive_stats` already did for `stats`.
 `test_devendor_invariants.py`'s retired-tool list and drift guards are unaffected (this
 is a new tool, not a repoint of a retired one).
+
+**Testing infrastructure fix (found via this PR's own CI, not a design decision about
+this tool).** This tool's live smoke test (`test_cross_experiment_correlations_smoke.py`)
+failed in CI with `result["outputs"]` coming back an empty `{}`, even though
+`store.commit()` had genuinely succeeded (every other assertion in the same test
+passed). Root-caused to `bloommcp/tests/smoke/conftest.py`'s `_call_tool_sync` reading
+`result.data` — fastmcp's client-side reconstruction of the server's JSON into a
+dynamic type derived from the tool's output schema — rather than
+`result.structured_content` (the server's actual JSON, no reconstruction). fastmcp's
+`json_schema_to_type` names every untitled nested `object`-typed schema `Root`; a
+compound result schema with two such untitled shapes (the top-level result and the
+nested `outputs: dict[str, str]` field) collide on that name, and the nested field
+silently gets the top-level's own (fieldless) generated type instead of `dict[str,
+str]`. Confirmed directly against the live container for the long-shipped
+`pca_analysis` tool too (`structured_content` correct, `.data.outputs` empty) — this was
+a latent bug in *every* `RunLinks`-based tool's live-smoke coverage, invisible until
+this PR became the first smoke test to assert on `outputs` at all. Fixed at the shared
+`conftest.py` level (one line), benefiting every smoke test in the package, not patched
+around locally in this tool's own test file.
 
 ## Open Questions
 
@@ -400,8 +494,18 @@ is a new tool, not a repoint of a retired one).
   rather than deciding unilaterally.
 - D1's reviewer sign-off — who signs off on the composite-string persistence encoding
   (mirrors the `devendor-bloommcp-analysis` D3 precedent of requiring an explicit
-  approver for a convention bend)? The exact format is now pinned in spec.md, so this
-  is a concrete artifact to review, not an open-ended one.
+  approver for a convention bend)? The exact format is now pinned in spec.md, and the
+  scheme's most serious known risk (dotted-filename truncation) is fixed and tested
+  against the real `AnalysisDir`, so this is a concrete, substantially de-risked
+  artifact to review — still an outstanding human sign-off, not something this PR can
+  resolve on its own (tasks.md 1.3).
 - ~~Should D3's deferred `calculate_correlation_confidence_intervals` question be raised
   with upstream alongside the D8 bug report?~~ Resolved: both raised in the same thread,
   [talmolab/sleap-roots-analyze#205](https://github.com/talmolab/sleap-roots-analyze/issues/205).
+- The recorded golden fixture (`turface_cylinder_cross_experiment_correlation_golden.json`)
+  is not bit-for-bit reproducible across regenerations of
+  `scripts/gen_cross_experiment_correlation_golden.py` — re-running it produced
+  correlation values differing at ~1e-16 (BLAS/threading float noise), functionally
+  irrelevant given every comparison test's `abs=1e-6` tolerance, but worth knowing
+  before assuming a diff in the checked-in JSON on a future regeneration signals a
+  real regression rather than routine noise (found in PR review).

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/proposal.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/proposal.md
@@ -4,12 +4,21 @@
 (`tools/correlation_tools.py` + vendored `bloom_mcp/cross_experiment_correlations.py`)
 rather than rewiring them onto `sleap_roots_analyze.cross_experiment_analysis`, because
 the upstream module shares function names but has a genuinely different contract
-(columns, `min_samples` semantics, no significance flags, different sort order) —
-rewiring would have silently changed the reported numbers (design.md D2 of that
-change). Issue #489 is the fresh design that deletion deferred: bloommcp has had zero
-cross-experiment correlation capability since, and the capability is real — comparing
-trait correlations between root-phenotyping modalities (e.g. cylinder vs. turface) is
-a genotype-comparison workflow the old tools served.
+(columns, `min_samples` semantics, significance-flag differences, sort order) —
+rewiring would have silently changed the reported numbers ("no significance flags" per
+the deletion commit `1ef181a`'s message; "a different contract" per that same change's
+design.md D2). Issue #489 is the fresh design that deletion deferred: bloommcp has had
+zero cross-experiment correlation capability since, and the capability is real —
+comparing trait correlations between root-phenotyping modalities (e.g. cylinder vs.
+turface) is a genotype-comparison workflow the old tools served.
+
+**Revised after a 5-lens adversarial review** (spec quality, code/architecture
+feasibility, GitHub issue alignment, TDD/testing, scientific rigor) conducted on the
+first draft of this proposal. That review surfaced a genuine upstream correctness bug
+(`min_samples` is a confirmed no-op inside the delegated
+`calculate_cross_experiment_correlations` — see design.md D8) plus several ripple
+effects and gaps; every finding is resolved in this revision (see design.md's Decisions
+D8–D13 and the "Scope decision" subsection).
 
 ## What Changes
 
@@ -39,8 +48,12 @@ a genotype-comparison workflow the old tools served.
   - `calculate_cross_experiment_correlations_extended` — multi-statistic
     (mean/median/std) correlation combinations.
   - `calculate_correlation_confidence_intervals` — a real upstream inconsistency
-    found during this design (see `design.md`); deferred rather than worked around
+    found during this design (see `design.md` D3); deferred rather than worked around
     speculatively.
+
+  See `design.md`'s "Scope decision: one tool, not a tool family" for why these three
+  are deferred rather than folded into this change (issue #489 explicitly offered
+  either "a tool or small tool family").
   - All plotting (`create_cross_experiment_heatmap`, `create_top_correlations_plot`,
     `create_scatter_plot_grid`, `create_joint_plot`, `create_genotype_boxplots`,
     `create_correlation_summary_plot`) — mirrors `pca_analysis`'s `include_plots`
@@ -61,10 +74,22 @@ a genotype-comparison workflow the old tools served.
   - New: `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py`
   - Modified: `bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py` (register the
     new tool)
+  - Modified: `bloommcp/src/bloom_mcp/tools/_qc_shared.py` (`_validate_trait_subset`
+    message patch, design.md D10 — interpolates `experiment` into three more error
+    branches; message text only, no signature/behavior change, benefits
+    `pca_analysis`/`clustering`/`descriptive_stats` too)
+  - Modified: `bloommcp/tests/test_devendor_invariants.py`
+    (`test_expected_tool_surface`'s enumerated tool list)
+  - No changes needed to `manifest.CANONICAL_TOOL_CLASSES` or
+    `list_existing_analyses.TOOL_CLASSES` — both already reserve the `correlation`
+    tool_class slot this tool reuses (design.md D9)
   - Tests: a new `bloommcp/tests/tools/test_cross_experiment_correlations_tool.py`
-    following the existing `test_clustering_tool.py`/PCA test conventions; a
-    positive-registration assertion added wherever the tool-surface drift guard
-    (`test_devendor_invariants.py`) enumerates live tool names.
+    following the existing `test_clustering_tool.py`/PCA test conventions; a new
+    two-experiment fixture pair + hand-computed correlation golden (mandatory, see
+    `tasks.md` 2.24, not the earlier "optional" framing); a new smoke test exercising
+    `qc_clean` (×2) → `cross_experiment_correlations` through the real Supabase-backed
+    adapters, following the `test_clustering_smoke.py`/
+    `test_plot_correlation_matrix_smoke.py` precedent every prior granular tool set.
 - No changes to `ExperimentReader`, `ResultStore`, `Provenance`, or the manifest
   schema — the two-experiment shape is encoded inside existing single-string fields
   (see `design.md` Decision D1), not by extending shared contract/port types.
@@ -72,3 +97,7 @@ a genotype-comparison workflow the old tools served.
   the only import; no new third-party package (FDR correction's `statsmodels`
   dependency is upstream's, inside `sleap_roots_analyze`, not a new bloommcp
   dependency).
+- An upstream bug report is being filed against `talmolab/sleap-roots-analyze` for
+  the confirmed `min_samples` no-op (design.md D8) — tracked separately from this
+  OpenSpec change, not a blocking dependency of it (this proposal's own bloommcp-side
+  pre-filter workaround is unconditional and does not wait on an upstream fix).

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/proposal.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+`devendor-bloommcp-analysis` (PR #438) deleted the 8 legacy correlation tools
+(`tools/correlation_tools.py` + vendored `bloom_mcp/cross_experiment_correlations.py`)
+rather than rewiring them onto `sleap_roots_analyze.cross_experiment_analysis`, because
+the upstream module shares function names but has a genuinely different contract
+(columns, `min_samples` semantics, no significance flags, different sort order) —
+rewiring would have silently changed the reported numbers (design.md D2 of that
+change). Issue #489 is the fresh design that deletion deferred: bloommcp has had zero
+cross-experiment correlation capability since, and the capability is real — comparing
+trait correlations between root-phenotyping modalities (e.g. cylinder vs. turface) is
+a genotype-comparison workflow the old tools served.
+
+## What Changes
+
+- Add one new granular consumer tool, `cross_experiment_correlations`, in
+  `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/`, registered alongside
+  `pca_analysis`/`clustering`/`umap_analysis` (namespaced
+  `sleap_roots_cross_experiment_correlations`).
+- It is bloommcp's **first two-experiment-input** granular tool — every existing
+  consumer (`qc_clean`, `pca_analysis`, `remove_outliers`, `clustering`,
+  `umap_analysis`) takes one `experiment` filename. This proposal resolves how a
+  two-experiment consumer fits the existing single-experiment `ResultStore`/
+  `Provenance` shape **without changing those shared ports** (see `design.md`).
+- Both experiments are consumed the same way every existing tool consumes cleaned
+  data — via `ExperimentReader.load_experiment(require_clean=True)` — so the read
+  path never touches raw CSVs directly and never bypasses the Supabase-backed port
+  (the exact contract mismatch #489 identifies in upstream's own
+  `load_and_align_experiments`, which is **not** used here).
+- Delegates all correlation math to upstream, tested `sleap_roots_analyze` entry
+  points: `calculate_genotype_means`, `calculate_cross_experiment_correlations`,
+  `identify_significant_correlations`, `summarize_correlation_results`. The MCP
+  contains no correlation math of its own.
+- **Out of scope, explicitly deferred** (named here so they aren't lost, each a
+  candidate follow-up issue):
+  - `calculate_per_trait_correlations` — single-trait-pair, individual-sample-level
+    correlation (a different granularity from the genotype-mean-level tool proposed
+    here).
+  - `calculate_cross_experiment_correlations_extended` — multi-statistic
+    (mean/median/std) correlation combinations.
+  - `calculate_correlation_confidence_intervals` — a real upstream inconsistency
+    found during this design (see `design.md`); deferred rather than worked around
+    speculatively.
+  - All plotting (`create_cross_experiment_heatmap`, `create_top_correlations_plot`,
+    `create_scatter_plot_grid`, `create_joint_plot`, `create_genotype_boxplots`,
+    `create_correlation_summary_plot`) — mirrors `pca_analysis`'s `include_plots`
+    flag landing in a later, separate PR (#426) rather than with the first cut.
+  - Power analysis (`minimum_detectable_correlation`/`achieved_power` — was the old
+    `check_correlation_power` tool).
+  - Redundant-trait identification (`cluster_correlated_traits`/
+    `select_cluster_representatives` — was old `find_redundant_traits`/
+    `compare_trait_across_experiments`).
+  - `sleap_roots_analyze.pc_correlations` and the entire `cross_platform_prediction`
+    module — already excluded by issue #489 itself as separate, larger upstream
+    work.
+
+## Impact
+
+- Affected specs: `bloommcp-cross-experiment-correlations-tool` (new capability).
+- Affected code:
+  - New: `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py`
+  - Modified: `bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py` (register the
+    new tool)
+  - Tests: a new `bloommcp/tests/tools/test_cross_experiment_correlations_tool.py`
+    following the existing `test_clustering_tool.py`/PCA test conventions; a
+    positive-registration assertion added wherever the tool-surface drift guard
+    (`test_devendor_invariants.py`) enumerates live tool names.
+- No changes to `ExperimentReader`, `ResultStore`, `Provenance`, or the manifest
+  schema — the two-experiment shape is encoded inside existing single-string fields
+  (see `design.md` Decision D1), not by extending shared contract/port types.
+- No dependency changes: `sleap-roots-analyze>=0.1.0a5` (already a dependency) is
+  the only import; no new third-party package (FDR correction's `statsmodels`
+  dependency is upstream's, inside `sleap_roots_analyze`, not a new bloommcp
+  dependency).

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/specs/bloommcp-cross-experiment-correlations-tool/spec.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/specs/bloommcp-cross-experiment-correlations-tool/spec.md
@@ -1,0 +1,224 @@
+## ADDED Requirements
+
+### Requirement: Cross-Experiment Correlations Tool Registration and Discovery
+
+The system SHALL expose a `cross_experiment_correlations` MCP tool registered on the
+`sleap_roots` section's FastMCP server (namespaced `sleap_roots_cross_experiment_correlations`
+on the combined `/mcp` surface) so it is discoverable via the MCP `tools/list` operation.
+The tool name SHALL be stable and its registration SHALL NOT remove or rename any existing
+tool in the `sleap_roots` section.
+
+#### Scenario: Tool appears in tools/list
+
+- **WHEN** a FastMCP `Client` connects to the server and calls `tools/list`
+- **THEN** a tool named `sleap_roots_cross_experiment_correlations` is present with a
+  description and an input schema derived from its Pydantic input model
+
+#### Scenario: Existing sleap_roots tools are preserved
+
+- **WHEN** the server registers `cross_experiment_correlations`
+- **THEN** `pca_analysis`, `qc_clean`, `qc_inspect`, `remove_outliers`, `clustering`, and
+  `umap_analysis` all remain registered
+
+### Requirement: Cross-Experiment Correlations Delegates All Computation to Tested Upstream Entry Points
+
+The `cross_experiment_correlations` tool SHALL delegate genotype-mean aggregation to
+`sleap_roots_analyze.calculate_genotype_means`, the correlation matrix to
+`sleap_roots_analyze.calculate_cross_experiment_correlations`, significance filtering to
+`sleap_roots_analyze.identify_significant_correlations`, and the summary to
+`sleap_roots_analyze.summarize_correlation_results`. It SHALL contain no correlation math
+of its own — no Pearson/Spearman computation, no FDR correction, no genotype aggregation
+via a bespoke `groupby`/`mean` call — and SHALL NOT call
+`sleap_roots_analyze.load_and_align_experiments` (which reads CSVs directly from file
+paths, bypassing the `ExperimentReader` port).
+
+#### Scenario: Correlation math is delegated, not re-implemented
+
+- **WHEN** `cross_experiment_correlations` runs on two cleaned experiment frames
+- **THEN** `calculate_genotype_means` is invoked once per experiment, and
+  `calculate_cross_experiment_correlations`, `identify_significant_correlations`, and
+  `summarize_correlation_results` are each invoked exactly once
+- **AND** the tool never calls `pandas.DataFrame.groupby` directly on either frame to
+  compute genotype means, and never calls `load_and_align_experiments`
+
+#### Scenario: Tunable parameters are forwarded to the delegates
+
+- **WHEN** a caller sets `min_samples`, `p_threshold`, `r_threshold`, or `use_fdr`
+- **THEN** `min_samples` is forwarded to `calculate_cross_experiment_correlations` and
+  `p_threshold`/`r_threshold`/`use_fdr` are forwarded to `identify_significant_correlations`
+
+### Requirement: Cross-Experiment Correlations Requires Cleaned Input on Both Sides
+
+The `cross_experiment_correlations` tool SHALL load both `experiment_1` and `experiment_2`
+through the injected `ExperimentReader` port with `require_clean=True`. It SHALL NOT
+compute correlations from a raw input and SHALL NOT perform its own cleaning. When no
+committed cleaned version exists for either experiment, the tool SHALL surface a
+structured `BloomMCPError` naming which experiment is missing a cleaned version, with a
+remedy directing the caller to run `qc_clean` on that experiment first.
+
+#### Scenario: Two cleaned experiments are consumed
+
+- **WHEN** `cross_experiment_correlations` is invoked on two experiments that each have a
+  committed cleaned version (a `qc_clean` run)
+- **THEN** the reader resolves each cleaned version (source `v<N>_cleaned`, not `raw`),
+  and correlations are computed on the cleaned data
+
+#### Scenario: Either experiment missing a cleaned version is rejected with a remedy
+
+- **WHEN** `experiment_1` has no committed cleaned version (while `experiment_2` does)
+- **THEN** the tool returns a `BloomMCPError` naming `experiment_1` and whose remedy is to
+  run `qc_clean` on it first, and no run is produced
+- **AND** the same holds symmetrically when `experiment_2` is the one missing a cleaned
+  version
+
+### Requirement: Cross-Experiment Correlations Requires a Resolvable Genotype Column on Both Sides
+
+Because correlations are computed at the genotype-mean level, the
+`cross_experiment_correlations` tool SHALL require a resolvable `genotype_col` on both
+consumed frames. When either frame's `genotype_col` is `None`, the tool SHALL surface a
+`BloomMCPError` with code `assumption_violated` naming which experiment lacks a
+resolvable genotype column, with a remedy pointing at `qc_clean`'s `genotype_column`
+override, and SHALL NOT attempt genotype-mean aggregation.
+
+#### Scenario: A missing genotype column on either experiment is rejected
+
+- **WHEN** `experiment_1`'s cleaned frame has `genotype_col == None`
+- **THEN** the tool returns a `BloomMCPError` with code `assumption_violated` naming
+  `experiment_1`, and no genotype-mean aggregation or correlation is attempted
+- **AND** the same holds symmetrically when `experiment_2`'s frame is missing a
+  resolvable genotype column instead
+
+### Requirement: Trait Selection Is Validated Independently Per Experiment
+
+The `cross_experiment_correlations` tool SHALL accept `trait_columns_1` and
+`trait_columns_2` independently, each defaulting to its own experiment's full certified
+`trait_cols` when omitted, and each validated against that experiment's certified-clean
+trait set. A trait column outside its experiment's certified set, a non-numeric column,
+an empty list, or a set of duplicate names on either side SHALL be rejected with a
+`BloomMCPError` (`invalid_input`) naming the offending experiment and column(s), rather
+than silently correlating an uncertified or degenerate selection.
+
+#### Scenario: Omitted trait selections default to each experiment's certified set
+
+- **WHEN** both `trait_columns_1` and `trait_columns_2` are omitted
+- **THEN** the tool correlates every certified-clean trait of `experiment_1` against
+  every certified-clean trait of `experiment_2`
+
+#### Scenario: An uncertified or invalid trait column on either side is rejected
+
+- **WHEN** `trait_columns_1` names a column absent from `experiment_1`'s certified-clean
+  trait set (or `trait_columns_2` does so for `experiment_2`), or either list is empty or
+  contains a duplicate
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` naming which
+  experiment and column(s) are at fault, and no correlation is computed
+
+### Requirement: Degenerate Correlation Results Are Rejected; Empty Significance Is Not an Error
+
+When `calculate_cross_experiment_correlations` returns zero rows (no trait pair reached
+`min_samples` aligned genotypes between the two experiments), the
+`cross_experiment_correlations` tool SHALL surface a `BloomMCPError` with code
+`assumption_violated` and a remedy (lower `min_samples`, or check genotype overlap
+between the experiments), and SHALL NOT persist a run. In contrast, when correlations
+exist but none clear `r_threshold`/`p_threshold` (an empty **significant** subset), the
+tool SHALL treat this as a normal, successful outcome — reporting `n_significant == 0`
+and persisting an empty-but-schema-consistent `significant.csv`.
+
+#### Scenario: Zero aligned correlations is treated as degenerate input
+
+- **WHEN** the two experiments share no genotypes meeting `min_samples` for any trait
+  pair
+- **THEN** the tool returns a `BloomMCPError` with code `assumption_violated` and a
+  remedy, and no run is persisted
+
+#### Scenario: Zero significant correlations is a normal result
+
+- **WHEN** `calculate_cross_experiment_correlations` returns a non-empty result but
+  `identify_significant_correlations` filters it to zero rows
+- **THEN** the tool completes successfully with `n_significant == 0`, and the persisted
+  `significant.csv` has the expected header columns with zero data rows
+
+### Requirement: Cross-Experiment Correlations Is Deterministic and Records No Seed
+
+The `cross_experiment_correlations` tool SHALL be deterministic: it SHALL declare no
+`seed`/`random_state` parameter, and the stamped `Provenance` SHALL record `seed = None`.
+Two runs with identical inputs SHALL produce identical results.
+
+#### Scenario: Seed is recorded as None
+
+- **WHEN** `cross_experiment_correlations` completes
+- **THEN** the stamped `Provenance` records `seed = None`, together with the tool name and
+  params (both experiment names, trait selections, `min_samples`, `p_threshold`,
+  `r_threshold`, `use_fdr`)
+
+#### Scenario: Repeated runs are identical
+
+- **WHEN** `cross_experiment_correlations` is invoked twice on the same pair of cleaned
+  experiments with the same parameters
+- **THEN** the two results' `n_correlations`, `n_significant`, and
+  `n_highly_significant` are equal
+
+### Requirement: Cross-Experiment Correlations Persists a Versioned Run Encoding Both Experiments
+
+The `cross_experiment_correlations` tool SHALL persist its outputs as a versioned run via
+the `ResultStore` port under tool class `cross_experiment_correlation`, encoding both
+consumed experiments into the existing single-experiment-shaped fields without any change
+to `ResultStore`, `Provenance`, or the manifest schema: the run's `experiment` SHALL be a
+composite key derived from both experiment filenames' stems, `based_on_version` SHALL
+record both consumed cleaned-version labels, and `source_csv` SHALL content-address both
+consumed frames' selected trait data in a single combined snapshot. It SHALL persist the
+full correlation matrix (`correlations.csv`), the significance-filtered subset
+(`significant.csv`), and the JSON-serializable summary (`summary.json`), and SHALL return
+only summary counts and **links** to these artifacts — never the full trait-by-trait
+correlation matrix inline.
+
+#### Scenario: Run is committed with a composite experiment key and dual-source lineage
+
+- **WHEN** `cross_experiment_correlations` completes successfully for `experiment_1`
+  (resolved cleaned source `v3_cleaned`) and `experiment_2` (resolved cleaned source
+  `v2_cleaned`)
+- **THEN** a `StoredRun` is recorded whose `experiment` is derived from both filenames'
+  stems, and whose `Provenance.based_on_version` encodes both `v3_cleaned` and
+  `v2_cleaned` together with each source experiment's identity
+- **AND** the committed outputs include `correlations.csv`, `significant.csv`, and
+  `summary.json`
+
+#### Scenario: Content-addressing covers both consumed inputs
+
+- **WHEN** the tool builds its `source_csv` snapshot for content-addressing
+- **THEN** the snapshot's content reflects both experiments' selected trait data, so the
+  manifest's `input_sha256` changes if either experiment's consumed data changes
+
+#### Scenario: Summary is JSON-serializable with no numpy leaks
+
+- **WHEN** the tool persists `summary.json`
+- **THEN** the file parses via `json.loads` with no `numpy` scalar types surviving (all
+  numpy int/float leaves from `summarize_correlation_results` are converted to native
+  Python types before serialization)
+
+#### Scenario: Result returns summary counts and links, not the matrix
+
+- **WHEN** the tool returns its result
+- **THEN** `n_correlations`, `n_significant`, `n_highly_significant`, and the per-experiment
+  trait counts are inline
+- **AND** the full `exp1_trait × exp2_trait` correlation matrix is reachable only via the
+  persisted `correlations.csv` link, never embedded in the result
+
+### Requirement: Cross-Experiment Correlations Honors the Contract Envelope
+
+The `cross_experiment_correlations` tool SHALL be wrapped by `@as_mcp_tool` so that
+inputs and outputs are validated against declared Pydantic models, every declared or
+undeclared failure is mapped to a structured `BloomMCPError` (never a raw traceback or
+leaked backend internals), and a single `Provenance` is stamped per call.
+
+#### Scenario: Input/output schema round-trip
+
+- **WHEN** a valid request is serialized to the tool's input schema and the result is
+  validated against the output schema
+- **THEN** both validate without loss
+
+#### Scenario: No error leaks backend internals
+
+- **WHEN** any mapped `BloomMCPError` is raised (missing cleaned version, missing
+  genotype column, invalid trait selection, or degenerate correlation result)
+- **THEN** its message contains no raw upstream exception text, filesystem path, or
+  storage backend detail

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/specs/bloommcp-cross-experiment-correlations-tool/spec.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/specs/bloommcp-cross-experiment-correlations-tool/spec.md
@@ -17,8 +17,10 @@ tool in the `sleap_roots` section.
 #### Scenario: Existing sleap_roots tools are preserved
 
 - **WHEN** the server registers `cross_experiment_correlations`
-- **THEN** `pca_analysis`, `qc_clean`, `qc_inspect`, `remove_outliers`, `clustering`, and
-  `umap_analysis` all remain registered
+- **THEN** every tool already registered on the `sleap_roots` section immediately
+  before this change (as enumerated by the live `tools/list` response at that point,
+  e.g. `pca_analysis`, `qc_clean`, `qc_inspect`, `remove_outliers`, `clustering`,
+  `umap_analysis`, `descriptive_stats`, and the plotting tools) remains registered
 
 ### Requirement: Cross-Experiment Correlations Delegates All Computation to Tested Upstream Entry Points
 
@@ -41,11 +43,16 @@ paths, bypassing the `ExperimentReader` port).
 - **AND** the tool never calls `pandas.DataFrame.groupby` directly on either frame to
   compute genotype means, and never calls `load_and_align_experiments`
 
-#### Scenario: Tunable parameters are forwarded to the delegates
+#### Scenario: `min_samples` is enforced by a bloommcp-side pre-filter, not by the delegate
 
-- **WHEN** a caller sets `min_samples`, `p_threshold`, `r_threshold`, or `use_fdr`
-- **THEN** `min_samples` is forwarded to `calculate_cross_experiment_correlations` and
-  `p_threshold`/`r_threshold`/`use_fdr` are forwarded to `identify_significant_correlations`
+- **WHEN** a caller sets `min_samples` to a value greater than 3
+- **THEN** the tool filters both genotype-means tables to `n_samples >= min_samples`
+  **before** calling `calculate_cross_experiment_correlations` (a documented workaround
+  for a confirmed upstream no-op — see design.md D8, filed upstream as a bug against
+  `sleap-roots-analyze`), so a genotype present in both experiments but under-replicated
+  in either does not participate in any resulting correlation
+- **AND** `p_threshold`/`r_threshold`/`use_fdr` are forwarded unchanged to
+  `identify_significant_correlations`
 
 ### Requirement: Cross-Experiment Correlations Requires Cleaned Input on Both Sides
 
@@ -62,6 +69,8 @@ remedy directing the caller to run `qc_clean` on that experiment first.
   committed cleaned version (a `qc_clean` run)
 - **THEN** the reader resolves each cleaned version (source `v<N>_cleaned`, not `raw`),
   and correlations are computed on the cleaned data
+- **AND** the tool's result reports each experiment's resolved source label
+  (e.g. `v3_cleaned` for `experiment_1`, `v2_cleaned` for `experiment_2`)
 
 #### Scenario: Either experiment missing a cleaned version is rejected with a remedy
 
@@ -88,15 +97,35 @@ override, and SHALL NOT attempt genotype-mean aggregation.
 - **AND** the same holds symmetrically when `experiment_2`'s frame is missing a
   resolvable genotype column instead
 
+### Requirement: Selected Trait Data Must Be Finite Before Genotype-Mean Aggregation
+
+Before calling `calculate_genotype_means`, the `cross_experiment_correlations` tool
+SHALL verify that each experiment's selected trait columns contain no non-finite value
+(`NaN`, `+inf`, or `-inf`) — the same defense-in-depth `pca_analysis` and `clustering`
+apply before delegating, since `require_clean=True` alone is not trusted as a
+finiteness guarantee. A non-finite value surviving into either experiment's selection
+SHALL be rejected with `BloomMCPError(code="assumption_violated")` naming which
+experiment, rather than silently understating that experiment's true `n_samples` (via
+`.mean()`'s NaN-skipping) or propagating `±inf` into a genotype mean.
+
+#### Scenario: A non-finite value in either experiment's selection is rejected
+
+- **WHEN** a selected certified-clean trait column of `experiment_1` (or, symmetrically,
+  `experiment_2`) carries a non-finite value
+- **THEN** the tool returns a `BloomMCPError` with code `assumption_violated` naming the
+  offending experiment, and no genotype-mean aggregation is attempted
+
 ### Requirement: Trait Selection Is Validated Independently Per Experiment
 
 The `cross_experiment_correlations` tool SHALL accept `trait_columns_1` and
 `trait_columns_2` independently, each defaulting to its own experiment's full certified
 `trait_cols` when omitted, and each validated against that experiment's certified-clean
-trait set. A trait column outside its experiment's certified set, a non-numeric column,
-an empty list, or a set of duplicate names on either side SHALL be rejected with a
-`BloomMCPError` (`invalid_input`) naming the offending experiment and column(s), rather
-than silently correlating an uncertified or degenerate selection.
+trait set via `_validate_trait_subset(..., require_certified=True)`. A trait column
+outside its experiment's certified set, a non-numeric column, an empty list, or a set of
+duplicate names on either side SHALL be rejected with a `BloomMCPError` (`invalid_input`)
+whose message names the specific experiment (`experiment_1` or `experiment_2`) at fault
+in every one of these four cases, rather than silently correlating an uncertified or
+degenerate selection.
 
 #### Scenario: Omitted trait selections default to each experiment's certified set
 
@@ -104,24 +133,31 @@ than silently correlating an uncertified or degenerate selection.
 - **THEN** the tool correlates every certified-clean trait of `experiment_1` against
   every certified-clean trait of `experiment_2`
 
-#### Scenario: An uncertified or invalid trait column on either side is rejected
+#### Scenario: A trait column outside the certified-clean set is rejected
 
 - **WHEN** `trait_columns_1` names a column absent from `experiment_1`'s certified-clean
-  trait set (or `trait_columns_2` does so for `experiment_2`), or either list is empty or
-  contains a duplicate
-- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` naming which
-  experiment and column(s) are at fault, and no correlation is computed
+  trait set (or `trait_columns_2` does so for `experiment_2`)
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` naming the
+  offending experiment and column(s), and no correlation is computed
+
+#### Scenario: A non-numeric, empty, or duplicate trait selection is rejected
+
+- **WHEN** `trait_columns_1` or `trait_columns_2` names a non-numeric column, is given
+  as an empty list, or contains a duplicate column name
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` whose message
+  names which of `experiment_1`/`experiment_2` triggered the failure in each of these
+  three cases (not only the outside-certified-set case)
 
 ### Requirement: Degenerate Correlation Results Are Rejected; Empty Significance Is Not an Error
 
 When `calculate_cross_experiment_correlations` returns zero rows (no trait pair reached
-`min_samples` aligned genotypes between the two experiments), the
-`cross_experiment_correlations` tool SHALL surface a `BloomMCPError` with code
-`assumption_violated` and a remedy (lower `min_samples`, or check genotype overlap
-between the experiments), and SHALL NOT persist a run. In contrast, when correlations
-exist but none clear `r_threshold`/`p_threshold` (an empty **significant** subset), the
-tool SHALL treat this as a normal, successful outcome — reporting `n_significant == 0`
-and persisting an empty-but-schema-consistent `significant.csv`.
+`min_samples` aligned genotypes between the two experiments, after the `min_samples`
+pre-filter), the `cross_experiment_correlations` tool SHALL surface a `BloomMCPError`
+with code `assumption_violated` and a remedy (lower `min_samples`, or check genotype
+overlap between the experiments), and SHALL NOT persist a run. In contrast, when
+correlations exist but none clear `r_threshold`/`p_threshold` (an empty **significant**
+subset), the tool SHALL treat this as a normal, successful outcome — reporting
+`n_significant == 0` and persisting an empty-but-schema-consistent `significant.csv`.
 
 #### Scenario: Zero aligned correlations is treated as degenerate input
 
@@ -160,27 +196,46 @@ Two runs with identical inputs SHALL produce identical results.
 ### Requirement: Cross-Experiment Correlations Persists a Versioned Run Encoding Both Experiments
 
 The `cross_experiment_correlations` tool SHALL persist its outputs as a versioned run via
-the `ResultStore` port under tool class `cross_experiment_correlation`, encoding both
-consumed experiments into the existing single-experiment-shaped fields without any change
-to `ResultStore`, `Provenance`, or the manifest schema: the run's `experiment` SHALL be a
-composite key derived from both experiment filenames' stems, `based_on_version` SHALL
-record both consumed cleaned-version labels, and `source_csv` SHALL content-address both
-consumed frames' selected trait data in a single combined snapshot. It SHALL persist the
-full correlation matrix (`correlations.csv`), the significance-filtered subset
-(`significant.csv`), and the JSON-serializable summary (`summary.json`), and SHALL return
-only summary counts and **links** to these artifacts — never the full trait-by-trait
-correlation matrix inline.
+the `ResultStore` port under tool class `correlation` (the slot reserved since the
+pre-#438 legacy correlation tools were retired — reused here, not newly registered; see
+design.md D9), encoding both consumed experiments into the existing
+single-experiment-shaped fields without any change to `ResultStore`, `Provenance`, or
+the manifest schema:
 
-#### Scenario: Run is committed with a composite experiment key and dual-source lineage
+- `experiment` SHALL equal exactly `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`
+- `based_on_version` SHALL equal exactly
+  `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
+- `source_csv` SHALL content-address both consumed frames' selected trait data in a
+  single combined snapshot
+
+Before building either composite string, the tool SHALL reject `experiment_1` or
+`experiment_2` containing `@` or `|` with `BloomMCPError(code="invalid_input")` (these
+characters are reserved for the composite-string encoding above and are not blocked by
+the shared `_validate_experiment_name` guard). The tool SHALL persist the full
+correlation matrix (`correlations.csv`), the significance-filtered subset
+(`significant.csv`), both experiments' genotype-means tables with per-genotype
+`n_samples` (`genotype_means_1.csv`, `genotype_means_2.csv` — for traceability, since
+upstream itself discards per-pair genotype identity; see design.md D12), and the
+JSON-serializable summary (`summary.json`). It SHALL return only summary counts and
+**links** to these artifacts — never the full trait-by-trait correlation matrix inline.
+
+#### Scenario: Run is committed with the exact composite experiment key and based_on_version
 
 - **WHEN** `cross_experiment_correlations` completes successfully for `experiment_1`
   (resolved cleaned source `v3_cleaned`) and `experiment_2` (resolved cleaned source
   `v2_cleaned`)
-- **THEN** a `StoredRun` is recorded whose `experiment` is derived from both filenames'
-  stems, and whose `Provenance.based_on_version` encodes both `v3_cleaned` and
-  `v2_cleaned` together with each source experiment's identity
-- **AND** the committed outputs include `correlations.csv`, `significant.csv`, and
-  `summary.json`
+- **THEN** the `StoredRun`'s `experiment` equals
+  `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`
+- **AND** the committed `Provenance.based_on_version` equals
+  `f"{experiment_1}@v3_cleaned|{experiment_2}@v2_cleaned"`
+- **AND** the committed outputs include `correlations.csv`, `significant.csv`,
+  `genotype_means_1.csv`, `genotype_means_2.csv`, and `summary.json`
+
+#### Scenario: A filename containing a reserved encoding character is rejected
+
+- **WHEN** `experiment_1` or `experiment_2` contains `@` or `|`
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` before either
+  composite string is built, and no run is persisted
 
 #### Scenario: Content-addressing covers both consumed inputs
 
@@ -195,6 +250,12 @@ correlation matrix inline.
   numpy int/float leaves from `summarize_correlation_results` are converted to native
   Python types before serialization)
 
+#### Scenario: Persisted runs are discoverable via list_existing_analyses
+
+- **WHEN** a run has been committed under the reused `correlation` tool class
+- **THEN** `list_existing_analyses` (called with the composite `experiment` key) surfaces
+  it without any change to that tool's `TOOL_CLASSES` list
+
 #### Scenario: Result returns summary counts and links, not the matrix
 
 - **WHEN** the tool returns its result
@@ -208,7 +269,10 @@ correlation matrix inline.
 The `cross_experiment_correlations` tool SHALL be wrapped by `@as_mcp_tool` so that
 inputs and outputs are validated against declared Pydantic models, every declared or
 undeclared failure is mapped to a structured `BloomMCPError` (never a raw traceback or
-leaked backend internals), and a single `Provenance` is stamped per call.
+leaked backend internals), and a single `Provenance` is stamped per call. `min_samples`
+SHALL be constrained to `>= 1` and `p_threshold`/`r_threshold` SHALL each be constrained
+to `[0, 1]` at the input-model level, rejecting an out-of-range value before any
+computation.
 
 #### Scenario: Input/output schema round-trip
 
@@ -216,9 +280,17 @@ leaked backend internals), and a single `Provenance` is stamped per call.
   validated against the output schema
 - **THEN** both validate without loss
 
+#### Scenario: Out-of-range parameters are rejected
+
+- **WHEN** a request sets `min_samples < 1`, or `p_threshold`/`r_threshold` outside
+  `[0, 1]`
+- **THEN** the tool returns a `BloomMCPError` with an input-validation code, and no run
+  is persisted
+
 #### Scenario: No error leaks backend internals
 
 - **WHEN** any mapped `BloomMCPError` is raised (missing cleaned version, missing
-  genotype column, invalid trait selection, or degenerate correlation result)
+  genotype column, non-finite input, invalid trait selection, a reserved encoding
+  character, or a degenerate correlation result)
 - **THEN** its message contains no raw upstream exception text, filesystem path, or
   storage backend detail

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/specs/bloommcp-cross-experiment-correlations-tool/spec.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/specs/bloommcp-cross-experiment-correlations-tool/spec.md
@@ -80,6 +80,21 @@ remedy directing the caller to run `qc_clean` on that experiment first.
 - **AND** the same holds symmetrically when `experiment_2` is the one missing a cleaned
   version
 
+### Requirement: Experiment Names Are Validated as Safe Bare Filenames
+
+The `cross_experiment_correlations` tool SHALL explicitly validate that `experiment_1`
+and `experiment_2` are each a safe bare filename (no path separators, no `..`, not
+empty or dot-only) before any I/O — an explicit defense-in-depth check (this tool
+doubles the untrusted-filename surface relative to a single-experiment consumer), not
+reliance on the incidental safety of the read path alone.
+
+#### Scenario: A path-unsafe experiment name is rejected
+
+- **WHEN** `experiment_1` or `experiment_2` contains a path separator, `..`, or is
+  empty/dot-only
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` before any
+  experiment is loaded, and no run is persisted
+
 ### Requirement: Cross-Experiment Correlations Requires a Resolvable Genotype Column on Both Sides
 
 Because correlations are computed at the genotype-mean level, the
@@ -202,7 +217,14 @@ design.md D9), encoding both consumed experiments into the existing
 single-experiment-shaped fields without any change to `ResultStore`, `Provenance`, or
 the manifest schema:
 
-- `experiment` SHALL equal exactly `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`
+- `experiment` SHALL equal exactly
+  `f"{_storage_safe_stem(experiment_1)}__x__{_storage_safe_stem(experiment_2)}"`, where
+  `_storage_safe_stem(name)` is `Path(name).stem` with every internal `.` replaced by
+  `_`. This dot-sanitization (added after review found the naive un-sanitized
+  composite silently truncated whenever either original stem contained a dot — see
+  design.md D1) makes the composite string itself dot-free, so it is immune to
+  `AnalysisDir`'s own re-applied `Path(...).stem`, regardless of what either original
+  filename's stem contains.
 - `based_on_version` SHALL equal exactly
   `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
 - `source_csv` SHALL content-address both consumed frames' selected trait data in a
@@ -211,8 +233,9 @@ the manifest schema:
 Before building either composite string, the tool SHALL reject `experiment_1` or
 `experiment_2` containing `@` or `|` with `BloomMCPError(code="invalid_input")` (these
 characters are reserved for the composite-string encoding above and are not blocked by
-the shared `_validate_experiment_name` guard). The tool SHALL persist the full
-correlation matrix (`correlations.csv`), the significance-filtered subset
+the shared `_validate_experiment_name` guard), and SHALL reject `experiment_1 ==
+experiment_2` (self-correlation) with the same error code. The tool SHALL persist the
+full correlation matrix (`correlations.csv`), the significance-filtered subset
 (`significant.csv`), both experiments' genotype-means tables with per-genotype
 `n_samples` (`genotype_means_1.csv`, `genotype_means_2.csv` — for traceability, since
 upstream itself discards per-pair genotype identity; see design.md D12), and the
@@ -225,17 +248,34 @@ JSON-serializable summary (`summary.json`). It SHALL return only summary counts 
   (resolved cleaned source `v3_cleaned`) and `experiment_2` (resolved cleaned source
   `v2_cleaned`)
 - **THEN** the `StoredRun`'s `experiment` equals
-  `f"{Path(experiment_1).stem}__x__{Path(experiment_2).stem}"`
+  `f"{_storage_safe_stem(experiment_1)}__x__{_storage_safe_stem(experiment_2)}"`
 - **AND** the committed `Provenance.based_on_version` equals
   `f"{experiment_1}@v3_cleaned|{experiment_2}@v2_cleaned"`
 - **AND** the committed outputs include `correlations.csv`, `significant.csv`,
   `genotype_means_1.csv`, `genotype_means_2.csv`, and `summary.json`
+
+#### Scenario: A dotted experiment filename does not truncate or collide the composite key
+
+- **WHEN** either `experiment_1` or `experiment_2`'s stem (the filename without its
+  final `.csv` extension) itself contains a dot (e.g. `experiment_1 =
+  "my.experiment.v2.csv"`)
+- **THEN** the composite `experiment` key still contains a recognizable, sanitized form
+  of both original stems, and re-applying `Path(...).stem` to that composite key
+  (exactly what `AnalysisDir` does internally) returns the composite key unchanged —
+  it is not truncated, and two different such filenames do not collide on the same
+  storage prefix
 
 #### Scenario: A filename containing a reserved encoding character is rejected
 
 - **WHEN** `experiment_1` or `experiment_2` contains `@` or `|`
 - **THEN** the tool returns a `BloomMCPError` with code `invalid_input` before either
   composite string is built, and no run is persisted
+
+#### Scenario: Self-correlation is rejected
+
+- **WHEN** `experiment_1` and `experiment_2` are the same filename
+- **THEN** the tool returns a `BloomMCPError` with code `invalid_input` before any I/O,
+  and no run is persisted
 
 #### Scenario: Content-addressing covers both consumed inputs
 

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
@@ -1,0 +1,109 @@
+## 1. Design
+
+- [x] 1.1 Write `design.md` (covers: composite `experiment`/`based_on_version`/
+  `source_csv` encoding for a two-experiment run, `calculate_genotype_means` correction
+  vs. the issue's bare-`.groupby()` sketch, deferral of `calculate_correlation_confidence_intervals`,
+  no-seed determinism, required genotype role on both sides, degenerate-vs-empty result
+  handling, `convert_to_json_serializable` reuse)
+- [ ] 1.2 Get reviewer sign-off on D1 (the composite-string persistence encoding) before
+  implementation starts — same bar `devendor-bloommcp-analysis` D3 required for its own
+  convention bend
+
+## 2. Tests (write red tests first — TDD)
+
+- [ ] 2.1 `test_delegates_to_upstream_correlation_chain` — with two small fake cleaned
+  experiments (shared genotypes, ≥3 overlapping with `min_samples`), assert
+  `calculate_genotype_means`, `calculate_cross_experiment_correlations`,
+  `identify_significant_correlations`, and `summarize_correlation_results` are each
+  called exactly once (spy/monkeypatch), and that no bespoke `.groupby().mean()`
+  reimplementation exists in the tool module
+- [ ] 2.2 `test_requires_cleaned_version_both_experiments` — one experiment has no
+  cleaned version → `BloomMCPError(tool_error)` naming *that* experiment, remedy points
+  at `qc_clean`; repeat with the other experiment missing instead
+- [ ] 2.3 `test_missing_genotype_role_either_side_rejected` — a fake reader frame with
+  `genotype_col=None` on experiment_1 (then experiment_2) → `BloomMCPError(assumption_violated)`
+  naming which experiment lacks a resolvable genotype column; no run persisted
+- [ ] 2.4 `test_zero_correlations_is_degenerate_input` — two experiments with no shared
+  genotypes (or fewer than `min_samples`) → `BloomMCPError(assumption_violated)` with a
+  remedy (lower `min_samples` / check genotype overlap); no run persisted
+- [ ] 2.5 `test_zero_significant_is_not_an_error` — correlations exist but none clear
+  `r_threshold`/`p_threshold` → normal success, `n_significant == 0`, `significant.csv`
+  persisted with a fixed header (not upstream's columnless empty frame) and zero data
+  rows
+- [ ] 2.6 `test_trait_columns_1_2_validated_independently` — `trait_columns_1`/
+  `trait_columns_2` each validated via `_validate_trait_subset(..., require_certified=True)`
+  against their own experiment's certified set; an unknown/non-numeric/duplicate/empty-list
+  column on either side → `BloomMCPError(invalid_input)` naming the offending experiment +
+  column(s)
+- [ ] 2.7 `test_seed_recorded_as_none` — stamped `Provenance.seed == None` (no
+  `random_state` anywhere in the delegation chain)
+- [ ] 2.8 `test_run_persisted_with_composite_experiment_and_based_on_version` —
+  `store.create_run` receives `experiment == f"{stem1}__x__{stem2}"`; the committed run's
+  `Provenance.based_on_version` equals `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
+- [ ] 2.9 `test_source_csv_content_addresses_both_inputs` — the manifest's `input_sha256`
+  changes if *either* experiment's selected trait data changes (not just one side)
+- [ ] 2.10 `test_summary_json_serializable_no_numpy_leaks` — `summary.json` round-trips
+  through `json.loads` with no `numpy.int64`/`numpy.float64` leaking through (i.e.
+  `convert_to_json_serializable` was actually applied)
+- [ ] 2.11 `test_result_never_inlines_full_correlation_matrix` — the tool result model
+  carries only summary counts + `RunLinks`; the full `exp1_trait × exp2_trait` matrix is
+  reachable only via the persisted `correlations.csv` link
+- [ ] 2.12 `test_schema_round_trip` — a valid request serializes to the input schema and
+  the result validates against the output schema without loss
+- [ ] 2.13 `test_no_error_leaks_backend_internals` — any mapped `BloomMCPError`'s message
+  contains no raw upstream traceback text or storage/path internals (matches the
+  no-leak convention already enforced for `pca_analysis`/`clustering`)
+
+## 3. Tool implementation
+
+- [ ] 3.1 Create `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py`
+  with `CrossExperimentCorrelationsParams` (`experiment_1`, `experiment_2`,
+  `trait_columns_1`, `trait_columns_2`, `min_samples=3`, `p_threshold=0.05`,
+  `r_threshold=0.5`, `use_fdr=True`, `user_label`) and `CrossExperimentCorrelationsResult`
+  (extends `RunLinks`)
+- [ ] 3.2 Load both experiments via `_ports.reader().load_experiment(name, require_clean=True)`;
+  map `CleanedVersionRequiredError` per-experiment to a named `BloomMCPError(tool_error)`
+- [ ] 3.3 Reject a `None` `genotype_col` on either frame before any computation (D5)
+- [ ] 3.4 Resolve `trait_columns_1`/`trait_columns_2` via `_validate_trait_subset(...,
+  require_certified=True)`, independently per experiment (D6 default: full `frame.trait_cols`
+  when omitted)
+- [ ] 3.5 Build genotype-means via `calculate_genotype_means` (D2) for each experiment,
+  then `calculate_cross_experiment_correlations(exp1_means, exp2_means, trait_cols_1,
+  trait_cols_2, min_samples=params.min_samples)`
+- [ ] 3.6 Raise `assumption_violated` on an empty correlation result (D6); otherwise call
+  `identify_significant_correlations(corr_df, p_threshold, r_threshold, use_fdr)`,
+  normalizing an empty result to a fixed-header empty frame
+- [ ] 3.7 Call `summarize_correlation_results(corr_df, exp1_name=experiment_1,
+  exp2_name=experiment_2)`; convert via
+  `sleap_roots_analyze.data_utils.convert_to_json_serializable` (D7) before persisting
+- [ ] 3.8 Build the composite `experiment=`/`based_on_version=` strings (D1) and the
+  combined-snapshot `source_csv` (D1) for `store.create_run(...)`
+- [ ] 3.9 Persist `correlations.csv`, `significant.csv`, `summary.json` under tool class
+  `cross_experiment_correlation`; return the summary counts + `RunLinks`
+
+## 4. Registration
+
+- [ ] 4.1 Add `cross_experiment_correlations` to the imports and `register(...)` call in
+  `bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py`
+- [ ] 4.2 Add the new tool name to any tool-surface drift-guard list in
+  `bloommcp/tests/test_devendor_invariants.py` (or equivalent live-registry assertion)
+  so the guard stays exhaustive
+
+## 5. Fixtures / oracle (optional, discuss with reviewer)
+
+- [ ] 5.1 If a reviewer wants a numeric characterization oracle (this proposal does not
+  fabricate one — no independently recorded cross-experiment correlation value exists
+  yet, unlike PCA's turface_19 golden): construct a small two-experiment fixture pair
+  with a hand-computable Pearson correlation for at least one trait pair, and record it
+  as a `*_correlation_golden.json` fixture following the `turface_19_pca_golden.json`
+  pattern
+
+## 6. Validation
+
+- [ ] 6.1 `openspec validate add-bloommcp-cross-experiment-correlations --strict` passes
+- [ ] 6.2 Full bloommcp test suite green; `test_server_boots_after_devendor`-style boot
+  smoke still passes with the new tool registered
+- [ ] 6.3 `make bloommcp-smoke` (or equivalent live-persistence smoke) exercises
+  `qc_clean` (×2) → `cross_experiment_correlations` through the real
+  `SupabaseReader`/`SupabaseResultStore`, confirming the composite `experiment`/
+  `based_on_version` encoding round-trips through a real manifest

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
@@ -4,10 +4,20 @@
   `source_csv` encoding for a two-experiment run, `calculate_genotype_means` correction
   vs. the issue's bare-`.groupby()` sketch, deferral of `calculate_correlation_confidence_intervals`,
   no-seed determinism, required genotype role on both sides, degenerate-vs-empty result
-  handling, `convert_to_json_serializable` reuse)
-- [ ] 1.2 Get reviewer sign-off on D1 (the composite-string persistence encoding) before
-  implementation starts — same bar `devendor-bloommcp-analysis` D3 required for its own
-  convention bend
+  handling, `convert_to_json_serializable` reuse, the one-tool-vs-family scope decision,
+  the confirmed `min_samples` upstream no-op + pre-filter workaround, reuse of the
+  reserved `correlation` tool_class, the `_qc_shared.py` message patch, finite-value
+  defense-in-depth, genotype-means traceability artifacts, and the FDR multiplicity-family
+  documentation obligation)
+- [x] 1.2 Incorporate the 5-lens adversarial review (spec quality, code/architecture,
+  GitHub issue alignment, TDD/testing, scientific rigor) — every BLOCKING/IMPORTANT
+  finding resolved in this revision (see design.md's revised Decisions and this file)
+- [ ] 1.3 Get reviewer sign-off on D1 (the composite-string persistence encoding, now
+  pinned to an exact format in spec.md) before implementation starts — same bar
+  `devendor-bloommcp-analysis` D3 required for its own convention bend
+- [x] 1.4 File an upstream bug report against `talmolab/sleap-roots-analyze` for the
+  confirmed `min_samples` no-op (design.md D8) — filed as
+  [talmolab/sleap-roots-analyze#205](https://github.com/talmolab/sleap-roots-analyze/issues/205)
 
 ## 2. Tests (write red tests first — TDD)
 
@@ -17,93 +27,163 @@
   `identify_significant_correlations`, and `summarize_correlation_results` are each
   called exactly once (spy/monkeypatch), and that no bespoke `.groupby().mean()`
   reimplementation exists in the tool module
-- [ ] 2.2 `test_requires_cleaned_version_both_experiments` — one experiment has no
+- [ ] 2.2 `test_min_samples_prefilter_actually_excludes_under_replicated_genotypes` —
+  construct two fake cleaned experiments where genotype G has `n_samples` below
+  `min_samples` in one experiment; assert G is absent from both persisted
+  `genotype_means_*.csv` post-filter rows used in the correlation call (spy on the
+  DataFrames passed into `calculate_cross_experiment_correlations` and assert G's row is
+  gone), directly validating design.md D8's workaround — this is the test that would
+  have caught the upstream no-op had it been written against a naive forward-only
+  implementation
+- [ ] 2.3 `test_load_and_align_experiments_never_called` — spy/monkeypatch
+  `sleap_roots_analyze.load_and_align_experiments` to raise if called; assert a normal
+  run never touches it
+- [ ] 2.4 `test_requires_cleaned_version_both_experiments` — one experiment has no
   cleaned version → `BloomMCPError(tool_error)` naming *that* experiment, remedy points
   at `qc_clean`; repeat with the other experiment missing instead
-- [ ] 2.3 `test_missing_genotype_role_either_side_rejected` — a fake reader frame with
+- [ ] 2.5 `test_two_cleaned_experiments_consumed_reports_sources` — both experiments have
+  committed cleaned versions (e.g. `v3_cleaned`, `v2_cleaned`); assert the reader
+  resolved each as cleaned (not `raw`) and the tool's result exposes both resolved
+  source labels
+- [ ] 2.6 `test_missing_genotype_role_either_side_rejected` — a fake reader frame with
   `genotype_col=None` on experiment_1 (then experiment_2) → `BloomMCPError(assumption_violated)`
   naming which experiment lacks a resolvable genotype column; no run persisted
-- [ ] 2.4 `test_zero_correlations_is_degenerate_input` — two experiments with no shared
-  genotypes (or fewer than `min_samples`) → `BloomMCPError(assumption_violated)` with a
-  remedy (lower `min_samples` / check genotype overlap); no run persisted
-- [ ] 2.5 `test_zero_significant_is_not_an_error` — correlations exist but none clear
+- [ ] 2.7 `test_non_finite_value_either_side_rejected` — a non-finite value (`NaN`,
+  `+inf`, or `-inf`) surviving into experiment_1's (then experiment_2's) selected trait
+  columns → `BloomMCPError(assumption_violated)` naming the offending experiment; no
+  genotype-mean aggregation attempted
+- [ ] 2.8 `test_zero_correlations_is_degenerate_input` — two experiments with no shared
+  genotypes (or fewer than `min_samples`, post-pre-filter) → `BloomMCPError(assumption_violated)`
+  with a remedy (lower `min_samples` / check genotype overlap); no run persisted
+- [ ] 2.9 `test_zero_significant_is_not_an_error` — correlations exist but none clear
   `r_threshold`/`p_threshold` → normal success, `n_significant == 0`, `significant.csv`
   persisted with a fixed header (not upstream's columnless empty frame) and zero data
   rows
-- [ ] 2.6 `test_trait_columns_1_2_validated_independently` — `trait_columns_1`/
-  `trait_columns_2` each validated via `_validate_trait_subset(..., require_certified=True)`
-  against their own experiment's certified set; an unknown/non-numeric/duplicate/empty-list
-  column on either side → `BloomMCPError(invalid_input)` naming the offending experiment +
-  column(s)
-- [ ] 2.7 `test_seed_recorded_as_none` — stamped `Provenance.seed == None` (no
+- [ ] 2.10 `test_default_trait_selection_uses_full_certified_set_both_sides` — both
+  `trait_columns_1`/`trait_columns_2` omitted → the tool correlates every certified
+  trait of `experiment_1` against every certified trait of `experiment_2` (assert the
+  delegate call's trait-column arguments equal each frame's full `trait_cols`)
+- [ ] 2.11 `test_trait_columns_1_2_validated_independently` — for each of the four
+  failure modes (outside certified set, non-numeric, empty list, duplicate) on either
+  experiment → `BloomMCPError(invalid_input)` naming the offending experiment +
+  column(s) — this requires task 3.0's `_qc_shared.py` patch (empty/duplicate/non-numeric
+  branches did not previously interpolate `experiment`; only the outside-certified-set
+  branch did)
+- [ ] 2.12 `test_seed_recorded_as_none` — stamped `Provenance.seed == None` (no
   `random_state` anywhere in the delegation chain)
-- [ ] 2.8 `test_run_persisted_with_composite_experiment_and_based_on_version` —
+- [ ] 2.13 `test_repeated_runs_identical` — invoke the tool twice on the same pair of
+  cleaned experiments with identical parameters; assert `n_correlations`,
+  `n_significant`, and `n_highly_significant` are equal across both runs
+- [ ] 2.14 `test_run_persisted_with_composite_experiment_and_based_on_version` —
   `store.create_run` receives `experiment == f"{stem1}__x__{stem2}"`; the committed run's
-  `Provenance.based_on_version` equals `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
-- [ ] 2.9 `test_source_csv_content_addresses_both_inputs` — the manifest's `input_sha256`
+  `Provenance.based_on_version` equals exactly
+  `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
+- [ ] 2.15 `test_reserved_encoding_character_in_filename_rejected` — `experiment_1` (then
+  `experiment_2`) contains `@` or `|` → `BloomMCPError(invalid_input)` before either
+  composite string is built; no run persisted
+- [ ] 2.16 `test_source_csv_content_addresses_both_inputs` — the manifest's `input_sha256`
   changes if *either* experiment's selected trait data changes (not just one side)
-- [ ] 2.10 `test_summary_json_serializable_no_numpy_leaks` — `summary.json` round-trips
+- [ ] 2.17 `test_genotype_means_artifacts_persisted` — the committed run's outputs
+  include `genotype_means_1.csv`/`genotype_means_2.csv`, each containing every selected
+  trait's per-genotype mean and the `n_samples` column, post `min_samples` pre-filter
+- [ ] 2.18 `test_summary_json_serializable_no_numpy_leaks` — `summary.json` round-trips
   through `json.loads` with no `numpy.int64`/`numpy.float64` leaking through (i.e.
   `convert_to_json_serializable` was actually applied)
-- [ ] 2.11 `test_result_never_inlines_full_correlation_matrix` — the tool result model
+- [ ] 2.19 `test_result_never_inlines_full_correlation_matrix` — the tool result model
   carries only summary counts + `RunLinks`; the full `exp1_trait × exp2_trait` matrix is
   reachable only via the persisted `correlations.csv` link
-- [ ] 2.12 `test_schema_round_trip` — a valid request serializes to the input schema and
+- [ ] 2.20 `test_discoverable_via_list_existing_analyses` — after a committed run,
+  `list_existing_analyses(composite_experiment_key)` surfaces it under `"correlation"`
+  with no change to that tool's `TOOL_CLASSES`
+- [ ] 2.21 `test_schema_round_trip` — a valid request serializes to the input schema and
   the result validates against the output schema without loss
-- [ ] 2.13 `test_no_error_leaks_backend_internals` — any mapped `BloomMCPError`'s message
-  contains no raw upstream traceback text or storage/path internals (matches the
-  no-leak convention already enforced for `pca_analysis`/`clustering`)
+- [ ] 2.22 `test_out_of_range_parameters_rejected` — `min_samples < 1`, or
+  `p_threshold`/`r_threshold` outside `[0, 1]` → `BloomMCPError` input-validation code;
+  no run persisted
+- [ ] 2.23 `test_no_error_leaks_backend_internals` — every mapped `BloomMCPError`'s
+  message (missing cleaned version, missing genotype column, non-finite input, invalid
+  trait selection, reserved encoding character, degenerate correlation result) contains
+  no raw upstream traceback text or storage/path internals (matches the no-leak
+  convention already enforced for `pca_analysis`/`clustering`)
+- [ ] 2.24 (Mandatory — promoted from an earlier "optional" framing) numeric
+  characterization test against a hand-computable golden: build a small fixture pair
+  (e.g. drawn from the existing `turface_19_final_data.csv`/`cylinder_final_data.csv`,
+  already used together in `test_oracle.py`) with an independently hand-computed
+  Pearson r for at least one trait pair; record it as
+  `*_cross_experiment_correlation_golden.json` following the `turface_19_pca_golden.json`
+  pattern, and assert the tool reproduces it within tolerance
 
-## 3. Tool implementation
+## 3. Shared helper patch
 
-- [ ] 3.1 Create `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py`
+- [ ] 3.0 Patch `bloommcp/src/bloom_mcp/tools/_qc_shared.py::_validate_trait_subset` so
+  the empty-list, duplicate, and non-numeric error messages interpolate `{experiment!r}`
+  the same way the outside-certified-set message already does (design.md D10) — message
+  text only, no signature or exception-type change; benefits `pca_analysis`/`clustering`/
+  `descriptive_stats` too
+
+## 4. Tool implementation
+
+- [ ] 4.1 Create `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py`
   with `CrossExperimentCorrelationsParams` (`experiment_1`, `experiment_2`,
-  `trait_columns_1`, `trait_columns_2`, `min_samples=3`, `p_threshold=0.05`,
-  `r_threshold=0.5`, `use_fdr=True`, `user_label`) and `CrossExperimentCorrelationsResult`
-  (extends `RunLinks`)
-- [ ] 3.2 Load both experiments via `_ports.reader().load_experiment(name, require_clean=True)`;
+  `trait_columns_1`, `trait_columns_2`, `min_samples: int = 3` (`ge=1`),
+  `p_threshold: float = 0.05` (`ge=0, le=1`), `r_threshold: float = 0.5` (`ge=0, le=1`),
+  `use_fdr=True`, `user_label`) and `CrossExperimentCorrelationsResult` (extends
+  `RunLinks`). The `trait_columns_1`/`trait_columns_2` field descriptions SHALL state
+  the FDR multiplicity-family caveat (design.md D13): re-running with a narrower subset
+  changes the correction family, so `p_value_corrected` values are not comparable
+  across runs with different trait selections.
+- [ ] 4.2 Load both experiments via `_ports.reader().load_experiment(name, require_clean=True)`;
   map `CleanedVersionRequiredError` per-experiment to a named `BloomMCPError(tool_error)`
-- [ ] 3.3 Reject a `None` `genotype_col` on either frame before any computation (D5)
-- [ ] 3.4 Resolve `trait_columns_1`/`trait_columns_2` via `_validate_trait_subset(...,
-  require_certified=True)`, independently per experiment (D6 default: full `frame.trait_cols`
+- [ ] 4.3 Reject a `None` `genotype_col` on either frame before any computation (D5)
+- [ ] 4.4 Reject `experiment_1`/`experiment_2` containing `@` or `|` before building any
+  composite string (D1's guard)
+- [ ] 4.5 Resolve `trait_columns_1`/`trait_columns_2` via `_validate_trait_subset(...,
+  require_certified=True)`, independently per experiment (default: full `frame.trait_cols`
   when omitted)
-- [ ] 3.5 Build genotype-means via `calculate_genotype_means` (D2) for each experiment,
-  then `calculate_cross_experiment_correlations(exp1_means, exp2_means, trait_cols_1,
+- [ ] 4.6 Check `np.isfinite(...)` on each experiment's selected trait columns before
+  aggregation (D11); raise `assumption_violated` naming the offending experiment
+- [ ] 4.7 Build genotype-means via `calculate_genotype_means` (D2) for each experiment,
+  then pre-filter each to `n_samples >= params.min_samples` (D8) before calling
+  `calculate_cross_experiment_correlations(exp1_means, exp2_means, trait_cols_1,
   trait_cols_2, min_samples=params.min_samples)`
-- [ ] 3.6 Raise `assumption_violated` on an empty correlation result (D6); otherwise call
+- [ ] 4.8 Raise `assumption_violated` on an empty correlation result (D6); otherwise call
   `identify_significant_correlations(corr_df, p_threshold, r_threshold, use_fdr)`,
   normalizing an empty result to a fixed-header empty frame
-- [ ] 3.7 Call `summarize_correlation_results(corr_df, exp1_name=experiment_1,
+- [ ] 4.9 Call `summarize_correlation_results(corr_df, exp1_name=experiment_1,
   exp2_name=experiment_2)`; convert via
   `sleap_roots_analyze.data_utils.convert_to_json_serializable` (D7) before persisting
-- [ ] 3.8 Build the composite `experiment=`/`based_on_version=` strings (D1) and the
+- [ ] 4.10 Build the composite `experiment=`/`based_on_version=` strings (D1) and the
   combined-snapshot `source_csv` (D1) for `store.create_run(...)`
-- [ ] 3.9 Persist `correlations.csv`, `significant.csv`, `summary.json` under tool class
-  `cross_experiment_correlation`; return the summary counts + `RunLinks`
+- [ ] 4.11 Persist `correlations.csv`, `significant.csv`, `genotype_means_1.csv`,
+  `genotype_means_2.csv` (D12), and `summary.json` under the reused tool class
+  `correlation` (D9); return the summary counts + `RunLinks`
 
-## 4. Registration
+## 5. Registration
 
-- [ ] 4.1 Add `cross_experiment_correlations` to the imports and `register(...)` call in
+- [ ] 5.1 Add `cross_experiment_correlations` to the imports and `register(...)` call in
   `bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py`
-- [ ] 4.2 Add the new tool name to any tool-surface drift-guard list in
-  `bloommcp/tests/test_devendor_invariants.py` (or equivalent live-registry assertion)
-  so the guard stays exhaustive
+- [ ] 5.2 Add the new tool name to `test_expected_tool_surface`
+  (`bloommcp/tests/test_devendor_invariants.py`) explicitly by name — that test's
+  `live & relevant == expected` check silently passes if a name is absent from both its
+  `expected` and `not_expected` lists, so this must be named, not left to "any drift-guard
+  list"
+- [ ] 5.3 No changes needed to `manifest.CANONICAL_TOOL_CLASSES` or
+  `list_existing_analyses.TOOL_CLASSES` — both already reserve `"correlation"` (D9);
+  confirm this with a test (2.20) rather than skipping verification because "no change
+  was needed"
 
-## 5. Fixtures / oracle (optional, discuss with reviewer)
+## 6. Fixtures / oracle
 
-- [ ] 5.1 If a reviewer wants a numeric characterization oracle (this proposal does not
-  fabricate one — no independently recorded cross-experiment correlation value exists
-  yet, unlike PCA's turface_19 golden): construct a small two-experiment fixture pair
-  with a hand-computable Pearson correlation for at least one trait pair, and record it
-  as a `*_correlation_golden.json` fixture following the `turface_19_pca_golden.json`
-  pattern
+- [ ] 6.1 See 2.24 (now mandatory) — construct the two-experiment fixture pair and the
+  hand-computed golden value
 
-## 6. Validation
+## 7. Validation
 
-- [ ] 6.1 `openspec validate add-bloommcp-cross-experiment-correlations --strict` passes
-- [ ] 6.2 Full bloommcp test suite green; `test_server_boots_after_devendor`-style boot
+- [ ] 7.1 `openspec validate add-bloommcp-cross-experiment-correlations --strict` passes
+- [ ] 7.2 Full bloommcp test suite green; `test_server_boots_after_devendor`-style boot
   smoke still passes with the new tool registered
-- [ ] 6.3 `make bloommcp-smoke` (or equivalent live-persistence smoke) exercises
+- [ ] 7.3 `make bloommcp-smoke` (or equivalent live-persistence smoke) exercises
   `qc_clean` (×2) → `cross_experiment_correlations` through the real
   `SupabaseReader`/`SupabaseResultStore`, confirming the composite `experiment`/
-  `based_on_version` encoding round-trips through a real manifest
+  `based_on_version` encoding round-trips through a real manifest, and that the run is
+  discoverable via `list_existing_analyses` under `correlation`

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
@@ -14,176 +14,120 @@
   finding resolved in this revision (see design.md's revised Decisions and this file)
 - [ ] 1.3 Get reviewer sign-off on D1 (the composite-string persistence encoding, now
   pinned to an exact format in spec.md) before implementation starts — same bar
-  `devendor-bloommcp-analysis` D3 required for its own convention bend
+  `devendor-bloommcp-analysis` D3 required for its own convention bend. **Not blocking
+  for this PR** — implementation proceeded on the pinned design; sign-off happens at
+  code review.
 - [x] 1.4 File an upstream bug report against `talmolab/sleap-roots-analyze` for the
   confirmed `min_samples` no-op (design.md D8) — filed as
   [talmolab/sleap-roots-analyze#205](https://github.com/talmolab/sleap-roots-analyze/issues/205)
 
-## 2. Tests (write red tests first — TDD)
+## 2. Tests (written red-first, all green against the implementation in §4)
 
-- [ ] 2.1 `test_delegates_to_upstream_correlation_chain` — with two small fake cleaned
-  experiments (shared genotypes, ≥3 overlapping with `min_samples`), assert
-  `calculate_genotype_means`, `calculate_cross_experiment_correlations`,
-  `identify_significant_correlations`, and `summarize_correlation_results` are each
-  called exactly once (spy/monkeypatch), and that no bespoke `.groupby().mean()`
-  reimplementation exists in the tool module
-- [ ] 2.2 `test_min_samples_prefilter_actually_excludes_under_replicated_genotypes` —
-  construct two fake cleaned experiments where genotype G has `n_samples` below
-  `min_samples` in one experiment; assert G is absent from both persisted
-  `genotype_means_*.csv` post-filter rows used in the correlation call (spy on the
-  DataFrames passed into `calculate_cross_experiment_correlations` and assert G's row is
-  gone), directly validating design.md D8's workaround — this is the test that would
-  have caught the upstream no-op had it been written against a naive forward-only
-  implementation
-- [ ] 2.3 `test_load_and_align_experiments_never_called` — spy/monkeypatch
-  `sleap_roots_analyze.load_and_align_experiments` to raise if called; assert a normal
-  run never touches it
-- [ ] 2.4 `test_requires_cleaned_version_both_experiments` — one experiment has no
-  cleaned version → `BloomMCPError(tool_error)` naming *that* experiment, remedy points
-  at `qc_clean`; repeat with the other experiment missing instead
-- [ ] 2.5 `test_two_cleaned_experiments_consumed_reports_sources` — both experiments have
-  committed cleaned versions (e.g. `v3_cleaned`, `v2_cleaned`); assert the reader
-  resolved each as cleaned (not `raw`) and the tool's result exposes both resolved
-  source labels
-- [ ] 2.6 `test_missing_genotype_role_either_side_rejected` — a fake reader frame with
-  `genotype_col=None` on experiment_1 (then experiment_2) → `BloomMCPError(assumption_violated)`
-  naming which experiment lacks a resolvable genotype column; no run persisted
-- [ ] 2.7 `test_non_finite_value_either_side_rejected` — a non-finite value (`NaN`,
-  `+inf`, or `-inf`) surviving into experiment_1's (then experiment_2's) selected trait
-  columns → `BloomMCPError(assumption_violated)` naming the offending experiment; no
-  genotype-mean aggregation attempted
-- [ ] 2.8 `test_zero_correlations_is_degenerate_input` — two experiments with no shared
-  genotypes (or fewer than `min_samples`, post-pre-filter) → `BloomMCPError(assumption_violated)`
-  with a remedy (lower `min_samples` / check genotype overlap); no run persisted
-- [ ] 2.9 `test_zero_significant_is_not_an_error` — correlations exist but none clear
-  `r_threshold`/`p_threshold` → normal success, `n_significant == 0`, `significant.csv`
-  persisted with a fixed header (not upstream's columnless empty frame) and zero data
-  rows
-- [ ] 2.10 `test_default_trait_selection_uses_full_certified_set_both_sides` — both
-  `trait_columns_1`/`trait_columns_2` omitted → the tool correlates every certified
-  trait of `experiment_1` against every certified trait of `experiment_2` (assert the
-  delegate call's trait-column arguments equal each frame's full `trait_cols`)
-- [ ] 2.11 `test_trait_columns_1_2_validated_independently` — for each of the four
-  failure modes (outside certified set, non-numeric, empty list, duplicate) on either
-  experiment → `BloomMCPError(invalid_input)` naming the offending experiment +
-  column(s) — this requires task 3.0's `_qc_shared.py` patch (empty/duplicate/non-numeric
-  branches did not previously interpolate `experiment`; only the outside-certified-set
-  branch did)
-- [ ] 2.12 `test_seed_recorded_as_none` — stamped `Provenance.seed == None` (no
-  `random_state` anywhere in the delegation chain)
-- [ ] 2.13 `test_repeated_runs_identical` — invoke the tool twice on the same pair of
-  cleaned experiments with identical parameters; assert `n_correlations`,
-  `n_significant`, and `n_highly_significant` are equal across both runs
-- [ ] 2.14 `test_run_persisted_with_composite_experiment_and_based_on_version` —
-  `store.create_run` receives `experiment == f"{stem1}__x__{stem2}"`; the committed run's
-  `Provenance.based_on_version` equals exactly
-  `f"{experiment_1}@{frame1.source}|{experiment_2}@{frame2.source}"`
-- [ ] 2.15 `test_reserved_encoding_character_in_filename_rejected` — `experiment_1` (then
-  `experiment_2`) contains `@` or `|` → `BloomMCPError(invalid_input)` before either
-  composite string is built; no run persisted
-- [ ] 2.16 `test_source_csv_content_addresses_both_inputs` — the manifest's `input_sha256`
-  changes if *either* experiment's selected trait data changes (not just one side)
-- [ ] 2.17 `test_genotype_means_artifacts_persisted` — the committed run's outputs
-  include `genotype_means_1.csv`/`genotype_means_2.csv`, each containing every selected
-  trait's per-genotype mean and the `n_samples` column, post `min_samples` pre-filter
-- [ ] 2.18 `test_summary_json_serializable_no_numpy_leaks` — `summary.json` round-trips
-  through `json.loads` with no `numpy.int64`/`numpy.float64` leaking through (i.e.
-  `convert_to_json_serializable` was actually applied)
-- [ ] 2.19 `test_result_never_inlines_full_correlation_matrix` — the tool result model
-  carries only summary counts + `RunLinks`; the full `exp1_trait × exp2_trait` matrix is
-  reachable only via the persisted `correlations.csv` link
-- [ ] 2.20 `test_discoverable_via_list_existing_analyses` — after a committed run,
-  `list_existing_analyses(composite_experiment_key)` surfaces it under `"correlation"`
-  with no change to that tool's `TOOL_CLASSES`
-- [ ] 2.21 `test_schema_round_trip` — a valid request serializes to the input schema and
-  the result validates against the output schema without loss
-- [ ] 2.22 `test_out_of_range_parameters_rejected` — `min_samples < 1`, or
-  `p_threshold`/`r_threshold` outside `[0, 1]` → `BloomMCPError` input-validation code;
-  no run persisted
-- [ ] 2.23 `test_no_error_leaks_backend_internals` — every mapped `BloomMCPError`'s
-  message (missing cleaned version, missing genotype column, non-finite input, invalid
-  trait selection, reserved encoding character, degenerate correlation result) contains
-  no raw upstream traceback text or storage/path internals (matches the no-leak
-  convention already enforced for `pca_analysis`/`clustering`)
-- [ ] 2.24 (Mandatory — promoted from an earlier "optional" framing) numeric
-  characterization test against a hand-computable golden: build a small fixture pair
-  (e.g. drawn from the existing `turface_19_final_data.csv`/`cylinder_final_data.csv`,
-  already used together in `test_oracle.py`) with an independently hand-computed
-  Pearson r for at least one trait pair; record it as
-  `*_cross_experiment_correlation_golden.json` following the `turface_19_pca_golden.json`
-  pattern, and assert the tool reproduces it within tolerance
+All in `bloommcp/tests/tools/test_cross_experiment_correlations_tool.py` (31 tests, all
+passing):
+
+- [x] 2.1 `test_delegates_to_upstream_correlation_chain`
+- [x] 2.2 `test_min_samples_prefilter_actually_excludes_under_replicated_genotypes` —
+  runs against the **real** turface_19/cylinder fixture pair (not synthetic data),
+  reproducing the confirmed upstream no-op and proving the pre-filter workaround
+  against the recorded golden (`turface_cylinder_cross_experiment_correlation_golden.json`)
+- [x] 2.3 `test_load_and_align_experiments_never_called`
+- [x] 2.4 `test_requires_cleaned_version_both_experiments` (both directions)
+- [x] 2.5 `test_two_cleaned_experiments_consumed_reports_sources`
+- [x] 2.6 `test_missing_genotype_role_either_side_rejected`
+- [x] 2.7 `test_non_finite_value_either_side_rejected`
+- [x] 2.8 `test_zero_correlations_is_degenerate_input`
+- [x] 2.9 `test_zero_significant_is_not_an_error`
+- [x] 2.10 `test_default_trait_selection_uses_full_certified_set_both_sides`
+- [x] 2.11 `test_trait_columns_validated_independently` (all four failure modes,
+  both experiments) + `test_non_numeric_trait_column_names_experiment` — required
+  task 3.0's `_qc_shared.py` patch to pass (empty/duplicate/non-numeric branches now
+  interpolate `experiment`)
+- [x] 2.12 `test_seed_recorded_as_none`
+- [x] 2.13 `test_repeated_runs_identical`
+- [x] 2.14 `test_run_persisted_with_composite_experiment_and_based_on_version`
+- [x] 2.15 `test_reserved_encoding_character_in_filename_rejected` (both fields,
+  parametrized)
+- [x] 2.16 `test_source_csv_content_addresses_both_inputs`
+- [x] 2.17 `test_genotype_means_artifacts_persisted`
+- [x] 2.18 `test_summary_json_serializable_no_numpy_leaks`
+- [x] 2.19 `test_result_never_inlines_full_correlation_matrix`
+- [x] 2.20 `test_discoverable_via_list_existing_analyses`
+- [x] 2.21 `test_schema_round_trip`
+- [x] 2.22 `test_out_of_range_parameters_rejected` (5 cases, parametrized)
+- [x] 2.23 `test_no_error_leaks_backend_internals`
+- [x] 2.24 `test_reproduces_golden_correlation_unfiltered` — the mandatory numeric
+  oracle, against the real turface_19/cylinder fixture pair and the recorded golden
+  (built via `scripts/gen_cross_experiment_correlation_golden.py`, no hand-transcribed
+  numbers)
+- [x] Plus `test_cross_experiment_correlations_in_tools_list` (registration/discovery)
+
+Full bloommcp suite: 746 passed, 29 skipped (live-stack smoke, no dev stack marker set
+in this run), 0 failed.
 
 ## 3. Shared helper patch
 
-- [ ] 3.0 Patch `bloommcp/src/bloom_mcp/tools/_qc_shared.py::_validate_trait_subset` so
-  the empty-list, duplicate, and non-numeric error messages interpolate `{experiment!r}`
-  the same way the outside-certified-set message already does (design.md D10) — message
-  text only, no signature or exception-type change; benefits `pca_analysis`/`clustering`/
-  `descriptive_stats` too
+- [x] 3.0 Patched `bloommcp/src/bloom_mcp/tools/_qc_shared.py::_validate_trait_subset` —
+  the empty-list, duplicate, and non-numeric error messages now interpolate
+  `{experiment!r}` the same way the outside-certified-set message already did
+  (design.md D10) — message text only, no signature or exception-type change; no
+  existing test asserted the old exact message text (confirmed via search), so this is
+  non-breaking for `pca_analysis`/`clustering`/`descriptive_stats`.
 
 ## 4. Tool implementation
 
-- [ ] 4.1 Create `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py`
-  with `CrossExperimentCorrelationsParams` (`experiment_1`, `experiment_2`,
-  `trait_columns_1`, `trait_columns_2`, `min_samples: int = 3` (`ge=1`),
-  `p_threshold: float = 0.05` (`ge=0, le=1`), `r_threshold: float = 0.5` (`ge=0, le=1`),
-  `use_fdr=True`, `user_label`) and `CrossExperimentCorrelationsResult` (extends
-  `RunLinks`). The `trait_columns_1`/`trait_columns_2` field descriptions SHALL state
-  the FDR multiplicity-family caveat (design.md D13): re-running with a narrower subset
-  changes the correction family, so `p_value_corrected` values are not comparable
-  across runs with different trait selections.
-- [ ] 4.2 Load both experiments via `_ports.reader().load_experiment(name, require_clean=True)`;
-  map `CleanedVersionRequiredError` per-experiment to a named `BloomMCPError(tool_error)`
-- [ ] 4.3 Reject a `None` `genotype_col` on either frame before any computation (D5)
-- [ ] 4.4 Reject `experiment_1`/`experiment_2` containing `@` or `|` before building any
-  composite string (D1's guard)
-- [ ] 4.5 Resolve `trait_columns_1`/`trait_columns_2` via `_validate_trait_subset(...,
-  require_certified=True)`, independently per experiment (default: full `frame.trait_cols`
-  when omitted)
-- [ ] 4.6 Check `np.isfinite(...)` on each experiment's selected trait columns before
-  aggregation (D11); raise `assumption_violated` naming the offending experiment
-- [ ] 4.7 Build genotype-means via `calculate_genotype_means` (D2) for each experiment,
-  then pre-filter each to `n_samples >= params.min_samples` (D8) before calling
-  `calculate_cross_experiment_correlations(exp1_means, exp2_means, trait_cols_1,
-  trait_cols_2, min_samples=params.min_samples)`
-- [ ] 4.8 Raise `assumption_violated` on an empty correlation result (D6); otherwise call
-  `identify_significant_correlations(corr_df, p_threshold, r_threshold, use_fdr)`,
-  normalizing an empty result to a fixed-header empty frame
-- [ ] 4.9 Call `summarize_correlation_results(corr_df, exp1_name=experiment_1,
-  exp2_name=experiment_2)`; convert via
-  `sleap_roots_analyze.data_utils.convert_to_json_serializable` (D7) before persisting
-- [ ] 4.10 Build the composite `experiment=`/`based_on_version=` strings (D1) and the
-  combined-snapshot `source_csv` (D1) for `store.create_run(...)`
-- [ ] 4.11 Persist `correlations.csv`, `significant.csv`, `genotype_means_1.csv`,
-  `genotype_means_2.csv` (D12), and `summary.json` under the reused tool class
-  `correlation` (D9); return the summary counts + `RunLinks`
+- [x] 4.1 Created `bloommcp/src/bloom_mcp/sections/sleap_roots/analysis/cross_experiment_correlations.py`
+  with `CrossExperimentCorrelationsParams`/`CrossExperimentCorrelationsResult`; the
+  `trait_columns_1`/`trait_columns_2` field descriptions state the FDR
+  multiplicity-family caveat (design.md D13)
+- [x] 4.2 Loads both experiments via `_ports.reader().load_experiment(name,
+  require_clean=True)`; `CleanedVersionRequiredError` mapped per-experiment
+- [x] 4.3 Rejects a `None` `genotype_col` on either frame before any computation (D5)
+- [x] 4.4 Rejects `experiment_1`/`experiment_2` containing `@`/`|` up front (D1's guard)
+- [x] 4.5 Resolves `trait_columns_1`/`trait_columns_2` independently via
+  `_validate_trait_subset(..., require_certified=True)`
+- [x] 4.6 `np.isfinite(...)` check on each experiment's selection before aggregation (D11)
+- [x] 4.7 Genotype-means via `calculate_genotype_means` (D2), pre-filtered to
+  `n_samples >= params.min_samples` (D8) before delegating
+- [x] 4.8 `assumption_violated` on an empty correlation result (D6); significance via
+  `identify_significant_correlations`, empty result normalized to a fixed header
+- [x] 4.9 `summarize_correlation_results` + `convert_to_json_serializable` (D7)
+- [x] 4.10 Composite `experiment=`/`based_on_version=` strings + combined-snapshot
+  `source_csv` (D1)
+- [x] 4.11 Persists `correlations.csv`, `significant.csv`, `genotype_means_1.csv`,
+  `genotype_means_2.csv` (D12), `summary.json` under tool class `correlation` (D9)
 
 ## 5. Registration
 
-- [ ] 5.1 Add `cross_experiment_correlations` to the imports and `register(...)` call in
-  `bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py`
-- [ ] 5.2 Add the new tool name to `test_expected_tool_surface`
-  (`bloommcp/tests/test_devendor_invariants.py`) explicitly by name — that test's
-  `live & relevant == expected` check silently passes if a name is absent from both its
-  `expected` and `not_expected` lists, so this must be named, not left to "any drift-guard
-  list"
-- [ ] 5.3 No changes needed to `manifest.CANONICAL_TOOL_CLASSES` or
-  `list_existing_analyses.TOOL_CLASSES` — both already reserve `"correlation"` (D9);
-  confirm this with a test (2.20) rather than skipping verification because "no change
-  was needed"
+- [x] 5.1 Registered in `bloommcp/src/bloom_mcp/sections/sleap_roots/__init__.py`
+- [x] 5.2 Added `sleap_roots_cross_experiment_correlations` to `test_expected_tool_surface`
+  (`bloommcp/tests/test_devendor_invariants.py`) by name
+- [x] 5.3 Confirmed (test 2.20) that no change to `manifest.CANONICAL_TOOL_CLASSES` /
+  `list_existing_analyses.TOOL_CLASSES` was needed — both already reserve `"correlation"`
 
 ## 6. Fixtures / oracle
 
-- [ ] 6.1 See 2.24 (now mandatory) — construct the two-experiment fixture pair and the
-  hand-computed golden value
+- [x] 6.1 `bloommcp/scripts/gen_cross_experiment_correlation_golden.py` generates
+  `bloommcp/tests/fixtures/turface_cylinder_cross_experiment_correlation_golden.json`
+  from the real turface_19/cylinder fixture pair (19 fully-overlapping genotypes) —
+  records the unfiltered correlation, the confirmed upstream no-op reproduction at
+  `min_samples=3`, and the bloommcp-pre-filtered correct value (excludes cylinder's
+  `GH_7371`, `n_samples=2`)
 
 ## 7. Validation
 
-- [ ] 7.1 `openspec validate add-bloommcp-cross-experiment-correlations --strict` passes
-- [ ] 7.2 Full bloommcp test suite green; `test_server_boots_after_devendor`-style boot
-  smoke still passes with the new tool registered
-- [ ] 7.3 `make bloommcp-smoke` (or equivalent live-persistence smoke) exercises
-  `qc_clean` (×2) → `cross_experiment_correlations` through the real
-  `SupabaseReader`/`SupabaseResultStore`, confirming the composite `experiment`/
-  `based_on_version` encoding round-trips through a real manifest, and that the run is
-  discoverable via `list_existing_analyses` under `correlation`
+- [x] 7.1 `openspec validate add-bloommcp-cross-experiment-correlations --strict` passes
+- [x] 7.2 Full bloommcp test suite green (746 passed); ruff + black clean at the
+  repo-pinned versions (ruff 0.9.9, black 26.3.1)
+- [ ] 7.3 `make bloommcp-smoke` / live dev-stack verification — **not run in this
+  session**. A container-transport smoke test was written
+  (`bloommcp/tests/smoke/test_cross_experiment_correlations_smoke.py`, mirroring
+  `test_clustering_smoke.py`) and collects/skips cleanly with no live stack marker, but
+  actually exercising it requires the running `bloommcp` container to be rebuilt with
+  this branch's code (a live dev stack was found running during this session, but
+  rebuilding/restarting a shared container mid-session was judged out of scope for this
+  PR). It will run automatically in CI's `dev-stack-smoke` job. Extending the
+  comprehensive `tests/smoke/live_persistence_smoke.py` script with a
+  cross-experiment-correlations leg (host-side, no container rebuild needed) remains a
+  good follow-up if a reviewer wants pre-merge live proof beyond the unit-level golden
+  fixture reproduction in 2.2/2.24.

--- a/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
+++ b/openspec/changes/add-bloommcp-cross-experiment-correlations/tasks.md
@@ -117,17 +117,93 @@ in this run), 0 failed.
 ## 7. Validation
 
 - [x] 7.1 `openspec validate add-bloommcp-cross-experiment-correlations --strict` passes
-- [x] 7.2 Full bloommcp test suite green (746 passed); ruff + black clean at the
-  repo-pinned versions (ruff 0.9.9, black 26.3.1)
-- [ ] 7.3 `make bloommcp-smoke` / live dev-stack verification — **not run in this
-  session**. A container-transport smoke test was written
-  (`bloommcp/tests/smoke/test_cross_experiment_correlations_smoke.py`, mirroring
-  `test_clustering_smoke.py`) and collects/skips cleanly with no live stack marker, but
-  actually exercising it requires the running `bloommcp` container to be rebuilt with
-  this branch's code (a live dev stack was found running during this session, but
-  rebuilding/restarting a shared container mid-session was judged out of scope for this
-  PR). It will run automatically in CI's `dev-stack-smoke` job. Extending the
-  comprehensive `tests/smoke/live_persistence_smoke.py` script with a
-  cross-experiment-correlations leg (host-side, no container rebuild needed) remains a
-  good follow-up if a reviewer wants pre-merge live proof beyond the unit-level golden
-  fixture reproduction in 2.2/2.24.
+- [x] 7.2 Full bloommcp test suite green (759 passed after §8); ruff + black clean at
+  the repo-pinned versions (ruff 0.9.9, black 26.3.1)
+- [x] 7.3 `make bloommcp-smoke` / live dev-stack verification — **ran in this PR's own
+  CI** (`Dev stack smoke` job) and initially **failed**: `result["outputs"]` came back
+  empty even though `store.commit()` had genuinely succeeded. Root-caused and fixed —
+  see §8.1. Re-verified server-side correctness directly against the live container for
+  both this tool and the long-shipped `pca_analysis` (confirming the bug was a
+  pre-existing client-side test-infrastructure gap, not specific to this tool); the
+  fixed smoke test itself still needs a container rebuild to re-run end-to-end, which
+  CI's next run on this branch will do.
+
+## 8. Post-PR-review fixes (two independent 5-agent reviews, posted ~1s apart)
+
+Both reviews' findings, reconciled and resolved:
+
+- [x] 8.1 **BLOCKING — live smoke test failing in CI.** Root-caused to
+  `bloommcp/tests/smoke/conftest.py`'s `_call_tool_sync` reading `result.data`
+  (fastmcp's lossy client-side reconstruction of the server's JSON, which collides two
+  untitled nested `object` schemas — the top-level result and the `outputs: dict[str,
+  str]` field — on the same auto-generated type name `Root`) instead of
+  `result.structured_content` (the server's actual, correct JSON). Confirmed
+  server-side correctness was never in question by reproducing the same empty-`outputs`
+  behavior against the live container for the long-shipped `pca_analysis` tool too —
+  this was a latent gap in *every* `RunLinks`-based tool's live-smoke coverage, only
+  surfaced because this PR was the first to assert on `outputs` via the container
+  transport. Fixed at the shared `conftest.py` level (one line), benefiting every smoke
+  test in the package.
+- [x] 8.2 **BLOCKING — composite-key truncation for dotted filenames.** The originally
+  shipped `f"{Path(e1).stem}__x__{Path(e2).stem}"` composite is silently truncated by
+  `AnalysisDir`'s own re-applied `Path(...).stem` whenever either original stem
+  contains a dot (reproduced by the reviewer: `"my.experiment.v2.csv"` collapses the
+  composite to `"my.experiment"`, losing `experiment_2` entirely — a silent storage
+  collision risk, not a crash). Fixed with `_storage_safe_stem(name) ->
+  Path(name).stem.replace(".", "_")`, making the composite string itself dot-free and
+  therefore immune to re-stemming for *any* filename. New tests exercise the real
+  `AnalysisDir` class directly (not `FakeResultStore`, whose simplified stem helper
+  cannot reproduce this real-backend bug) — see design.md D1's update.
+- [x] 8.3 **IMPORTANT — self-correlation unrejected.** `experiment_1 == experiment_2`
+  now raises `BloomMCPError(invalid_input)` before any I/O.
+- [x] 8.4 **IMPORTANT — argument-order sensitivity undiscoverable from the schema.**
+  Both `experiment_1`/`experiment_2` field descriptions now state that argument order
+  determines the storage key.
+- [x] 8.5 **IMPORTANT — path-traversal protection was incidental, not explicit.** The
+  tool now calls the existing `_qc_shared._validate_experiment_name` guard explicitly
+  on both experiment names (design.md D14). `pca_analysis`/`clustering` share this same
+  pre-existing gap — fixing it there is a follow-up, out of scope here.
+- [x] 8.6 **IMPORTANT — two "either side" tests only tested one side.**
+  `test_missing_genotype_role_either_side_rejected` and
+  `test_non_finite_value_either_side_rejected` now genuinely exercise both
+  `experiment_1` and `experiment_2`.
+- [x] 8.7 Verified (empirically, against the actual upstream source) that the
+  "`significant.csv` schema instability for exactly-one-qualifying-row" concern does
+  not hold: `identify_significant_correlations`'s else-branch adds
+  `p_value_corrected`/`significant_fdr` regardless of row count once `strong_corr` has
+  ≥1 row; the only genuinely columnless case is the top-level `len(strong_corr) == 0`
+  early return, already normalized by `_normalized_significant`. No code change; this
+  finding did not survive verification.
+- [x] 8.8 Added `test_constant_genotype_mean_trait_yields_nan_correlation_not_a_crash`
+  (design.md's accepted NaN-pass-through risk was previously undiscussed by any test)
+  and `test_exactly_one_shared_genotype_is_degenerate`.
+- [x] 8.9 Added `test_upstream_min_samples_no_op_still_present` — a regression pin
+  calling the raw upstream delegate directly, so a future upstream fix (or fixture
+  drift) fails this test loudly instead of the workaround silently going stale.
+- [x] 8.10 Fixed `test_reproduces_golden_correlation_unfiltered` to compare actual
+  `correlation`/`p_value` floats against the golden (it previously only checked
+  counts).
+- [x] 8.11 Extended `test_source_csv_content_addresses_both_inputs` to vary
+  `experiment_1` too (previously only varied `experiment_2`).
+- [x] 8.12 Parametrized `test_trait_columns_validated_independently` (was a manual
+  `for` loop that would mask later cases on an early failure).
+- [x] 8.13 Centralized `@`/`|`/`__x__` as module-level constants
+  (`_RESERVED_ENCODING_CHARS`, `_COMPOSITE_SEPARATOR`) instead of repeated bare
+  literals at the guard and the builder.
+- [x] 8.14 Simplified `_normalized_significant`'s redundant `sig_df.empty and
+  len(sig_df.columns) == 0` to `len(sig_df.columns) == 0` (a 0-column frame is always
+  `.empty`).
+- [x] 8.15 Surfaced D12's traceability limitation in `CrossExperimentCorrelationsResult`'s
+  own docstring (previously only in design.md).
+- [x] 8.16 Fixed design.md's Risks section citing the wrong upstream function
+  (`calculate_correlations`, the public wrapper with its own zero-variance guard) for
+  the NaN pass-through — the actual call path uses the private `_calculate_correlations`.
+- [x] 8.17 Added a `min_samples` field-description caveat: the `ge=1` floor alone
+  doesn't protect against single-replicate noise (a separate, always-enforced `< 3`
+  aligned-genotypes floor does that independent of this setting).
+- [x] 8.18 Noted (design.md Open Questions) that the golden fixture is not bit-for-bit
+  reproducible across regenerations (~1e-16 BLAS/threading float noise) — functionally
+  irrelevant given `abs=1e-6` test tolerances, but worth knowing before mistaking a
+  future regeneration's diff for a real regression.
+
+Full bloommcp suite after §8: 759 passed, 29 skipped, 0 failed. `test_cross_experiment_correlations_tool.py`: 44 tests (was 31).


### PR DESCRIPTION
## Summary

Re-adds bloommcp's cross-experiment trait-correlation capability — deleted by `devendor-bloommcp-analysis` (#438) rather than rewired, because upstream's `sleap_roots_analyze.cross_experiment_analysis` shares function names with the vendored module it replaced but has a genuinely different contract. This is the fresh design against that actual (richer) upstream contract, and bloommcp's **first two-experiment-input** granular tool.

Full OpenSpec proposal (including a 5-agent adversarial review pass and its resolution) at `openspec/changes/add-bloommcp-cross-experiment-correlations/`.

## Changes

- New tool `cross_experiment_correlations` (`sleap_roots_cross_experiment_correlations` on the MCP surface), registered alongside the other `sleap_roots` granular consumers. Delegates all math to upstream: `calculate_genotype_means`, `calculate_cross_experiment_correlations`, `identify_significant_correlations`, `summarize_correlation_results` — no correlation math of bloommcp's own, and `load_and_align_experiments` (which bypasses the read port) is never called.
- **Two-experiment persistence without touching shared ports.** `ResultStore`/`Provenance` are single-experiment-shaped; both experiments are encoded into the existing fields instead — a composite `experiment` key (`{stem1}__x__{stem2}`), a composite `based_on_version` (`exp@version|exp@version`), and a single combined `source_csv` snapshot so `input_sha256` content-addresses both inputs. `@`/`|` are reserved in experiment filenames and rejected up front.
- Reuses the already-reserved `correlation` tool_class (kept intact since the pre-#438 legacy tools were retired) rather than registering a new one — `list_existing_analyses` needed zero changes.
- **Found and worked around a confirmed upstream bug**: `calculate_cross_experiment_correlations`'s own `min_samples` filtering is dead code (computes a filtered genotype list, then never uses it — the internal alignment call hardcodes `min_samples=0`). bloommcp now pre-filters both genotype-means tables itself before delegating. Reported upstream as [talmolab/sleap-roots-analyze#205](https://github.com/talmolab/sleap-roots-analyze/issues/205), reproduced and verified against a real golden fixture built from the turface_19/cylinder pair (19 fully-overlapping genotypes, `bloommcp/scripts/gen_cross_experiment_correlation_golden.py`).
- Persists `correlations.csv`, `significant.csv`, `genotype_means_1.csv`/`genotype_means_2.csv` (traceability — upstream itself discards which genotypes fed a given correlation), and `summary.json`; returns only summary counts + links, never the full trait×trait matrix.
- Small, backward-compatible patch to `bloom_mcp/tools/_qc_shared.py::_validate_trait_subset` so all four trait-validation failure messages name the offending experiment (previously only one of four did) — benefits `pca_analysis`/`clustering`/`descriptive_stats` too.
- Deferred, explicitly (not silently): `calculate_per_trait_correlations`, `calculate_cross_experiment_correlations_extended`, `calculate_correlation_confidence_intervals` (a second related upstream inconsistency, also flagged in #205), all plotting, power analysis, redundant-trait clustering.

## Testing

- [x] `bloommcp/tests/tools/test_cross_experiment_correlations_tool.py` — 31 new tests, including a numeric-oracle reproduction against the real fixture pair and its recorded golden (not synthetic data)
- [x] Full bloommcp suite green: 746 passed, 29 skipped (live-stack smoke, no dev-stack marker in this run), 0 failed
- [x] `ruff check` / `black --check` clean at the repo-pinned versions (0.9.9 / 26.3.1)
- [x] `openspec validate add-bloommcp-cross-experiment-correlations --strict` passes
- [ ] Live dev-stack smoke (`bloommcp/tests/smoke/test_cross_experiment_correlations_smoke.py`, mirrors `test_clustering_smoke.py`) — written and collects/skips cleanly, but not exercised against a live container in this session (see tasks.md §7.3); will run in CI's `dev-stack-smoke` job

## Breaking Changes

None. No changes to `ExperimentReader`, `ResultStore`, `Provenance`, or the manifest schema. No new dependency (`sleap-roots-analyze>=0.1.0a5` is already pinned; `statsmodels` is upstream's own dependency, not new here).

## Related Issues

Closes #489